### PR TITLE
CI: add prod Firebase health probe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -46,3 +47,51 @@ jobs:
             echo "No test script; skipping"
           fi
         working-directory: services/api
+
+      # --- NEW: Prod Firebase health probe (only on pushes to main) ---
+      - name: Install jq
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Probe Firebase health (prod)
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        env:
+          CLOUD_RUN_URL: ${{ secrets.CLOUD_RUN_URL }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Probing $CLOUD_RUN_URL/api/firebase/healthz"
+          for i in {1..10}; do
+            RESP="$(curl -fsS "$CLOUD_RUN_URL/api/firebase/healthz" || true)"
+            echo "::group::Probe attempt $i"
+            echo "$RESP"
+            echo "::endgroup::"
+            if echo "$RESP" | jq -e '.ok == true and (.firestore.exists == true)'; then
+              echo "✅ Prod Firebase health probe passed."
+              exit 0
+            fi
+            sleep 6
+          done
+          echo "❌ Prod Firebase health probe failed."
+          exit 1
+      - name: Probe Firebase health (prod)
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        env:
+          CLOUD_RUN_URL: ${{ secrets.CLOUD_RUN_URL }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Probing $CLOUD_RUN_URL/api/firebase/healthz"
+          for i in {1..10}; do
+            RESP="$(curl -fsS "$CLOUD_RUN_URL/api/firebase/healthz" || true)"
+            echo "::group::Probe attempt $i"
+            echo "$RESP"
+            echo "::endgroup::"
+            if echo "$RESP" | jq -e '.ok == true and (.firestore.exists == true)'; then
+              echo "✅ Prod Firebase health probe passed."
+              exit 0
+            fi
+            sleep 6
+          done
+          echo "❌ Prod Firebase health probe failed."
+          exit 1


### PR DESCRIPTION
Adds a production Firebase health probe to CI.
- Runs only on pushes to main
- Installs jq
- Probes /api/firebase/healthz and retries up to 10 times
- Fails CI if probe does not return ok:true and firestore.exists:true
