### PR TITLE
feat: add Derived Ledger runs, replay API, and Command Center replay …

### DIFF
--- a/lib/api/derivedLedger.ts
+++ b/lib/api/derivedLedger.ts
@@ -1,0 +1,49 @@
+// lib/api/derivedLedgerMe.ts
+import type { ApiResult } from "@/lib/api/http";
+import { apiGetJsonAuthed } from "@/lib/api/http";
+
+import type { TruthGetOptions } from "@/lib/api/usersMe";
+
+import type {
+  DerivedLedgerReplayResponseDto,
+  DerivedLedgerRunsResponseDto,
+} from "@/lib/contracts/derivedLedger";
+
+function truthGetOpts(opts?: TruthGetOptions) {
+  return {
+    noStore: true as const,
+    ...(opts?.cacheBust ? { cacheBust: opts.cacheBust } : {}),
+  };
+}
+
+export const getDerivedLedgerRuns = async (
+  day: string,
+  idToken: string,
+  opts?: TruthGetOptions,
+): Promise<ApiResult<DerivedLedgerRunsResponseDto>> => {
+  return apiGetJsonAuthed<DerivedLedgerRunsResponseDto>(
+    `/users/me/derived-ledger/runs?day=${encodeURIComponent(day)}`,
+    idToken,
+    truthGetOpts(opts),
+  );
+};
+
+export const getDerivedLedgerReplay = async (
+  args: {
+    day: string;
+    runId?: string;
+    asOf?: string;
+  },
+  idToken: string,
+  opts?: TruthGetOptions,
+): Promise<ApiResult<DerivedLedgerReplayResponseDto>> => {
+  const params = new URLSearchParams({ day: args.day });
+  if (args.runId) params.set("runId", args.runId);
+  if (args.asOf) params.set("asOf", args.asOf);
+
+  return apiGetJsonAuthed<DerivedLedgerReplayResponseDto>(
+    `/users/me/derived-ledger/replay?${params.toString()}`,
+    idToken,
+    truthGetOpts(opts),
+  );
+};

--- a/lib/api/derivedLedgerMe.ts
+++ b/lib/api/derivedLedgerMe.ts
@@ -1,0 +1,111 @@
+// lib/api/derivedLedgerMe.ts
+import type { ApiFailure, ApiResult, JsonValue } from "@/lib/api/http";
+import { apiGetJsonAuthed } from "@/lib/api/http";
+
+import {
+  derivedLedgerReplayResponseDtoSchema,
+  derivedLedgerRunsResponseDtoSchema,
+  type DerivedLedgerReplayResponseDto,
+  type DerivedLedgerRunsResponseDto,
+} from "@/lib/contracts/derivedLedger";
+
+export type TruthGetOptions = {
+  cacheBust?: string;
+};
+
+function truthGetOpts(opts?: TruthGetOptions) {
+  return {
+    noStore: true as const,
+    ...(opts?.cacheBust ? { cacheBust: opts.cacheBust } : {}),
+  };
+}
+
+function isJsonValue(v: unknown): v is JsonValue {
+  if (v === null) return true;
+  const t = typeof v;
+  if (t === "string" || t === "number" || t === "boolean") return true;
+  if (Array.isArray(v)) return v.every(isJsonValue);
+  if (t === "object") {
+    const rec = v as Record<string, unknown>;
+    return Object.values(rec).every(isJsonValue);
+  }
+  return false;
+}
+
+function attachJsonIfSafe(failure: ApiFailure, jsonUnknown: unknown): ApiFailure {
+  // ApiFailure.json?: JsonValue (optional). With exactOptionalPropertyTypes, we must not pass undefined explicitly.
+  if (jsonUnknown !== undefined && isJsonValue(jsonUnknown)) {
+    return { ...failure, json: jsonUnknown };
+  }
+  return failure;
+}
+
+export async function getDerivedLedgerRuns(
+  day: string,
+  idToken: string,
+  opts?: TruthGetOptions,
+): Promise<ApiResult<DerivedLedgerRunsResponseDto>> {
+  const res = await apiGetJsonAuthed<unknown>(
+    `/users/me/derived-ledger/runs?day=${encodeURIComponent(day)}`,
+    idToken,
+    truthGetOpts(opts),
+  );
+
+  if (!res.ok) return res as ApiResult<DerivedLedgerRunsResponseDto>;
+
+  const parsed = derivedLedgerRunsResponseDtoSchema.safeParse(res.json);
+  if (!parsed.success) {
+    const base: ApiFailure = {
+      ok: false,
+      status: res.status,
+      kind: "parse",
+      error: "Invalid DerivedLedgerRuns response",
+      requestId: res.requestId,
+    };
+    return attachJsonIfSafe(base, res.json) as ApiResult<DerivedLedgerRunsResponseDto>;
+  }
+
+  return {
+    ok: true,
+    status: res.status,
+    requestId: res.requestId,
+    json: parsed.data,
+  };
+}
+
+export async function getDerivedLedgerReplay(
+  args: { day: string; runId?: string; asOf?: string },
+  idToken: string,
+  opts?: TruthGetOptions,
+): Promise<ApiResult<DerivedLedgerReplayResponseDto>> {
+  const params = new URLSearchParams({ day: args.day });
+  if (args.runId) params.set("runId", args.runId);
+  if (args.asOf) params.set("asOf", args.asOf);
+
+  const res = await apiGetJsonAuthed<unknown>(
+    `/users/me/derived-ledger/replay?${params.toString()}`,
+    idToken,
+    truthGetOpts(opts),
+  );
+
+  if (!res.ok) return res as ApiResult<DerivedLedgerReplayResponseDto>;
+
+  const parsed = derivedLedgerReplayResponseDtoSchema.safeParse(res.json);
+  if (!parsed.success) {
+    const base: ApiFailure = {
+      ok: false,
+      status: res.status,
+      kind: "parse",
+      error: "Invalid DerivedLedgerReplay response",
+      requestId: res.requestId,
+    };
+    return attachJsonIfSafe(base, res.json) as ApiResult<DerivedLedgerReplayResponseDto>;
+  }
+
+  return {
+    ok: true,
+    status: res.status,
+    requestId: res.requestId,
+    json: parsed.data,
+  };
+}

--- a/lib/contracts/derivedLedger.ts
+++ b/lib/contracts/derivedLedger.ts
@@ -1,0 +1,76 @@
+// lib/contracts/derivedLedger.ts
+import { z } from "zod";
+import { dayKeySchema } from "./day";
+import { dailyFactsDtoSchema } from "./dailyFacts";
+import { intelligenceContextDtoSchema } from "./intelligenceContext";
+import { insightsResponseDtoSchema } from "./insights";
+
+const isoString = z.string().min(1);
+
+const triggerSchema = z.union([
+  z
+    .object({
+      type: z.literal("realtime"),
+      name: z.literal("onCanonicalEventCreated"),
+      eventId: z.string().min(1),
+    })
+    .strip(),
+  z
+    .object({
+      type: z.literal("scheduled"),
+      name: z.string().min(1),
+      eventId: z.string().min(1),
+    })
+    .strip(),
+]);
+
+export const derivedLedgerRunSummaryDtoSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    runId: z.string().min(1),
+    userId: z.string().min(1),
+    date: dayKeySchema,
+    computedAt: isoString,
+    pipelineVersion: z.number().int().positive(),
+    trigger: triggerSchema,
+    latestCanonicalEventAt: isoString.optional(),
+    outputs: z
+      .object({
+        hasDailyFacts: z.boolean(),
+        insightsCount: z.number().int().nonnegative(),
+        hasIntelligenceContext: z.boolean(),
+      })
+      .strip(),
+    createdAt: isoString, // API-normalized
+  })
+  .strip();
+
+export type DerivedLedgerRunSummaryDto = z.infer<typeof derivedLedgerRunSummaryDtoSchema>;
+
+export const derivedLedgerRunsResponseDtoSchema = z
+  .object({
+    day: dayKeySchema,
+    latestRunId: z.string().min(1).optional(),
+    runs: z.array(derivedLedgerRunSummaryDtoSchema),
+  })
+  .strip();
+
+export type DerivedLedgerRunsResponseDto = z.infer<typeof derivedLedgerRunsResponseDtoSchema>;
+
+export const derivedLedgerReplayResponseDtoSchema = z
+  .object({
+    day: dayKeySchema,
+    runId: z.string().min(1),
+    computedAt: isoString,
+    pipelineVersion: z.number().int().positive(),
+    trigger: triggerSchema,
+    latestCanonicalEventAt: isoString.optional(),
+
+    // Snapshots (nullable when missing)
+    dailyFacts: dailyFactsDtoSchema.optional(),
+    intelligenceContext: intelligenceContextDtoSchema.optional(),
+    insights: insightsResponseDtoSchema.optional(),
+  })
+  .strip();
+
+export type DerivedLedgerReplayResponseDto = z.infer<typeof derivedLedgerReplayResponseDtoSchema>;

--- a/lib/contracts/index.ts
+++ b/lib/contracts/index.ts
@@ -6,3 +6,4 @@ export * from "./insights";
 export * from "./intelligenceContext";
 export * from "./rawEvent";
 export * from "./dayTruth";
+export * from "./derivedLedger";

--- a/lib/data/__tests__/truthOutcome.test.ts
+++ b/lib/data/__tests__/truthOutcome.test.ts
@@ -1,0 +1,30 @@
+import { truthOutcomeFromApiResult } from "../truthOutcome";
+
+describe("truthOutcomeFromApiResult", () => {
+  it("returns ready for ok results", () => {
+    const res = { ok: true as const, status: 200, requestId: "r1", json: { a: 1 } };
+    expect(truthOutcomeFromApiResult(res)).toEqual({ status: "ready", data: { a: 1 } });
+  });
+
+  it("returns missing for HTTP 404", () => {
+    const res = {
+      ok: false as const,
+      status: 404,
+      kind: "http" as const,
+      error: "HTTP 404",
+      requestId: "r2",
+    };
+    expect(truthOutcomeFromApiResult(res)).toEqual({ status: "missing" });
+  });
+
+  it("returns error for non-404 failures", () => {
+    const res = {
+      ok: false as const,
+      status: 500,
+      kind: "http" as const,
+      error: "HTTP 500",
+      requestId: "r3",
+    };
+    expect(truthOutcomeFromApiResult(res)).toEqual({ status: "error", error: "HTTP 500", requestId: "r3" });
+  });
+});

--- a/lib/data/replaySession.ts
+++ b/lib/data/replaySession.ts
@@ -1,0 +1,13 @@
+// lib/data/replaySession.ts
+export type ReplaySelection =
+  | { mode: "latest" }
+  | { mode: "run"; runId: string }
+  | { mode: "asOf"; asOf: string }; // ISO datetime string
+
+export const replaySelectionLatest = (): ReplaySelection => ({ mode: "latest" });
+export const replaySelectionRun = (runId: string): ReplaySelection => ({ mode: "run", runId });
+export const replaySelectionAsOf = (asOf: string): ReplaySelection => ({ mode: "asOf", asOf });
+
+export function isReplayEnabled(sel: ReplaySelection): boolean {
+  return sel.mode !== "latest";
+}

--- a/lib/data/truthOutcome.ts
+++ b/lib/data/truthOutcome.ts
@@ -1,0 +1,17 @@
+// lib/data/truthOutcome.ts
+import type { ApiFailure, ApiResult } from "@/lib/api/http";
+
+export type TruthOutcome<T> =
+  | { status: "ready"; data: T }
+  | { status: "missing" }
+  | { status: "error"; error: string; requestId: string | null };
+
+const isNotFound = (res: ApiFailure): boolean => res.kind === "http" && res.status === 404;
+
+export function truthOutcomeFromApiResult<T>(res: ApiResult<T>): TruthOutcome<T> {
+  if (res.ok) return { status: "ready", data: res.json };
+
+  if (isNotFound(res)) return { status: "missing" };
+
+  return { status: "error", error: res.error, requestId: res.requestId };
+}

--- a/lib/data/useDerivedLedger.ts
+++ b/lib/data/useDerivedLedger.ts
@@ -1,0 +1,3 @@
+// lib/data/useDerivedLedger.ts
+export { useDerivedLedgerRuns } from "@/lib/data/useDerivedLedgerRuns";
+export { useDerivedLedgerReplay } from "@/lib/data/useDerivedLedgerReplay";

--- a/lib/data/useDerivedLedgerReplay.ts
+++ b/lib/data/useDerivedLedgerReplay.ts
@@ -1,23 +1,34 @@
-// lib/data/useIntelligenceContext.ts
+// lib/data/useDerivedLedgerReplay.ts
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAuth } from "@/lib/auth/AuthProvider";
-import { getIntelligenceContext, type TruthGetOptions } from "@/lib/api/usersMe";
-import type { IntelligenceContextDto } from "@/lib/contracts";
+
+import { getDerivedLedgerReplay, type TruthGetOptions } from "@/lib/api/derivedLedgerMe";
+import type { DerivedLedgerReplayResponseDto } from "@/lib/contracts/derivedLedger";
 import { truthOutcomeFromApiResult } from "@/lib/data/truthOutcome";
 
 type State =
   | { status: "loading" }
   | { status: "missing" }
   | { status: "error"; error: string; requestId: string | null }
-  | { status: "ready"; data: IntelligenceContextDto };
+  | { status: "ready"; data: DerivedLedgerReplayResponseDto };
 
 type RefetchOpts = TruthGetOptions;
 
-export function useIntelligenceContext(day: string): State & { refetch: (opts?: RefetchOpts) => void } {
+function withUniqueCacheBust(opts: RefetchOpts | undefined, seq: number): RefetchOpts | undefined {
+  const cb = opts?.cacheBust;
+  if (!cb) return opts;
+  return { ...opts, cacheBust: `${cb}:${seq}` };
+}
+
+export function useDerivedLedgerReplay(args: {
+  day: string;
+  runId?: string;
+  asOf?: string;
+}): State & { refetch: (opts?: RefetchOpts) => void } {
   const { user, initializing, getIdToken } = useAuth();
 
-  const dayRef = useRef(day);
-  dayRef.current = day;
+  const argsRef = useRef(args);
+  argsRef.current = args;
 
   const reqSeq = useRef(0);
 
@@ -35,17 +46,12 @@ export function useIntelligenceContext(day: string): State & { refetch: (opts?: 
         if (seq === reqSeq.current) setState(next);
       };
 
-      if (initializing) {
+      if (initializing || !user) {
         if (stateRef.current.status !== "ready") safeSet({ status: "loading" });
         return;
       }
 
-      if (!user) {
-        if (stateRef.current.status !== "ready") safeSet({ status: "loading" });
-        return;
-      }
-
-      const token = await getIdToken();
+      const token = await getIdToken(false);
       if (seq !== reqSeq.current) return;
 
       if (!token) {
@@ -54,10 +60,11 @@ export function useIntelligenceContext(day: string): State & { refetch: (opts?: 
         return;
       }
 
-      // Stale-while-revalidate
       if (stateRef.current.status !== "ready") safeSet({ status: "loading" });
 
-      const res = await getIntelligenceContext(dayRef.current, token, opts);
+      const optsUnique = withUniqueCacheBust(opts, seq);
+
+      const res = await getDerivedLedgerReplay(argsRef.current, token, optsUnique);
       if (seq !== reqSeq.current) return;
 
       const outcome = truthOutcomeFromApiResult(res);
@@ -68,15 +75,12 @@ export function useIntelligenceContext(day: string): State & { refetch: (opts?: 
       }
 
       if (outcome.status === "missing") {
-        // Important: missing derived truth is NOT computed truth.
         if (stateRef.current.status === "ready") return;
         safeSet({ status: "missing" });
         return;
       }
 
-      // outcome.status === "error"
       if (stateRef.current.status === "ready") return;
-
       safeSet({ status: "error", error: outcome.error, requestId: outcome.requestId });
     },
     [getIdToken, initializing, user],
@@ -84,7 +88,8 @@ export function useIntelligenceContext(day: string): State & { refetch: (opts?: 
 
   useEffect(() => {
     void fetchOnce();
-  }, [fetchOnce, day, user?.uid]);
+    // re-fetch when key inputs change
+  }, [fetchOnce, args.day, args.runId, args.asOf, user?.uid]);
 
   return useMemo(() => ({ ...state, refetch: fetchOnce }), [state, fetchOnce]);
 }

--- a/services/api/src/types/dtos.ts
+++ b/services/api/src/types/dtos.ts
@@ -1,4 +1,5 @@
 // services/api/src/types/dtos.ts
+
 export { dailyFactsDtoSchema } from "../../../../lib/contracts/dailyFacts";
 export type { DailyFactsDto } from "../../../../lib/contracts/dailyFacts";
 
@@ -15,3 +16,15 @@ export type { IntelligenceContextDto } from "../../../../lib/contracts/intellige
 
 export { logWeightRequestDtoSchema, logWeightResponseDtoSchema } from "../../../../lib/contracts/weight";
 export type { LogWeightRequestDto, LogWeightResponseDto } from "../../../../lib/contracts/weight";
+
+// ✅ Step 4 — Derived Ledger replay contracts
+export {
+  derivedLedgerRunSummaryDtoSchema,
+  derivedLedgerRunsResponseDtoSchema,
+  derivedLedgerReplayResponseDtoSchema,
+} from "../../../../lib/contracts/derivedLedger";
+export type {
+  DerivedLedgerRunSummaryDto,
+  DerivedLedgerRunsResponseDto,
+  DerivedLedgerReplayResponseDto,
+} from "../../../../lib/contracts/derivedLedger";

--- a/services/functions/src/insights/onInsightsRecomputeScheduled.ts
+++ b/services/functions/src/insights/onInsightsRecomputeScheduled.ts
@@ -1,22 +1,51 @@
 // services/functions/src/insights/onInsightsRecomputeScheduled.ts
 
-import { onSchedule } from 'firebase-functions/v2/scheduler';
-import * as logger from 'firebase-functions/logger';
-import type { WriteBatch } from 'firebase-admin/firestore';
+import { onSchedule } from "firebase-functions/v2/scheduler";
+import * as logger from "firebase-functions/logger";
+import type { WriteBatch } from "firebase-admin/firestore";
 
-import { db } from '../firebaseAdmin';
-import type { DailyFacts, IsoDateTimeString, YmdDateString } from '../types/health';
-import { generateInsightsForDailyFacts } from './rules';
+import { db } from "../firebaseAdmin";
+import type { DailyFacts, IsoDateTimeString, YmdDateString } from "../types/health";
+import { generateInsightsForDailyFacts } from "./rules";
+
+import { makeLedgerRunIdFromSeed, writeDerivedLedgerRun } from "../pipeline/derivedLedger";
+
+type PipelineMetaLike = {
+  pipelineVersion?: number;
+  source?: Record<string, unknown>;
+};
+
+function readPipelineMetaLike(value: unknown): PipelineMetaLike | null {
+  if (!value || typeof value !== "object") return null;
+  const rec = value as Record<string, unknown>;
+  const meta = rec["meta"];
+  if (!meta || typeof meta !== "object") return null;
+  const m = meta as Record<string, unknown>;
+
+  const pipelineVersion = typeof m["pipelineVersion"] === "number" ? m["pipelineVersion"] : undefined;
+  const source =
+    typeof m["source"] === "object" && m["source"] !== null ? (m["source"] as Record<string, unknown>) : undefined;
+
+    return {
+      ...(pipelineVersion !== undefined ? { pipelineVersion } : {}),
+      ...(source !== undefined ? { source } : {}),
+    };    
+}
+
+function readLatestCanonicalEventAtFromMeta(value: unknown): string | undefined {
+  const meta = readPipelineMetaLike(value);
+  if (!meta?.source) return undefined;
+  const v = meta.source["latestCanonicalEventAt"];
+  return typeof v === "string" ? v : undefined;
+}
 
 const toYmdUtc = (date: Date): YmdDateString => {
   const year = date.getUTCFullYear();
   const month = date.getUTCMonth() + 1;
   const day = date.getUTCDate();
-
-  const paddedMonth = month.toString().padStart(2, '0');
-  const paddedDay = day.toString().padStart(2, '0');
-
-  return `${year.toString().padStart(4, '0')}-${paddedMonth}-${paddedDay}`;
+  return `${year.toString().padStart(4, "0")}-${month.toString().padStart(2, "0")}-${day
+    .toString()
+    .padStart(2, "0")}`;
 };
 
 const parseIntStrict = (value: string): number | null => {
@@ -26,21 +55,12 @@ const parseIntStrict = (value: string): number | null => {
 };
 
 const parseYmdUtc = (ymd: YmdDateString): Date => {
-  // ymd is "YYYY-MM-DD"
-  const parts = ymd.split('-');
-  if (parts.length !== 3) {
-    throw new Error(`Invalid YmdDateString: "${ymd}"`);
-  }
-
-  const y = parseIntStrict(parts[0] ?? '');
-  const m = parseIntStrict(parts[1] ?? '');
-  const d = parseIntStrict(parts[2] ?? '');
-
-  if (y === null || m === null || d === null) {
-    throw new Error(`Invalid YmdDateString: "${ymd}"`);
-  }
-
-  // monthIndex is 0-based
+  const parts = ymd.split("-");
+  if (parts.length !== 3) throw new Error(`Invalid YmdDateString: "${ymd}"`);
+  const y = parseIntStrict(parts[0] ?? "");
+  const m = parseIntStrict(parts[1] ?? "");
+  const d = parseIntStrict(parts[2] ?? "");
+  if (y === null || m === null || d === null) throw new Error(`Invalid YmdDateString: "${ymd}"`);
   return new Date(Date.UTC(y, m - 1, d));
 };
 
@@ -52,76 +72,46 @@ const addDaysUtc = (ymd: YmdDateString, deltaDays: number): YmdDateString => {
 
 const getYesterdayUtcYmd = (): YmdDateString => {
   const now = new Date();
-  const year = now.getUTCFullYear();
-  const month = now.getUTCMonth();
-  const day = now.getUTCDate();
-  const yesterday = new Date(Date.UTC(year, month, day - 1));
-  return toYmdUtc(yesterday);
+  return toYmdUtc(new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 1)));
 };
 
 const buildWindowDatesInclusive = (endDate: YmdDateString, windowSizeDays: number): YmdDateString[] => {
-  // Returns [end-6, ..., end] for windowSizeDays=7
   const dates: YmdDateString[] = [];
-  for (let i = windowSizeDays - 1; i >= 0; i--) {
-    dates.push(addDaysUtc(endDate, -i));
-  }
+  for (let i = windowSizeDays - 1; i >= 0; i--) dates.push(addDaysUtc(endDate, -i));
   return dates;
 };
 
 const sortByDateAsc = (a: DailyFacts, b: DailyFacts): number => {
-  // YYYY-MM-DD string compare works for chronological order
   if (a.date < b.date) return -1;
   if (a.date > b.date) return 1;
   return 0;
 };
 
 const commitBatches = async (batches: WriteBatch[]): Promise<void> => {
-  for (const batch of batches) {
-    await batch.commit();
-  }
+  for (const batch of batches) await batch.commit();
 };
 
-/**
- * Scheduled job:
- *  - Runs daily (UTC)
- *  - Finds users who have DailyFacts for the target date (yesterday UTC)
- *  - Loads a 7-day DailyFacts window for each user (history + today)
- *  - Generates Insights using Sprint 6 IntelligenceContext-aware rules
- *  - Writes results under /users/{userId}/insights/{insightId}
- *
- * Firestore paths:
- *  - Input:  /users/{userId}/dailyFacts/{yyyy-MM-dd}
- *  - Output: /users/{userId}/insights/{insightId}
- */
 export const onInsightsRecomputeScheduled = onSchedule(
   {
-    // Run shortly after DailyFacts recompute (which is at 03:00 UTC).
-    schedule: '15 3 * * *',
-    region: 'us-central1',
-    serviceAccount: 'oli-functions-runtime@oli-staging-fdbba.iam.gserviceaccount.com',
+    schedule: "15 3 * * *",
+    region: "us-central1",
+    serviceAccount: "oli-functions-runtime@oli-staging-fdbba.iam.gserviceaccount.com",
   },
-  async () => {
+  async (event) => {
     const targetDate = getYesterdayUtcYmd();
     const now: IsoDateTimeString = new Date().toISOString();
 
-    // 7-day window ending at targetDate (inclusive).
     const windowDates = buildWindowDatesInclusive(targetDate, 7);
 
-    logger.info('Insights recompute started', { targetDate, windowDates });
+    logger.info("Insights recompute started", { targetDate, windowDates });
 
-    // Find all users who have DailyFacts for targetDate.
-    const dailyFactsSnapshot = await db
-      .collectionGroup('dailyFacts')
-      .where('date', '==', targetDate)
-      .get();
-
+    const dailyFactsSnapshot = await db.collectionGroup("dailyFacts").where("date", "==", targetDate).get();
     if (dailyFactsSnapshot.empty) {
-      logger.info('No DailyFacts found for target date', { targetDate });
+      logger.info("No DailyFacts found for target date", { targetDate });
       return;
     }
 
-    // We will batch writes (<= 500 ops per batch). Use 450 to keep margin.
-    const MAX_OPS_PER_BATCH = 450;
+    const MAX_OPS_PER_BATCH = 350;
     const batches: WriteBatch[] = [];
     let currentBatch = db.batch();
     let currentOps = 0;
@@ -130,18 +120,24 @@ export const onInsightsRecomputeScheduled = onSchedule(
     let insightsWritten = 0;
     let usersWithNoHistory = 0;
 
+    // Stable-ish seed for this scheduled invocation (ScheduledEvent has no .id)
+    const runIdBase = makeLedgerRunIdFromSeed(
+      "sch_insights",
+      `${String(event.jobName ?? "insights")}_${String(event.scheduleTime ?? now)}_${targetDate}`,
+    );
+
+    const triggerEventId = `${String(event.jobName ?? "insights")}_${String(event.scheduleTime ?? now)}`;
+
     for (const doc of dailyFactsSnapshot.docs) {
       const userId = doc.ref.parent.parent?.id;
-
       if (!userId) {
-        logger.warn('Skipping DailyFacts doc with unexpected path', { path: doc.ref.path });
+        logger.warn("Skipping DailyFacts doc with unexpected path", { path: doc.ref.path });
         continue;
       }
 
       const todayFacts = doc.data() as DailyFacts;
-
       if (!todayFacts || todayFacts.userId !== userId || todayFacts.date !== targetDate) {
-        logger.warn('Skipping DailyFacts doc with inconsistent data', {
+        logger.warn("Skipping DailyFacts doc with inconsistent data", {
           path: doc.ref.path,
           userIdFromPath: userId,
           userIdFromDoc: todayFacts?.userId,
@@ -151,22 +147,15 @@ export const onInsightsRecomputeScheduled = onSchedule(
         continue;
       }
 
-      const userRef = db.collection('users').doc(userId);
+      const userRef = db.collection("users").doc(userId);
 
-      // 7-day window facts for this user (including today).
-      const windowSnap = await userRef
-        .collection('dailyFacts')
-        .where('date', 'in', windowDates)
-        .get();
-
+      const windowSnap = await userRef.collection("dailyFacts").where("date", "in", windowDates).get();
       const windowFacts = windowSnap.docs.map((d) => d.data() as DailyFacts).sort(sortByDateAsc);
 
       const today = windowFacts.find((f) => f.date === targetDate) ?? todayFacts;
       const history = windowFacts.filter((f) => f.date !== targetDate);
 
-      if (history.length === 0) {
-        usersWithNoHistory += 1;
-      }
+      if (history.length === 0) usersWithNoHistory += 1;
 
       const insights = generateInsightsForDailyFacts({
         userId,
@@ -178,11 +167,29 @@ export const onInsightsRecomputeScheduled = onSchedule(
 
       usersProcessed += 1;
 
-      if (insights.length === 0) {
-        continue;
-      }
+      // Always write a ledger run even if no insights (“no insights were known”)
+      const runId = `${runIdBase}_${userId}`;
 
-      const insightsCol = userRef.collection('insights');
+      // Anchor (best available): dailyFacts meta source.latestCanonicalEventAt if present
+      const latestCanonicalEventAt = readLatestCanonicalEventAtFromMeta(todayFacts);
+
+      const pipelineVersion = readPipelineMetaLike(todayFacts)?.pipelineVersion ?? 1;
+
+      await writeDerivedLedgerRun({
+        db,
+        userId,
+        date: targetDate,
+        runId,
+        computedAt: now,
+        pipelineVersion,
+        trigger: { type: "scheduled", name: "onInsightsRecomputeScheduled", eventId: triggerEventId },
+        ...(latestCanonicalEventAt ? { latestCanonicalEventAt } : {}),
+        insights,
+      });
+
+      if (insights.length === 0) continue;
+
+      const insightsCol = userRef.collection("insights");
 
       for (const insight of insights) {
         if (currentOps >= MAX_OPS_PER_BATCH) {
@@ -191,25 +198,16 @@ export const onInsightsRecomputeScheduled = onSchedule(
           currentOps = 0;
         }
 
-        const ref = insightsCol.doc(insight.id);
-        currentBatch.set(ref, insight);
+        currentBatch.set(insightsCol.doc(insight.id), insight);
         currentOps += 1;
         insightsWritten += 1;
       }
     }
 
-    if (currentOps > 0) {
-      batches.push(currentBatch);
-    }
+    if (currentOps > 0) batches.push(currentBatch);
+    if (batches.length > 0) await commitBatches(batches);
 
-    if (batches.length === 0) {
-      logger.info('No insights generated for target date', { targetDate, usersProcessed });
-      return;
-    }
-
-    await commitBatches(batches);
-
-    logger.info('Insights recompute completed', {
+    logger.info("Insights recompute completed", {
       targetDate,
       usersProcessed,
       usersWithNoHistory,

--- a/services/functions/src/normalization/__tests__/canonicalImmutability.test.ts
+++ b/services/functions/src/normalization/__tests__/canonicalImmutability.test.ts
@@ -1,0 +1,35 @@
+import crypto from "node:crypto";
+import { stableStringify } from "../canonicalImmutability";
+
+function sha256Hex(input: string): string {
+  return crypto.createHash("sha256").update(input).digest("hex");
+}
+
+describe("canonicalImmutability helpers", () => {
+  it("stableStringify sorts keys deterministically (including nested objects)", () => {
+    const a = { b: 1, a: 2, c: { y: 1, x: 2 } };
+    const b = { a: 2, b: 1, c: { x: 2, y: 1 } };
+
+    expect(stableStringify(a)).toBe(stableStringify(b));
+  });
+
+  it("stableStringify preserves array order (arrays are not key-sorted)", () => {
+    const a = { xs: [1, 2, 3] };
+    const b = { xs: [1, 3, 2] };
+
+    expect(stableStringify(a)).not.toBe(stableStringify(b));
+  });
+
+  it("hashing stableStringify output is stable for semantically identical objects", () => {
+    const a = { id: "abc", meta: { x: 1, y: 2 }, data: { b: 1, a: 2 } };
+    const b = { data: { a: 2, b: 1 }, meta: { y: 2, x: 1 }, id: "abc" };
+    const c = { id: "abc", meta: { x: 1, y: 2 }, data: { b: 1, a: 999 } };
+
+    const ha = sha256Hex(stableStringify(a));
+    const hb = sha256Hex(stableStringify(b));
+    const hc = sha256Hex(stableStringify(c));
+
+    expect(ha).toBe(hb);
+    expect(ha).not.toBe(hc);
+  });
+});

--- a/services/functions/src/normalization/canonicalImmutability.ts
+++ b/services/functions/src/normalization/canonicalImmutability.ts
@@ -1,0 +1,43 @@
+// services/functions/src/normalization/canonicalImmutability.ts
+
+import crypto from "node:crypto";
+import type { CanonicalEvent } from "../types/health";
+
+/**
+ * Stable stringify for deterministic hashing/comparison.
+ * - Sorts object keys recursively
+ * - Preserves array order
+ */
+export function stableStringify(value: unknown): string {
+  if (value === null) return "null";
+
+  const t = typeof value;
+
+  if (t === "string" || t === "number" || t === "boolean") {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+
+  if (t === "object") {
+    const obj = value as Record<string, unknown>;
+    const keys = Object.keys(obj).sort();
+    const parts = keys.map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`);
+    return `{${parts.join(",")}}`;
+  }
+
+  // symbols/functions/undefined shouldn't appear in CanonicalEvent; stringify safely anyway
+  return JSON.stringify(String(value));
+}
+
+export function canonicalHash(canonical: CanonicalEvent): string {
+  const s = stableStringify(canonical);
+  return crypto.createHash("sha256").update(s).digest("hex");
+}
+
+export function canonicalEquals(a: CanonicalEvent, b: CanonicalEvent): boolean {
+  // Fast path via stable stringify (deterministic)
+  return stableStringify(a) === stableStringify(b);
+}

--- a/services/functions/src/normalization/writeCanonicalEventImmutable.ts
+++ b/services/functions/src/normalization/writeCanonicalEventImmutable.ts
@@ -1,0 +1,54 @@
+// services/functions/src/normalization/writeCanonicalEventImmutable.ts
+
+import * as logger from "firebase-functions/logger";
+import { db } from "../firebaseAdmin";
+import type { CanonicalEvent } from "../types/health";
+import { canonicalEquals, canonicalHash } from "./canonicalImmutability";
+
+export type WriteCanonicalResult =
+  | { ok: true; mode: "created" | "identical_noop" }
+  | { ok: false; mode: "conflict"; existingHash: string; incomingHash: string };
+
+export async function writeCanonicalEventImmutable(params: {
+  userId: string;
+  canonical: CanonicalEvent;
+  sourceRawEventId: string;
+  sourceRawEventPath: string;
+}): Promise<WriteCanonicalResult> {
+  const { userId, canonical, sourceRawEventId, sourceRawEventPath } = params;
+
+  const ref = db.collection("users").doc(userId).collection("events").doc(canonical.id);
+
+  return db.runTransaction(async (tx) => {
+    const snap = await tx.get(ref);
+
+    if (!snap.exists) {
+      // Create-only: canonical truth is immutable once written.
+      tx.create(ref, canonical);
+      return { ok: true, mode: "created" } as const;
+    }
+
+    const existing = snap.data() as CanonicalEvent;
+
+    if (canonicalEquals(existing, canonical)) {
+      // Idempotent replay: identical canonical event is allowed, but we do not rewrite.
+      return { ok: true, mode: "identical_noop" } as const;
+    }
+
+    // Conflict: same canonical ID but different content (corruption vector).
+    const existingHash = canonicalHash(existing);
+    const incomingHash = canonicalHash(canonical);
+
+    logger.error("Canonical immutability violation: attempted overwrite with different content", {
+      userId,
+      canonicalId: canonical.id,
+      sourceRawEventId,
+      sourceRawEventPath,
+      existingHash,
+      incomingHash,
+    });
+
+    // Do NOT overwrite. Return conflict so caller can decide retry/alert behavior.
+    return { ok: false, mode: "conflict", existingHash, incomingHash } as const;
+  });
+}

--- a/services/functions/src/pipeline/derivedLedger.ts
+++ b/services/functions/src/pipeline/derivedLedger.ts
@@ -1,0 +1,232 @@
+// services/functions/src/pipeline/derivedLedger.ts
+
+import crypto from "node:crypto";
+import type { DocumentReference, Firestore, Timestamp } from "firebase-admin/firestore";
+
+export type IsoDateTimeString = string;
+export type YmdDateString = string;
+
+type Trigger =
+  | { type: "realtime"; name: "onCanonicalEventCreated"; eventId: string }
+  | { type: "scheduled"; name: string; eventId: string };
+
+type SnapshotKind = "dailyFacts" | "intelligenceContext";
+
+type LedgerRunRecord = {
+  schemaVersion: 1;
+  runId: string;
+  userId: string;
+  date: YmdDateString;
+
+  computedAt: IsoDateTimeString;
+  pipelineVersion: number;
+
+  trigger: Trigger;
+
+  // “what was known” truth anchor for replay/debug
+  latestCanonicalEventAt?: IsoDateTimeString;
+
+  outputs: {
+    hasDailyFacts: boolean;
+    insightsCount: number;
+    hasIntelligenceContext: boolean;
+  };
+
+  createdAt: Timestamp;
+};
+
+type SnapshotDoc<T> = {
+  schemaVersion: 1;
+  kind: string;
+  hash: string;
+  createdAt: Timestamp;
+  data: T;
+};
+
+function stableStringify(value: unknown): string {
+  const seen = new WeakSet<object>();
+
+  const normalize = (v: unknown): unknown => {
+    if (v === null) return null;
+    if (typeof v !== "object") return v;
+
+    // arrays preserve order
+    if (Array.isArray(v)) return v.map(normalize);
+
+    const obj = v as Record<string, unknown>;
+    if (seen.has(obj)) throw new Error("stableStringify: circular structure");
+    seen.add(obj);
+
+    const out: Record<string, unknown> = {};
+    for (const k of Object.keys(obj).sort()) {
+      out[k] = normalize(obj[k]);
+    }
+    return out;
+  };
+
+  return JSON.stringify(normalize(value));
+}
+
+function sha256Hex(input: string): string {
+  return crypto.createHash("sha256").update(input).digest("hex");
+}
+
+function sanitizeDocId(id: string): string {
+  // Firestore doc ids cannot contain "/" and should be reasonably short.
+  return id.replace(/\//g, "_");
+}
+
+async function createOrAssertIdentical<T extends object>(ref: DocumentReference, doc: T): Promise<void> {
+  await ref.firestore.runTransaction(async (tx) => {
+    const snap = await tx.get(ref);
+    if (!snap.exists) {
+      tx.create(ref, doc);
+      return;
+    }
+
+    const existing = snap.data();
+    const a = stableStringify(existing);
+    const b = stableStringify(doc);
+
+    if (a !== b) {
+      throw new Error(
+        `Derived ledger immutability violation: attempted to overwrite ${ref.path} with different content.`,
+      );
+    }
+    // identical: no-op
+  });
+}
+
+function tryGetString(obj: Record<string, unknown> | undefined, key: string): string | undefined {
+  const v = obj?.[key];
+  return typeof v === "string" && v.length > 0 ? v : undefined;
+}
+
+/**
+ * Deterministic ledger run id builder for schedulers/retries.
+ * (onSchedule ScheduledEvent does not provide a stable .id field.)
+ */
+export function makeLedgerRunIdFromSeed(prefix: string, seed: string): string {
+  const h = sha256Hex(seed).slice(0, 32);
+  return sanitizeDocId(`${prefix}_${h}`);
+}
+
+export async function writeDerivedLedgerRun(args: {
+  db: Firestore;
+  userId: string;
+  date: YmdDateString;
+  runId: string;
+
+  computedAt: IsoDateTimeString;
+  pipelineVersion: number;
+
+  trigger: Trigger;
+
+  // optional anchor
+  latestCanonicalEventAt?: IsoDateTimeString;
+
+  // snapshots (optional per job)
+  dailyFacts?: object;
+  intelligenceContext?: object;
+  insights?: object[];
+}): Promise<void> {
+  const {
+    db,
+    userId,
+    date,
+    runId,
+    computedAt,
+    pipelineVersion,
+    trigger,
+    latestCanonicalEventAt,
+    dailyFacts,
+    intelligenceContext,
+    insights,
+  } = args;
+
+  const userRef = db.collection("users").doc(userId);
+
+  // Pointer doc (mutable) – allowed: this is "latest pointer", not historical truth.
+  const dayPointerRef = userRef.collection("derivedLedger").doc(date);
+
+  // Append-only run doc + snapshots
+  const runRef = dayPointerRef.collection("runs").doc(runId);
+  const snapshotsRef = runRef.collection("snapshots");
+
+  const now = (await import("firebase-admin/firestore")).Timestamp.now();
+
+  // NOTE: exactOptionalPropertyTypes=true → omit optional props when undefined
+  const runRecord: LedgerRunRecord = {
+    schemaVersion: 1,
+    runId,
+    userId,
+    date,
+    computedAt,
+    pipelineVersion,
+    trigger,
+    ...(latestCanonicalEventAt ? { latestCanonicalEventAt } : {}),
+    outputs: {
+      hasDailyFacts: Boolean(dailyFacts),
+      insightsCount: Array.isArray(insights) ? insights.length : 0,
+      hasIntelligenceContext: Boolean(intelligenceContext),
+    },
+    createdAt: now,
+  };
+
+  // 1) Run record (append-only)
+  await createOrAssertIdentical(runRef, runRecord);
+
+  // 2) Snapshots (append-only)
+  const writeSnapshot = async (kind: SnapshotKind, data: object): Promise<void> => {
+    const body = stableStringify(data);
+    const hash = sha256Hex(body);
+    const snapDoc: SnapshotDoc<object> = {
+      schemaVersion: 1,
+      kind,
+      hash,
+      createdAt: now,
+      data,
+    };
+    await createOrAssertIdentical(snapshotsRef.doc(kind), snapDoc);
+  };
+
+  if (dailyFacts) await writeSnapshot("dailyFacts", dailyFacts);
+  if (intelligenceContext) await writeSnapshot("intelligenceContext", intelligenceContext);
+
+  if (Array.isArray(insights) && insights.length > 0) {
+    const insightsCol = snapshotsRef.doc("insights").collection("items");
+    for (const insight of insights) {
+      const insightObj = insight as Record<string, unknown>;
+      const insightId =
+        tryGetString(insightObj, "id") ?? sha256Hex(stableStringify(insightObj)).slice(0, 24);
+
+      const body = stableStringify(insightObj);
+      const hash = sha256Hex(body);
+
+      const snapDoc: SnapshotDoc<Record<string, unknown>> = {
+        schemaVersion: 1,
+        kind: "insight",
+        hash,
+        createdAt: now,
+        data: insightObj,
+      };
+
+      await createOrAssertIdentical(insightsCol.doc(sanitizeDocId(insightId)), snapDoc);
+    }
+  }
+
+  // 3) Update pointer doc (mutable “latest” pointer)
+  await dayPointerRef.set(
+    {
+      schemaVersion: 1,
+      userId,
+      date,
+      latestRunId: runId,
+      latestComputedAt: computedAt,
+      pipelineVersion,
+      trigger,
+      updatedAt: now,
+    },
+    { merge: true },
+  );
+}


### PR DESCRIPTION
…mode

- Introduce Derived Ledger run emission in pipeline
- Add authenticated APIs for listing and replaying runs
- Add replay hooks and TruthOutcome handling on client
- Implement dev-only Replay Mode UI in Command Center
- Enforce canonical immutability + ledger invariants
- Update CI invariant checks to cover Derived Ledger guarantees