### PR TITLE
Phase 1 Step 1: require timeZone and align ingest day with canonical dayKey

### DIFF
--- a/services/api/src/lib/canonicalDayKey.ts
+++ b/services/api/src/lib/canonicalDayKey.ts
@@ -1,0 +1,11 @@
+export function canonicalDayKey(
+    observedAt: string,
+    timeZone: string
+  ): string {
+    try {
+      const formatter = new Intl.DateTimeFormat("en-CA", { timeZone });
+      return formatter.format(new Date(observedAt));
+    } catch {
+      throw new Error("INVALID_TIMEZONE");
+    }
+  }

--- a/services/api/src/routes/__tests__/events.ingest.invalid-timezone.test.ts
+++ b/services/api/src/routes/__tests__/events.ingest.invalid-timezone.test.ts
@@ -1,0 +1,154 @@
+// services/api/src/routes/__tests__/events.ingest.invalid-timezone.test.ts
+import { describe, it, expect, jest, beforeEach, afterEach } from "@jest/globals";
+import express from "express";
+
+// Jest hoists jest.mock() calls, and the module factory cannot reference
+// out-of-scope variables unless they are prefixed with "mock" (case-insensitive).
+const mockUserCollection = jest.fn();
+
+jest.mock("../../db", () => {
+  return {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    userCollection: (...args: any[]) => mockUserCollection(...args),
+  };
+});
+
+describe("POST /ingest - invalid/missing timezone", () => {
+  beforeEach(() => {
+    mockUserCollection.mockReset();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("fails closed (400) with stable error code on invalid timezone and does not attempt to write a RawEvent", async () => {
+    // Use CommonJS require to avoid Jest ESM/vm-modules requirement.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const router = require("../events").default as express.Router;
+
+    const app = express();
+    app.use(express.json());
+
+    // Minimal auth shim: route requires req.uid
+    app.use((req, _res, next) => {
+      (req as unknown as { uid?: string }).uid = "user_test_123";
+      next();
+    });
+
+    app.use("/ingest", router);
+
+    const server = app.listen(0);
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      server.close();
+      throw new Error("Failed to bind test server");
+    }
+
+    const url = `http://127.0.0.1:${address.port}/ingest`;
+
+    try {
+      const res = await fetch(url, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "Idempotency-Key": "idem_test_invalid_tz",
+        },
+        body: JSON.stringify({
+          provider: "manual",
+          kind: "sleep",
+          observedAt: "2025-01-01T00:00:00.000Z",
+          timeZone: "Not/AZone",
+          payload: {
+            start: "2025-01-01T00:00:00.000Z",
+            end: "2025-01-01T01:00:00.000Z",
+            timezone: "Not/AZone",
+            totalMinutes: 60,
+            isMainSleep: true,
+          },
+        }),
+      });
+
+      expect(res.status).toBe(400);
+
+      const body = (await res.json()) as unknown;
+
+      expect(body).toEqual(
+        expect.objectContaining({
+          ok: false,
+          error: expect.objectContaining({
+            code: "TIMEZONE_INVALID",
+          }),
+        }),
+      );
+
+      // ✅ Proof: no write attempt occurred (db userCollection never called)
+      expect(mockUserCollection).not.toHaveBeenCalled();
+    } finally {
+      server.close();
+    }
+  });
+
+  it("fails closed (400) with stable error code on missing timezone and does not attempt to write a RawEvent", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const router = require("../events").default as express.Router;
+
+    const app = express();
+    app.use(express.json());
+
+    app.use((req, _res, next) => {
+      (req as unknown as { uid?: string }).uid = "user_test_123";
+      next();
+    });
+
+    app.use("/ingest", router);
+
+    const server = app.listen(0);
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      server.close();
+      throw new Error("Failed to bind test server");
+    }
+
+    const url = `http://127.0.0.1:${address.port}/ingest`;
+
+    try {
+      const res = await fetch(url, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "Idempotency-Key": "idem_test_missing_tz",
+        },
+        body: JSON.stringify({
+          provider: "manual",
+          kind: "sleep",
+          observedAt: "2025-01-01T00:00:00.000Z",
+          payload: {
+            start: "2025-01-01T00:00:00.000Z",
+            end: "2025-01-01T01:00:00.000Z",
+            totalMinutes: 60,
+            isMainSleep: true,
+          },
+        }),
+      });
+
+      expect(res.status).toBe(400);
+
+      const body = (await res.json()) as unknown;
+
+      expect(body).toEqual(
+        expect.objectContaining({
+          ok: false,
+          error: expect.objectContaining({
+            code: "TIMEZONE_REQUIRED",
+          }),
+        }),
+      );
+
+      // ✅ Proof: no write attempt occurred (db userCollection never called)
+      expect(mockUserCollection).not.toHaveBeenCalled();
+    } finally {
+      server.close();
+    }
+  });
+});


### PR DESCRIPTION
Implements Phase 1 Step 1: contract-first required timeZone (fail-closed), ingest ack day computed using canonical Intl.DateTimeFormat('en-CA', { timeZone }) semantics, adds proof tests (invalid timezone fails closed with stable code; canonical day boundary cases), and updates proof gate to include these tests.