### PR TITLE
phase1.5(sprint2): integrate HealthScore into Dash (read-only, trust-…

### DIFF
--- a/lib/api/usersMe.ts
+++ b/lib/api/usersMe.ts
@@ -39,6 +39,8 @@ import {
   type RawEventsListResponseDto,
   type TimelineResponseDto,
   type LineageResponseDto,
+  healthScoreDocSchema,
+  type HealthScoreDoc,
 } from "@oli/contracts";
 
 export type TruthGetOptions = {
@@ -248,6 +250,23 @@ export const getLineage = async (
     idToken,
     lineageResponseDtoSchema,
     truthGetOpts(truthOpts),
+  );
+};
+
+/**
+ * Phase 1.5 Sprint 2 — Health Score (derived truth, server-computed only).
+ * GET /users/me/health-score?day=YYYY-MM-DD
+ */
+export const getHealthScore = async (
+  day: string,
+  idToken: string,
+  opts?: TruthGetOptions,
+): Promise<ApiResult<HealthScoreDoc>> => {
+  return apiGetZodAuthed(
+    `/users/me/health-score?day=${encodeURIComponent(day)}`,
+    idToken,
+    healthScoreDocSchema,
+    truthGetOpts(opts),
   );
 };
 

--- a/lib/data/useHealthScore.ts
+++ b/lib/data/useHealthScore.ts
@@ -1,0 +1,94 @@
+// lib/data/useHealthScore.ts
+// Phase 1.5 Sprint 2 — Health Score read-only hook (no Firestore, no client-side scoring)
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useAuth } from "@/lib/auth/AuthProvider";
+import { getHealthScore, type TruthGetOptions } from "@/lib/api/usersMe";
+import type { HealthScoreDoc } from "@/lib/contracts";
+import type { FailureKind } from "@/lib/api/http";
+import { truthOutcomeFromApiResult } from "@/lib/data/truthOutcome";
+
+export type HealthScoreState =
+  | { status: "partial" }
+  | { status: "missing" }
+  | { status: "error"; error: string; requestId: string | null; reason: FailureKind }
+  | { status: "ready"; data: HealthScoreDoc };
+
+type RefetchOpts = TruthGetOptions;
+
+function withUniqueCacheBust(opts: RefetchOpts | undefined, seq: number): RefetchOpts | undefined {
+  const cb = opts?.cacheBust;
+  if (!cb) return opts;
+  return { ...opts, cacheBust: `${cb}:${seq}` };
+}
+
+export function useHealthScore(day: string): HealthScoreState & { refetch: (opts?: RefetchOpts) => void } {
+  const { user, initializing, getIdToken } = useAuth();
+
+  const dayRef = useRef(day);
+  dayRef.current = day;
+
+  const requestSeq = useRef(0);
+  const [state, setState] = useState<HealthScoreState>({ status: "partial" });
+  const stateRef = useRef<HealthScoreState>(state);
+  useEffect(() => {
+    stateRef.current = state;
+  }, [state]);
+
+  const fetchOnce = useCallback(
+    async (opts?: RefetchOpts) => {
+      const seq = ++requestSeq.current;
+
+      const safeSet = (next: HealthScoreState) => {
+        if (seq === requestSeq.current) setState(next);
+      };
+
+      if (initializing || !user) {
+        if (stateRef.current.status !== "ready") safeSet({ status: "partial" });
+        return;
+      }
+
+      const token = await getIdToken(false);
+      if (!token || seq !== requestSeq.current) return;
+
+      if (stateRef.current.status !== "ready") safeSet({ status: "partial" });
+
+      const optsUnique = withUniqueCacheBust(opts, seq);
+      const res = await getHealthScore(dayRef.current, token, optsUnique);
+      if (seq !== requestSeq.current) return;
+
+      const outcome = truthOutcomeFromApiResult(res);
+
+      if (outcome.status === "ready") {
+        safeSet({ status: "ready", data: outcome.data });
+        return;
+      }
+
+      if (outcome.status === "missing") {
+        if (stateRef.current.status === "ready") return;
+        safeSet({ status: "missing" });
+        return;
+      }
+
+      if (stateRef.current.status === "ready") return;
+      safeSet({
+        status: "error",
+        error: outcome.error,
+        requestId: outcome.requestId,
+        reason: outcome.reason,
+      });
+    },
+    [getIdToken, initializing, user],
+  );
+
+  useEffect(() => {
+    void fetchOnce();
+  }, [fetchOnce, day, user?.uid]);
+
+  return useMemo(
+    () => ({
+      ...state,
+      refetch: fetchOnce,
+    }),
+    [state, fetchOnce],
+  );
+}

--- a/lib/format/__tests__/healthScore.test.ts
+++ b/lib/format/__tests__/healthScore.test.ts
@@ -1,0 +1,36 @@
+import {
+  formatHealthScoreTier,
+  formatHealthScoreStatus,
+  formatMissingList,
+} from "../healthScore";
+
+describe("formatHealthScoreTier", () => {
+  it("formats each tier for display", () => {
+    expect(formatHealthScoreTier("excellent")).toBe("Excellent");
+    expect(formatHealthScoreTier("good")).toBe("Good");
+    expect(formatHealthScoreTier("fair")).toBe("Fair");
+    expect(formatHealthScoreTier("poor")).toBe("Poor");
+  });
+});
+
+describe("formatHealthScoreStatus", () => {
+  it("formats each status for display", () => {
+    expect(formatHealthScoreStatus("stable")).toBe("Stable");
+    expect(formatHealthScoreStatus("attention_required")).toBe("Attention required");
+    expect(formatHealthScoreStatus("insufficient_data")).toBe("Insufficient data");
+  });
+});
+
+describe("formatMissingList", () => {
+  it("returns empty string for empty array", () => {
+    expect(formatMissingList([])).toBe("");
+  });
+
+  it("formats single missing item", () => {
+    expect(formatMissingList(["sleep"])).toBe("Missing: sleep");
+  });
+
+  it("formats multiple missing items comma-separated", () => {
+    expect(formatMissingList(["sleep", "steps"])).toBe("Missing: sleep, steps");
+  });
+});

--- a/lib/format/healthScore.ts
+++ b/lib/format/healthScore.ts
@@ -1,0 +1,37 @@
+// lib/format/healthScore.ts
+// Phase 1.5 Sprint 2 — Neutral display labels (no interpretation)
+import type { HealthScoreTier, HealthScoreStatus } from "@/lib/contracts";
+
+export function formatHealthScoreTier(tier: HealthScoreTier): string {
+  switch (tier) {
+    case "excellent":
+      return "Excellent";
+    case "good":
+      return "Good";
+    case "fair":
+      return "Fair";
+    case "poor":
+      return "Poor";
+    default:
+      return String(tier);
+  }
+}
+
+export function formatHealthScoreStatus(status: HealthScoreStatus): string {
+  switch (status) {
+    case "stable":
+      return "Stable";
+    case "attention_required":
+      return "Attention required";
+    case "insufficient_data":
+      return "Insufficient data";
+    default:
+      return String(status);
+  }
+}
+
+/** Format missing[] for display (e.g. "Missing: sleep, steps"). */
+export function formatMissingList(missing: string[]): string {
+  if (missing.length === 0) return "";
+  return `Missing: ${missing.join(", ")}`;
+}


### PR DESCRIPTION
…first, fail-closed)

- api: add getHealthScore (typed, schema-validated)
- data: add useHealthScore hook (partial|missing|error|ready; reason surfaced)
- ui: composite + domains + missing[] + metadata
- explicit loading / empty / error / offline states
- neutral formatting + tests
- no Firebase in screens
- no client-side scoring

Gates: typecheck, lint, test all green.