### PR TITLE
phase1.5(sprint3): add multi-baseline drawer (display-only)

### DIFF
--- a/app/(app)/(tabs)/dash.tsx
+++ b/app/(app)/(tabs)/dash.tsx
@@ -1,8 +1,9 @@
 // app/(app)/(tabs)/dash.tsx
 // Phase 1.5 Sprint 2 — Command Center: Health Score surface (read-only, trust-first)
-import { ScrollView, View, Text, StyleSheet } from "react-native";
+import { ScrollView, View, Text, StyleSheet, Pressable } from "react-native";
 import { useRouter } from "expo-router";
 import { ScreenContainer, LoadingState, ErrorState, EmptyState } from "@/lib/ui/ScreenStates";
+import { BaselineDrawer } from "@/lib/ui/BaselineDrawer";
 import { useFailuresRange } from "@/lib/data/useFailuresRange";
 import { useUploadsPresence } from "@/lib/data/useUploadsPresence";
 import { useTimeline } from "@/lib/data/useTimeline";
@@ -13,7 +14,7 @@ import {
   formatMissingList,
 } from "@/lib/format/healthScore";
 import { getTodayDayKey } from "@/lib/time/dayKey";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import type { HealthScoreDomainScores } from "@/lib/contracts";
 
 function formatIsoToLocal(iso: string | null | undefined): string {
@@ -40,6 +41,7 @@ const DOMAIN_LABELS: Record<keyof HealthScoreDomainScores, string> = {
 function HealthScoreSection() {
   const todayKey = useMemo(() => getTodayDayKey(), []);
   const healthScore = useHealthScore(todayKey);
+  const [baselineDrawerVisible, setBaselineDrawerVisible] = useState(false);
 
   if (healthScore.status === "partial") {
     return (
@@ -120,6 +122,17 @@ function HealthScoreSection() {
           Model {d.modelVersion} · Computed {formatIsoToLocal(d.computedAt)}
         </Text>
       </View>
+      <Pressable
+        style={styles.baselineTrigger}
+        onPress={() => setBaselineDrawerVisible(true)}
+      >
+        <Text style={styles.link}>View baselines</Text>
+      </Pressable>
+      <BaselineDrawer
+        visible={baselineDrawerVisible}
+        onClose={() => setBaselineDrawerVisible(false)}
+        doc={d}
+      />
     </View>
   );
 }
@@ -252,6 +265,7 @@ const styles = StyleSheet.create({
   domainMissing: { fontSize: 12, color: "#8E8E93", marginLeft: 0 },
   metadata: { marginTop: 8, paddingTop: 8, borderTopWidth: 1, borderTopColor: "#C6C6C8" },
   metadataText: { fontSize: 12, color: "#8E8E93" },
+  baselineTrigger: { marginTop: 8 },
   stateContainer: {
     padding: 24,
     gap: 12,

--- a/lib/format/__tests__/baselines.test.ts
+++ b/lib/format/__tests__/baselines.test.ts
@@ -1,0 +1,73 @@
+import {
+  getGeneralBaselineContent,
+  getPersonalBaselineContent,
+  getOptimizationBaselineContent,
+} from "../baselines";
+import type { HealthScoreDoc } from "@/lib/contracts";
+
+function makeDoc(overrides?: Partial<HealthScoreDoc>): HealthScoreDoc {
+  return {
+    schemaVersion: 1,
+    modelVersion: "1.0",
+    date: "2025-02-13",
+    compositeScore: 72,
+    compositeTier: "good",
+    domainScores: {
+      recovery: { score: 80, tier: "good", missing: [] },
+      training: { score: 70, tier: "good", missing: [] },
+      nutrition: { score: 65, tier: "fair", missing: ["meals"] },
+      body: { score: 72, tier: "good", missing: [] },
+    },
+    status: "stable",
+    computedAt: "2025-02-13T14:00:00.000Z",
+    pipelineVersion: 1,
+    inputs: { hasDailyFacts: true, historyDaysUsed: 7 },
+    ...overrides,
+  };
+}
+
+describe("getGeneralBaselineContent", () => {
+  it("returns date, computedAt, status from doc", () => {
+    const doc = makeDoc();
+    const out = getGeneralBaselineContent(doc);
+    expect(out.date).toBe("2025-02-13");
+    expect(out.computedAt).toBeDefined();
+    expect(out.status).toBe("Stable");
+  });
+
+  it("formats status variants", () => {
+    expect(getGeneralBaselineContent(makeDoc({ status: "attention_required" })).status).toBe(
+      "Attention required",
+    );
+    expect(getGeneralBaselineContent(makeDoc({ status: "insufficient_data" })).status).toBe(
+      "Insufficient data",
+    );
+  });
+});
+
+describe("getPersonalBaselineContent", () => {
+  it("returns inputs summary from doc", () => {
+    const doc = makeDoc();
+    const out = getPersonalBaselineContent(doc);
+    expect(out.historyDaysUsed).toBe(7);
+    expect(out.hasDailyFacts).toBe(true);
+  });
+
+  it("reflects doc.inputs changes", () => {
+    const out = getPersonalBaselineContent(
+      makeDoc({ inputs: { hasDailyFacts: false, historyDaysUsed: 0 } }),
+    );
+    expect(out.historyDaysUsed).toBe(0);
+    expect(out.hasDailyFacts).toBe(false);
+  });
+});
+
+describe("getOptimizationBaselineContent", () => {
+  it("returns model and pipeline context from doc", () => {
+    const doc = makeDoc();
+    const out = getOptimizationBaselineContent(doc);
+    expect(out.modelVersion).toBe("1.0");
+    expect(out.pipelineVersion).toBe(1);
+    expect(out.schemaVersion).toBe(1);
+  });
+});

--- a/lib/format/baselines.ts
+++ b/lib/format/baselines.ts
@@ -1,0 +1,72 @@
+// lib/format/baselines.ts
+// Phase 1.5 Sprint 3 — Multi-Baseline display (UI-only, HealthScoreDoc fields only)
+import type { HealthScoreDoc } from "@/lib/contracts";
+
+/** Display content for General baseline panel (date, computedAt, status). */
+export type GeneralBaselineContent = {
+  date: string;
+  computedAt: string;
+  status: string;
+};
+
+/** Display content for Personal baseline panel (inputs used). */
+export type PersonalBaselineContent = {
+  historyDaysUsed: number;
+  hasDailyFacts: boolean;
+};
+
+/** Display content for Optimization baseline panel (model/pipeline context). */
+export type OptimizationBaselineContent = {
+  modelVersion: string;
+  pipelineVersion: number;
+  schemaVersion: number;
+};
+
+function formatIsoToLocal(iso: string): string {
+  const ms = Date.parse(iso);
+  if (!Number.isFinite(ms)) return "—";
+  return new Date(ms).toLocaleDateString(undefined, {
+    dateStyle: "medium",
+  });
+}
+
+function formatStatus(status: HealthScoreDoc["status"]): string {
+  switch (status) {
+    case "stable":
+      return "Stable";
+    case "attention_required":
+      return "Attention required";
+    case "insufficient_data":
+      return "Insufficient data";
+    default:
+      return String(status);
+  }
+}
+
+/** Derive General baseline display from HealthScoreDoc. */
+export function getGeneralBaselineContent(doc: HealthScoreDoc): GeneralBaselineContent {
+  return {
+    date: doc.date,
+    computedAt: formatIsoToLocal(doc.computedAt),
+    status: formatStatus(doc.status),
+  };
+}
+
+/** Derive Personal baseline display from HealthScoreDoc. */
+export function getPersonalBaselineContent(doc: HealthScoreDoc): PersonalBaselineContent {
+  return {
+    historyDaysUsed: doc.inputs.historyDaysUsed,
+    hasDailyFacts: doc.inputs.hasDailyFacts,
+  };
+}
+
+/** Derive Optimization baseline display from HealthScoreDoc. */
+export function getOptimizationBaselineContent(
+  doc: HealthScoreDoc,
+): OptimizationBaselineContent {
+  return {
+    modelVersion: doc.modelVersion,
+    pipelineVersion: doc.pipelineVersion,
+    schemaVersion: doc.schemaVersion,
+  };
+}

--- a/lib/ui/BaselineDrawer.tsx
+++ b/lib/ui/BaselineDrawer.tsx
@@ -1,0 +1,135 @@
+// lib/ui/BaselineDrawer.tsx
+// Phase 1.5 Sprint 3 — Multi-Baseline display (UI-only, no mutation)
+import { View, Text, StyleSheet, Modal, Pressable, ScrollView } from "react-native";
+import {
+  getGeneralBaselineContent,
+  getPersonalBaselineContent,
+  getOptimizationBaselineContent,
+} from "@/lib/format/baselines";
+import type { HealthScoreDoc } from "@/lib/contracts";
+
+type Props = {
+  visible: boolean;
+  onClose: () => void;
+  doc: HealthScoreDoc;
+};
+
+function BaselinePanel({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <View style={styles.panel}>
+      <Text style={styles.panelTitle}>{title}</Text>
+      <View style={styles.panelContent}>{children}</View>
+    </View>
+  );
+}
+
+export function BaselineDrawer({ visible, onClose, doc }: Props) {
+  const general = getGeneralBaselineContent(doc);
+  const personal = getPersonalBaselineContent(doc);
+  const optimization = getOptimizationBaselineContent(doc);
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+    >
+      <Pressable style={styles.overlay} onPress={onClose}>
+        <Pressable style={styles.drawer} onPress={(e) => e.stopPropagation()}>
+          <Text style={styles.heading}>Baselines</Text>
+          <ScrollView
+            style={styles.scroll}
+            contentContainerStyle={styles.scrollContent}
+            showsVerticalScrollIndicator={false}
+          >
+            <BaselinePanel title="General">
+              <Text style={styles.rowLabel}>Date</Text>
+              <Text style={styles.rowValue}>{general.date}</Text>
+              <Text style={styles.rowLabel}>Computed</Text>
+              <Text style={styles.rowValue}>{general.computedAt}</Text>
+              <Text style={styles.rowLabel}>Status</Text>
+              <Text style={styles.rowValue}>{general.status}</Text>
+            </BaselinePanel>
+            <BaselinePanel title="Personal">
+              <Text style={styles.rowLabel}>History days used</Text>
+              <Text style={styles.rowValue}>{String(personal.historyDaysUsed)}</Text>
+              <Text style={styles.rowLabel}>Daily facts available</Text>
+              <Text style={styles.rowValue}>{personal.hasDailyFacts ? "Yes" : "No"}</Text>
+            </BaselinePanel>
+            <BaselinePanel title="Optimization">
+              <Text style={styles.rowLabel}>Model version</Text>
+              <Text style={styles.rowValue}>{optimization.modelVersion}</Text>
+              <Text style={styles.rowLabel}>Pipeline version</Text>
+              <Text style={styles.rowValue}>{String(optimization.pipelineVersion)}</Text>
+              <Text style={styles.rowLabel}>Schema version</Text>
+              <Text style={styles.rowValue}>{String(optimization.schemaVersion)}</Text>
+            </BaselinePanel>
+          </ScrollView>
+          <Pressable style={styles.closeButton} onPress={onClose}>
+            <Text style={styles.closeButtonText}>Close</Text>
+          </Pressable>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.5)",
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 24,
+  },
+  drawer: {
+    backgroundColor: "#FFFFFF",
+    borderRadius: 16,
+    padding: 24,
+    maxWidth: 400,
+    maxHeight: "85%",
+  },
+  heading: {
+    fontSize: 20,
+    fontWeight: "700",
+    color: "#1C1C1E",
+    marginBottom: 16,
+  },
+  scroll: { flexGrow: 0 },
+  scrollContent: { gap: 20, paddingBottom: 8 },
+  panel: {
+    backgroundColor: "#F2F2F7",
+    borderRadius: 12,
+    padding: 14,
+    gap: 6,
+  },
+  panelTitle: {
+    fontSize: 15,
+    fontWeight: "700",
+    color: "#1C1C1E",
+    marginBottom: 4,
+  },
+  panelContent: { gap: 4 },
+  rowLabel: { fontSize: 13, color: "#8E8E93" },
+  rowValue: { fontSize: 15, fontWeight: "600", color: "#1C1C1E" },
+  closeButton: {
+    marginTop: 16,
+    alignSelf: "flex-end",
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+    backgroundColor: "#F2F2F7",
+    borderRadius: 12,
+  },
+  closeButtonText: {
+    fontSize: 15,
+    fontWeight: "600",
+    color: "#1C1C1E",
+  },
+});


### PR DESCRIPTION
- add BaselineDrawer UI (General/Personal/Optimization shown simultaneously)
- add baseline formatting utils + tests
- add Dash trigger for baselines
- display context only: no score mutation, no writes, no ledger change

Gates: typecheck, lint, test all green.