### PR TITLE
W1.2: Withings auto-update + Body Composition refetch

### DIFF
--- a/app/(app)/body/__tests__/weight-screen.test.tsx
+++ b/app/(app)/body/__tests__/weight-screen.test.tsx
@@ -12,6 +12,15 @@ jest.mock("react-native", () => ({
   ScrollView: "ScrollView",
   Modal: "Modal",
   StyleSheet: { create: (s: unknown) => s },
+  AppState: {
+    addEventListener: jest.fn(() => ({ remove: jest.fn() })),
+  },
+}));
+
+jest.mock("@react-navigation/native", () => ({
+  useFocusEffect: (cb: () => void) => {
+    if (typeof cb === "function") cb();
+  },
 }));
 
 jest.mock("expo-router", () => ({

--- a/app/(app)/body/weight.tsx
+++ b/app/(app)/body/weight.tsx
@@ -1,6 +1,7 @@
 // app/(app)/body/weight.tsx — Body Composition: nav header, hero, stat tiles, chart (fail-closed).
-import React, { useState, useEffect, useRef } from "react";
-import { View, Text, Pressable, StyleSheet, Modal, ScrollView } from "react-native";
+import React, { useState, useEffect, useRef, useCallback } from "react";
+import { View, Text, Pressable, StyleSheet, Modal, ScrollView, AppState } from "react-native";
+import { useFocusEffect } from "@react-navigation/native";
 import { useNavigation } from "expo-router";
 
 import { ModuleScreenShell } from "@/lib/ui/ModuleScreenShell";
@@ -211,7 +212,32 @@ export default function BodyWeightScreen() {
   const [updateState, setUpdateState] = useState<UpdateState>({ status: "idle" });
   const lastUpdateTapMs = useRef(0);
   const pullNowIdemRef = useRef<string | null>(null);
+  const lastAutoRefetchMsRef = useRef<number>(0);
   const UPDATE_COOLDOWN_MS = 15000;
+
+  const maybeAutoRefetch = useCallback(
+    (reason: "focus" | "foreground") => {
+      const now = Date.now();
+      if (now - lastAutoRefetchMsRef.current < 60_000) return;
+      lastAutoRefetchMsRef.current = now;
+      void weightSeries.refetch({ cacheBust: `auto:${reason}:${now}` });
+      void withingsPresence.refetch({ cacheBust: `auto:${reason}:${now}` });
+    },
+    [weightSeries, withingsPresence],
+  );
+
+  useFocusEffect(
+    useCallback(() => {
+      maybeAutoRefetch("focus");
+    }, [maybeAutoRefetch]),
+  );
+
+  useEffect(() => {
+    const sub = AppState.addEventListener("change", (state) => {
+      if (state === "active") maybeAutoRefetch("foreground");
+    });
+    return () => sub.remove();
+  }, [maybeAutoRefetch]);
 
   useEffect(() => {
     navigation.setOptions({

--- a/services/functions/src/index.ts
+++ b/services/functions/src/index.ts
@@ -36,6 +36,7 @@ import { onDailyFactsRecomputeScheduled } from "./dailyFacts/onDailyFactsRecompu
 import { onInsightsRecomputeScheduled } from "./insights/onInsightsRecomputeScheduled";
 import { onDailyIntelligenceContextRecomputeScheduled } from "./intelligence/onDailyIntelligenceContextRecomputeScheduled";
 import { onWithingsBackfillScheduled } from "./withings/onWithingsBackfillScheduled";
+import { onWithingsPullScheduled } from "./withings/onWithingsPullScheduled";
 
 // Account executors (Pub/Sub)
 import { onAccountDeleteRequested } from "./account/onAccountDeleteRequested";
@@ -103,6 +104,7 @@ export { onDailyFactsRecomputeScheduled };
 export { onInsightsRecomputeScheduled };
 export { onDailyIntelligenceContextRecomputeScheduled };
 export { onWithingsBackfillScheduled };
+export { onWithingsPullScheduled };
 
 // Account executors (Pub/Sub)
 export { onAccountDeleteRequested };

--- a/services/functions/src/withings/onWithingsPullScheduled.ts
+++ b/services/functions/src/withings/onWithingsPullScheduled.ts
@@ -1,0 +1,57 @@
+/**
+ * W1.2 — Scheduled latest-weight pull for Withings.
+ * Calls POST /integrations/withings/pull (invoker-only). Pulls last 72h for all connected users.
+ *
+ * Requirements:
+ * - OLI_API_BASE_URL must be set (Cloud Run API base).
+ * - WITHINGS_PULL_INVOKER_EMAILS on the API must include this function's service account.
+ * - Cloud Run IAM must grant roles/run.invoker to that SA.
+ */
+
+import { onSchedule } from "firebase-functions/v2/scheduler";
+import * as logger from "firebase-functions/logger";
+import { GoogleAuth } from "google-auth-library";
+
+export const onWithingsPullScheduled = onSchedule(
+  {
+    schedule: "every 15 minutes",
+    region: "us-central1",
+    serviceAccount: "oli-functions-runtime@oli-staging-fdbba.iam.gserviceaccount.com",
+  },
+  async () => {
+    const baseUrl = (process.env.OLI_API_BASE_URL ?? "").trim().replace(/\/+$/, "");
+    if (!baseUrl) {
+      logger.warn("onWithingsPullScheduled: OLI_API_BASE_URL not set; skipping");
+      return;
+    }
+
+    logger.info("withings_pull_scheduled_start");
+
+    const url = `${baseUrl}/integrations/withings/pull`;
+    try {
+      const auth = new GoogleAuth();
+      const client = await auth.getIdTokenClient(baseUrl);
+      const res = await client.request({
+        url,
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        data: {},
+      });
+
+      const status = res.status;
+      const data = res.data as
+        | { ok?: boolean; usersProcessed?: number; eventsCreated?: number; eventsAlreadyExists?: number }
+        | undefined;
+      logger.info("withings_pull_scheduled_done", {
+        status,
+        ok: data?.ok,
+        usersProcessed: data?.usersProcessed,
+        eventsCreated: data?.eventsCreated,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error("onWithingsPullScheduled failed", { err: message });
+      throw err;
+    }
+  },
+);


### PR DESCRIPTION
Summary

Adds:

Client improvement

Body Composition screen now refetches weight + Withings presence:

On screen focus

On app foreground

Throttled to once per 60 seconds

Prevents stale UI when new data exists.

True auto-update (backend)

New Firebase Gen2 scheduled function:

onWithingsPullScheduled

Runs every 15 minutes

Calls invoker-only POST /integrations/withings/pull

No Gateway exposure

No secrets logged

Why

Previously:

There was no repo-defined automatic “latest weights” sync

New weigh-ins required manual Update or an external job

UI did not refetch on focus/foreground

Now:

New weights are automatically pulled every 15 minutes

UI refreshes deterministically on focus/foreground

All routes remain correctly scoped (pull remains invoker-only)

Safety / Invariants

/integrations/withings/pull remains behind requireInvokerAuth

Not exposed in OpenAPI / API Gateway

No client → Cloud Run direct calls

All gates passed:

typecheck

lint

test (98 suites / 428 tests)

check:invariants

Expected Behavior After Deploy

Weigh in

Within ≤ 15 minutes, scheduler pulls new weight

Open Body Composition → refetch runs → weight appears without pressing Update