### PR TITLE
feat(oura): automatic sync after OAuth callback; remove manual sync; …

### DIFF
--- a/app/(app)/oura-connected.tsx
+++ b/app/(app)/oura-connected.tsx
@@ -1,0 +1,5 @@
+import { Redirect } from "expo-router";
+
+export default function OuraConnectedScreen() {
+  return <Redirect href="/(app)/settings/devices/oura" />;
+}

--- a/app/(app)/settings/devices/[deviceId].tsx
+++ b/app/(app)/settings/devices/[deviceId].tsx
@@ -372,23 +372,46 @@ function DeviceDetailScreen() {
           ))}
         </View>
 
-        {isWithings &&
+        {(isWithings &&
           withingsPresence.status === "ready" &&
-          withingsPresence.data.backfill?.status === "running" && (
-            <Text style={styles.footerHint}>Importing history from Withings…</Text>
-          )}
-
-        {isAppleHealth && appleLastSyncAt && (
-          <Text style={styles.footerHint}>
-            Last new Apple Health data: {new Date(appleLastSyncAt).toLocaleString()}
-          </Text>
-        )}
-
-        {isOura && ouraPresence.status === "ready" && ouraPresence.data.lastSyncAt && (
-          <Text style={styles.footerHint}>
-            Last sync: {new Date(ouraPresence.data.lastSyncAt).toLocaleString()}
-          </Text>
-        )}
+          (withingsPresence.data.backfill?.status === "running" || withingsPresence.data.lastMeasurementAt)) ||
+        (isAppleHealth && appleLastSyncAt) ||
+        (isOura && ouraPresence.status === "ready" && ouraPresence.data.lastSyncAt) ? (
+          <View style={styles.group}>
+            <View style={styles.sectionHeader}>
+              <Text style={styles.sectionTitle}>Sync status</Text>
+            </View>
+            {isWithings && withingsPresence.status === "ready" ? (
+              <>
+                {withingsPresence.data.backfill?.status === "running" && (
+                  <View style={styles.metricRow}>
+                    <Text style={styles.metricText}>Importing history from Withings…</Text>
+                  </View>
+                )}
+                {withingsPresence.data.lastMeasurementAt && (
+                  <View style={styles.metricRow}>
+                    <Text style={styles.metricText}>
+                      Last measurement:{" "}
+                      {new Date(withingsPresence.data.lastMeasurementAt).toLocaleString()}
+                    </Text>
+                  </View>
+                )}
+              </>
+            ) : isAppleHealth && appleLastSyncAt ? (
+              <View style={styles.metricRow}>
+                <Text style={styles.metricText}>
+                  Last new Apple Health data: {new Date(appleLastSyncAt).toLocaleString()}
+                </Text>
+              </View>
+            ) : isOura && ouraPresence.status === "ready" && ouraPresence.data.lastSyncAt ? (
+              <View style={styles.metricRow}>
+                <Text style={styles.metricText}>
+                  Last sync: {new Date(ouraPresence.data.lastSyncAt).toLocaleString()}
+                </Text>
+              </View>
+            ) : null}
+          </View>
+        ) : null}
       </ScrollView>
     </ModuleScreenShell>
   );
@@ -505,11 +528,6 @@ const styles = StyleSheet.create({
   metricText: {
     fontSize: 15,
     color: "#1C1C1E",
-  },
-  footerHint: {
-    marginTop: 4,
-    fontSize: 13,
-    color: "#6E6E73",
   },
 });
 

--- a/app/(app)/settings/devices/__tests__/device-detail-oura.test.tsx
+++ b/app/(app)/settings/devices/__tests__/device-detail-oura.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * Device detail screen (Oura): no "Sync now" button — sync is automatic after connect.
+ */
+import React from "react";
+import { act } from "react";
+import renderer from "react-test-renderer";
+
+import DeviceDetailScreen from "../[deviceId]";
+
+jest.mock("react-native", () => ({
+  View: "View",
+  Text: "Text",
+  Pressable: "Pressable",
+  Alert: { alert: jest.fn() },
+  ScrollView: "ScrollView",
+  StyleSheet: { create: (s: unknown) => s },
+}));
+
+jest.mock("expo-router", () => ({
+  useLocalSearchParams: () => ({ deviceId: "oura" }),
+  useNavigation: () => ({ setOptions: jest.fn() }),
+}));
+
+jest.mock("expo-web-browser", () => ({}));
+
+jest.mock("@/lib/auth/AuthProvider", () => ({
+  useAuth: () => ({
+    user: { uid: "u1" },
+    getIdToken: async () => "token",
+  }),
+}));
+
+jest.mock("@/lib/data/useWithingsPresence", () => ({
+  useWithingsPresence: () => ({
+    status: "ready",
+    data: { connected: false },
+    refetch: jest.fn(),
+  }),
+}));
+
+jest.mock("@/lib/data/useOuraPresence", () => ({
+  useOuraPresence: () => ({
+    status: "ready",
+    data: { connected: true, lastSyncAt: "2025-03-14T12:00:00.000Z" },
+    refetch: jest.fn(),
+  }),
+}));
+
+jest.mock("@/lib/api/withings", () => ({}));
+jest.mock("@/lib/api/oura", () => ({
+  getOuraConnectUrl: jest.fn(),
+  postOuraRevoke: jest.fn(),
+}));
+jest.mock("@/lib/api/appleHealth", () => ({}));
+
+jest.mock("@/lib/ui/ModuleScreenShell", () => ({
+  ModuleScreenShell: ({ children }: { children: unknown }) => children,
+}));
+
+describe("DeviceDetailScreen (Oura)", () => {
+  it("does not show Sync now when Oura is connected (sync is automatic)", async () => {
+    let tree: renderer.ReactTestRenderer | undefined;
+    await act(async () => {
+      tree = renderer.create(<DeviceDetailScreen />);
+    });
+    const json = tree!.toJSON();
+    const str = JSON.stringify(json);
+    expect(str).not.toContain("Sync now");
+    expect(str).toContain("Oura");
+  });
+});

--- a/docs/90_audits/OURA_AUTO_SYNC_VERIFICATION_PLAN.md
+++ b/docs/90_audits/OURA_AUTO_SYNC_VERIFICATION_PLAN.md
@@ -1,0 +1,205 @@
+# Audit: Verification plan for automatic Oura sync after callback
+
+**Scope:** Live verification steps and log signatures for automatic Oura sync (callback-triggered; no app “Sync now”). No code changes.
+
+**Source of truth:** `services/api/src/routes/integrations.ts` (callback, redirect, fire-and-forget), `services/api/src/routes/integrations/ouraPullNow.ts` (performOuraPullNowCore), `services/api/src/lib/logger.ts` (structured logs), `app/(app)/settings/devices/[deviceId].tsx` (Oura device screen, lastSyncAt display).
+
+---
+
+## 1. Connect Oura
+
+**Goal:** Run the full OAuth connect flow so the callback is hit and auto-sync is triggered.
+
+**Steps:**
+
+1. Deploy/use staging API and app with:
+   - Backend: `PUBLIC_BASE_URL` (or gateway host) and `OURA_REDIRECT_URI` aligned to the callback URL; `OURA_CLIENT_ID` and Oura client secret in Secret Manager.
+   - App: `EXPO_PUBLIC_BACKEND_BASE_URL` set to the same base (e.g. gateway URL) so return URL is `{base}/integrations/oura/complete`.
+2. As a test user, open the app → **Settings → Devices** → tap **Oura** (device detail screen).
+3. Tap **On** (or “Turn on Oura”) to start connect. App calls `GET /integrations/oura/connect` (auth), gets OAuth URL, opens it in the browser.
+4. Complete Oura authorization in the browser. Oura redirects to `GET /integrations/oura/callback?code=...&state=...` (public, no auth).
+5. Backend runs `handleOuraCallback`: validates state, exchanges code, persists refresh token and integration doc, redirects to completion URL, then fires `performOuraPullNowCore(uid, rid)` (fire-and-forget).
+6. Browser follows redirect to `/integrations/oura/complete` (or deep link). App returns to foreground; device screen refetches Oura status.
+
+**Log/API checks (optional for this step):** Access log for `GET /integrations/oura/connect` (200) and later for `GET /integrations/oura/callback` (302). See steps 2 and 3 for exact signatures.
+
+---
+
+## 2. Confirm callback still returns 302
+
+**Goal:** Prove the callback response is unchanged: 302 redirect to completion URL.
+
+**Steps:**
+
+1. Trigger the callback (either by doing “Connect Oura” as in step 1, or by replaying a valid callback URL in a browser session that has valid `code` and `state` — replay only for verification, not in production).
+2. **HTTP:** From the response:
+   - **Status:** `302`
+   - **Location:** Either:
+     - `{PUBLIC_BASE_URL or gateway host}/integrations/oura/complete` (when callback URL matches `/integrations/oura/callback`), or
+     - `com.olifitness.oli://oura-connected` (when callback URL does not match that path).
+   Example (gateway): `Location: https://your-gateway.uc.gateway.dev/integrations/oura/complete`
+
+**Log queries (Cloud Run / GCP Logging):**
+
+- **Structured log (access):** One JSON line per request on `res.on("finish")` from `accessLogMiddleware` (`services/api/src/lib/logger.ts`).
+
+  **Query (example):**
+  ```text
+  jsonPayload.msg="request"
+  jsonPayload.method="GET"
+  jsonPayload.path=~"/integrations/oura/callback"
+  jsonPayload.status=302
+  ```
+
+  **Expected signature (subset):**
+  ```json
+  {
+    "level": "info",
+    "msg": "request",
+    "rid": "<request-id>",
+    "method": "GET",
+    "path": "/integrations/oura/callback?code=...&state=...",
+    "status": 302,
+    "ms": <number>,
+    "uid": null
+  }
+  ```
+  - `path` may be sanitized (e.g. query params present; `key`/token-like params redacted per `sanitizePathForLogs`). Callback has no auth, so `uid` is typically `null`.
+  - `status: 302` is the proof the callback still returns redirect.
+
+- **Console redirect log (callback handler):** Emitted immediately before `res.redirect(302, completionUrl)`.
+
+  **Query (example):**
+  ```text
+  textPayload=~"OURA_CALLBACK_REDIRECT"
+  ```
+  or, if logs are JSON:
+  ```text
+  jsonPayload.message=~"OURA_CALLBACK_REDIRECT"
+  ```
+
+  **Expected signature (from `integrations.ts`):**
+  ```text
+  [OURA_CALLBACK_REDIRECT] { requestId: '<rid>', stateValid: true, completionUrl: '<completionUrl>' }
+  ```
+  - `completionUrl` must be either `.../integrations/oura/complete` (same host as callback) or `com.olifitness.oli://oura-connected`.
+
+---
+
+## 3. Confirm pull logic is triggered automatically
+
+**Goal:** Prove `performOuraPullNowCore(uid, requestId)` runs after the callback without any app “Sync now” or `POST /integrations/oura/pull-now` call.
+
+**Behavior (from code):** Right after `res.redirect(302, completionUrl)`, the handler runs `void performOuraPullNowCore(uid, rid).catch(...)`. There is **no success log** inside `performOuraPullNowCore`; only error logs. So “triggered” is evidenced by (a) absence of fire-and-forget error, and (b) downstream effects (lastSyncAt or raw events updated).
+
+**Log queries:**
+
+1. **Fire-and-forget error (if auto-sync fails):** If the promise rejects, the callback handler logs:
+
+   **Query:**
+   ```text
+  jsonPayload.msg="oura_callback_auto_sync_error"
+   ```
+
+   **Expected signature:**
+   ```json
+   {
+     "level": "error",
+     "msg": "oura_callback_auto_sync_error",
+     "rid": "<request-id>",
+     "uid": "<uid>",
+     "err": "<string>"
+   }
+   ```
+   - **Success case:** This log should **not** appear (no rejection).
+   - **Failure case:** If it appears, pull logic was triggered but failed; use `err` and optional pull-now error logs below to debug.
+
+2. **Pull-now error logs (only if something fails inside performOuraPullNowCore):** Any of these indicate pull logic ran and hit an error path:
+
+   | Log `msg` | Meaning |
+   |-----------|--------|
+   | `oura_pull_now_no_refresh_token` | No refresh token for uid (should not happen right after callback). |
+   | `oura_pull_now_misconfig` | Missing OURA_CLIENT_ID or client secret. |
+   | `oura_pull_now_token_refresh_failed` | Token refresh failed. |
+   | `oura_pull_now_fetch_failed` | Sleep/HRV fetch failed. |
+   | `oura_pull_now_metadata_error` | Failed to write `lastSyncAt`. |
+   | `oura_pull_now_reconnect_cleanup_error` | Reconnect cleanup failed. |
+
+   **Query (any of these):**
+   ```text
+  jsonPayload.msg=~"oura_pull_now_"
+   ```
+
+   **Success case:** None of these appear (pull completes without logging errors). Evidence of “triggered” is then step 4 (lastSyncAt or raw events).
+
+3. **Correlation:** Same `rid` can appear in:
+   - Access log for `GET /integrations/oura/callback` (302),
+   - `[OURA_CALLBACK_REDIRECT]` (contains `requestId` = `rid`),
+   - And, if any, `oura_callback_auto_sync_error` or `oura_pull_now_*` (both include `rid`). Use `rid` to tie callback request to auto-sync.
+
+---
+
+## 4. Confirm lastSyncAt changes without pressing any button
+
+**Goal:** Prove that after connect, `lastSyncAt` is updated by the callback-triggered sync only (no manual “Sync now” or `POST /integrations/oura/pull-now`).
+
+**Data (from code):**
+
+- **Write:** `performOuraPullNowCore` updates Firestore at `users/{uid}/integrations/oura` with `{ lastSyncAt: FieldValue.serverTimestamp() }` on success (`ouraPullNow.ts`).
+- **Read (API):** `GET /integrations/oura/status` (auth) returns `lastSyncAt` from that doc (`integrations.ts` status handler).
+- **App:** Device detail screen (`[deviceId].tsx`) shows “Last sync: …” when `ouraPresence.status === "ready"` and `ouraPresence.data.lastSyncAt` is set (from status API).
+
+**Steps:**
+
+1. **Before connect:** Optionally call `GET /integrations/oura/status` for the test user and confirm no Oura connection or `lastSyncAt` null.
+2. **Connect Oura** (step 1). Do **not** tap any “Sync now” (Oura device screen has none) and do **not** call `POST /integrations/oura/pull-now`.
+3. Wait for auto-sync (e.g. 10–60 seconds; depends on Oura API and load).
+4. **After:**
+   - **API:** Call `GET /integrations/oura/status` with the user’s auth. Response must include `connected: true` and `lastSyncAt` a non-null ISO string (e.g. `"2025-03-14T12:00:00.000Z"`).
+   - **Firestore (if you have access):** Read `users/{uid}/integrations/oura`. Document must have `lastSyncAt` set (server timestamp). Path: `users/<uid>/integrations/oura`, field: `lastSyncAt`.
+   - **App:** Open **Settings → Devices → Oura**. After refetch, the screen must show “Last sync: &lt;date/time&gt;” (from `ouraPresence.data.lastSyncAt`).
+
+**Log (optional):** No success log for pull; confirm again that `oura_callback_auto_sync_error` and `oura_pull_now_*` do not appear for that `rid` (or that any `oura_pull_now_*` is a known acceptable failure and lastSyncAt still updates later).
+
+---
+
+## 5. Confirm app no longer shows “Sync now” (Oura device screen)
+
+**Goal:** Prove the Oura device detail screen does not show a “Sync now” button (sync is automatic only).
+
+**Scope:** This applies only to the **Oura device detail** screen: **Settings → Devices → Oura** (route/segment `deviceId === "oura"`). The **workouts** overview screen still has its own “Sync now” for workouts; that is unrelated to Oura.
+
+**Steps:**
+
+1. Connect Oura (or use an account that already has Oura connected).
+2. Open **Settings → Devices** → tap **Oura** so the device detail screen is visible.
+3. **Check UI:**
+   - There must be **no** button or link labeled **“Sync now”** (or “Sync Oura now”) on this screen.
+   - There may be: “On”/“Off” toggle, description text, “Metrics this device provides”, and, if synced, “Last sync: &lt;date/time&gt;”.
+4. **Automated (if running device tests):** Render the Oura device detail screen with `deviceId: "oura"` and Oura connected; assert the tree does not contain the text `"Sync now"` (see `app/(app)/settings/devices/__tests__/device-detail-oura.test.tsx`).
+
+**Expected:** No “Sync now” on the Oura device screen. “Last sync” appears when `lastSyncAt` is set (step 4).
+
+---
+
+## Summary table
+
+| # | Verification | How |
+|---|--------------|-----|
+| 1 | Connect Oura | App: Settings → Devices → Oura → On; complete OAuth; return to app. |
+| 2 | Callback returns 302 | Response: status 302, Location = `.../integrations/oura/complete` or deep link. Log: `msg="request"`, `method="GET"`, path contains `/integrations/oura/callback`, `status=302`. |
+| 3 | Pull logic triggered | No `oura_callback_auto_sync_error` for that request; optional correlation by `rid`; success path has no log, so evidence is step 4. |
+| 4 | lastSyncAt changes | After connect (no manual sync): GET /integrations/oura/status returns `lastSyncAt` non-null; Firestore `users/{uid}/integrations/oura.lastSyncAt` set; app shows “Last sync: …”. |
+| 5 | No “Sync now” on Oura screen | Settings → Devices → Oura: no “Sync now” button. |
+
+---
+
+## Log reference (exact messages)
+
+- **Access (every request):** `msg: "request"`, `method`, `path`, `status`, `ms`, `rid`, `uid`.
+- **Callback redirect (console):** `[OURA_CALLBACK_REDIRECT]` with `requestId`, `stateValid: true`, `completionUrl`.
+- **Callback state invalid:** `msg: "oura_callback_state_invalid"`, `rid`, `reason`.
+- **Auto-sync failure (fire-and-forget):** `msg: "oura_callback_auto_sync_error"`, `rid`, `uid`, `err`.
+- **Pull-now errors:** `msg` one of: `oura_pull_now_no_refresh_token`, `oura_pull_now_misconfig`, `oura_pull_now_token_refresh_failed`, `oura_pull_now_fetch_failed`, `oura_pull_now_metadata_error`, `oura_pull_now_reconnect_cleanup_error`; all include `rid` and `uid` where relevant.
+
+All backend logs above are JSON from `logger.info` / `logger.error` (`services/api/src/lib/logger.ts`): `console.log(JSON.stringify({ level: "info", ...o }))` or `level: "error"`. The redirect line is `console.log("[OURA_CALLBACK_REDIRECT]", ...)` (plain text unless your runtime wraps it).

--- a/docs/90_audits/OURA_OAUTH_FLOW_REPO_AUDIT.md
+++ b/docs/90_audits/OURA_OAUTH_FLOW_REPO_AUDIT.md
@@ -1,0 +1,239 @@
+# Oura OAuth Flow — Repo Audit Report
+
+**Scope:** Code-only audit of Oura integration (auth, callback, complete, status, persistence, ingestion). No runtime or log inference.
+
+---
+
+## 1. Executive summary
+
+- **Mobile flow:** Oura connect is started from `app/(app)/settings/devices/[deviceId].tsx` when `deviceId === "oura"`. `handleConnectOura` calls `getOuraConnectUrl(token)` then `WebBrowser.openAuthSessionAsync(authUrl, getOuraReturnUrl())`. Return URL is `EXPO_PUBLIC_BACKEND_BASE_URL` + `/integrations/oura/complete` when base is HTTPS, else `com.olifitness.oli://oura-connected`. **PROVEN IN CODE.**
+
+- **Backend routes:** `/integrations/oura/callback` and `/integrations/oura/complete` are registered on the Express app in `services/api/src/index.ts` (exact `app.get`); `/integrations/oura/status`, `/connect`, `/revoke` live on the integrations router mounted at `/integrations` with `authMiddleware`. **PROVEN IN CODE.**
+
+- **Callback handler:** `handleOuraCallback` in `integrations.ts` requires `code` and `state`; validates state via `validateAndConsumeState(state, OURA_OAUTH_PURPOSE)`; exchanges code at `OURA_TOKEN_URL`; persists only refresh token (Secret Manager) and integration doc at `users/{uid}/integrations/oura`; redirects to completion URL derived from callback URL (same host, path `/integrations/oura/complete`) or fallback `com.olifitness.oli://oura-connected`. **PROVEN IN CODE.**
+
+- **Complete route:** `GET /integrations/oura/complete` serves 200 `text/html` with script + fallback link to `com.olifitness.oli://oura-connected`. No redirect; no query params used. **PROVEN IN CODE.**
+
+- **Status:** `GET /integrations/oura/status` (auth required) reads `users/{uid}/integrations/oura` and returns `connected`, `lastSyncAt`, `revoked`, `failureState`. **PROVEN IN CODE.**
+
+- **Persistence:** Refresh token in Secret Manager (`oura-refresh-token-{uid}`); integration metadata in Firestore `users/{uid}/integrations/oura` and registry `system/integrations/oura_connected/{uid}`. Access token and expiry are not stored. **PROVEN IN CODE.**
+
+- **Ingestion:** `POST /integrations/oura/ingest` (auth + Idempotency-Key) accepts `sleep`/`hrv` arrays and writes raw events with `provider: "manual"`, `sourceId: "oura"`. No automatic sync or pull from Oura API in callback. **PROVEN IN CODE.**
+
+- **Return URL alignment:** App return URL = `EXPO_PUBLIC_BACKEND_BASE_URL` + `/integrations/oura/complete`. Backend callback redirects to same host as callback + `/integrations/oura/complete`. If app uses gateway base URL, both point at gateway; match is **PROVEN IN CODE** provided env is consistent.
+
+- **Scheme:** `app.json` declares `scheme: "com.olifitness.oli"`. Backend complete HTML and app fallback use `com.olifitness.oli://oura-connected`. No `oli://` scheme in repo; deep link is consistent. **PROVEN IN CODE.**
+
+---
+
+## 2. Oura flow file inventory
+
+| File | Purpose |
+|------|--------|
+| `app/(app)/settings/devices/[deviceId].tsx` | Device detail UI; starts Oura connect, openAuthSessionAsync, return URL, refetch after auth |
+| `app/(app)/settings/devices.tsx` | Devices list; uses `useOuraPresence`, links to `/(app)/settings/devices/oura` |
+| `lib/api/oura.ts` | Client: getOuraStatus, getOuraConnectUrl, postOuraRevoke (paths /status, /connect, /revoke) |
+| `lib/data/useOuraPresence.ts` | Hook: fetches Oura status, 404 backoff, exposes connected + lastSyncAt |
+| `lib/integrations/oura/storage.ts` | AsyncStorage: lastCheckedAt, lastKnownConnected, status 404 backoff |
+| `services/api/src/index.ts` | Mounts GET /integrations/oura/callback → handleOuraCallback; GET /integrations/oura/complete → HTML; /integrations + auth → integrationsRoutes; /integrations/oura/ingest + auth → ouraIngestRouter |
+| `services/api/src/routes/integrations.ts` | Oura: getCanonicalRedirectUriOura, assertOuraRedirectUriOrFailClosed, GET /oura/status, GET /oura/connect, handleOuraCallback (exported), POST /oura/revoke; writeOuraFailureState |
+| `services/api/src/lib/oauthState.ts` | createStateAsync(uid, purpose), validateAndConsumeState(state, purpose); state format uid:stateId; Firestore users/{uid}/oauthStates/{stateId} |
+| `services/api/src/lib/ouraSecrets.ts` | Secret Manager: getClientSecret, setRefreshToken(uid), getRefreshToken(uid), deleteRefreshToken(uid); OuraConfigError |
+| `services/api/src/routes/integrations/ouraIngest.ts` | POST /: ingest sleep/hrv arrays → rawEvents with provider "manual", sourceId "oura" |
+| `services/api/src/db.ts` | userCollection(uid, "integrations").doc("oura"); ouraConnectedRegistryDoc(uid) → system/integrations/oura_connected/{uid} |
+| `infra/gateway/openapi.yaml` | Paths for /integrations/oura/status, /connect, /revoke, /callback, /complete, /ingest; callback/complete security: [] |
+| `app.json` | Expo scheme: "com.olifitness.oli" |
+| `docs/runbooks/OURA_OAUTH_VERIFICATION_AND_REPAIR.md` | Runbook (not code truth) |
+
+---
+
+## 3. Mobile flow audit
+
+| # | Claim | Evidence | Conclusion | Status |
+|---|-------|----------|------------|--------|
+| 1 | Screen that starts Oura connect | `app/(app)/settings/devices/[deviceId].tsx`: `isOura = id === "oura"`, `onPress={... handleConnectOura}` for Oura row | Device detail screen for `deviceId === "oura"` (e.g. route `/(app)/settings/devices/oura`) | PROVEN |
+| 2 | Function called on tap | `handleConnectOura` (useCallback) — lines 166–205 | `handleConnectOura` | PROVEN |
+| 3 | Auth URL construction path | `getOuraConnectUrl(token)` → `lib/api/oura.ts` → `apiGetZodAuthed("/integrations/oura/connect", ...)` → backend returns `{ url }`; authUrl = res.json.url | Backend builds URL; app uses returned URL | PROVEN |
+| 4 | redirect_uri source (backend) | Backend: `getCanonicalRedirectUriOura(req)` → PUBLIC_BASE_URL or x-forwarded-proto/host → `.../integrations/oura/callback` (`integrations.ts` 119–130) | Backend; not from app | PROVEN |
+| 5 | Return URL passed to openAuthSessionAsync | `getOuraReturnUrl()`: base = `process.env.EXPO_PUBLIC_BACKEND_BASE_URL`; if base and startsWith("https://") then `base/integrations/oura/complete` else `com.olifitness.oli://oura-connected` (`[deviceId].tsx` 25–31, 192) | Exact: `EXPO_PUBLIC_BACKEND_BASE_URL` + `/integrations/oura/complete` (when HTTPS) | PROVEN |
+| 6 | Success/failure/cancel after auth session | `result.type === "cancel"` → Alert "Cancelled"; else `await ouraPresence.refetch()` (lines 193–199) | On success/dismiss (non-cancel): refetch; no explicit URL check in code | PROVEN |
+| 7 | Polling status after auth | No polling loop. Refetch once after openAuthSessionAsync resolves (non-cancel). useOuraPresence fetches on mount and when refetch() called | No continuous poll; single refetch after return | PROVEN |
+| 8 | iOS-specific logic | None found; same WebBrowser.openAuthSessionAsync for Oura as Withings | UNKNOWN (no iOS-only branch in repo) | PROVEN (no special case) |
+| 9 | Deep link / scheme / universal link config | `app.json` scheme `"com.olifitness.oli"`. Android manifest has `com.olifitness.oli`; no Oura-specific linking config in repo | Scheme registered; no oura-specific linking file | PROVEN |
+
+---
+
+## 4. Backend route wiring audit
+
+| Route | Registered | Handler | Middleware/Auth |
+|-------|------------|---------|-----------------|
+| GET /integrations/oura/callback | Yes | `app.get("/integrations/oura/callback", (req, res) => { void handleOuraCallback(req, res); })` — `index.ts` 172–174 | None (public) |
+| GET /integrations/oura/complete | Yes | `app.get("/integrations/oura/complete", ...)` sends HTML — `index.ts` 179–190 | None (public) |
+| GET /integrations/oura/status | Yes | Router in integrations.ts: `router.get("/oura/status", ...)`; app.use("/integrations", authMiddleware, integrationsRoutes) — `index.ts` 198 | authMiddleware |
+| GET /integrations/oura/connect | Yes | `router.get("/oura/connect", ...)` — `integrations.ts` 659 | authMiddleware (via mount) |
+| POST /integrations/oura/revoke | Yes | `router.post("/oura/revoke", ...)` — `integrations.ts` 851 | authMiddleware |
+| POST /integrations/oura/ingest | Yes | `app.use("/integrations/oura/ingest", authMiddleware, ouraIngestRouter)` — `index.ts` 192 | authMiddleware |
+
+**Gateway/base-url in code:** Callback uses `getCanonicalRedirectUriOura(req)` (PUBLIC_BASE_URL or forwarded host). Completion URL is derived from that callback URL: same host, path replaced with `/integrations/oura/complete`. No separate gateway host constant for Oura; same pattern as Withings.
+
+---
+
+## 5. /complete route audit
+
+- **Exists:** Yes. `app.get("/integrations/oura/complete", ...)` in `services/api/src/index.ts` (179–190).
+- **Content-Type:** `text/html; charset=utf-8`.
+- **Cache-Control:** `no-store`.
+- **Status/Body:** 200, HTML body with:
+  - `<script>window.location.href = "com.olifitness.oli://oura-connected";</script>`
+  - `<p>Redirecting…</p>`
+  - Fallback link (same scheme) shown after 500ms.
+- **Redirect:** No HTTP redirect; client-side navigation via script.
+- **Intent for openAuthSessionAsync:** HTML loads in browser; script sets location to custom scheme so the app (opened with that scheme) can be resumed. Comment in Withings complete: "so WebBrowser.openAuthSessionAsync reliably auto-closes even when Safari lands on a JSON/wrong host." So yes, intended to satisfy return URL match and close the session.
+- **Logging:** None in the /complete handler.
+
+---
+
+## 6. Callback behavior (exact sequence from code)
+
+1. **Required query params:** `code` and `state` (both strings, trimmed). If missing → 400 `failure("BAD_REQUEST", "Missing code or state")`. (`integrations.ts` 699–708)
+2. **State validation:** `validateAndConsumeState(state, OURA_OAUTH_PURPOSE)` where `OURA_OAUTH_PURPOSE = "oura_oauth"`. State format `uid:stateId`; Firestore `users/{uid}/oauthStates/{stateId}` must exist, purpose match, hash match, not expired, not used; then marked used. (`oauthState.ts` 37–73; `integrations.ts` 710–716)
+3. **Pending auth state:** Loaded from Firestore `users/{uid}/oauthStates/{stateId}` inside `validateAndConsumeState`. No separate "pending auth" doc; state doc holds purpose, hash, expiresAt, usedAt.
+4. **Code exchange vs state:** State is validated first (and consumed). Token exchange happens after state validation. (`integrations.ts` 710–771)
+5. **Token endpoint:** `OURA_TOKEN_URL = "https://api.ouraring.com/oauth/token"`. POST, `application/x-www-form-urlencoded`, body: grant_type=authorization_code, code, redirect_uri, client_id, client_secret. (`integrations.ts` 21, 761–771)
+6. **Fields persisted after exchange:** Refresh token only → Secret Manager via `ouraSecrets.setRefreshToken(uid, refreshToken)`. Integration doc: `connected: true`, `connectedAt`, `lastSyncAt: null`, `revoked: false`, `failureState: null` at `users/{uid}/integrations/oura`. Registry: `ouraConnectedRegistryDoc(uid).set({ connected: true, updatedAt })`. Access token and expiry are not persisted.
+7. **Collection/document path:** `userCollection(uid, "integrations").doc("oura")` → `users/{uid}/integrations/oura`; registry `system/integrations/oura_connected/{uid}`. (`integrations.ts` 796–816; `db.ts`)
+8. **Error branches:** Missing code/state → 400. Invalid state → 400 + log oura_callback_state_invalid. Redirect assert fail → assert has already sent 500 in assertOuraRedirectUriOrFailClosed; then writeOuraFailureState + return. Client secret/config error → 500 + writeOuraFailureState. Token exchange non-200 or tokenJson.error → writeOuraFailureState + 400. Missing refresh_token → writeOuraFailureState + 400. Other errors → 500 + writeOuraFailureState.
+9. **Redirect target after success:** `callbackUrl = redirect.redirectUri`; `completionUrl = /\/integrations\/oura\/callback$/i.test(callbackUrl) ? callbackUrl.replace(/\/integrations\/oura\/callback$/i, "/integrations/oura/complete") : "com.olifitness.oli://oura-connected"`; `res.redirect(302, completionUrl)`. (`integrations.ts` 819–824)
+10. **Fallback redirect:** If callback URL does not match regex, completionUrl = `com.olifitness.oli://oura-connected`. So redirect is either same-host /integrations/oura/complete or deep link.
+11. **Logging:** `logger.info({ msg: "oura_callback_state_invalid", ... })`; `logger.error` for secret/config, token exchange failure, registry write; `console.log("[OURA_CALLBACK_REDIRECT]", { requestId, stateValid: true, completionUrl })` on success path.
+
+---
+
+## 7. Persistence + status + ingestion audit
+
+- **Where Oura tokens stored:** Refresh token in Google Secret Manager, secret id `oura-refresh-token-{uid}`. (`ouraSecrets.ts`)
+- **Refresh token stored:** Yes. Access token not stored.
+- **Expiry stored:** No. Only integration doc fields: connected, connectedAt, lastSyncAt, revoked, failureState.
+- **Scopes stored:** No. Not written in callback or status.
+- **Integration status fields (Firestore):** connected, connectedAt, lastSyncAt, revoked, failureState. (`integrations.ts` 797–806)
+- **Ingestion/sync endpoint:** `POST /integrations/oura/ingest` (auth + Idempotency-Key). Body: `sleep[]`, `hrv[]`; writes to `users/{uid}/rawEvents` with provider "manual", sourceId/sourceType "oura". (`ouraIngest.ts`)
+- **Initial sync triggered in callback:** No. Callback does not call Oura API or ingest; no sync job triggered in callback code.
+- **Downstream:** Ingest writes raw events only. No automatic pull from Oura API in repo (no equivalent of Withings pull/pull-now/backfill for Oura in this codebase).
+- **TODOs/placeholders:** None found in Oura callback/status/ingest paths.
+
+---
+
+## 8. Environment / config dependencies
+
+| Variable | File(s) | Required/Optional (from code) | What breaks if missing (only if shown in code) |
+|----------|---------|-------------------------------|--------------------------------------------------|
+| PUBLIC_BASE_URL | integrations.ts (getCanonicalRedirectUriOura) | Optional (fallback to x-forwarded-proto/host) | If unset, callback URL uses forwarded host; completion URL still derived from that. |
+| OURA_CLIENT_ID | integrations.ts (connect + callback) | Required for connect and callback | Connect: 500 "Oura OAuth not configured". Callback: 500 "Oura OAuth not configured". |
+| OURA_REDIRECT_URI | integrations.ts (assertOuraRedirectUriOrFailClosed) | Optional; if set must match canonical | If set and mismatch → 500 OURA_REDIRECT_URI mismatch. |
+| Oura client secret | ouraSecrets.ts (Secret Manager) | Required for callback | getClientSecret() from Secret Manager; OuraConfigError or null → 500 or callback failure. |
+| EXPO_PUBLIC_BACKEND_BASE_URL | [deviceId].tsx (getOuraReturnUrl), lib/api/http.ts, lib/env.ts | Required (env assert; http returns error if missing) | App: return URL becomes fallback `com.olifitness.oli://oura-connected`. API calls: return `ok: false`, error "Missing EXPO_PUBLIC_BACKEND_BASE_URL". |
+| EXPO_PUBLIC_GATEWAY_API_KEY | lib/api/http.ts (requireGatewayApiKey) | Required when base URL hostname ends with `.uc.gateway.dev` | apiGetZodAuthed/apiPostZodAuthed return error "Missing EXPO_PUBLIC_GATEWAY_API_KEY (required for API Gateway)". |
+| GOOGLE_CLOUD_PROJECT / GCLOUD_PROJECT / GCP_PROJECT / PROJECT_ID | ouraSecrets.ts (resolveProjectIdFromEnv) | Required for Secret Manager | getProjectId() throws OuraConfigError → callback 500. |
+
+---
+
+## 9. Expected end-to-end flow from code
+
+| Step | Description | Status |
+|------|-------------|--------|
+| 1 | User taps connect in app (devices/oura) | PROVEN IN CODE |
+| 2 | App opens browser/auth session to Oura authorize URL (from GET /integrations/oura/connect) | PROVEN IN CODE |
+| 3 | Oura redirects to backend callback (GET /integrations/oura/callback?code=&state=) | DEPENDS ON RUNTIME / NOT PROVEN IN REPO |
+| 4 | Backend validates state, exchanges code, writes integration state | PROVEN IN CODE |
+| 5 | Backend writes integration state (Firestore + Secret Manager + registry) | PROVEN IN CODE |
+| 6 | Backend redirects to /integrations/oura/complete (same host) or deep link | PROVEN IN CODE |
+| 7 | Browser reaches /complete and gets HTML → script navigates to com.olifitness.oli://oura-connected | PROVEN IN CODE |
+| 8 | App auth session resolves (Expo matches return URL or scheme) | DEPENDS ON RUNTIME / NOT PROVEN IN REPO |
+| 9 | App calls ouraPresence.refetch() (no polling) | PROVEN IN CODE |
+| 10 | Connected state appears in UI (status from GET /integrations/oura/status) | PROVEN IN CODE |
+
+---
+
+## 10. Repo-level gaps only
+
+1. **No automatic Oura data pull/sync after connect:** Callback does not trigger any Oura API fetch or ingest. Ingestion is only via explicit POST /integrations/oura/ingest. So "connected" is stored but no initial sync is started in code. Evidence: callback only writes integration doc + refresh token; ouraIngest is manual POST. (`integrations.ts` callback path; `ouraIngest.ts` is standalone POST handler.)
+
+---
+
+## 11. Open runtime questions (repo cannot answer)
+
+1. Whether real callback requests with valid code/state reach the backend (logs/metrics).
+2. Whether the browser actually loads the gateway URL for /integrations/oura/complete after redirect (or a different host).
+3. Whether Expo’s openAuthSessionAsync matches the return URL when the user lands on the gateway /complete page (same origin as return URL).
+4. Whether iOS Universal Links or Android App Links are configured for the gateway domain to open the app.
+5. Whether PUBLIC_BASE_URL is set in the deployed Cloud Run service and matches the gateway base URL.
+6. Whether OURA_CLIENT_ID and Oura client secret (Secret Manager) are set in the deployment.
+
+---
+
+*End of audit. All conclusions are from repo code only; no fixes proposed unless requested.*
+
+---
+
+## Appendix: Expo Router handling for deep link `com.olifitness.oli://oura-connected`
+
+**1. Whether any Expo Router file currently handles path `/oura-connected`**  
+**No.** No route file exists for that path. Evidence:
+- `git grep -n "oura-connected"` shows only backend/mobile usage of the string (backend fallback URL, app fallback return URL, API complete HTML). No file under `app/` is named or references a route for it.
+- `Glob app/**/oura*` → 0 files under `app/`.
+- `app/(app)/_layout.tsx` declares `Stack.Screen` for many routes; none is `oura-connected` or `oura-connected/index`. No `oura-connected.tsx` under `app/` or `app/(app)/`.
+
+**Conclusion:** No route found for /oura-connected from repo code.
+
+**2. Whether any custom linking config remaps that path**  
+**No.** Evidence:
+- `app.json` has only `"scheme": "com.olifitness.oli"`. No `linking`, `path`, or path-mapping config.
+- No `getStateFromPath`, `getPathFromState`, or `Linking`-based path remapping in the repo.
+- No `expo.config.js`/`expo.config.ts` in project root; Expo config is `app.json` only.
+
+**Conclusion:** No custom linking config remaps `/oura-connected`.
+
+**3. Smallest valid route file to handle it**  
+Expo Router (file-based) would resolve `com.olifitness.oli://oura-connected` to a path; the path segment is `oura-connected`. To be inside the authenticated `(app)` group (so `RouteGuard` in `app/_layout.tsx` does not redirect to sign-in), the file must live under the `(app)` group. Smallest valid route file:
+
+- **Path:** `app/(app)/oura-connected.tsx`
+- **Minimal content (redirect only):**
+```tsx
+import { Redirect } from "expo-router";
+
+export default function OuraConnected() {
+  return <Redirect href="/(app)/settings/devices/oura" />;
+}
+```
+
+**4. Which existing screen should own that route (repo conventions)**  
+The Oura connect flow and UI live in **`app/(app)/settings/devices/[deviceId].tsx`** with `deviceId === "oura"` (and `router.push("/(app)/settings/devices/oura")` from `app/(app)/settings/devices.tsx` line 168). So the screen that “owns” the post-connect experience is the Oura device detail screen. Convention in this repo: index routes often only redirect (e.g. `app/index.tsx` → `Redirect href="/(app)"`, `app/(app)/index.tsx` → `Redirect href="/(app)/(tabs)/dash"`). So the route that handles the deep link should redirect to the existing owner screen: **`/(app)/settings/devices/oura`**, i.e. the same `[deviceId].tsx` screen with segment `oura`.
+
+---
+
+## Appendix: Oura post-connect ingestion path (repo-only audit)
+
+**1. Whether any automatic sync is triggered after successful callback**  
+**PROVEN FROM CODE: No.** The Oura callback in `services/api/src/routes/integrations.ts` (lines 759–825) after success only: exchanges token, calls `ouraSecrets.setRefreshToken(uid, refreshToken)`, writes `integrationRef.set({ connected: true, connectedAt, lastSyncAt: null, revoked: false, failureState: null })`, writes `ouraConnectedRegistryDoc(uid).set(...)`, then `res.redirect(302, completionUrl)`. There is no call to any ingest function, no fetch to Oura API, and no enqueue of a sync job. Compare Withings: `handleWithingsCallback` sets `backfill: { status: "running", ... }` and the status handler can auto-start backfill; Oura has no equivalent backfill or pull in the callback path.
+
+**2. What POST /integrations/oura/ingest expects exactly**  
+**PROVEN FROM CODE.**  
+- **Route:** `POST /integrations/oura/ingest` — mounted in `services/api/src/index.ts` line 192: `app.use("/integrations/oura/ingest", authMiddleware, ouraIngestRouter)`. Handler: `services/api/src/routes/integrations/ouraIngest.ts` `router.post("/", ...)`.  
+- **Auth:** JWT required (`authMiddleware`); `uid` from `(req as AuthedRequest).uid`. No uid → 401.  
+- **Headers:** `Idempotency-Key` or `X-Idempotency-Key` (string, trimmed) required. Missing → 400 "Idempotency-Key header is required for Oura ingest". (Lines 58–85.)  
+- **Body:** JSON matching `ouraIngestBodySchema` (lines 50–56):
+  - `sleep`: optional array of items matching `sleepItemSchema` (lines 27–38): `idempotencyKey`, `start`, `end`, `timezone` (strings min 1), `day` optional YYYY-MM-DD, `totalMinutes` (number ≥ 0), `efficiency` (0–1 or null), `latencyMinutes`, `awakenings` (≥ 0 or null), `isMainSleep` (boolean).
+  - `hrv`: optional array of items matching `hrvItemSchema` (lines 40–47): `idempotencyKey`, `time`, `timezone`, `day` optional, `rmssdMs`, `sdnnMs` (≥ 0 or null), `measurementType` optional enum `["nightly", "spot"]`.
+  - Refine: at least one of `sleep` or `hrv` must have length > 0.  
+- **Response (success):** 200 JSON `{ ok: true, requestId, eventsCreated, eventsAlreadyExists }`.
+
+**3. Whether any caller in the app or backend currently invokes that ingest endpoint**  
+**PROVEN FROM CODE: No.** Grep for `/integrations/oura/ingest`, `postOuraIngest`, or `oura.*ingest` in `*.ts`/`*.tsx` shows only: (1) `services/api/src/index.ts` (mount), (2) `services/api/src/routes/integrations/ouraIngest.ts` (handler), (3) `services/api/src/routes/integrations/__tests__/ouraIngest.test.ts` (supertest). No `lib/api/oura.ts` or other app/backend module POSTs to `/integrations/oura/ingest`. **NOT IMPLEMENTED:** no production caller.
+
+**4. Raw event shapes written for Oura**  
+**PROVEN FROM CODE.** Handler builds a doc per item and validates with `rawEventDocSchema` from `@oli/contracts` (`lib/contracts/rawEvent.ts`). Written to `userCollection(uid, "rawEvents").doc(item.idempotencyKey)` → `users/{uid}/rawEvents/{idempotencyKey}`.  
+- **Sleep:** `id`, `userId`, `sourceId: "oura"`, `sourceType: "oura"`, `provider: "manual"`, `kind: "sleep"`, `receivedAt`, `observedAt: item.start`, `schemaVersion: 1`, `payload` per `manualSleepPayloadSchema` (start, end, timezone, day?, totalMinutes, efficiency?, latencyMinutes?, awakenings?, isMainSleep).  
+- **HRV:** same metadata with `kind: "hrv"`, `observedAt: item.time`, `payload` per `manualHrvPayloadSchema` (time, timezone, day?, rmssdMs?, sdnnMs?, measurementType?). Duplicates: doc id = idempotencyKey; `.create()` used → duplicate counts as `eventsAlreadyExists`.
+
+**5. Smallest production-safe first-sync implementation (from code only)**  
+**From repo evidence:** Ingest is the only writer for Oura raw events and expects the body/headers above. Refresh token is stored per uid; there is no Oura API client in repo (no fetch to api.ouraring.com for sleep/HRV). Withings pattern: user-authenticated `POST /integrations/withings/pull-now` (withingsPullNow.ts) gets refresh token, fetches Withings API, builds raw-event docs, validates with `rawEventDocSchema`, writes. **Smallest production-safe first-sync:** a backend path (e.g. pull-now style route or job) that (1) is authenticated, (2) reads Oura refresh token via `ouraSecrets.getRefreshToken(uid)`, (3) exchanges for access token (refresh grant not in repo today), (4) calls Oura sleep/HRV APIs (not in repo), (5) maps to `sleepItemSchema`/`hrvItemSchema` shapes, (6) either reuses ingest write logic or POSTs to `POST /integrations/oura/ingest` with Idempotency-Key and body. **NOT IMPLEMENTED** in repo: no Oura fetch client, no pull-now/pull/backfill for Oura, no automatic trigger after callback.

--- a/infra/gateway/openapi.yaml
+++ b/infra/gateway/openapi.yaml
@@ -671,6 +671,39 @@ paths:
         500:
           description: Server Error
 
+  # Oura pull-now — user-authenticated. Fetch sleep + HRV from Oura API, write raw events, update lastSyncAt.
+  /integrations/oura/pull-now:
+    options:
+      operationId: ouraPullNowOptions
+      security: []
+      responses:
+        204:
+          description: No Content
+    post:
+      operationId: ouraPullNow
+      summary: Oura pull-now (user scoped)
+      description: Fetch sleep and daily_readiness (HRV) from Oura API for the authed user; write rawEvents idempotently; update lastSyncAt.
+      security:
+        - firebase: []
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: true
+          type: string
+      responses:
+        200:
+          description: OK (eventsCreated, eventsAlreadyExists)
+        400:
+          description: Bad Request (missing Idempotency-Key)
+        401:
+          description: Unauthorized
+        409:
+          description: Request already in progress
+        502:
+          description: Oura fetch failed / not connected
+        500:
+          description: Server Error
+
   # Withings pull-now — user-authenticated. Pull last 72h for authed user; idempotent RawEvent writes.
   /integrations/withings/pull-now:
     options:

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -15,6 +15,7 @@ import withingsBackfillRouter from "./routes/withingsBackfill";
 import withingsPullNowRouter from "./routes/integrations/withingsPullNow";
 import appleHealthStatusRouter from "./routes/integrations/appleHealthStatus";
 import ouraIngestRouter from "./routes/integrations/ouraIngest";
+import ouraPullNowRouter from "./routes/integrations/ouraPullNow";
 import { authMiddleware } from "./middleware/auth";
 import { requireInvokerAuth } from "./middleware/invokerAuth";
 import { accessLogMiddleware, requestIdMiddleware, logger, type RequestWithRid } from "./lib/logger";
@@ -190,6 +191,7 @@ app.get("/integrations/oura/complete", (_req: Request, res: Response) => {
 });
 
 app.use("/integrations/oura/ingest", authMiddleware, ouraIngestRouter);
+app.use("/integrations/oura/pull-now", authMiddleware, ouraPullNowRouter);
 
 /**
  * Integrations (authenticated): connect, revoke.

--- a/services/api/src/lib/ouraApi.ts
+++ b/services/api/src/lib/ouraApi.ts
@@ -1,0 +1,251 @@
+/**
+ * Oura API v2 — token refresh and fetch sleep + daily_readiness (HRV).
+ * Used by POST /integrations/oura/pull-now. OAuth token URL and scopes match integrations.ts.
+ */
+
+const OURA_TOKEN_URL = "https://api.ouraring.com/oauth/token";
+const OURA_API_BASE = "https://api.ouraring.com/v2/usercollection";
+
+/** Oura token refresh returns new access_token and new refresh_token (single-use). */
+export type OuraTokenResult = {
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
+};
+
+/** Minimal Oura API v2 sleep document (from GET /v2/usercollection/sleep). */
+export type OuraSleepDocument = {
+  id?: string;
+  bed_time?: string;
+  wake_time?: string;
+  end_time?: string;
+  total_sleep_duration?: number;
+  efficiency?: number | null;
+  latency?: number | null;
+  restful_sleep?: number | null;
+  awake_time?: number | null;
+  type?: string;
+  [key: string]: unknown;
+};
+
+/** Minimal Oura API v2 daily_readiness document (HRV in rmssd_5min or similar). */
+export type OuraDailyReadinessDocument = {
+  id?: string;
+  day?: string;
+  timestamp?: string;
+  score?: number | null;
+  rmssd_5min?: number | null;
+  rmssd_5min_balance?: number | null;
+  [key: string]: unknown;
+};
+
+export class OuraApiError extends Error {
+  constructor(
+    message: string,
+    public readonly code: string,
+    public readonly status?: number,
+  ) {
+    super(message);
+    this.name = "OuraApiError";
+  }
+}
+
+/**
+ * Exchange refresh_token for new access_token and refresh_token.
+ * Caller must persist the new refresh_token (Oura refresh tokens are single-use).
+ */
+export async function refreshOuraAccessToken(
+  refreshToken: string,
+  clientId: string,
+  clientSecret: string,
+): Promise<OuraTokenResult> {
+  const res = await fetch(OURA_TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+      client_id: clientId,
+      client_secret: clientSecret,
+    }),
+  });
+
+  const json = (await res.json()) as {
+    access_token?: string;
+    refresh_token?: string;
+    expires_in?: number;
+    error?: string;
+    error_description?: string;
+  };
+
+  if (res.status !== 200 || json.error) {
+    const msg = json.error_description ?? json.error ?? `HTTP ${res.status}`;
+    throw new OuraApiError(msg, "OURA_TOKEN_REFRESH_FAILED", res.status);
+  }
+
+  const access_token = json.access_token;
+  const refresh_token = json.refresh_token;
+  if (!access_token || !refresh_token || typeof json.expires_in !== "number") {
+    throw new OuraApiError("Invalid token response", "OURA_TOKEN_INVALID", res.status);
+  }
+
+  return {
+    access_token,
+    refresh_token,
+    expires_in: json.expires_in,
+  };
+}
+
+/**
+ * GET /v2/usercollection/sleep?start_date=YYYY-MM-DD&end_date=YYYY-MM-DD
+ */
+export async function fetchOuraSleep(
+  accessToken: string,
+  startDate: string,
+  endDate: string,
+): Promise<OuraSleepDocument[]> {
+  const url = new URL(`${OURA_API_BASE}/sleep`);
+  url.searchParams.set("start_date", startDate);
+  url.searchParams.set("end_date", endDate);
+
+  const res = await fetch(url.toString(), {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+
+  if (res.status === 401) {
+    throw new OuraApiError("Unauthorized", "OURA_UNAUTHORIZED", 401);
+  }
+  if (res.status !== 200) {
+    const text = await res.text();
+    throw new OuraApiError(
+      text || `HTTP ${res.status}`,
+      "OURA_SLEEP_FETCH_FAILED",
+      res.status,
+    );
+  }
+
+  const json = (await res.json()) as { data?: OuraSleepDocument[]; next_token?: string };
+  const data = Array.isArray(json.data) ? json.data : [];
+  return data;
+}
+
+/**
+ * GET /v2/usercollection/daily_readiness?start_date=...&end_date=...
+ * Used for HRV (rmssd); day + timestamp identify the document.
+ */
+export async function fetchOuraDailyReadiness(
+  accessToken: string,
+  startDate: string,
+  endDate: string,
+): Promise<OuraDailyReadinessDocument[]> {
+  const url = new URL(`${OURA_API_BASE}/daily_readiness`);
+  url.searchParams.set("start_date", startDate);
+  url.searchParams.set("end_date", endDate);
+
+  const res = await fetch(url.toString(), {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+
+  if (res.status === 401) {
+    throw new OuraApiError("Unauthorized", "OURA_UNAUTHORIZED", 401);
+  }
+  if (res.status !== 200) {
+    const text = await res.text();
+    throw new OuraApiError(
+      text || `HTTP ${res.status}`,
+      "OURA_READINESS_FETCH_FAILED",
+      res.status,
+    );
+  }
+
+  const json = (await res.json()) as {
+    data?: OuraDailyReadinessDocument[];
+    next_token?: string;
+  };
+  const data = Array.isArray(json.data) ? json.data : [];
+  return data;
+}
+
+// Ingest item shapes (must match ouraIngest / ouraIngestWrite contract)
+export type OuraSleepIngestItem = {
+  idempotencyKey: string;
+  start: string;
+  end: string;
+  timezone: string;
+  day?: string;
+  totalMinutes: number;
+  efficiency?: number | null;
+  latencyMinutes?: number | null;
+  awakenings?: number | null;
+  isMainSleep: boolean;
+};
+
+export type OuraHrvIngestItem = {
+  idempotencyKey: string;
+  time: string;
+  timezone: string;
+  day?: string;
+  rmssdMs?: number | null;
+  sdnnMs?: number | null;
+  measurementType?: "nightly" | "spot";
+};
+
+function toYmd(iso: string): string {
+  return iso.slice(0, 10);
+}
+
+export function mapOuraSleepToIngestItem(doc: OuraSleepDocument): OuraSleepIngestItem | null {
+  const start = doc.bed_time ?? doc.end_time;
+  const end = doc.wake_time ?? doc.end_time;
+  if (!start || !end) return null;
+
+  const totalSec = doc.total_sleep_duration ?? 0;
+  const totalMinutes = Math.round(totalSec / 60);
+  const efficiencyRaw = doc.efficiency;
+  const efficiency =
+    typeof efficiencyRaw === "number" && efficiencyRaw >= 0 && efficiencyRaw <= 100
+      ? efficiencyRaw / 100
+      : null;
+  const latencyMinutes =
+    typeof doc.latency === "number" && doc.latency >= 0 ? Math.round(doc.latency) : null;
+  const awakenings =
+    typeof (doc as { number_of_awakenings?: number }).number_of_awakenings === "number"
+      ? (doc as { number_of_awakenings: number }).number_of_awakenings
+      : null;
+  const id = doc.id ?? `oura_sleep_${start}`;
+  const isMainSleep = doc.type === "long_sleep" || doc.type === "sleep";
+
+  return {
+    idempotencyKey: String(id),
+    start,
+    end,
+    timezone: "UTC",
+    day: toYmd(start),
+    totalMinutes,
+    ...(efficiency != null ? { efficiency } : {}),
+    ...(latencyMinutes != null ? { latencyMinutes } : {}),
+    ...(awakenings != null ? { awakenings } : {}),
+    isMainSleep,
+  };
+}
+
+export function mapOuraReadinessToHrvItem(
+  doc: OuraDailyReadinessDocument,
+): OuraHrvIngestItem | null {
+  const day = doc.day ?? (doc.timestamp ? toYmd(doc.timestamp) : null);
+  const time = doc.timestamp ?? (doc.day ? `${doc.day}T12:00:00.000Z` : null);
+  if (!day || !time) return null;
+
+  const id = doc.id ?? `oura_hrv_${day}`;
+  const rmssd = doc.rmssd_5min ?? doc.rmssd_5min_balance;
+  const rmssdMs = typeof rmssd === "number" && rmssd >= 0 ? rmssd : null;
+
+  return {
+    idempotencyKey: String(id),
+    time,
+    timezone: "UTC",
+    day,
+    ...(rmssdMs != null ? { rmssdMs } : {}),
+    measurementType: "nightly",
+  };
+}

--- a/services/api/src/lib/ouraIngestWrite.ts
+++ b/services/api/src/lib/ouraIngestWrite.ts
@@ -1,0 +1,161 @@
+/**
+ * Shared Oura raw-event write logic for POST /integrations/oura/ingest and POST /integrations/oura/pull-now.
+ * Validates with rawEventDocSchema and writes to users/{uid}/rawEvents. No auth; caller must pass uid.
+ */
+
+import { rawEventDocSchema } from "@oli/contracts";
+import type { OuraHrvIngestItem, OuraSleepIngestItem } from "./ouraApi";
+import { userCollection } from "../db";
+import { writeFailure } from "./writeFailure";
+import { logger } from "./logger";
+
+const OURA_SOURCE_ID = "oura";
+const OURA_SOURCE_TYPE = "oura";
+
+function dayUtcNow(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export type WriteOuraRawEventsResult = {
+  eventsCreated: number;
+  eventsAlreadyExists: number;
+};
+
+/**
+ * Write sleep and HRV items to rawEvents. Idempotent by doc id (idempotencyKey).
+ * Returns counts; logs and writes FailureEntry on schema or write errors.
+ */
+export async function writeOuraRawEvents(
+  uid: string,
+  sleepItems: OuraSleepIngestItem[],
+  hrvItems: OuraHrvIngestItem[],
+  requestId: string,
+): Promise<WriteOuraRawEventsResult> {
+  const rawEventsCol = userCollection(uid, "rawEvents");
+  const receivedAt = new Date().toISOString();
+  let eventsCreated = 0;
+  let eventsAlreadyExists = 0;
+
+  for (const item of sleepItems) {
+    const payload = {
+      start: item.start,
+      end: item.end,
+      timezone: item.timezone,
+      ...(item.day != null ? { day: item.day } : {}),
+      totalMinutes: item.totalMinutes,
+      ...(item.efficiency != null ? { efficiency: item.efficiency } : {}),
+      ...(item.latencyMinutes != null ? { latencyMinutes: item.latencyMinutes } : {}),
+      ...(item.awakenings != null ? { awakenings: item.awakenings } : {}),
+      isMainSleep: item.isMainSleep,
+    };
+    const doc = {
+      id: item.idempotencyKey,
+      userId: uid,
+      sourceId: OURA_SOURCE_ID,
+      sourceType: OURA_SOURCE_TYPE,
+      provider: "manual" as const,
+      kind: "sleep" as const,
+      receivedAt,
+      observedAt: item.start,
+      payload,
+      schemaVersion: 1 as const,
+    };
+    const validated = rawEventDocSchema.safeParse(doc);
+    if (!validated.success) {
+      try {
+        await writeFailure({
+          userId: uid,
+          source: "ingestion",
+          stage: "oura.ingest.schema",
+          reasonCode: "RAW_EVENT_SCHEMA_INVALID",
+          message: "Invalid sleep RawEvent payload",
+          day: item.day ?? dayUtcNow(),
+          rawEventId: item.idempotencyKey,
+          details: validated.error.flatten(),
+          requestId,
+        });
+      } catch {
+        // best-effort
+      }
+      continue;
+    }
+    try {
+      await rawEventsCol.doc(item.idempotencyKey).create(validated.data);
+      eventsCreated += 1;
+    } catch (err: unknown) {
+      const existing = await rawEventsCol.doc(item.idempotencyKey).get();
+      if (existing.exists) {
+        eventsAlreadyExists += 1;
+      } else {
+        logger.error({
+          msg: "oura_ingest_sleep_write_error",
+          uid,
+          rawEventId: item.idempotencyKey,
+          requestId,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  }
+
+  for (const item of hrvItems) {
+    const payload = {
+      time: item.time,
+      timezone: item.timezone,
+      ...(item.day != null ? { day: item.day } : {}),
+      ...(item.rmssdMs != null ? { rmssdMs: item.rmssdMs } : {}),
+      ...(item.sdnnMs != null ? { sdnnMs: item.sdnnMs } : {}),
+      ...(item.measurementType != null ? { measurementType: item.measurementType } : {}),
+    };
+    const doc = {
+      id: item.idempotencyKey,
+      userId: uid,
+      sourceId: OURA_SOURCE_ID,
+      sourceType: OURA_SOURCE_TYPE,
+      provider: "manual" as const,
+      kind: "hrv" as const,
+      receivedAt,
+      observedAt: item.time,
+      payload,
+      schemaVersion: 1 as const,
+    };
+    const validated = rawEventDocSchema.safeParse(doc);
+    if (!validated.success) {
+      try {
+        await writeFailure({
+          userId: uid,
+          source: "ingestion",
+          stage: "oura.ingest.schema",
+          reasonCode: "RAW_EVENT_SCHEMA_INVALID",
+          message: "Invalid hrv RawEvent payload",
+          day: item.day ?? dayUtcNow(),
+          rawEventId: item.idempotencyKey,
+          details: validated.error.flatten(),
+          requestId,
+        });
+      } catch {
+        // best-effort
+      }
+      continue;
+    }
+    try {
+      await rawEventsCol.doc(item.idempotencyKey).create(validated.data);
+      eventsCreated += 1;
+    } catch (err: unknown) {
+      const existing = await rawEventsCol.doc(item.idempotencyKey).get();
+      if (existing.exists) {
+        eventsAlreadyExists += 1;
+      } else {
+        logger.error({
+          msg: "oura_ingest_hrv_write_error",
+          uid,
+          rawEventId: item.idempotencyKey,
+          requestId,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  }
+
+  return { eventsCreated, eventsAlreadyExists };
+}

--- a/services/api/src/routes/integrations.ts
+++ b/services/api/src/routes/integrations.ts
@@ -10,6 +10,7 @@ import { createStateAsync, validateAndConsumeState } from "../lib/oauthState";
 import * as withingsSecrets from "../lib/withingsSecrets";
 import * as ouraSecrets from "../lib/ouraSecrets";
 import { logger } from "../lib/logger";
+import { performOuraPullNowCore } from "./integrations/ouraPullNow";
 
 const router = Router();
 
@@ -823,6 +824,15 @@ export async function handleOuraCallback(req: Request, res: Response): Promise<v
     // eslint-disable-next-line no-console -- temporary debug for Oura callback return flow
     console.log("[OURA_CALLBACK_REDIRECT]", { requestId: rid, stateValid: true, completionUrl });
     res.redirect(302, completionUrl);
+    // Fire-and-forget: kick off first sync so lastSyncAt updates without blocking redirect.
+    void performOuraPullNowCore(uid, rid).catch((err: unknown) =>
+      logger.error({
+        msg: "oura_callback_auto_sync_error",
+        rid,
+        uid,
+        err: err instanceof Error ? err.message : String(err),
+      }),
+    );
   } catch (err) {
     if (err instanceof ouraSecrets.OuraConfigError) {
       logger.error({ msg: "oura_callback_secret_manager_config_missing", rid });

--- a/services/api/src/routes/integrations/__tests__/ouraCallback.test.ts
+++ b/services/api/src/routes/integrations/__tests__/ouraCallback.test.ts
@@ -1,0 +1,101 @@
+/**
+ * GET /integrations/oura/callback — OAuth callback; redirects to complete and kicks off auto-sync.
+ */
+import express from "express";
+import request from "supertest";
+
+const mockPerformOuraPullNowCore = jest.fn().mockResolvedValue({ statusCode: 200, body: { ok: true } });
+
+jest.mock("../ouraPullNow", () => ({
+  ...jest.requireActual("../ouraPullNow"),
+  performOuraPullNowCore: (...args: unknown[]) => mockPerformOuraPullNowCore(...args),
+}));
+
+const mockGet = jest.fn();
+const mockSet = jest.fn();
+const mockDoc = jest.fn();
+
+jest.mock("../../../db", () => ({
+  userCollection: jest.fn(() => ({
+    doc: (...args: unknown[]) => mockDoc(...args),
+  })),
+  FieldValue: { serverTimestamp: () => ({ _serverTimestamp: true }) },
+  withingsConnectedRegistryDoc: jest.fn(() => ({ set: jest.fn(), delete: jest.fn() })),
+  ouraConnectedRegistryDoc: jest.fn(() => ({ set: jest.fn().mockResolvedValue(undefined), delete: jest.fn() })),
+}));
+
+jest.mock("../../../lib/ouraSecrets", () => ({
+  getClientSecret: jest.fn().mockResolvedValue("client-secret"),
+  setRefreshToken: jest.fn().mockResolvedValue(undefined),
+  deleteRefreshToken: jest.fn(),
+  OuraConfigError: class OuraConfigError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "OuraConfigError";
+    }
+  },
+}));
+
+jest.mock("../../../lib/oauthState", () => ({
+  createStateAsync: jest.fn(),
+  validateAndConsumeState: jest.fn(),
+}));
+
+import { handleOuraCallback } from "../../integrations";
+
+describe("GET /integrations/oura/callback", () => {
+  let app: express.Express;
+  const validateAndConsumeState = require("../../../lib/oauthState").validateAndConsumeState as jest.Mock;
+
+  beforeAll(() => {
+    app = express();
+    app.get("/integrations/oura/callback", (req, res) => {
+      void handleOuraCallback(req, res);
+    });
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDoc.mockReturnValue({ get: mockGet, set: mockSet });
+    mockGet.mockResolvedValue({ exists: false });
+    mockSet.mockResolvedValue(undefined);
+    process.env.OURA_CLIENT_ID = "oura-client";
+    process.env.PUBLIC_BASE_URL = "https://api.example.com";
+    process.env.OURA_REDIRECT_URI = "https://api.example.com/integrations/oura/callback";
+    validateAndConsumeState.mockResolvedValue({
+      ok: true,
+      uid: "user_oura_cb",
+    });
+    (global as unknown as { fetch: unknown }).fetch = jest.fn().mockResolvedValue({
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          access_token: "at",
+          refresh_token: "rt",
+          expires_in: 3600,
+        }),
+    });
+  });
+
+  it("redirects to completion URL and invokes performOuraPullNowCore after success", async () => {
+    const res = await request(app)
+      .get("/integrations/oura/callback")
+      .query({ code: "auth_code", state: "valid_state" })
+      .set("Host", "api.example.com")
+      .set("x-forwarded-host", "api.example.com")
+      .set("x-forwarded-proto", "https");
+
+    expect(res.status).toBe(302);
+    expect(res.header.location).toBe("https://api.example.com/integrations/oura/complete");
+
+    await new Promise((r) => setImmediate(r));
+    expect(mockPerformOuraPullNowCore).toHaveBeenCalledWith("user_oura_cb", expect.any(String));
+  });
+
+  it("returns 400 when code or state is missing", async () => {
+    validateAndConsumeState.mockResolvedValue({ ok: true, uid: "u1" });
+    const res = await request(app).get("/integrations/oura/callback").query({ state: "s" });
+    expect(res.status).toBe(400);
+    expect(mockPerformOuraPullNowCore).not.toHaveBeenCalled();
+  });
+});

--- a/services/api/src/routes/integrations/__tests__/ouraPullNow.test.ts
+++ b/services/api/src/routes/integrations/__tests__/ouraPullNow.test.ts
@@ -1,0 +1,208 @@
+/**
+ * POST /integrations/oura/pull-now — user-authenticated Oura first-sync; fetch sleep + HRV, write raw events.
+ */
+
+import express from "express";
+import request from "supertest";
+import { allowConsoleForThisTest } from "../../../../../../scripts/test/consoleGuard";
+import ouraPullNowRouter from "../ouraPullNow";
+
+const requestRecordState: Record<
+  string,
+  { status: string; statusCode?: number; result?: Record<string, unknown> }
+> = {};
+
+const mockUserCollection = jest.fn();
+const mockRegistryDelete = jest.fn().mockResolvedValue(undefined);
+
+function makeRequestRecordRef(id: string) {
+  return {
+    create: jest.fn().mockImplementation(async (data: Record<string, unknown>) => {
+      if (requestRecordState[id]) {
+        const err = new Error("ALREADY_EXISTS") as Error & { code?: number };
+        err.code = 6;
+        throw err;
+      }
+      requestRecordState[id] = { ...(data as { status: string }), status: "in_progress" };
+    }),
+    get: jest.fn().mockImplementation(async () => ({
+      exists: !!requestRecordState[id],
+      data: () => requestRecordState[id],
+    })),
+    set: jest.fn().mockImplementation(async (data: Record<string, unknown>, opts?: { merge?: boolean }) => {
+      const existing = requestRecordState[id] ?? {};
+      requestRecordState[id] = (opts?.merge ? { ...existing, ...data } : { ...data }) as typeof requestRecordState[string];
+    }),
+  };
+}
+
+jest.mock("../../../db", () => ({
+  userCollection: (...args: unknown[]) => mockUserCollection(...args),
+  FieldValue: { serverTimestamp: () => ({ _serverTimestamp: true }) },
+  ouraConnectedRegistryDoc: jest.fn(() => ({ delete: mockRegistryDelete })),
+}));
+
+jest.mock("../../../lib/ouraSecrets", () => ({
+  getRefreshToken: jest.fn(),
+  getClientSecret: jest.fn(),
+  setRefreshToken: jest.fn().mockResolvedValue(undefined),
+  deleteRefreshToken: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("../../../lib/ouraApi", () => ({
+  refreshOuraAccessToken: jest.fn(),
+  fetchOuraSleep: jest.fn(),
+  fetchOuraDailyReadiness: jest.fn(),
+  mapOuraSleepToIngestItem: jest.fn((d: { id?: string; bed_time?: string; wake_time?: string; total_sleep_duration?: number; type?: string }) =>
+    d.bed_time && d.wake_time
+      ? {
+          idempotencyKey: d.id ?? "sleep_1",
+          start: d.bed_time,
+          end: d.wake_time,
+          timezone: "UTC",
+          day: d.bed_time.slice(0, 10),
+          totalMinutes: Math.round((d.total_sleep_duration ?? 0) / 60),
+          isMainSleep: d.type === "long_sleep",
+        }
+      : null,
+  ),
+  mapOuraReadinessToHrvItem: jest.fn((d: { id?: string; day?: string; timestamp?: string; rmssd_5min?: number }) =>
+    (d.day || d.timestamp)
+      ? {
+          idempotencyKey: d.id ?? "hrv_1",
+          time: d.timestamp ?? `${d.day}T12:00:00.000Z`,
+          timezone: "UTC",
+          day: d.day ?? (d.timestamp ? d.timestamp.slice(0, 10) : undefined),
+          rmssdMs: d.rmssd_5min ?? undefined,
+          measurementType: "nightly" as const,
+        }
+      : null,
+  ),
+  OuraApiError: class OuraApiError extends Error {
+    code: string;
+    status?: number;
+    constructor(message: string, code: string, status?: number) {
+      super(message);
+      this.code = code;
+      this.status = status;
+    }
+  },
+}));
+
+jest.mock("../../../lib/ouraIngestWrite", () => ({
+  writeOuraRawEvents: jest.fn().mockResolvedValue({ eventsCreated: 2, eventsAlreadyExists: 0 }),
+}));
+
+jest.mock("../../../lib/writeFailure", () => ({
+  writeFailure: jest.fn().mockResolvedValue({ id: "fail_1" }),
+}));
+
+const ouraSecrets = require("../../../lib/ouraSecrets");
+const ouraApi = require("../../../lib/ouraApi");
+const ouraIngestWrite = require("../../../lib/ouraIngestWrite");
+
+describe("POST /integrations/oura/pull-now", () => {
+  let app: express.Express;
+  let appNoUid: express.Express;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as unknown as { uid: string; rid: string }).uid = "user_oura_1";
+      (req as unknown as { rid: string }).rid = "req-oura-pull";
+      next();
+    });
+    app.use("/integrations/oura/pull-now", ouraPullNowRouter);
+
+    appNoUid = express();
+    appNoUid.use(express.json());
+    appNoUid.use((req, _res, next) => {
+      (req as unknown as { rid: string }).rid = "req-no-uid";
+      next();
+    });
+    appNoUid.use("/integrations/oura/pull-now", ouraPullNowRouter);
+  });
+
+  beforeEach(() => {
+    allowConsoleForThisTest({
+      error: [(args: unknown[]) => String(args[0] ?? "").includes("oura_pull_now")],
+    });
+    jest.clearAllMocks();
+    Object.keys(requestRecordState).forEach((k) => delete requestRecordState[k]);
+    (ouraSecrets.getRefreshToken as jest.Mock).mockResolvedValue("rt_xxx");
+    (ouraSecrets.getClientSecret as jest.Mock).mockResolvedValue("secret");
+    (ouraApi.refreshOuraAccessToken as jest.Mock).mockResolvedValue({
+      access_token: "at_yyy",
+      refresh_token: "rt_new",
+      expires_in: 86400,
+    });
+    (ouraApi.fetchOuraSleep as jest.Mock).mockResolvedValue([
+      { id: "s1", bed_time: "2025-03-13T22:00:00Z", wake_time: "2025-03-14T06:00:00Z", total_sleep_duration: 28800, type: "long_sleep" },
+    ]);
+    (ouraApi.fetchOuraDailyReadiness as jest.Mock).mockResolvedValue([
+      { id: "r1", day: "2025-03-14", timestamp: "2025-03-14T08:00:00Z", rmssd_5min: 42 },
+    ]);
+    (ouraIngestWrite.writeOuraRawEvents as jest.Mock).mockResolvedValue({ eventsCreated: 2, eventsAlreadyExists: 0 });
+
+    mockUserCollection.mockImplementation((uid: string, col: string) => {
+      if (col === "requestRecords") {
+        return { doc: (id: string) => makeRequestRecordRef(id) };
+      }
+      if (col === "integrations") {
+        return {
+          doc: () => ({
+            set: jest.fn().mockResolvedValue(undefined),
+          }),
+        };
+      }
+      return { doc: () => ({ create: jest.fn().mockResolvedValue(undefined), get: jest.fn().mockResolvedValue({ exists: false }) }) };
+    });
+    process.env.OURA_CLIENT_ID = "oura-client-id";
+  });
+
+  it("returns 401 when uid is missing", async () => {
+    const res = await request(appNoUid)
+      .post("/integrations/oura/pull-now")
+      .set("Idempotency-Key", "oura-pull-1");
+    expect(res.status).toBe(401);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error?.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 400 when Idempotency-Key header is missing", async () => {
+    const res = await request(app).post("/integrations/oura/pull-now");
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error?.message).toContain("Idempotency-Key");
+  });
+
+  it("returns 502 when no refresh token (Oura not connected)", async () => {
+    (ouraSecrets.getRefreshToken as jest.Mock).mockResolvedValue(null);
+    const res = await request(app)
+      .post("/integrations/oura/pull-now")
+      .set("Idempotency-Key", "oura-pull-no-token");
+    expect(res.status).toBe(502);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error?.code).toBe("OURA_NOT_CONNECTED");
+  });
+
+  it("returns 200 with eventsCreated and eventsAlreadyExists on success", async () => {
+    const res = await request(app)
+      .post("/integrations/oura/pull-now")
+      .set("Idempotency-Key", "oura-pull-success");
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.requestId).toBe("req-oura-pull");
+    expect(res.body.eventsCreated).toBe(2);
+    expect(res.body.eventsAlreadyExists).toBe(0);
+    expect(res.body.windowDays).toBe(30);
+    expect(ouraSecrets.setRefreshToken).toHaveBeenCalledWith("user_oura_1", "rt_new");
+    expect(ouraIngestWrite.writeOuraRawEvents).toHaveBeenCalledWith(
+      "user_oura_1",
+      expect.any(Array),
+      expect.any(Array),
+      "req-oura-pull",
+    );
+  });
+});

--- a/services/api/src/routes/integrations/ouraIngest.ts
+++ b/services/api/src/routes/integrations/ouraIngest.ts
@@ -7,22 +7,13 @@
 
 import { Router, type Request, type Response } from "express";
 import { z } from "zod";
-import { rawEventDocSchema } from "@oli/contracts";
 import type { AuthedRequest } from "../../middleware/auth";
-import { userCollection } from "../../db";
-import { writeFailure } from "../../lib/writeFailure";
-import { logger } from "../../lib/logger";
+import { writeOuraRawEvents } from "../../lib/ouraIngestWrite";
 
 const router = Router();
-const OURA_SOURCE_ID = "oura";
-const OURA_SOURCE_TYPE = "oura";
 
 function getRequestId(req: Request): string {
   return (req as AuthedRequest).rid ?? (req.header("x-request-id") ?? "unknown").toString();
-}
-
-function dayUtcNow(): string {
-  return new Date().toISOString().slice(0, 10);
 }
 
 const sleepItemSchema = z.object({
@@ -99,132 +90,33 @@ router.post("/", async (req: Request, res: Response) => {
   }
 
   const { sleep = [], hrv = [] } = parsed.data;
-  const rawEventsCol = userCollection(uid, "rawEvents");
-  const receivedAt = new Date().toISOString();
-
-  let eventsCreated = 0;
-  let eventsAlreadyExists = 0;
-
-  for (const item of sleep) {
-    const payload = {
-      start: item.start,
-      end: item.end,
-      timezone: item.timezone,
-      ...(item.day != null ? { day: item.day } : {}),
-      totalMinutes: item.totalMinutes,
-      ...(item.efficiency != null ? { efficiency: item.efficiency } : {}),
-      ...(item.latencyMinutes != null ? { latencyMinutes: item.latencyMinutes } : {}),
-      ...(item.awakenings != null ? { awakenings: item.awakenings } : {}),
-      isMainSleep: item.isMainSleep,
-    };
-    const doc = {
-      id: item.idempotencyKey,
-      userId: uid,
-      sourceId: OURA_SOURCE_ID,
-      sourceType: OURA_SOURCE_TYPE,
-      provider: "manual" as const,
-      kind: "sleep" as const,
-      receivedAt,
-      observedAt: item.start,
-      payload,
-      schemaVersion: 1 as const,
-    };
-    const validated = rawEventDocSchema.safeParse(doc);
-    if (!validated.success) {
-      try {
-        await writeFailure({
-          userId: uid,
-          source: "ingestion",
-          stage: "oura.ingest.schema",
-          reasonCode: "RAW_EVENT_SCHEMA_INVALID",
-          message: "Invalid sleep RawEvent payload",
-          day: item.day ?? dayUtcNow(),
-          rawEventId: item.idempotencyKey,
-          details: validated.error.flatten(),
-          requestId,
-        });
-      } catch {
-        // best-effort
-      }
-      continue;
-    }
-    try {
-      await rawEventsCol.doc(item.idempotencyKey).create(validated.data);
-      eventsCreated += 1;
-    } catch (err: unknown) {
-      const existing = await rawEventsCol.doc(item.idempotencyKey).get();
-      if (existing.exists) {
-        eventsAlreadyExists += 1;
-      } else {
-        logger.error({
-          msg: "oura_ingest_sleep_write_error",
-          uid,
-          rawEventId: item.idempotencyKey,
-          requestId,
-          err: err instanceof Error ? err.message : String(err),
-        });
-      }
-    }
-  }
-
-  for (const item of hrv) {
-    const payload = {
-      time: item.time,
-      timezone: item.timezone,
-      ...(item.day != null ? { day: item.day } : {}),
-      ...(item.rmssdMs != null ? { rmssdMs: item.rmssdMs } : {}),
-      ...(item.sdnnMs != null ? { sdnnMs: item.sdnnMs } : {}),
-      ...(item.measurementType != null ? { measurementType: item.measurementType } : {}),
-    };
-    const doc = {
-      id: item.idempotencyKey,
-      userId: uid,
-      sourceId: OURA_SOURCE_ID,
-      sourceType: OURA_SOURCE_TYPE,
-      provider: "manual" as const,
-      kind: "hrv" as const,
-      receivedAt,
-      observedAt: item.time,
-      payload,
-      schemaVersion: 1 as const,
-    };
-    const validated = rawEventDocSchema.safeParse(doc);
-    if (!validated.success) {
-      try {
-        await writeFailure({
-          userId: uid,
-          source: "ingestion",
-          stage: "oura.ingest.schema",
-          reasonCode: "RAW_EVENT_SCHEMA_INVALID",
-          message: "Invalid hrv RawEvent payload",
-          day: item.day ?? dayUtcNow(),
-          rawEventId: item.idempotencyKey,
-          details: validated.error.flatten(),
-          requestId,
-        });
-      } catch {
-        // best-effort
-      }
-      continue;
-    }
-    try {
-      await rawEventsCol.doc(item.idempotencyKey).create(validated.data);
-      eventsCreated += 1;
-    } catch (err: unknown) {
-      const existing = await rawEventsCol.doc(item.idempotencyKey).get();
-      if (existing.exists) {
-        eventsAlreadyExists += 1;
-      } else {
-        logger.error({
-          msg: "oura_ingest_hrv_write_error",
-          uid,
-          rawEventId: item.idempotencyKey,
-          requestId,
-          err: err instanceof Error ? err.message : String(err),
-        });
-      }
-    }
-  }
+  const sleepItems = sleep.map((item) => ({
+    idempotencyKey: item.idempotencyKey,
+    start: item.start,
+    end: item.end,
+    timezone: item.timezone,
+    ...(item.day !== undefined ? { day: item.day } : {}),
+    totalMinutes: item.totalMinutes,
+    ...(item.efficiency !== undefined ? { efficiency: item.efficiency ?? null } : {}),
+    ...(item.latencyMinutes !== undefined ? { latencyMinutes: item.latencyMinutes ?? null } : {}),
+    ...(item.awakenings !== undefined ? { awakenings: item.awakenings ?? null } : {}),
+    isMainSleep: item.isMainSleep,
+  }));
+  const hrvItems = hrv.map((item) => ({
+    idempotencyKey: item.idempotencyKey,
+    time: item.time,
+    timezone: item.timezone,
+    ...(item.day !== undefined ? { day: item.day } : {}),
+    ...(item.rmssdMs !== undefined ? { rmssdMs: item.rmssdMs ?? null } : {}),
+    ...(item.sdnnMs !== undefined ? { sdnnMs: item.sdnnMs ?? null } : {}),
+    ...(item.measurementType !== undefined ? { measurementType: item.measurementType } : {}),
+  }));
+  const { eventsCreated, eventsAlreadyExists } = await writeOuraRawEvents(
+    uid,
+    sleepItems,
+    hrvItems,
+    requestId,
+  );
 
   return res.status(200).json({
     ok: true as const,

--- a/services/api/src/routes/integrations/ouraPullNow.ts
+++ b/services/api/src/routes/integrations/ouraPullNow.ts
@@ -1,0 +1,351 @@
+/**
+ * POST /integrations/oura/pull-now — user-authenticated first-sync / pull from Oura API.
+ * Fetches sleep + daily_readiness (HRV), maps to ingest shapes, writes raw events, updates lastSyncAt.
+ * Requires Idempotency-Key; uses users/{uid}/requestRecords for replay-safe behavior.
+ * Reuses writeOuraRawEvents (shared with POST /integrations/oura/ingest).
+ */
+
+import { Router, type Request, type Response } from "express";
+import type { AuthedRequest } from "../../middleware/auth";
+import { FieldValue, userCollection, ouraConnectedRegistryDoc } from "../../db";
+import * as ouraSecrets from "../../lib/ouraSecrets";
+import {
+  refreshOuraAccessToken,
+  fetchOuraSleep,
+  fetchOuraDailyReadiness,
+  mapOuraSleepToIngestItem,
+  mapOuraReadinessToHrvItem,
+  type OuraSleepIngestItem,
+  type OuraHrvIngestItem,
+  OuraApiError,
+} from "../../lib/ouraApi";
+import { writeOuraRawEvents } from "../../lib/ouraIngestWrite";
+import { writeFailure } from "../../lib/writeFailure";
+import { logger } from "../../lib/logger";
+
+const router = Router();
+
+/** Pull last N days of data (sleep + readiness). */
+const WINDOW_DAYS = 30;
+
+export type OuraPullNowResult = { statusCode: number; body: Record<string, unknown> };
+
+function getRequestId(req: Request): string {
+  return (req as AuthedRequest).rid ?? (req.header("x-request-id") ?? "unknown").toString();
+}
+
+function getIdempotencyKey(req: Request): string | undefined {
+  const fromHeader =
+    (typeof req.header("Idempotency-Key") === "string" ? req.header("Idempotency-Key") : undefined) ??
+    (typeof req.header("X-Idempotency-Key") === "string" ? req.header("X-Idempotency-Key") : undefined);
+  return fromHeader?.trim() || undefined;
+}
+
+function toYmd(date: Date): string {
+  const y = date.getUTCFullYear();
+  const m = (date.getUTCMonth() + 1).toString().padStart(2, "0");
+  const d = date.getUTCDate().toString().padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+async function performReconnectCleanupBestEffort(
+  uid: string,
+  requestId: string,
+): Promise<void> {
+  try {
+    await ouraSecrets.deleteRefreshToken(uid);
+    await userCollection(uid, "integrations").doc("oura").set(
+      {
+        connected: false,
+        revoked: false,
+        failureState: {
+          code: "OURA_REFRESH_TOKEN_INVALID",
+          message: "Oura connection expired. Please reconnect.",
+          lastOccurredAt: FieldValue.serverTimestamp(),
+        },
+      },
+      { merge: true },
+    );
+    await ouraConnectedRegistryDoc(uid).delete();
+  } catch (cleanupErr) {
+    const sanitized = cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr);
+    logger.error({
+      msg: "oura_pull_now_reconnect_cleanup_error",
+      uid,
+      requestId,
+      err: sanitized,
+    });
+  }
+}
+
+/**
+ * Core Oura sync: refresh token → fetch sleep + HRV → write raw events → update lastSyncAt.
+ * Used by POST /integrations/oura/pull-now and by callback after successful connect (fire-and-forget).
+ */
+export async function performOuraPullNowCore(
+  uid: string,
+  requestId: string,
+): Promise<OuraPullNowResult> {
+  const refreshToken = await ouraSecrets.getRefreshToken(uid);
+  if (!refreshToken) {
+    logger.error({ msg: "oura_pull_now_no_refresh_token", rid: requestId, uid });
+    try {
+      await writeFailure({
+        userId: uid,
+        source: "ingestion",
+        stage: "oura.pullNow",
+        reasonCode: "OURA_NOT_CONNECTED",
+        message: "No Oura refresh token; connect Oura first",
+        day: toYmd(new Date()),
+        details: {},
+        requestId,
+      });
+    } catch {
+      // best-effort
+    }
+    return {
+      statusCode: 502,
+      body: {
+        ok: false as const,
+        error: {
+          code: "OURA_NOT_CONNECTED" as const,
+          message: "Oura not connected. Connect Oura in Settings first.",
+          requestId,
+        },
+      },
+    };
+  }
+
+  const clientId = process.env.OURA_CLIENT_ID?.trim();
+  let clientSecret: string | null = null;
+  try {
+    clientSecret = await ouraSecrets.getClientSecret();
+  } catch {
+    // fall through
+  }
+
+  if (!clientId || !clientSecret) {
+    logger.error({ msg: "oura_pull_now_misconfig", rid: requestId, hasClientId: !!clientId });
+    return {
+      statusCode: 500,
+      body: {
+        ok: false as const,
+        error: {
+          code: "SERVER_MISCONFIG" as const,
+          message: "Oura OAuth not configured",
+          requestId,
+        },
+      },
+    };
+  }
+
+  let accessToken: string;
+  try {
+    const tokens = await refreshOuraAccessToken(refreshToken, clientId, clientSecret);
+    accessToken = tokens.access_token;
+    await ouraSecrets.setRefreshToken(uid, tokens.refresh_token);
+  } catch (err) {
+    const isUnauth = err instanceof OuraApiError && (err.status === 401 || err.code === "OURA_TOKEN_REFRESH_FAILED");
+    if (isUnauth) {
+      await performReconnectCleanupBestEffort(uid, requestId);
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error({ msg: "oura_pull_now_token_refresh_failed", rid: requestId, uid, err: message });
+    try {
+      await writeFailure({
+        userId: uid,
+        source: "ingestion",
+        stage: "oura.pullNow",
+        reasonCode: "OURA_TOKEN_REFRESH_FAILED",
+        message,
+        day: toYmd(new Date()),
+        details: {},
+        requestId,
+      });
+    } catch {
+      // best-effort
+    }
+    return {
+      statusCode: 502,
+      body: {
+        ok: false as const,
+        error: {
+          code: "OURA_FETCH_FAILED" as const,
+          message: "Could not refresh Oura token. Try reconnecting Oura.",
+          requestId,
+        },
+      },
+    };
+  }
+
+  const endDate = new Date();
+  const startDate = new Date(endDate);
+  startDate.setUTCDate(startDate.getUTCDate() - WINDOW_DAYS);
+  const startStr = toYmd(startDate);
+  const endStr = toYmd(endDate);
+
+  let sleepItems: OuraSleepIngestItem[];
+  let hrvItems: OuraHrvIngestItem[];
+
+  try {
+    const [sleepDocs, readinessDocs] = await Promise.all([
+      fetchOuraSleep(accessToken, startStr, endStr),
+      fetchOuraDailyReadiness(accessToken, startStr, endStr),
+    ]);
+    sleepItems = sleepDocs.map(mapOuraSleepToIngestItem).filter((x): x is OuraSleepIngestItem => x !== null);
+    hrvItems = readinessDocs.map(mapOuraReadinessToHrvItem).filter((x): x is OuraHrvIngestItem => x !== null);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const code = err instanceof OuraApiError ? err.code : "OURA_FETCH_FAILED";
+    logger.error({ msg: "oura_pull_now_fetch_failed", rid: requestId, uid, code, err: message });
+    try {
+      await writeFailure({
+        userId: uid,
+        source: "ingestion",
+        stage: "oura.pullNow",
+        reasonCode: code,
+        message,
+        day: toYmd(new Date()),
+        details: {},
+        requestId,
+      });
+    } catch {
+      // best-effort
+    }
+    return {
+      statusCode: 502,
+      body: {
+        ok: false as const,
+        error: {
+          code: "OURA_FETCH_FAILED" as const,
+          message: "Failed to fetch Oura data",
+          requestId,
+        },
+      },
+    };
+  }
+
+  const { eventsCreated, eventsAlreadyExists } = await writeOuraRawEvents(
+    uid,
+    sleepItems,
+    hrvItems,
+    requestId,
+  );
+
+  try {
+    const integrationRef = userCollection(uid, "integrations").doc("oura");
+    await integrationRef.set(
+      { lastSyncAt: FieldValue.serverTimestamp() },
+      { merge: true },
+    );
+  } catch (metaErr) {
+    logger.error({
+      msg: "oura_pull_now_metadata_error",
+      uid,
+      requestId,
+      err: metaErr instanceof Error ? metaErr.message : String(metaErr),
+    });
+    return {
+      statusCode: 500,
+      body: {
+        ok: false as const,
+        error: {
+          code: "INTERNAL" as const,
+          message: "Failed to update lastSyncAt",
+          requestId,
+        },
+      },
+    };
+  }
+
+  return {
+    statusCode: 200,
+    body: {
+      ok: true as const,
+      requestId,
+      windowDays: WINDOW_DAYS,
+      eventsCreated,
+      eventsAlreadyExists,
+    },
+  };
+}
+
+router.post("/", async (req: Request, res: Response) => {
+  const requestId = getRequestId(req);
+  const uid = (req as AuthedRequest).uid;
+
+  if (!uid) {
+    return res.status(401).json({
+      ok: false as const,
+      error: { code: "UNAUTHORIZED" as const, message: "Unauthorized", requestId },
+    });
+  }
+
+  const idempotencyKey = getIdempotencyKey(req);
+  if (!idempotencyKey) {
+    return res.status(400).json({
+      ok: false as const,
+      error: {
+        code: "BAD_REQUEST" as const,
+        message: "Idempotency-Key header is required for pull-now",
+        requestId,
+      },
+    });
+  }
+
+  const recordRef = userCollection(uid, "requestRecords").doc(idempotencyKey);
+
+  try {
+    await recordRef.create({
+      kind: "oura.pullNow",
+      windowDays: WINDOW_DAYS,
+      status: "in_progress",
+      createdAt: FieldValue.serverTimestamp(),
+    });
+  } catch (createErr: unknown) {
+    const isAlreadyExists =
+      createErr &&
+      typeof createErr === "object" &&
+      "code" in createErr &&
+      (createErr as { code?: number }).code === 6;
+
+    if (!isAlreadyExists) throw createErr;
+
+    const existing = await recordRef.get();
+    const data = existing.exists ? existing.data() : undefined;
+    const status = data?.status;
+    const statusCode = data?.statusCode as number | undefined;
+    const result = data?.result as Record<string, unknown> | undefined;
+
+    if (status === "complete" && typeof statusCode === "number" && result && typeof result === "object") {
+      const body = { ...result, requestId } as Record<string, unknown>;
+      if (body.error && typeof body.error === "object" && body.error !== null) {
+        body.error = { ...(body.error as Record<string, unknown>), requestId };
+      }
+      return res.status(statusCode).json(body);
+    }
+
+    return res.status(409).json({
+      ok: false as const,
+      error: {
+        code: "CONFLICT" as const,
+        message: "Request already in progress",
+        requestId,
+      },
+    });
+  }
+
+  const result = await performOuraPullNowCore(uid, requestId);
+  await recordRef.set(
+    {
+      status: "complete",
+      statusCode: result.statusCode,
+      result: result.body,
+      completedAt: FieldValue.serverTimestamp(),
+    },
+    { merge: true },
+  );
+  return res.status(result.statusCode).json(result.body);
+});
+
+export default router;


### PR DESCRIPTION
…unify device sync UI

- Trigger Oura sync automatically after successful OAuth callback
- Reuse performOuraPullNowCore for background sync
- Remove app-side 'Sync now' button for Oura
- Add Oura API client + shared ingest writer
- Add pull-now endpoint and tests
- Update gateway OpenAPI to expose /integrations/oura/pull-now
- Add Oura auto-sync verification docs
- UI polish: render Last sync inside card style for devices