### PR TITLE
feat(oura): foreground auto-refresh + scheduled background sync

### DIFF
--- a/app/(app)/settings/devices.tsx
+++ b/app/(app)/settings/devices.tsx
@@ -1,6 +1,6 @@
 // app/(app)/settings/devices.tsx
 import React, { useState, useEffect, useCallback, useRef } from "react";
-import { View, Text, Pressable, StyleSheet, ScrollView } from "react-native";
+import { View, Text, Pressable, StyleSheet, ScrollView, AppState } from "react-native";
 import { useRouter } from "expo-router";
 import { useFocusEffect } from "@react-navigation/native";
 import { Ionicons } from "@expo/vector-icons";
@@ -10,11 +10,20 @@ import { useWithingsPresence } from "@/lib/data/useWithingsPresence";
 import { useOuraPresence } from "@/lib/data/useOuraPresence";
 import { useAuth } from "@/lib/auth/AuthProvider";
 import { getAppleHealthStatus } from "@/lib/api/appleHealth";
+import { postOuraPullNow } from "@/lib/api/oura";
 import { getAppleHealthConnected } from "@/lib/integrations/appleHealth/storage";
 import { getWithingsLastKnownConnected } from "@/lib/integrations/withings/storage";
-import { getOuraLastKnownConnected } from "@/lib/integrations/oura/storage";
+import {
+  getOuraLastKnownConnected,
+  getOuraLastCheckedAt,
+  setOuraLastCheckedAt,
+} from "@/lib/integrations/oura/storage";
+import { shouldRun, nowIso } from "@/lib/sync/throttle";
 
 type AppleHealthStatus = "loading" | "connected" | "not_connected" | "error";
+
+/** Throttle: do not call pull-now again if last attempt was within this many ms. */
+const OURA_AUTO_MIN_MS = 15 * 60 * 1000;
 
 function DevicesScreen() {
   const router = useRouter();
@@ -56,6 +65,25 @@ function DevicesScreen() {
     }
   }, [user, getIdToken]);
 
+  const maybeAutoOuraPullNow = useCallback(
+    async (reason: "focus" | "foreground") => {
+      if (!user) return;
+      if (!(ouraPresence.status === "ready" && ouraPresence.data?.connected)) return;
+      const last = await getOuraLastCheckedAt().catch(() => null);
+      if (!shouldRun(last, OURA_AUTO_MIN_MS)) return;
+      const token = await getIdToken(false);
+      if (!token) return;
+      const idempotencyKey = `ouraPullNow:auto:${reason}:${Date.now()}`;
+      try {
+        await postOuraPullNow(token, { idempotencyKey });
+      } finally {
+        await setOuraLastCheckedAt(nowIso()).catch(() => undefined);
+        ouraPresence.refetch({ cacheBust: `ouraAuto:${reason}:${Date.now()}` });
+      }
+    },
+    [user, ouraPresence, getIdToken],
+  );
+
   useFocusEffect(
     useCallback(() => {
       getWithingsLastKnownConnected().then((connected) => {
@@ -67,8 +95,16 @@ function DevicesScreen() {
       presence.refetch();
       ouraPresence.refetch();
       void fetchAppleStatus();
-    }, [presence, ouraPresence, fetchAppleStatus]),
+      void maybeAutoOuraPullNow("focus");
+    }, [presence, ouraPresence, fetchAppleStatus, maybeAutoOuraPullNow]),
   );
+
+  useEffect(() => {
+    const sub = AppState.addEventListener("change", (state) => {
+      if (state === "active") void maybeAutoOuraPullNow("foreground");
+    });
+    return () => sub.remove();
+  }, [maybeAutoOuraPullNow]);
 
   useEffect(() => {
     void fetchAppleStatus();

--- a/app/(app)/settings/devices/__tests__/devices-status.test.tsx
+++ b/app/(app)/settings/devices/__tests__/devices-status.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Devices list — integration status display.
- * Verifies screen renders; status flow fixes (refetch on focus, Apple Health try/catch, Withings error state) are in implementation.
+ * Verifies screen renders; refetch on focus; Oura auto-refresh (throttled) when connected.
  */
 import React from "react";
 import { act } from "react";
@@ -8,12 +8,27 @@ import renderer from "react-test-renderer";
 import { allowConsoleForThisTest } from "../../../../../scripts/test/consoleGuard";
 import DevicesScreen from "../../devices";
 
+const mockPostOuraPullNow = jest.fn().mockResolvedValue({
+  ok: true,
+  requestId: "req-oura",
+  windowDays: 30,
+  eventsCreated: 0,
+  eventsAlreadyExists: 0,
+});
+const mockGetOuraLastCheckedAt = jest.fn().mockResolvedValue(null);
+const mockSetOuraLastCheckedAt = jest.fn().mockResolvedValue(undefined);
+
+let mockOuraConnected = false;
+
 jest.mock("react-native", () => ({
   View: "View",
   Text: "Text",
   Pressable: "Pressable",
   ScrollView: "ScrollView",
   StyleSheet: { create: (s: unknown) => s },
+  AppState: {
+    addEventListener: jest.fn(() => ({ remove: jest.fn() })),
+  },
 }));
 
 jest.mock("@react-navigation/native", () => ({
@@ -44,9 +59,15 @@ jest.mock("@/lib/data/useWithingsPresence", () => ({
 jest.mock("@/lib/data/useOuraPresence", () => ({
   useOuraPresence: () => ({
     status: "ready",
-    data: { connected: false, lastSyncAt: null },
+    data: { connected: mockOuraConnected, lastSyncAt: null },
     refetch: jest.fn(),
   }),
+}));
+
+jest.mock("@/lib/api/oura", () => ({
+  getOuraConnectUrl: jest.fn(),
+  postOuraRevoke: jest.fn(),
+  postOuraPullNow: (...args: unknown[]) => mockPostOuraPullNow(...args),
 }));
 
 jest.mock("@expo/vector-icons", () => ({
@@ -67,10 +88,16 @@ jest.mock("@/lib/integrations/withings/storage", () => ({
 
 jest.mock("@/lib/integrations/oura/storage", () => ({
   getOuraLastKnownConnected: jest.fn(() => Promise.resolve(null)),
+  getOuraLastCheckedAt: (...args: unknown[]) => mockGetOuraLastCheckedAt(...args),
+  setOuraLastCheckedAt: (...args: unknown[]) => mockSetOuraLastCheckedAt(...args),
 }));
 
 describe("DevicesScreen", () => {
   beforeEach(() => {
+    mockOuraConnected = false;
+    mockGetOuraLastCheckedAt.mockResolvedValue(null);
+    mockPostOuraPullNow.mockClear();
+    mockSetOuraLastCheckedAt.mockClear();
     (global as unknown as { fetch: unknown }).fetch = jest.fn(() =>
       Promise.resolve({
         ok: true,
@@ -105,5 +132,53 @@ describe("DevicesScreen", () => {
     const json = tree!.toJSON() as { children?: unknown[] } | null;
     const str = JSON.stringify(json);
     expect(str).toContain("Oura");
+  });
+
+  describe("Oura auto-refresh", () => {
+    it("calls postOuraPullNow when Oura is connected and lastCheckedAt is null", async () => {
+      mockOuraConnected = true;
+      mockGetOuraLastCheckedAt.mockResolvedValue(null);
+      await act(async () => {
+        renderer.create(<DevicesScreen />);
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockPostOuraPullNow).toHaveBeenCalled();
+      expect(mockSetOuraLastCheckedAt).toHaveBeenCalled();
+    });
+
+    it("does not call postOuraPullNow when Oura is disconnected", async () => {
+      mockOuraConnected = false;
+      mockGetOuraLastCheckedAt.mockResolvedValue(null);
+      await act(async () => {
+        renderer.create(<DevicesScreen />);
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockPostOuraPullNow).not.toHaveBeenCalled();
+    });
+
+    it("does not call postOuraPullNow when lastCheckedAt is recent (throttle)", async () => {
+      mockOuraConnected = true;
+      mockGetOuraLastCheckedAt.mockResolvedValue(new Date().toISOString());
+      await act(async () => {
+        renderer.create(<DevicesScreen />);
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockPostOuraPullNow).not.toHaveBeenCalled();
+    });
   });
 });

--- a/docs/90_audits/OURA_SCHEDULED_SYNC_PATTERN_AUDIT.md
+++ b/docs/90_audits/OURA_SCHEDULED_SYNC_PATTERN_AUDIT.md
@@ -1,0 +1,176 @@
+# Audit: Existing background/scheduled sync pattern to reuse for Oura
+
+**Scope:** Evidence-only audit of repo to identify the exact pattern for scheduled pull; no code changes. Outcome: pattern to mirror for Oura scheduled sync.
+
+---
+
+## 1. Proven existing pattern: Withings scheduled pull
+
+### 1.1 Component triggered on a schedule
+
+| Item | Evidence (file path + symbol) |
+|------|-------------------------------|
+| **Scheduler** | `services/functions/src/withings/onWithingsPullScheduled.ts` — exported `onWithingsPullScheduled` |
+| **Trigger type** | Firebase Gen2 `onSchedule` from `firebase-functions/v2/scheduler` |
+| **Schedule** | `every 15 minutes` |
+| **Region** | `us-central1` |
+| **Service account** | `oli-functions-runtime@oli-staging-fdbba.iam.gserviceaccount.com` (hardcoded in options) |
+| **Behavior** | Reads `OLI_API_BASE_URL`, then `GoogleAuth().getIdTokenClient(baseUrl)` and POSTs to `baseUrl/integrations/withings/pull` with empty body `{}`. Logs `withings_pull_scheduled_start`, then on success `withings_pull_scheduled_done` with status, ok, usersProcessed, eventsCreated; on failure throws after logging. |
+
+### 1.2 How it authenticates
+
+| Item | Evidence |
+|------|----------|
+| **Mechanism** | ID token for the Cloud Run API base URL. `GoogleAuth` from `google-auth-library`; `getIdTokenClient(baseUrl)` returns a client that attaches a Bearer ID token with audience = baseUrl. |
+| **API protection** | Route mounted with `requireInvokerAuth` middleware only (no user auth). |
+| **Middleware** | `services/api/src/middleware/invokerAuth.ts` — `requireInvokerAuth`. Accepts (1) `x-goog-authenticated-user-email` (Cloud Run IAM-injected) or (2) `Authorization: Bearer <Google-signed ID token>` verified with `verifyIdToken` (audience + allowlist). |
+| **Allowlist** | `WITHINGS_PULL_INVOKER_EMAILS` (comma-separated emails) and/or `WITHINGS_PULL_INVOKER_SUBS` (comma-separated subs). Production: fail-closed if allowlist empty. |
+| **Audience** | `INVOKER_TOKEN_AUDIENCE` (required in prod for Bearer path). Scheduler uses same SA; token audience = Cloud Run service URL. |
+
+### 1.3 How it finds connected users
+
+| Item | Evidence |
+|------|----------|
+| **Registry** | `services/api/src/db.ts` — `withingsConnectedRegistryCollection()` returns `db.collection("system").doc("integrations").collection("withings_connected")`. |
+| **Path** | `system/integrations/withings_connected/{uid}`. Doc fields: `{ connected: true, updatedAt }`. On revoke, doc is deleted. |
+| **Query** | `services/api/src/routes/withingsPull.ts` — `getConnectedWithingsUids()`: `withingsConnectedRegistryCollection().get()`, then for each doc where `data?.connected === true` push `doc.id` (uid). Returns `string[]`. |
+
+### 1.4 How it iterates users safely
+
+| Item | Evidence |
+|------|----------|
+| **Loop** | `for (const uid of uids)` in `withingsPull.ts` router. No batching; sequential. |
+| **Per user** | For each uid: `fetchWithingsMeasures(uid, startMs, endMs)` (72h window). On throw: `writeFailure(..., stage: "withings.pull", ...)`, increment failuresWritten or failureWriteErrors, `continue`. On success: write RawEvents (create; on exists count as eventsAlreadyExists). No per-user request record; idempotency via RawEvent doc id. |
+| **Aggregation** | Counters: usersProcessed, eventsCreated, eventsAlreadyExists, failuresWritten, failureWriteErrors. Returned in 200 JSON. |
+
+### 1.5 How it records failures
+
+| Item | Evidence |
+|------|----------|
+| **Write** | `writeFailure` from `services/api/src/lib/writeFailure.ts` (userId, source, stage, reasonCode, message, day, details, etc.). |
+| **Stages** | `withings.pull` (fetch error), `withings.pull.schema` (schema validation), `withings.pull.write` (write error). |
+| **No silent drop** | On failure to write FailureEntry, `failureWriteErrors` incremented and `logger.error` with `withings_pull_failure_write_error`. |
+
+### 1.6 How it updates integration metadata
+
+| Item | Evidence |
+|------|----------|
+| **Withings pull** | Withings invoker pull does **not** update `users/{uid}/integrations/withings` (no lastSyncAt in that route). It only writes raw events and FailureEntry. Status/lastMeasurementAt for Withings come from elsewhere (e.g. status endpoint reading integration doc or derived from raw events). |
+| **Oura today** | `performOuraPullNowCore` in `ouraPullNow.ts` updates `users/{uid}/integrations/oura` with `lastSyncAt: FieldValue.serverTimestamp()` on success. So an invoker route that calls this core would get lastSyncAt updated. |
+
+### 1.7 API route registration and infra
+
+| Item | Evidence |
+|------|----------|
+| **Mount** | `services/api/src/index.ts`: `app.use("/integrations/withings/pull", requireInvokerAuth, withingsPullRouter);` — no authMiddleware; invoker only. |
+| **Gateway** | `integrations/withings/pull` is **not** in `infra/gateway/openapi.yaml`. Scheduler calls Cloud Run URL directly (by design; see PHASE_3_PRINCIPAL_AUDIT_REPORT.md). |
+| **Deploy** | No dedicated script in `scripts/deploy` for the schedule. Scheduler is created when Firebase Functions (Gen2) are deployed; `onSchedule` registers with Cloud Scheduler. |
+
+### 1.8 Related: Withings backfill (scheduled resume)
+
+| Item | Evidence |
+|------|----------|
+| **Function** | `services/functions/src/withings/onWithingsBackfillScheduled.ts` — `onWithingsBackfillScheduled`, same schedule/region/SA, POSTs to `baseUrl/integrations/withings/backfill` with body `{ mode: "resume", yearsBack, chunkDays, maxChunks }`. |
+| **API** | `services/api/src/routes/withingsBackfill.ts` — invoker-only, reads backfill state from `users/{uid}/integrations/withings.backfill`, only processes status running/error; different use case (historical backfill). |
+| **Oura** | No backfill in repo for Oura; only pull-now and callback-triggered first sync. Scheduled Oura would be “recent window” pull only, analogous to Withings **pull** (not backfill). |
+
+---
+
+## 2. Why this is the closest fit for Oura
+
+- **Same product shape:** “Pull recent data for all connected users on a schedule.” Withings pull = 72h for all connected; Oura = last N days (e.g. 30) for all connected.
+- **Same auth model:** Invoker-only route; scheduler uses same pattern (getIdTokenClient(apiBase), POST with no user token). Same `requireInvokerAuth` and allowlist (or Oura-specific env if desired).
+- **Same registry shape:** `ouraConnectedRegistryCollection()` exists in `db.ts` — path `system/integrations/oura_connected/{uid}`. Same pattern as Withings for “get all connected uids.”
+- **Core already exists:** `performOuraPullNowCore(uid, requestId)` in `ouraPullNow.ts` does token refresh, fetch sleep+HRV, write raw events, update lastSyncAt. Invoker route only needs to: get uids from registry, loop, call core, aggregate counts and handle errors (writeFailure on failure, continue).
+- **No backfill needed for MVP:** Withings has separate backfill (historical) and pull (recent). Oura has no backfill in repo; scheduled “pull” is the only scheduled job to add.
+
+---
+
+## 3. Exact files to add or modify for Oura
+
+### 3.1 API (invoker-only route)
+
+| Action | File | Purpose |
+|--------|------|---------|
+| **Add** | `services/api/src/routes/ouraPull.ts` | New router: GET connected UIDs from `ouraConnectedRegistryCollection()`, for each uid call `performOuraPullNowCore(uid, requestId)`, aggregate usersProcessed/eventsCreated/eventsAlreadyExists and failures; return 200 JSON. Use same structure as `withingsPull.ts` (getConnectedUids, loop, writeFailure on error, no requestRecords). Generate a single requestId per request (e.g. from req or uuid). |
+| **Modify** | `services/api/src/index.ts` | Mount: `app.use("/integrations/oura/pull", requireInvokerAuth, ouraPullRouter);` (same order as Withings: requireInvokerAuth then router). |
+| **Do not add** | `infra/gateway/openapi.yaml` | Invoker route not exposed via gateway; scheduler calls Cloud Run directly (match Withings). |
+
+### 3.2 Functions (scheduler)
+
+| Action | File | Purpose |
+|--------|------|---------|
+| **Add** | `services/functions/src/oura/onOuraPullScheduled.ts` | New scheduled function: same pattern as `onWithingsPullScheduled` — `onSchedule({ schedule: "every 15 minutes", region: "us-central1", serviceAccount: same SA })`, `OLI_API_BASE_URL`, `getIdTokenClient(baseUrl)`, POST `baseUrl/integrations/oura/pull`, log start/done/fail. |
+| **Modify** | `services/functions/src/index.ts` | Import and export `onOuraPullScheduled`. |
+
+### 3.3 Invoker auth
+
+| Option | Files | Note |
+|--------|-------|------|
+| **A. Reuse allowlist** | None | Keep using `WITHINGS_PULL_INVOKER_EMAILS` / `WITHINGS_PULL_INVOKER_SUBS`. Same SA calls both Withings and Oura pull; no new env. |
+| **B. Oura-specific allowlist** | `services/api/src/middleware/invokerAuth.ts` | Add `OURA_PULL_INVOKER_EMAILS` / `OURA_PULL_INVOKER_SUBS` and a separate middleware or branch that checks path + allowlist. More config, same security. |
+
+Recommendation: **Option A** (reuse) unless you need separate allowlists.
+
+### 3.4 Tests
+
+| Action | File | Purpose |
+|--------|------|---------|
+| **Add** | `services/api/src/routes/__tests__/oura.pull.test.ts` | Invoker auth required; 403 without invoker; with mock invoker identity and mock registry/core, expect 200 and counts. Mirror `withings.pull.test.ts`. |
+| **Add** | `services/functions/src/oura/__tests__/onOuraPullScheduled.test.ts` | Export exists and is scheduled trigger (mirror `onWithingsBackfillScheduled.test.ts`). |
+
+### 3.5 Scripts / infra
+
+| Action | File | Purpose |
+|--------|------|---------|
+| **None** | `scripts/deploy` | No change; Functions deploy creates the schedule. |
+| **None** | `infra/` | No new Terraform for scheduler; same as Withings. |
+
+---
+
+## 4. Smallest production-safe implementation plan
+
+1. **API: invoker route**  
+   Add `ouraPull.ts`: get UIDs from `ouraConnectedRegistryCollection()`, loop, call `performOuraPullNowCore(uid, requestId)` for each, on error call `writeFailure(..., stage: "oura.pull", ...)` and continue; aggregate and return `{ ok: true, usersProcessed, eventsCreated, eventsAlreadyExists, failuresWritten, failureWriteErrors }`. Mount under `requireInvokerAuth` at `POST /integrations/oura/pull`.
+
+2. **Functions: scheduler**  
+   Add `onOuraPullScheduled.ts`: same schedule/region/SA as Withings pull, POST to `OLI_API_BASE_URL/integrations/oura/pull` with ID token client. Export in `index.ts`.
+
+3. **Auth**  
+   Use existing `requireInvokerAuth` and existing allowlist (same SA as Withings pull). No new env for MVP.
+
+4. **Tests**  
+   Add API test for `POST /integrations/oura/pull` (invoker required, mock registry and core). Add Functions test that scheduler export exists and is scheduled.
+
+5. **No gateway change**  
+   Do not add `/integrations/oura/pull` to openapi.yaml; invoker calls Cloud Run directly.
+
+6. **Failure and metadata**  
+   Reuse `writeFailure` with stage `oura.pull` (and sub-stages if needed). `performOuraPullNowCore` already updates `lastSyncAt` on success; no extra metadata step in the invoker route.
+
+---
+
+## Summary table
+
+| Aspect | Withings (existing) | Oura (to add) |
+|--------|---------------------|---------------|
+| **Scheduler** | `onWithingsPullScheduled` (Functions) | `onOuraPullScheduled` (Functions) |
+| **API route** | `POST /integrations/withings/pull` (invoker) | `POST /integrations/oura/pull` (invoker) |
+| **Registry** | `withingsConnectedRegistryCollection()` | `ouraConnectedRegistryCollection()` |
+| **Core logic** | Inline in withingsPull (fetchWithingsMeasures, write raw) | `performOuraPullNowCore(uid, requestId)` (existing) |
+| **Auth** | `requireInvokerAuth`, WITHINGS_PULL_INVOKER_* | Same middleware; reuse allowlist or add OURA_* |
+| **Failure** | `writeFailure`, stage withings.pull* | `writeFailure`, stage oura.pull* |
+| **Metadata** | Withings pull does not set lastSyncAt | Core sets lastSyncAt on success |
+| **Gateway** | Not in openapi | Not in openapi |
+
+---
+
+## Exact next implementation task
+
+Implement **scheduled Oura pull** by:
+
+1. Adding **`services/api/src/routes/ouraPull.ts`** (invoker-only): query `ouraConnectedRegistryCollection()` for connected UIDs; for each uid call `performOuraPullNowCore(uid, requestId)`; on failure call `writeFailure` with stage `oura.pull` and continue; return 200 with usersProcessed, eventsCreated, eventsAlreadyExists, failuresWritten, failureWriteErrors.
+2. Mounting it in **`services/api/src/index.ts`** with `app.use("/integrations/oura/pull", requireInvokerAuth, ouraPullRouter)`.
+3. Adding **`services/functions/src/oura/onOuraPullScheduled.ts`**: `onSchedule` every 15 minutes, same region/SA as Withings pull, POST to `OLI_API_BASE_URL/integrations/oura/pull` via `getIdTokenClient(baseUrl)`; export in **`services/functions/src/index.ts`**.
+4. Adding tests: **`services/api/src/routes/__tests__/oura.pull.test.ts`** and **`services/functions/src/oura/__tests__/onOuraPullScheduled.test.ts`** (contract: export exists, is scheduled).
+5. Leaving gateway and invoker allowlist unchanged (reuse WITHINGS_PULL_INVOKER_* for the same SA).

--- a/lib/api/oura.ts
+++ b/lib/api/oura.ts
@@ -4,7 +4,7 @@
  */
 
 import type { ApiResult } from "@/lib/api/http";
-import type { GetOptions } from "@/lib/api/http";
+import type { GetOptions, PostOptions } from "@/lib/api/http";
 import { apiGetZodAuthed, apiPostZodAuthed } from "@/lib/api/validate";
 import { z } from "zod";
 
@@ -27,6 +27,41 @@ const ouraRevokeResponseSchema = z.object({
 });
 
 export type OuraStatusResponse = z.infer<typeof ouraStatusResponseSchema>;
+
+export type OuraPullNowResponse = {
+  ok: true;
+  requestId: string;
+  windowDays: number;
+  eventsCreated: number;
+  eventsAlreadyExists: number;
+};
+
+const ouraPullNowResponseSchema = z.object({
+  ok: z.literal(true),
+  requestId: z.string(),
+  windowDays: z.number(),
+  eventsCreated: z.number(),
+  eventsAlreadyExists: z.number(),
+});
+
+/** POST /integrations/oura/pull-now — sync sleep + HRV from Oura for authed user; requires Idempotency-Key. */
+export async function postOuraPullNow(
+  idToken: string,
+  opts?: PostOptions,
+): Promise<ApiResult<OuraPullNowResponse>> {
+  return apiPostZodAuthed(
+    "/integrations/oura/pull-now",
+    {},
+    idToken,
+    ouraPullNowResponseSchema,
+    {
+      timeoutMs: 30000,
+      noStore: true,
+      ...(opts?.cacheBust ? { cacheBust: opts.cacheBust } : {}),
+      ...(opts?.idempotencyKey ? { idempotencyKey: opts.idempotencyKey } : {}),
+    },
+  );
+}
 
 function truthGetOpts(opts?: GetOptions): GetOptions {
   return { noStore: true as const, ...(opts?.cacheBust ? { cacheBust: opts.cacheBust } : {}) };

--- a/scripts/ci/check-invariants.mjs
+++ b/scripts/ci/check-invariants.mjs
@@ -139,16 +139,17 @@ function checkApiIdempotency() {
   const routesDir = path.join(ROOT, "services", "api", "src", "routes");
   if (!exists(routesDir)) return;
 
-  const IDEMPOTENCY_POST_EXEMPT_FILES = new Set(["withingsPull.ts", "withingsBackfill.ts"]);
+  const IDEMPOTENCY_POST_EXEMPT_FILES = new Set(["withingsPull.ts", "withingsBackfill.ts", "ouraPull.ts"]);
   const EXEMPT_FILE_TO_MOUNT_PATH = new Map([
     ["withingsPull.ts", "/integrations/withings/pull"],
     ["withingsBackfill.ts", "/integrations/withings/backfill"],
+    ["ouraPull.ts", "/integrations/oura/pull"],
   ]);
   for (const basename of IDEMPOTENCY_POST_EXEMPT_FILES) {
     const mountPath = EXEMPT_FILE_TO_MOUNT_PATH.get(basename);
-    if (!mountPath || !mountPath.startsWith("/integrations/") || !mountPath.includes("withings")) {
+    if (!mountPath || !mountPath.startsWith("/integrations/")) {
       fail(
-        `CHECK 3 (API idempotency): exempt file "${basename}" must have a mount path in EXEMPT_FILE_TO_MOUNT_PATH starting with /integrations/ and including "withings".`,
+        `CHECK 3 (API idempotency): exempt file "${basename}" must have a mount path in EXEMPT_FILE_TO_MOUNT_PATH starting with /integrations/.`,
       );
     }
   }

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -16,6 +16,7 @@ import withingsPullNowRouter from "./routes/integrations/withingsPullNow";
 import appleHealthStatusRouter from "./routes/integrations/appleHealthStatus";
 import ouraIngestRouter from "./routes/integrations/ouraIngest";
 import ouraPullNowRouter from "./routes/integrations/ouraPullNow";
+import ouraPullRouter from "./routes/ouraPull";
 import { authMiddleware } from "./middleware/auth";
 import { requireInvokerAuth } from "./middleware/invokerAuth";
 import { accessLogMiddleware, requestIdMiddleware, logger, type RequestWithRid } from "./lib/logger";
@@ -191,6 +192,7 @@ app.get("/integrations/oura/complete", (_req: Request, res: Response) => {
 });
 
 app.use("/integrations/oura/ingest", authMiddleware, ouraIngestRouter);
+app.use("/integrations/oura/pull", requireInvokerAuth, ouraPullRouter);
 app.use("/integrations/oura/pull-now", authMiddleware, ouraPullNowRouter);
 
 /**

--- a/services/api/src/routes/__tests__/oura.pull.test.ts
+++ b/services/api/src/routes/__tests__/oura.pull.test.ts
@@ -1,0 +1,135 @@
+/**
+ * POST /integrations/oura/pull: invoker auth, performOuraPullNowCore per uid, FailureEntry on error.
+ */
+
+import express from "express";
+import request from "supertest";
+import { requireInvokerAuth } from "../../middleware/invokerAuth";
+import ouraPullRouter from "../ouraPull";
+
+const mockRegistryGet = jest.fn();
+
+jest.mock("../../db", () => ({
+  ouraConnectedRegistryCollection: () => ({ get: mockRegistryGet }),
+}));
+
+const mockPerformOuraPullNowCore = jest.fn();
+
+jest.mock("../integrations/ouraPullNow", () => ({
+  performOuraPullNowCore: (...args: unknown[]) => mockPerformOuraPullNowCore(...args),
+}));
+
+jest.mock("../../lib/writeFailure", () => ({
+  writeFailure: jest.fn().mockResolvedValue(undefined),
+}));
+
+const writeFailure = require("../../lib/writeFailure");
+
+describe("POST /integrations/oura/pull", () => {
+  let app: express.Express;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as unknown as { rid: string }).rid = "req-oura-pull";
+      next();
+    });
+    app.use("/integrations/oura/pull", requireInvokerAuth, ouraPullRouter);
+  });
+
+  const registryDoc = (id: string) => ({ id, data: () => ({ connected: true }) });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.WITHINGS_PULL_INVOKER_EMAILS = "";
+    mockRegistryGet.mockResolvedValue({ docs: [] });
+  });
+
+  describe("invoker auth enforced", () => {
+    it("returns 403 when X-Goog-Authenticated-User-Email is missing", async () => {
+      const res = await request(app).post("/integrations/oura/pull");
+      expect(res.status).toBe(403);
+      expect(res.body?.error?.code).toBe("INVOKER_AUTH_REQUIRED");
+    });
+
+    it("returns 200 when header is present (no allowlist)", async () => {
+      mockRegistryGet.mockResolvedValueOnce({ docs: [] });
+      const res = await request(app)
+        .post("/integrations/oura/pull")
+        .set("x-goog-authenticated-user-email", "accounts.google.com:scheduler@project.iam.gserviceaccount.com");
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        ok: true,
+        usersProcessed: 0,
+        eventsCreated: 0,
+        eventsAlreadyExists: 0,
+        failuresWritten: 0,
+        failureWriteErrors: 0,
+      });
+    });
+  });
+
+  describe("performOuraPullNowCore per uid", () => {
+    it("aggregates eventsCreated and eventsAlreadyExists when core returns 200", async () => {
+      mockRegistryGet.mockResolvedValueOnce({ docs: [registryDoc("uid1")] });
+      mockPerformOuraPullNowCore.mockResolvedValueOnce({
+        statusCode: 200,
+        body: { ok: true, requestId: "r1", windowDays: 30, eventsCreated: 2, eventsAlreadyExists: 1 },
+      });
+
+      const res = await request(app)
+        .post("/integrations/oura/pull")
+        .set("x-goog-authenticated-user-email", "accounts.google.com:invoker@proj.iam.gserviceaccount.com");
+      expect(res.status).toBe(200);
+      expect(mockPerformOuraPullNowCore).toHaveBeenCalledWith("uid1", "req-oura-pull");
+      expect(res.body.usersProcessed).toBe(1);
+      expect(res.body.eventsCreated).toBe(2);
+      expect(res.body.eventsAlreadyExists).toBe(1);
+      expect(res.body.failuresWritten).toBe(0);
+      expect(res.body.failureWriteErrors).toBe(0);
+    });
+
+    it("writes FailureEntry and continues when core returns non-200", async () => {
+      mockRegistryGet.mockResolvedValueOnce({ docs: [registryDoc("uid1")] });
+      mockPerformOuraPullNowCore.mockResolvedValueOnce({
+        statusCode: 502,
+        body: { ok: false, error: { code: "OURA_NOT_CONNECTED", message: "Not connected" } },
+      });
+
+      const res = await request(app)
+        .post("/integrations/oura/pull")
+        .set("x-goog-authenticated-user-email", "accounts.google.com:invoker@proj.iam.gserviceaccount.com");
+      expect(res.status).toBe(200);
+      expect(writeFailure.writeFailure).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: "uid1",
+          source: "ingestion",
+          stage: "oura.pull",
+          reasonCode: "OURA_PULL_FAILED",
+        }),
+      );
+      expect(res.body.failuresWritten).toBe(1);
+      expect(res.body.failureWriteErrors).toBe(0);
+    });
+
+    it("writes FailureEntry when performOuraPullNowCore throws", async () => {
+      mockRegistryGet.mockResolvedValueOnce({ docs: [registryDoc("uid1")] });
+      mockPerformOuraPullNowCore.mockRejectedValueOnce(new Error("Network error"));
+
+      const res = await request(app)
+        .post("/integrations/oura/pull")
+        .set("x-goog-authenticated-user-email", "accounts.google.com:invoker@proj.iam.gserviceaccount.com");
+      expect(res.status).toBe(200);
+      expect(writeFailure.writeFailure).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: "uid1",
+          source: "ingestion",
+          stage: "oura.pull",
+          reasonCode: "OURA_PULL_ERROR",
+        }),
+      );
+      expect(res.body.failuresWritten).toBe(1);
+    });
+  });
+});

--- a/services/api/src/routes/ouraPull.ts
+++ b/services/api/src/routes/ouraPull.ts
@@ -1,0 +1,146 @@
+/**
+ * POST /integrations/oura/pull (invoker-only).
+ * Pulls sleep + HRV from Oura for all connected users via performOuraPullNowCore.
+ * Never uses user auth; protected by requireInvokerAuth only.
+ *
+ * Constitutional notes:
+ * - No silent drops: if failure writing fails, we log and increment failureWriteErrors.
+ * - Uses performOuraPullNowCore (shared with pull-now and callback); updates lastSyncAt on success.
+ */
+
+import { Router, type Request, type Response } from "express";
+import { ouraConnectedRegistryCollection } from "../db";
+import { performOuraPullNowCore } from "./integrations/ouraPullNow";
+import { writeFailure } from "../lib/writeFailure";
+import { logger } from "../lib/logger";
+import type { RequestWithRid } from "../lib/logger";
+
+const router = Router();
+
+function getRequestId(req: Request): string {
+  return (req as RequestWithRid).rid ?? (req.header("x-request-id") ?? "unknown").toString();
+}
+
+/** Derive day (YYYY-MM-DD) from ISO timestamp in UTC. */
+function toYmdUtc(iso: string): string {
+  const d = new Date(iso);
+  const y = d.getUTCFullYear();
+  const m = (d.getUTCMonth() + 1).toString().padStart(2, "0");
+  const day = d.getUTCDate().toString().padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+/**
+ * Get UIDs with connected Oura from registry.
+ * Path: system/integrations/oura_connected/{uid}; doc has { connected: true, updatedAt }.
+ */
+async function getConnectedOuraUids(): Promise<string[]> {
+  const snap = await ouraConnectedRegistryCollection().get();
+  const uids: string[] = [];
+  for (const doc of snap.docs) {
+    const data = doc.data();
+    if (data?.connected === true) uids.push(doc.id);
+  }
+  return uids;
+}
+
+/**
+ * POST /integrations/oura/pull
+ * Invoker-only. For each connected user, calls performOuraPullNowCore; on error writes FailureEntry and continues.
+ */
+router.post("/", async (req: Request, res: Response) => {
+  const requestId = getRequestId(req);
+  let usersProcessed = 0;
+  let eventsCreated = 0;
+  let eventsAlreadyExists = 0;
+  let failuresWritten = 0;
+  let failureWriteErrors = 0;
+
+  let uids: string[];
+  try {
+    uids = await getConnectedOuraUids();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.error({ msg: "oura_pull_query_error", err: msg, rid: requestId });
+    return res.status(500).json({
+      ok: false as const,
+      error: { code: "INTERNAL" as const, message: "Failed to query connected users" },
+    });
+  }
+
+  for (const uid of uids) {
+    usersProcessed += 1;
+
+    let result;
+    try {
+      result = await performOuraPullNowCore(uid, requestId);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      try {
+        await writeFailure({
+          userId: uid,
+          source: "ingestion",
+          stage: "oura.pull",
+          reasonCode: "OURA_PULL_ERROR",
+          message,
+          day: toYmdUtc(new Date().toISOString()),
+          details: {},
+          requestId,
+        });
+        failuresWritten += 1;
+      } catch (writeErr) {
+        failureWriteErrors += 1;
+        logger.error({
+          msg: "oura_pull_failure_write_error",
+          uid,
+          rid: requestId,
+          err: writeErr instanceof Error ? writeErr.message : String(writeErr),
+        });
+      }
+      continue;
+    }
+
+    if (result.statusCode === 200 && result.body && typeof result.body === "object") {
+      const body = result.body as { eventsCreated?: number; eventsAlreadyExists?: number };
+      eventsCreated += typeof body.eventsCreated === "number" ? body.eventsCreated : 0;
+      eventsAlreadyExists += typeof body.eventsAlreadyExists === "number" ? body.eventsAlreadyExists : 0;
+    } else {
+      const message =
+        result.body && typeof result.body === "object" && result.body.error && typeof result.body.error === "object"
+          ? String((result.body.error as { message?: unknown }).message ?? "Oura pull failed")
+          : "Oura pull failed";
+      try {
+        await writeFailure({
+          userId: uid,
+          source: "ingestion",
+          stage: "oura.pull",
+          reasonCode: "OURA_PULL_FAILED",
+          message,
+          day: toYmdUtc(new Date().toISOString()),
+          details: { statusCode: result.statusCode },
+          requestId,
+        });
+        failuresWritten += 1;
+      } catch (writeErr) {
+        failureWriteErrors += 1;
+        logger.error({
+          msg: "oura_pull_failure_write_error",
+          uid,
+          rid: requestId,
+          err: writeErr instanceof Error ? writeErr.message : String(writeErr),
+        });
+      }
+    }
+  }
+
+  return res.status(200).json({
+    ok: true as const,
+    usersProcessed,
+    eventsCreated,
+    eventsAlreadyExists,
+    failuresWritten,
+    failureWriteErrors,
+  });
+});
+
+export default router;

--- a/services/functions/src/index.ts
+++ b/services/functions/src/index.ts
@@ -37,6 +37,7 @@ import { onInsightsRecomputeScheduled } from "./insights/onInsightsRecomputeSche
 import { onDailyIntelligenceContextRecomputeScheduled } from "./intelligence/onDailyIntelligenceContextRecomputeScheduled";
 import { onWithingsBackfillScheduled } from "./withings/onWithingsBackfillScheduled";
 import { onWithingsPullScheduled } from "./withings/onWithingsPullScheduled";
+import { onOuraPullScheduled } from "./oura/onOuraPullScheduled";
 
 // Account executors (Pub/Sub)
 import { onAccountDeleteRequested } from "./account/onAccountDeleteRequested";
@@ -105,6 +106,7 @@ export { onInsightsRecomputeScheduled };
 export { onDailyIntelligenceContextRecomputeScheduled };
 export { onWithingsBackfillScheduled };
 export { onWithingsPullScheduled };
+export { onOuraPullScheduled };
 
 // Account executors (Pub/Sub)
 export { onAccountDeleteRequested };

--- a/services/functions/src/oura/__tests__/onOuraPullScheduled.test.ts
+++ b/services/functions/src/oura/__tests__/onOuraPullScheduled.test.ts
@@ -1,0 +1,23 @@
+/**
+ * Unit test: Oura pull scheduler export and contract.
+ * Ensures scheduler exists and is a scheduled trigger (invoker-only, not HTTP-callable by client).
+ */
+jest.mock("google-auth-library", () => ({
+  GoogleAuth: jest.fn().mockImplementation(() => ({
+    getIdTokenClient: jest.fn().mockResolvedValue({
+      request: jest.fn().mockResolvedValue({
+        status: 200,
+        data: { ok: true, usersProcessed: 0, eventsCreated: 0, eventsAlreadyExists: 0 },
+      }),
+    }),
+  })),
+}));
+
+import { onOuraPullScheduled } from "../onOuraPullScheduled";
+
+describe("onOuraPullScheduled", () => {
+  it("is defined and is a scheduled trigger (not HTTP callable by client)", () => {
+    expect(onOuraPullScheduled).toBeDefined();
+    expect(typeof onOuraPullScheduled.run).toBe("function");
+  });
+});

--- a/services/functions/src/oura/onOuraPullScheduled.ts
+++ b/services/functions/src/oura/onOuraPullScheduled.ts
@@ -1,0 +1,57 @@
+/**
+ * Scheduled Oura pull — sleep + HRV for all connected users.
+ * Calls POST /integrations/oura/pull (invoker-only). Same pattern as Withings pull.
+ *
+ * Requirements:
+ * - OLI_API_BASE_URL must be set (Cloud Run API base).
+ * - WITHINGS_PULL_INVOKER_EMAILS (or SUBS) on the API must include this function's service account.
+ * - Cloud Run IAM must grant roles/run.invoker to that SA.
+ */
+
+import { onSchedule } from "firebase-functions/v2/scheduler";
+import * as logger from "firebase-functions/logger";
+import { GoogleAuth } from "google-auth-library";
+
+export const onOuraPullScheduled = onSchedule(
+  {
+    schedule: "every 15 minutes",
+    region: "us-central1",
+    serviceAccount: "oli-functions-runtime@oli-staging-fdbba.iam.gserviceaccount.com",
+  },
+  async () => {
+    const baseUrl = (process.env.OLI_API_BASE_URL ?? "").trim().replace(/\/+$/, "");
+    if (!baseUrl) {
+      logger.warn("onOuraPullScheduled: OLI_API_BASE_URL not set; skipping");
+      return;
+    }
+
+    logger.info("oura_pull_scheduled_start");
+
+    const url = `${baseUrl}/integrations/oura/pull`;
+    try {
+      const auth = new GoogleAuth();
+      const client = await auth.getIdTokenClient(baseUrl);
+      const res = await client.request({
+        url,
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        data: {},
+      });
+
+      const status = res.status;
+      const data = res.data as
+        | { ok?: boolean; usersProcessed?: number; eventsCreated?: number; eventsAlreadyExists?: number }
+        | undefined;
+      logger.info("oura_pull_scheduled_done", {
+        status,
+        ok: data?.ok,
+        usersProcessed: data?.usersProcessed,
+        eventsCreated: data?.eventsCreated,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error("onOuraPullScheduled failed", { err: message });
+      throw err;
+    }
+  },
+);


### PR DESCRIPTION
Adds full autonomous Oura syncing.

Includes:
- auto-refresh when the app opens or returns to foreground (15-minute throttle)
- scheduled background sync via Firebase onSchedule
- invoker-only POST /integrations/oura/pull endpoint
- tests for scheduler and API pull route

No manual Sync button. OAuth callback auto-sync remains intact.
