### PR TITLE
Backfill Apple Health cardio distance and enable historical avg pace

### DIFF
--- a/app/(app)/workouts/__tests__/anchored-sync.test.ts
+++ b/app/(app)/workouts/__tests__/anchored-sync.test.ts
@@ -152,4 +152,38 @@ describe("anchored sync determinism", () => {
     expect(mockSetWorkoutsAnchor).toHaveBeenCalledWith("u1", "anchor-done");
     expect(mockIngest).toHaveBeenCalledTimes(1);
   });
+
+  it("includes distanceMeters on workout ingest payload when pull provides it", async () => {
+    const withDistance: TodayWorkout = { ...oneWorkout, distanceMeters: 1609.344 };
+    const mockPullAnchored = jest.fn().mockResolvedValue({
+      ok: true,
+      data: { workouts: [withDistance], anchor: "anchor-done" },
+    });
+    const mockPullToday = jest.fn().mockResolvedValue({
+      ok: true,
+      data: {
+        day: "2026-03-01",
+        steps: null,
+        exerciseMinutes: null,
+        activeEnergyKcal: null,
+        restingHeartRateBpm: null,
+        workouts: [],
+      },
+    });
+    const mockIngest = jest.fn().mockResolvedValue({ ok: true });
+
+    const deps = baseDeps({
+      pullAnchoredWorkouts: mockPullAnchored,
+      pullTodaySnapshot: mockPullToday,
+      ingestRawEvent: mockIngest,
+    });
+
+    await runAnchoredWorkoutsSync({ uid: "u1", token: "tok", limit: ANCHOR_LIMIT }, deps);
+
+    const workoutCall = (mockIngest as jest.Mock).mock.calls.find(
+      (c) => c[0]?.kind === "workout",
+    );
+    expect(workoutCall).toBeDefined();
+    expect(workoutCall![0].payload.distanceMeters).toBe(1609.344);
+  });
 });

--- a/app/(app)/workouts/__tests__/day-display.test.tsx
+++ b/app/(app)/workouts/__tests__/day-display.test.tsx
@@ -429,6 +429,68 @@ describe("WorkoutDayScreen display", () => {
     expect(JSON.stringify(test.toJSON())).toContain("Exercises");
   });
 
+  it("renders premium cardio card for a single cardio session with overview-style zones section", async () => {
+    mockUseWorkoutDayDetail.mockReturnValue({
+      status: "ready",
+      day: "2026-03-18",
+      workouts: [
+        {
+          id: "c1",
+          observedAt: "2026-03-18T12:00:00.000Z",
+          sourceId: "apple_health",
+          title: "Running",
+          start: "2026-03-18T12:00:00.000Z",
+          end: "2026-03-18T13:00:00.000Z",
+          durationMinutes: 60,
+          calories: 400,
+          workoutType: "cardio" as const,
+        },
+      ],
+    });
+
+    let test!: renderer.ReactTestRenderer;
+    act(() => {
+      test = renderer.create(<WorkoutDayScreen />);
+    });
+    const json = JSON.stringify(test.toJSON());
+    expect(json).toContain("Running");
+    expect(json).toContain("Distance");
+    expect(json).toContain("Avg Pace");
+    expect(json).toContain("Heart rate zones");
+    expect(json).toContain("Heart rate zones are not available for this workout.");
+    expect(json).not.toContain("Exercises");
+  });
+
+  it("renders zone rows when heartRateZoneMinutes is present on the workout", async () => {
+    mockUseWorkoutDayDetail.mockReturnValue({
+      status: "ready",
+      day: "2026-03-18",
+      workouts: [
+        {
+          id: "c1",
+          observedAt: "2026-03-18T12:00:00.000Z",
+          sourceId: "apple_health",
+          title: "Running",
+          start: "2026-03-18T12:00:00.000Z",
+          end: "2026-03-18T13:00:00.000Z",
+          durationMinutes: 60,
+          calories: 400,
+          workoutType: "cardio" as const,
+          heartRateZoneMinutes: [5, 10, 20, 8, 2] as const,
+        },
+      ],
+    });
+
+    let test!: renderer.ReactTestRenderer;
+    act(() => {
+      test = renderer.create(<WorkoutDayScreen />);
+    });
+    const json = JSON.stringify(test.toJSON());
+    expect(json).toContain("Zone 1");
+    expect(json).toContain("Zone 5");
+    expect(json).toContain("20 min");
+  });
+
   it("exercise history action reuses logger route pattern", async () => {
     mockUseWorkoutDayDetail.mockReturnValue({
       status: "ready",

--- a/app/(app)/workouts/day/[day].tsx
+++ b/app/(app)/workouts/day/[day].tsx
@@ -1,11 +1,13 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { ScrollView, View, Text, StyleSheet, Pressable } from "react-native";
+import { ScrollView, View, Text, StyleSheet, Pressable, Platform } from "react-native";
 import { useLocalSearchParams, useNavigation, useRouter } from "expo-router";
 import { ScreenContainer, LoadingState, ErrorState, EmptyState } from "@/lib/ui/ScreenStates";
 import { useWorkoutDayDetail } from "@/lib/data/workouts/useWorkoutsCalendar";
 import type { DayKey } from "@/lib/ui/calendar/types";
 import {
+  formatAvgPaceMinPerMileLabel,
   formatIntegerWithCommas,
+  formatWorkoutDistanceLabel,
   formatWorkoutTimeLabel,
   formatWorkoutDurationLabel,
   resolveWorkoutDisplay,
@@ -16,7 +18,7 @@ import { reconcileWorkoutSessionsForDay } from "@/lib/data/workouts/workoutSessi
 import { WorkoutActionSheet } from "@/lib/ui/WorkoutActionSheet";
 import { HeaderBackButton } from "@/lib/ui/HeaderBackButton";
 import { workoutsStackNavigationOptions } from "@/lib/ui/headers/workoutsStackHeader";
-import { WORKOUT_STRENGTH_COLOR } from "@/lib/ui/calendar/WorkoutDayRing";
+import { CARDIO_RED, WORKOUT_STRENGTH_COLOR } from "@/lib/ui/calendar/WorkoutDayRing";
 import { useAuth } from "@/lib/auth/AuthProvider";
 import {
   listManualWorkoutDaySummaries,
@@ -27,7 +29,7 @@ import { formatStrengthSetTableCells, LB_PER_KG } from "@/lib/workouts/strengthS
 import { overviewAccentForTab } from "@/lib/ui/workouts/workoutOverviewAnalyticsTheme";
 import { workoutOverviewInCardHeaderStyles } from "@/lib/ui/workouts/workoutOverviewInCardHeaderStyles";
 import type { ReconciledWorkoutSession } from "@/lib/data/workouts/workoutSessionReconciliation";
-import type { WorkoutHistoryItem } from "@/lib/data/workouts/parseWorkoutFromRawEvent";
+import type { HeartRateZoneMinutes5, WorkoutHistoryItem } from "@/lib/data/workouts/parseWorkoutFromRawEvent";
 import type { WorkoutOverride } from "@/lib/data/workouts/workoutOverrides";
 
 /** Matches exercise-history numeric accents for set grid values. */
@@ -47,14 +49,21 @@ function formatHeaderDate(dayKey: string): string {
   return `${weekday} ${rest}`;
 }
 
-function formatMiles(representative: { id: string }): string {
-  void representative;
-  return "—";
-}
-
-function formatAvgPace(representative: { id: string }): string {
-  void representative;
-  return "—";
+function aggregateHeartRateZoneMinutes(session: ReconciledWorkoutSession): HeartRateZoneMinutes5 | null {
+  const sums = [0, 0, 0, 0, 0];
+  let any = false;
+  for (const w of session.workouts) {
+    const z = w.heartRateZoneMinutes;
+    if (!z) continue;
+    any = true;
+    const tuple = z as readonly [number, number, number, number, number];
+    for (let i = 0; i < 5; i += 1) {
+      const m = tuple[i];
+      const add = typeof m === "number" && Number.isFinite(m) && m >= 0 ? m : 0;
+      sums[i] = (sums[i] ?? 0) + add;
+    }
+  }
+  return any ? (sums as unknown as HeartRateZoneMinutes5) : null;
 }
 
 export function kgToLbs(kg: number): number {
@@ -135,6 +144,23 @@ export default function WorkoutDayScreen() {
     };
   }, [sessions, overridesByWorkoutId, manualDaySummary]);
 
+  /**
+   * Multiple pure-cardio sessions the same day → legacy cards (no per-session zone merge contract).
+   * Single cardio session → premium cardio layout (zones optional; empty state if missing).
+   */
+  const { usePremiumCardioLayout, premiumCardioSessionId } = useMemo(() => {
+    const cardioOnly = sessions.filter((s) => s.sessionType === "cardio");
+    const useLayout = cardioOnly.length === 1;
+    return {
+      usePremiumCardioLayout: useLayout,
+      premiumCardioSessionId: useLayout ? cardioOnly[0]!.id : null,
+    };
+  }, [sessions]);
+
+  const singleSessionPremiumCardioDay = sessions.length === 1 && usePremiumCardioLayout;
+
+  const cardioAccent = overviewAccentForTab("cardio");
+
   const primarySession = useMemo(() => sessions[0] ?? null, [sessions]);
   const primaryWorkout = primarySession?.workouts[0] ?? null;
 
@@ -174,9 +200,12 @@ export default function WorkoutDayScreen() {
     };
   }, [user?.uid, day, isDayKey]);
 
+  /** Stack header already sits below status bar; omit top safe-area to avoid a gray band under the nav bar. */
+  const screenEdges = ["left", "right", "bottom"] as const;
+
   if (!isDayKey) {
     return (
-      <ScreenContainer backgroundColor="#F2F2F7" padded={false}>
+      <ScreenContainer backgroundColor="#F2F2F7" padded={false} edges={[...screenEdges]}>
         <ErrorState message="Invalid day parameter" />
       </ScreenContainer>
     );
@@ -184,7 +213,7 @@ export default function WorkoutDayScreen() {
 
   if (detail.status === "partial") {
     return (
-      <ScreenContainer backgroundColor="#F2F2F7" padded={false}>
+      <ScreenContainer backgroundColor="#F2F2F7" padded={false} edges={[...screenEdges]}>
         <LoadingState message="Loading workouts…" />
       </ScreenContainer>
     );
@@ -192,7 +221,7 @@ export default function WorkoutDayScreen() {
 
   if (detail.status === "error") {
     return (
-      <ScreenContainer backgroundColor="#F2F2F7" padded={false}>
+      <ScreenContainer backgroundColor="#F2F2F7" padded={false} edges={[...screenEdges]}>
         <ErrorState
           message={detail.error}
           requestId={detail.requestId}
@@ -206,7 +235,7 @@ export default function WorkoutDayScreen() {
 
   if (workouts.length === 0 && !dailyFacts) {
     return (
-      <ScreenContainer backgroundColor="#F2F2F7" padded={false}>
+      <ScreenContainer backgroundColor="#F2F2F7" padded={false} edges={[...screenEdges]}>
         <EmptyState
           title="No workouts for this day"
           description="When workouts are imported or logged for this day, they will automatically appear here."
@@ -216,9 +245,15 @@ export default function WorkoutDayScreen() {
   }
 
   return (
-    <ScreenContainer backgroundColor="#F2F2F7" padded={false}>
+    <ScreenContainer backgroundColor="#F2F2F7" padded={false} edges={[...screenEdges]}>
       <View style={styles.pageBackground}>
-      <ScrollView contentContainerStyle={styles.scroll}>
+      <ScrollView
+        style={styles.scrollView}
+        contentContainerStyle={styles.scroll}
+        {...(Platform.OS === "ios"
+          ? { contentInsetAdjustmentBehavior: "never" as const }
+          : {})}
+      >
         {dailyFacts && (
           <View style={styles.card}>
             <Text style={styles.cardTitle}>Daily metrics</Text>
@@ -259,20 +294,19 @@ export default function WorkoutDayScreen() {
 
         <View style={styles.summarySection}>
           {sessions.length === 0 ? (
-            <Text style={styles.placeholder}>No workouts from RawEvents for this day.</Text>
+            <Text style={styles.summarySectionPlaceholder}>No workouts from RawEvents for this day.</Text>
           ) : (
             sessions.map((session) => {
               const representative = session.workouts[0];
               if (!representative) return null;
               const timeLabel = formatWorkoutTimeLabel(session.start ?? representative.start ?? representative.observedAt);
               const resolved = resolveWorkoutDisplay(representative, overridesByWorkoutId[representative.id] ?? null);
-              const duration = formatWorkoutDurationLabel(
-                resolveWorkoutDisplayDurationMinutes({
-                  overrideDurationMinutes: resolved.displayDurationMinutes,
-                  sessionDurationMinutes: session.durationMinutes,
-                  fallbackWorkoutDurationMinutes: representative.durationMinutes,
-                }),
-              );
+              const resolvedDurationMinutes = resolveWorkoutDisplayDurationMinutes({
+                overrideDurationMinutes: resolved.displayDurationMinutes,
+                sessionDurationMinutes: session.durationMinutes,
+                fallbackWorkoutDurationMinutes: representative.durationMinutes,
+              });
+              const duration = formatWorkoutDurationLabel(resolvedDurationMinutes);
               const calories = typeof session.calories === "number" ? `${Math.round(session.calories)} kcal` : "—";
               const isStrength =
                 resolved.displayWorkoutType === "strength" ||
@@ -280,11 +314,22 @@ export default function WorkoutDayScreen() {
                 session.sessionType === "mixed";
               const showPremiumBlock =
                 usePremiumStrengthLayout && premiumSessionId === session.id && isStrength;
+              const showPremiumCardioBlock =
+                usePremiumCardioLayout &&
+                premiumCardioSessionId === session.id &&
+                session.sessionType === "cardio" &&
+                !isStrength;
 
               const titleText =
                 manualDaySummary?.customName && representative.sourceId === "manual"
                   ? manualDaySummary.customName
                   : resolved.displayTitle;
+
+              const distanceLabel = formatWorkoutDistanceLabel(representative.distanceMeters ?? null);
+              const paceLabel = formatAvgPaceMinPerMileLabel(
+                representative.distanceMeters ?? null,
+                resolvedDurationMinutes,
+              );
 
               if (showPremiumBlock && manualDaySummary) {
                 const exercises = manualDaySummary.exercises;
@@ -292,8 +337,8 @@ export default function WorkoutDayScreen() {
                 const maxVolKg = Math.max(1, ...volumesKg);
 
                 return (
-                  <View key={session.id} style={styles.summaryBlock}>
-                    <View style={styles.strengthOverviewCard} testID={`summary-card-${session.id}`}>
+                  <View key={session.id}>
+                    <View style={styles.premiumWorkoutCard} testID={`summary-card-${session.id}`}>
                       <View style={[workoutOverviewInCardHeaderStyles.row, styles.inCardHeaderRowSpacing]}>
                         <View style={styles.strengthOverviewTitleWrap}>
                           <Text style={workoutOverviewInCardHeaderStyles.title} numberOfLines={2}>
@@ -461,10 +506,95 @@ export default function WorkoutDayScreen() {
                 );
               }
 
+              if (showPremiumCardioBlock) {
+                const zoneMinutes = aggregateHeartRateZoneMinutes(session);
+                const maxZoneMin = zoneMinutes ? Math.max(1, ...zoneMinutes) : 1;
+
+                return (
+                  <View key={session.id}>
+                    <View style={styles.premiumWorkoutCard} testID={`summary-card-${session.id}`}>
+                      <View style={[workoutOverviewInCardHeaderStyles.row, styles.inCardHeaderRowSpacing]}>
+                        <View style={styles.strengthOverviewTitleWrap}>
+                          <Text style={workoutOverviewInCardHeaderStyles.title} numberOfLines={2}>
+                            {titleText}
+                          </Text>
+                        </View>
+                        <Text style={styles.strengthOverviewTime}>{timeLabel}</Text>
+                      </View>
+                      <View style={styles.overviewMetricsGrid}>
+                        <View style={styles.overviewMetricsRow}>
+                          <View
+                            style={[styles.overviewMetricTile, { backgroundColor: cardioAccent.metricTileBg }]}
+                          >
+                            <Text style={styles.overviewMetricLabel}>Duration</Text>
+                            <Text style={styles.overviewMetricValue}>{duration}</Text>
+                          </View>
+                          <View
+                            style={[styles.overviewMetricTile, { backgroundColor: cardioAccent.metricTileBg }]}
+                          >
+                            <Text style={styles.overviewMetricLabel}>Calories</Text>
+                            <Text style={styles.overviewMetricValue}>{calories}</Text>
+                          </View>
+                        </View>
+                        <View style={styles.overviewMetricsRow}>
+                          <View
+                            style={[styles.overviewMetricTile, { backgroundColor: cardioAccent.metricTileBg }]}
+                          >
+                            <Text style={styles.overviewMetricLabel}>Distance</Text>
+                            <Text style={styles.overviewMetricValue}>{distanceLabel}</Text>
+                          </View>
+                          <View
+                            style={[styles.overviewMetricTile, { backgroundColor: cardioAccent.metricTileBg }]}
+                          >
+                            <Text style={styles.overviewMetricLabel}>Avg Pace</Text>
+                            <Text style={styles.overviewMetricValue}>{paceLabel}</Text>
+                          </View>
+                        </View>
+                      </View>
+
+                      <View style={styles.performanceInner}>
+                        <Text style={styles.cardioZonesSectionTitle}>Heart rate zones</Text>
+                        {zoneMinutes == null ? (
+                          <Text style={styles.placeholder}>
+                            Heart rate zones are not available for this workout.
+                          </Text>
+                        ) : (
+                          [1, 2, 3, 4, 5].map((zoneNum, idx) => {
+                            const minutes = zoneMinutes[idx] ?? 0;
+                            const progress = Math.max(0, Math.min(1, minutes / maxZoneMin));
+                            const minLabel =
+                              minutes > 0 && minutes < 1 ? "<1 min" : `${Math.round(minutes)} min`;
+                            return (
+                              <View key={zoneNum} style={styles.cardioZoneRowWrap}>
+                                <View style={styles.cardioZoneLine1}>
+                                  <Text style={styles.cardioZoneLabel}>{`Zone ${zoneNum}`}</Text>
+                                  <Text style={styles.cardioZoneMinutes}>{minLabel}</Text>
+                                </View>
+                                <View style={styles.performanceBarTrack}>
+                                  <View
+                                    style={[
+                                      styles.performanceBarFillCardio,
+                                      { width: `${progress * 100}%` },
+                                    ]}
+                                  />
+                                </View>
+                              </View>
+                            );
+                          })
+                        )}
+                      </View>
+                    </View>
+                  </View>
+                );
+              }
+
               return (
-                <View key={session.id} style={styles.summaryBlock}>
+                <View key={session.id}>
                   <View style={styles.sectionHeaderRow}>
-                    <Text style={styles.sectionHeaderTitle} numberOfLines={1}>
+                    <Text
+                      style={[workoutOverviewInCardHeaderStyles.title, styles.legacySessionTitle]}
+                      numberOfLines={2}
+                    >
                       {manualDaySummary?.customName && representative.sourceId === "manual"
                         ? manualDaySummary.customName
                         : resolved.displayTitle}
@@ -488,7 +618,7 @@ export default function WorkoutDayScreen() {
                         <Text style={styles.kpiValue}>
                           {isStrength
                             ? formatIntegerWithCommas(manualDaySummary?.totalVolume ?? null)
-                            : formatMiles(representative)}
+                            : distanceLabel}
                         </Text>
                       </View>
                       <View style={styles.kpiCell}>
@@ -498,7 +628,7 @@ export default function WorkoutDayScreen() {
                             ? typeof manualDaySummary?.avgIntensity === "number"
                               ? manualDaySummary.avgIntensity.toFixed(1)
                               : "—"
-                            : formatAvgPace(representative)}
+                            : paceLabel}
                         </Text>
                       </View>
                     </View>
@@ -508,15 +638,16 @@ export default function WorkoutDayScreen() {
             })
           )}
         </View>
-        {!usePremiumStrengthLayout && (
+        {!usePremiumStrengthLayout && !singleSessionPremiumCardioDay && (
           <View style={styles.exercisesSection}>
-            <Text style={styles.sectionHeaderTitle}>Exercises</Text>
+            <Text style={styles.exercisesSectionHeading}>Exercises</Text>
             {!manualDaySummary || manualDaySummary.exercises.length === 0 ? (
               <View style={styles.card}>
                 <Text style={styles.placeholder}>No logged exercises</Text>
               </View>
             ) : (
-              manualDaySummary.exercises.map((exercise) => (
+              <View style={styles.exercisesList}>
+              {manualDaySummary.exercises.map((exercise) => (
                 <View key={exercise.name} style={styles.exerciseCard} testID={`exercise-card-${exercise.name}`}>
                   <View style={styles.exerciseTitleRow}>
                     <Text style={styles.exerciseName}>{toTitleCase(exercise.name)}</Text>
@@ -553,7 +684,8 @@ export default function WorkoutDayScreen() {
                     </View>
                   ))}
                 </View>
-              ))
+              ))}
+              </View>
             )}
           </View>
         )}
@@ -610,9 +742,10 @@ export default function WorkoutDayScreen() {
 }
 
 const styles = StyleSheet.create({
+  scrollView: { flex: 1, backgroundColor: "#F2F2F7" },
   scroll: {
     paddingHorizontal: 16,
-    paddingTop: 8,
+    paddingTop: 16,
     paddingBottom: 32,
     gap: 0,
   },
@@ -631,9 +764,12 @@ const styles = StyleSheet.create({
   },
   summarySection: {
     marginBottom: 16,
+    gap: 16,
   },
-  summaryBlock: {
-    marginBottom: 12,
+  summarySectionPlaceholder: {
+    fontSize: 14,
+    color: "#8E8E93",
+    paddingVertical: 4,
   },
   cardTitle: {
     fontSize: 18,
@@ -659,13 +795,12 @@ const styles = StyleSheet.create({
     fontWeight: "600",
     color: "#1C1C1E",
   },
-  strengthOverviewCard: {
+  premiumWorkoutCard: {
     backgroundColor: "#FFFFFF",
     borderRadius: 12,
     padding: 16,
     borderWidth: StyleSheet.hairlineWidth,
     borderColor: "#E5E5EA",
-    marginBottom: 4,
   },
   strengthOverviewTitleWrap: { flex: 1, minWidth: 0, marginRight: 8 },
   strengthOverviewTime: {
@@ -730,6 +865,30 @@ const styles = StyleSheet.create({
     backgroundColor: WORKOUT_STRENGTH_COLOR,
     borderRadius: 3,
   },
+  performanceBarFillCardio: {
+    height: "100%",
+    backgroundColor: CARDIO_RED,
+    borderRadius: 3,
+  },
+  cardioZonesSectionTitle: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: "#8E8E93",
+    letterSpacing: 0.15,
+    marginBottom: 8,
+  },
+  cardioZoneRowWrap: { marginBottom: 12, gap: 6 },
+  cardioZoneLine1: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  cardioZoneLabel: {
+    fontSize: 15,
+    fontWeight: "500",
+    color: "#1C1C1E",
+  },
+  cardioZoneMinutes: { fontSize: 15, fontWeight: "600", color: "#1C1C1E" },
   performanceExpanded: { marginTop: 8, paddingTop: 4 },
   perfTableHeaderRow: {
     flexDirection: "row",
@@ -770,31 +929,30 @@ const styles = StyleSheet.create({
   perfColVol: { flex: 1, fontWeight: "600" },
   workoutCard: {
     backgroundColor: "#FFFFFF",
-    borderRadius: 20,
+    borderRadius: 12,
     padding: 16,
     gap: 10,
-    shadowColor: "#000",
-    shadowOpacity: 0.04,
-    shadowRadius: 8,
-    shadowOffset: { width: 0, height: 2 },
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: "#E5E5EA",
+  },
+  legacySessionTitle: {
+    flex: 1,
+    minWidth: 0,
+    marginRight: 8,
   },
   sectionHeaderRow: {
     flexDirection: "row",
     justifyContent: "space-between",
-    alignItems: "center",
-    marginBottom: 8,
-  },
-  sectionHeaderTitle: {
-    fontSize: 20,
-    fontWeight: "600",
-    color: "#1C1C1E",
-    flex: 1,
-    marginRight: 8,
+    alignItems: "flex-start",
+    marginBottom: 12,
   },
   sectionHeaderTime: {
-    fontSize: 16,
+    fontSize: 15,
+    fontWeight: "600",
     color: "#8E8E93",
-    fontWeight: "500",
+    letterSpacing: -0.2,
+    flexShrink: 0,
+    marginTop: 2,
   },
   kpiRow: {
     flexDirection: "row",
@@ -826,15 +984,23 @@ const styles = StyleSheet.create({
     paddingVertical: 8,
   },
   exercisesSection: {
-    marginTop: 8,
+    marginTop: 0,
+    gap: 12,
+  },
+  exercisesSectionHeading: {
+    fontSize: 17,
+    fontWeight: "700",
+    color: "#1C1C1E",
+    letterSpacing: -0.25,
+  },
+  exercisesList: {
+    gap: 12,
   },
   exerciseCard: {
     backgroundColor: "#FFFFFF",
-    borderRadius: 20,
+    borderRadius: 12,
     padding: 16,
     gap: 6,
-    marginTop: 12,
-    marginBottom: 4,
     borderWidth: StyleSheet.hairlineWidth,
     borderColor: "#E5E5EA",
   },

--- a/lib/contracts/rawEvent.ts
+++ b/lib/contracts/rawEvent.ts
@@ -88,6 +88,8 @@ export const ingestAcceptedResponseDtoSchema = z
     rawEventId: z.string().min(1),
     day: dayKeySchema.optional(),
     idempotentReplay: z.literal(true).optional(),
+    /** Set when an existing apple_health workout doc had distanceMeters added without creating a duplicate. */
+    payloadEnriched: z.literal(true).optional(),
   })
   .strip();
 
@@ -132,8 +134,12 @@ const manualWorkoutPayloadSchema = manualWindowBaseSchema
     intensity: z.enum(["easy", "moderate", "hard"]).optional(),
     durationMinutes: z.number().finite().positive(),
     trainingLoad: z.number().finite().nonnegative().nullable().optional(),
+    /** Apple Health / device-ingested cardio distance (meters); optional for manual-only payloads. */
+    distanceMeters: z.number().finite().positive().optional(),
+    calories: z.number().finite().nonnegative().optional(),
   })
-  .strip();
+  // Preserve HealthKit-only keys (hk, sync, etc.) stored on workout raw payloads.
+  .passthrough();
 
 const manualWeightPayloadSchema = z
   .object({

--- a/lib/data/workouts/__tests__/parseWorkoutFromRawEvent.test.ts
+++ b/lib/data/workouts/__tests__/parseWorkoutFromRawEvent.test.ts
@@ -124,6 +124,35 @@ describe("parseWorkoutHistoryItem", () => {
     expect(parseWorkoutHistoryItem(raw).workoutType).toBe("cardio");
   });
 
+  it("parses optional distanceMeters and heartRateZoneMinutes from payload", () => {
+    const raw = minimalRaw({
+      id: "ev-zones",
+      observedAt: "2024-06-10T08:00:00Z",
+      payload: {
+        sport: "Running",
+        start: "2024-06-10T08:00:00Z",
+        end: "2024-06-10T09:00:00Z",
+        durationMinutes: 60,
+        distanceKm: 10.5,
+        heartRateZoneMinutes: [5, 10, 15, 8, 2],
+      },
+    });
+    const item = parseWorkoutHistoryItem(raw);
+    expect(item.distanceMeters).toBeCloseTo(10500, 5);
+    expect(item.heartRateZoneMinutes).toEqual([5, 10, 15, 8, 2]);
+  });
+
+  it("rejects heartRateZoneMinutes when not exactly five finite nonnegative numbers", () => {
+    const raw = minimalRaw({
+      id: "ev-bad-zones",
+      payload: {
+        sport: "Running",
+        heartRateZoneMinutes: [1, 2, 3],
+      },
+    });
+    expect(parseWorkoutHistoryItem(raw).heartRateZoneMinutes).toBeUndefined();
+  });
+
   it("missing payload returns fallback without throw", () => {
     const raw = minimalRaw({
       id: "ev-2",

--- a/lib/data/workouts/__tests__/workoutDisplay.test.ts
+++ b/lib/data/workouts/__tests__/workoutDisplay.test.ts
@@ -1,6 +1,8 @@
 import type { WorkoutHistoryItem } from "@/lib/data/workouts/parseWorkoutFromRawEvent";
 import {
+  formatAvgPaceMinPerMileLabel,
   formatIntegerWithCommas,
+  formatWorkoutDistanceLabel,
   formatWorkoutDurationLabel,
   formatWorkoutRowSummary,
   formatWorkoutSourceLabel,
@@ -67,6 +69,17 @@ describe("workoutDisplay", () => {
 
   it("formats integers with comma separators", () => {
     expect(formatIntegerWithCommas(2345)).toBe("2,345");
+  });
+
+  it("formats distance from meters", () => {
+    expect(formatWorkoutDistanceLabel(null)).toBe("—");
+    expect(formatWorkoutDistanceLabel(80)).toMatch(/km/);
+    expect(formatWorkoutDistanceLabel(8046)).toMatch(/mi/);
+  });
+
+  it("formats avg pace min/mi when distance and duration known", () => {
+    expect(formatAvgPaceMinPerMileLabel(null, 30)).toBe("—");
+    expect(formatAvgPaceMinPerMileLabel(1609.344, 10)).toBe("10:00 /mi");
   });
 
   it("resolves display values with override precedence", () => {

--- a/lib/data/workouts/parseWorkoutFromRawEvent.ts
+++ b/lib/data/workouts/parseWorkoutFromRawEvent.ts
@@ -1,6 +1,9 @@
 import type { RawEventDoc } from "@oli/contracts";
 import { classifyWorkoutType } from "@/lib/data/workouts/workoutMarkerFlags";
 
+/** Best-effort minutes per zone (1–5) when present on raw payload; not part of strict ingest schema. */
+export type HeartRateZoneMinutes5 = readonly [number, number, number, number, number];
+
 export type WorkoutHistoryItem = {
   id: string;
   observedAt: string;
@@ -13,6 +16,10 @@ export type WorkoutHistoryItem = {
   end: string | null;
   durationMinutes: number | null;
   calories: number | null;
+  /** Meters when upstream stores it on payload (e.g. future HK fields); otherwise omitted. */
+  distanceMeters?: number | null;
+  /** Optional zone minutes on payload; omitted when absent or invalid. */
+  heartRateZoneMinutes?: HeartRateZoneMinutes5 | null;
   hk?: { sourceId: string | null; activityId: number | null };
 };
 
@@ -26,6 +33,28 @@ function asString(v: unknown): string | null {
 
 function asNumber(v: unknown): number | null {
   return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
+function parseDistanceMetersFromPayload(payload: Record<string, unknown> | null): number | null {
+  if (!payload) return null;
+  const m =
+    asNumber(payload.distanceMeters) ??
+    asNumber(payload.totalDistanceMeters) ??
+    (asNumber(payload.distanceKm) != null ? (asNumber(payload.distanceKm) ?? 0) * 1000 : null);
+  if (m == null || m <= 0) return null;
+  return m;
+}
+
+function parseHeartRateZoneMinutesFromPayload(payload: Record<string, unknown> | null): HeartRateZoneMinutes5 | null {
+  if (!payload) return null;
+  const z = payload.heartRateZoneMinutes;
+  if (!Array.isArray(z) || z.length !== 5) return null;
+  const out: number[] = [];
+  for (const v of z) {
+    if (typeof v !== "number" || !Number.isFinite(v) || v < 0) return null;
+    out.push(v);
+  }
+  return out as unknown as HeartRateZoneMinutes5;
 }
 
 /**
@@ -86,6 +115,9 @@ export function parseWorkoutHistoryItem(raw: RawEventDoc): WorkoutHistoryItem {
 
   const calories = asNumber(payload?.calories) ?? null;
 
+  const distanceMeters = parseDistanceMetersFromPayload(payload);
+  const heartRateZoneMinutes = parseHeartRateZoneMinutesFromPayload(payload);
+
   let hk: WorkoutHistoryItem["hk"] | undefined;
   if (isRecord(payload?.hk)) {
     const hkPayload = payload.hk as Record<string, unknown>;
@@ -106,6 +138,8 @@ export function parseWorkoutHistoryItem(raw: RawEventDoc): WorkoutHistoryItem {
     end,
     durationMinutes,
     calories,
+    ...(distanceMeters != null ? { distanceMeters } : {}),
+    ...(heartRateZoneMinutes != null ? { heartRateZoneMinutes } : {}),
     ...(hk ? { hk } : {}),
   };
 }

--- a/lib/data/workouts/workoutDisplay.ts
+++ b/lib/data/workouts/workoutDisplay.ts
@@ -72,6 +72,41 @@ export function formatWorkoutDurationLabel(minutes: number | null | undefined): 
   return `${hours} hr ${mins} min`;
 }
 
+const METERS_PER_MILE = 1609.344;
+
+/** Running/cycling-style distance when `distanceMeters` is present on the workout item. */
+export function formatWorkoutDistanceLabel(distanceMeters: number | null | undefined): string {
+  if (typeof distanceMeters !== "number" || !Number.isFinite(distanceMeters) || distanceMeters <= 0) {
+    return "—";
+  }
+  const mi = distanceMeters / METERS_PER_MILE;
+  if (mi >= 0.15) return `${mi.toFixed(2)} mi`;
+  return `${(distanceMeters / 1000).toFixed(2)} km`;
+}
+
+/** Minutes per mile when distance and duration are known; otherwise "—". */
+export function formatAvgPaceMinPerMileLabel(
+  distanceMeters: number | null | undefined,
+  durationMinutes: number | null | undefined,
+): string {
+  if (
+    typeof distanceMeters !== "number" ||
+    typeof durationMinutes !== "number" ||
+    !Number.isFinite(distanceMeters) ||
+    !Number.isFinite(durationMinutes) ||
+    distanceMeters <= 0 ||
+    durationMinutes <= 0
+  ) {
+    return "—";
+  }
+  const mi = distanceMeters / METERS_PER_MILE;
+  if (mi < 1e-6) return "—";
+  const minPerMi = durationMinutes / mi;
+  const whole = Math.floor(minPerMi);
+  const sec = Math.min(59, Math.round((minPerMi - whole) * 60));
+  return `${whole}:${sec.toString().padStart(2, "0")} /mi`;
+}
+
 export function formatWorkoutRowSummary(workout: WorkoutHistoryItem): string | null {
   const parts: string[] = [];
   if (typeof workout.durationMinutes === "number") {

--- a/lib/integrations/appleHealth/__tests__/runWorkoutHistoryBackfill.test.ts
+++ b/lib/integrations/appleHealth/__tests__/runWorkoutHistoryBackfill.test.ts
@@ -150,6 +150,7 @@ describe("runWorkoutHistoryBackfillPasses", () => {
               sourceId: "watch",
               durationMinutes: 60,
               calories: 200,
+              distanceMeters: 3218.688,
             },
           ],
           pagesFetched: 1,
@@ -185,6 +186,8 @@ describe("runWorkoutHistoryBackfillPasses", () => {
       },
     });
     expect((deps.ingestRawEvent as jest.Mock)).toHaveBeenCalled();
+    const workoutCall = (deps.ingestRawEvent as jest.Mock).mock.calls.find((c) => c[0]?.kind === "workout");
+    expect(workoutCall?.[0]?.payload?.distanceMeters).toBe(3218.688);
     expect(spy).toHaveBeenCalledTimes(1);
   });
 

--- a/lib/integrations/appleHealth/healthKit.ts
+++ b/lib/integrations/appleHealth/healthKit.ts
@@ -47,7 +47,32 @@ type HKWorkoutQueriedSampleType = {
   sourceId?: string;
   duration: number;
   calories: number;
+  /** Miles from react-native-health anchored workout query (RCTAppleHealthKit+Queries.m uses HKUnit mileUnit). */
+  distance?: number;
 };
+
+/** Matches HKUnit mileUnit in RCTAppleHealthKit+Queries.m `fetchAnchoredWorkouts`. */
+const METERS_PER_MILE = 1609.344;
+
+function distanceMetersFromNativeDistanceMiles(distanceMiles: unknown): number | null {
+  if (typeof distanceMiles !== "number" || !Number.isFinite(distanceMiles) || distanceMiles <= 0) return null;
+  return distanceMiles * METERS_PER_MILE;
+}
+
+function mapQueriedWorkoutToTodayWorkout(w: HKWorkoutQueriedSampleType): TodayWorkout {
+  const distanceMeters = distanceMetersFromNativeDistanceMiles(w.distance);
+  return {
+    id: w.id ?? `${w.start}_${w.end}_${w.activityId}`,
+    start: w.start,
+    end: w.end,
+    activityId: w.activityId,
+    activityName: typeof w.activityName === "string" ? w.activityName : String(w.activityId),
+    sourceId: w.sourceId ?? null,
+    durationMinutes: Math.round((w.duration ?? 0) / 60),
+    calories: typeof w.calories === "number" ? w.calories : 0,
+    ...(distanceMeters != null ? { distanceMeters } : {}),
+  };
+}
 type AnchoredQueryResults = { anchor: string; data: HKWorkoutQueriedSampleType[] };
 
 type HealthKitInstance = {
@@ -258,16 +283,7 @@ function pAnchoredWorkouts(HK: HealthKitInstance, startDate: string, endDate: st
         resolve([]);
         return;
       }
-      const list = (result.data as HKWorkoutQueriedSampleType[]).slice(0, limit).map((w) => ({
-        id: w.id ?? `${w.start}_${w.end}_${w.activityId}`,
-        start: w.start,
-        end: w.end,
-        activityId: w.activityId,
-        activityName: typeof w.activityName === "string" ? w.activityName : String(w.activityId),
-        sourceId: w.sourceId ?? null,
-        durationMinutes: Math.round((w.duration ?? 0) / 60),
-        calories: typeof w.calories === "number" ? w.calories : 0,
-      }));
+      const list = (result.data as HKWorkoutQueriedSampleType[]).slice(0, limit).map(mapQueriedWorkoutToTodayWorkout);
       resolve(list);
     });
   });
@@ -307,16 +323,7 @@ export async function pullAnchoredWorkouts(opts: {
         resolve({ ok: false, error: "Anchored workouts response missing anchor." });
         return;
       }
-      const list = (result.data ?? []).slice(0, opts.limit).map((w: HKWorkoutQueriedSampleType) => ({
-        id: w.id ?? `${w.start}_${w.end}_${w.activityId}`,
-        start: w.start,
-        end: w.end,
-        activityId: w.activityId,
-        activityName: typeof w.activityName === "string" ? w.activityName : String(w.activityId),
-        sourceId: w.sourceId ?? null,
-        durationMinutes: Math.round((w.duration ?? 0) / 60),
-        calories: typeof w.calories === "number" ? w.calories : 0,
-      }));
+      const list = (result.data ?? []).slice(0, opts.limit).map(mapQueriedWorkoutToTodayWorkout);
       resolve({ ok: true, data: { workouts: list, anchor: result.anchor } });
     });
   });
@@ -378,16 +385,7 @@ export async function pullWorkoutsByDateRange(opts: {
           resolve({ ok: false, error: "Date-range workouts response missing anchor." });
           return;
         }
-        const list = (r.data ?? []).slice(0, opts.limit).map((w: HKWorkoutQueriedSampleType) => ({
-          id: w.id ?? `${w.start}_${w.end}_${w.activityId}`,
-          start: w.start,
-          end: w.end,
-          activityId: w.activityId,
-          activityName: typeof w.activityName === "string" ? w.activityName : String(w.activityId),
-          sourceId: w.sourceId ?? null,
-          durationMinutes: Math.round((w.duration ?? 0) / 60),
-          calories: typeof w.calories === "number" ? w.calories : 0,
-        }));
+        const list = (r.data ?? []).slice(0, opts.limit).map(mapQueriedWorkoutToTodayWorkout);
         resolve({ ok: true, data: { workouts: list, anchor: r.anchor } });
       });
     });

--- a/lib/integrations/appleHealth/runAnchoredWorkoutsSync.ts
+++ b/lib/integrations/appleHealth/runAnchoredWorkoutsSync.ts
@@ -96,6 +96,11 @@ export async function runAnchoredWorkoutsSync(
       ...(typeof w.calories === "number" && Number.isFinite(w.calories) && w.calories > 0
         ? { calories: Math.round(w.calories) }
         : {}),
+      ...(typeof w.distanceMeters === "number" &&
+      Number.isFinite(w.distanceMeters) &&
+      w.distanceMeters > 0
+        ? { distanceMeters: w.distanceMeters }
+        : {}),
       hk: { sourceId: w.sourceId ?? null, activityId: w.activityId },
       sync: {
         mode: "anchored" as const,

--- a/lib/integrations/appleHealth/runWorkoutHistoryBackfill.ts
+++ b/lib/integrations/appleHealth/runWorkoutHistoryBackfill.ts
@@ -23,7 +23,23 @@ export type RunWorkoutHistoryBackfillDeps = RunAnchoredWorkoutsSyncDeps & {
     limit: number;
     maxPages?: number;
   }) => Promise<
-    | { ok: true; data: { workouts: { start: string; end: string; activityId: number; activityName: string; sourceId: string | null; durationMinutes: number; calories: number; }[]; pagesFetched: number; truncated: boolean } }
+    | {
+        ok: true;
+        data: {
+          workouts: {
+            start: string;
+            end: string;
+            activityId: number;
+            activityName: string;
+            sourceId: string | null;
+            durationMinutes: number;
+            calories: number;
+            distanceMeters?: number;
+          }[];
+          pagesFetched: number;
+          truncated: boolean;
+        };
+      }
     | { ok: false; error: string }
   >;
 };
@@ -132,6 +148,11 @@ async function runRangeBootstrap(
       durationMinutes: Math.max(1, w.durationMinutes),
       ...(typeof w.calories === "number" && Number.isFinite(w.calories) && w.calories > 0
         ? { calories: Math.round(w.calories) }
+        : {}),
+      ...(typeof w.distanceMeters === "number" &&
+      Number.isFinite(w.distanceMeters) &&
+      w.distanceMeters > 0
+        ? { distanceMeters: w.distanceMeters }
         : {}),
       hk: { sourceId: w.sourceId ?? null, activityId: w.activityId },
       sync: {

--- a/lib/integrations/appleHealth/types.ts
+++ b/lib/integrations/appleHealth/types.ts
@@ -27,4 +27,6 @@ export type TodayWorkout = {
   sourceId: string | null;
   durationMinutes: number;
   calories: number;
+  /** From HealthKit total distance when present (meters); see healthKit mapping from native `distance` (miles). */
+  distanceMeters?: number;
 };

--- a/lib/integrations/appleHealth/workoutBootstrapPolicy.ts
+++ b/lib/integrations/appleHealth/workoutBootstrapPolicy.ts
@@ -7,7 +7,7 @@
  */
 
 /** Bump when we need all iOS clients to re-run HealthKit range bootstrap. */
-export const WORKOUT_RANGE_BOOTSTRAP_BUILD_ID = "oli-wb-v2-2026-03-21";
+export const WORKOUT_RANGE_BOOTSTRAP_BUILD_ID = "oli-wb-v3-2026-03-22-distance";
 
 export function shouldRequestHistoricalBootstrapRange(args: {
   platformOs: string;

--- a/services/api/src/lib/__tests__/mergeAppleHealthWorkoutDistance.test.ts
+++ b/services/api/src/lib/__tests__/mergeAppleHealthWorkoutDistance.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, jest } from "@jest/globals";
+import { mergeDistanceIntoExistingAppleHealthWorkoutIfNeeded } from "../mergeAppleHealthWorkoutDistance";
+import type { IngestRawEventBody } from "../../types/events";
+
+const baseExisting = {
+  schemaVersion: 1 as const,
+  id: "appleHealth:v2:workout:k",
+  userId: "u1",
+  sourceId: "healthkit",
+  sourceType: "manual",
+  provider: "apple_health",
+  kind: "workout" as const,
+  receivedAt: "2025-01-01T00:00:00.000Z",
+  observedAt: "2025-01-01T10:00:00.000Z",
+  payload: {
+    start: "2025-01-01T10:00:00.000Z",
+    end: "2025-01-01T11:00:00.000Z",
+    timezone: "UTC",
+    sport: "Running",
+    durationMinutes: 60,
+  },
+};
+
+describe("mergeDistanceIntoExistingAppleHealthWorkoutIfNeeded", () => {
+  it("returns false when provider is not apple_health", async () => {
+    const u = jest.fn();
+    const r = await mergeDistanceIntoExistingAppleHealthWorkoutIfNeeded({
+      body: {
+        provider: "manual",
+        kind: "workout",
+        payload: { distanceMeters: 1000 },
+      } as IngestRawEventBody,
+      existingData: baseExisting,
+      update: u,
+    });
+    expect(r).toBe(false);
+    expect(u).not.toHaveBeenCalled();
+  });
+
+  it("returns false when existing already has positive distanceMeters", async () => {
+    const u = jest.fn();
+    const r = await mergeDistanceIntoExistingAppleHealthWorkoutIfNeeded({
+      body: {
+        provider: "apple_health",
+        kind: "workout",
+        payload: { distanceMeters: 2000 },
+      } as IngestRawEventBody,
+      existingData: {
+        ...baseExisting,
+        payload: { ...baseExisting.payload, distanceMeters: 100 },
+      },
+      update: u,
+    });
+    expect(r).toBe(false);
+    expect(u).not.toHaveBeenCalled();
+  });
+
+  it("merges distanceMeters and calls update when missing", async () => {
+    const u = jest.fn(() => Promise.resolve());
+    const r = await mergeDistanceIntoExistingAppleHealthWorkoutIfNeeded({
+      body: {
+        provider: "apple_health",
+        kind: "workout",
+        payload: { distanceMeters: 1609.344 },
+      } as IngestRawEventBody,
+      existingData: baseExisting,
+      update: u,
+    });
+    expect(r).toBe(true);
+    expect(u).toHaveBeenCalledTimes(1);
+    expect(u.mock.calls[0]![0]).toMatchObject({
+      ...baseExisting.payload,
+      distanceMeters: 1609.344,
+    });
+  });
+});

--- a/services/api/src/lib/mergeAppleHealthWorkoutDistance.ts
+++ b/services/api/src/lib/mergeAppleHealthWorkoutDistance.ts
@@ -1,0 +1,56 @@
+import { rawEventDocSchema } from "@oli/contracts";
+import type { IngestRawEventBody } from "../types/events";
+
+/**
+ * When POST /ingest hits an idempotency collision, the default behavior is no-op.
+ * For historical Apple Health workouts ingested before distance was captured, the same
+ * idempotency key + new payload with distanceMeters should merge distance onto the
+ * existing raw doc (no duplicate doc, no second create).
+ */
+export async function mergeDistanceIntoExistingAppleHealthWorkoutIfNeeded(params: {
+  body: IngestRawEventBody;
+  existingData: unknown;
+  update: (payload: Record<string, unknown>) => Promise<unknown>;
+}): Promise<boolean> {
+  const { body, existingData, update } = params;
+
+  if (body.provider !== "apple_health" || body.kind !== "workout") {
+    return false;
+  }
+
+  const incoming = body.payload;
+  if (incoming == null || typeof incoming !== "object" || Array.isArray(incoming)) {
+    return false;
+  }
+  const inc = incoming as Record<string, unknown>;
+  const dm = inc["distanceMeters"];
+  if (typeof dm !== "number" || !Number.isFinite(dm) || dm <= 0) {
+    return false;
+  }
+
+  const parsedExisting = rawEventDocSchema.safeParse(existingData);
+  if (!parsedExisting.success) {
+    return false;
+  }
+
+  const doc = parsedExisting.data;
+  if (doc.provider !== "apple_health" || doc.kind !== "workout") {
+    return false;
+  }
+
+  const prev = doc.payload as Record<string, unknown>;
+  const prevDm = prev["distanceMeters"];
+  if (typeof prevDm === "number" && Number.isFinite(prevDm) && prevDm > 0) {
+    return false;
+  }
+
+  const mergedPayload = { ...prev, distanceMeters: dm };
+  const mergedDoc = { ...doc, payload: mergedPayload };
+  const validatedMerged = rawEventDocSchema.safeParse(mergedDoc);
+  if (!validatedMerged.success) {
+    return false;
+  }
+
+  await update(validatedMerged.data.payload as Record<string, unknown>);
+  return true;
+}

--- a/services/api/src/routes/__tests__/events.ingest.apple-health-distance-enrich.test.ts
+++ b/services/api/src/routes/__tests__/events.ingest.apple-health-distance-enrich.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Idempotent replay enriches existing apple_health workout raw docs with distanceMeters
+ * when the client re-sends the same Idempotency-Key (historical backfill replay).
+ */
+import { describe, it, expect, jest, beforeEach, afterEach } from "@jest/globals";
+import express from "express";
+
+const mockUpdate = jest.fn().mockResolvedValue(undefined);
+const mockDocRef = {
+  id: "appleHealth:v2:workout:idem_run_1",
+  get: jest.fn(),
+  create: jest.fn(),
+  update: mockUpdate,
+};
+const mockColRef = {
+  doc: jest.fn(() => mockDocRef),
+};
+
+jest.mock("../../db", () => ({
+  userCollection: (...args: unknown[]) => {
+    if (args[1] === "rawEvents") return mockColRef;
+    return {};
+  },
+}));
+
+function createIngestApp(): express.Express {
+  const router = require("../events").default as express.Router;
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as unknown as { uid?: string }).uid = "user_apple_enrich";
+    next();
+  });
+  app.use("/ingest", router);
+  return app;
+}
+
+const existingDoc = {
+  schemaVersion: 1,
+  id: "appleHealth:v2:workout:idem_run_1",
+  userId: "user_apple_enrich",
+  sourceId: "healthkit",
+  sourceType: "manual",
+  provider: "apple_health",
+  kind: "workout",
+  receivedAt: "2025-01-01T00:00:00.000Z",
+  observedAt: "2025-01-01T10:00:00.000Z",
+  payload: {
+    start: "2025-01-01T10:00:00.000Z",
+    end: "2025-01-01T11:00:00.000Z",
+    timezone: "America/New_York",
+    sport: "Running",
+    durationMinutes: 60,
+  },
+};
+
+describe("POST /ingest — apple_health workout distance enrichment on idempotent replay", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDocRef.create.mockRejectedValue(new Error("ALREADY_EXISTS"));
+    mockDocRef.get.mockResolvedValue({
+      exists: true,
+      data: () => existingDoc,
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("updates payload.distanceMeters when replay adds distance to legacy doc", async () => {
+    const app = createIngestApp();
+    const server = app.listen(0);
+    const addr = server.address();
+    if (!addr || typeof addr === "string") {
+      server.close();
+      throw new Error("Failed to bind");
+    }
+
+    try {
+      const res = await fetch(`http://127.0.0.1:${addr.port}/ingest`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "Idempotency-Key": "appleHealth:v2:workout:idem_run_1",
+        },
+        body: JSON.stringify({
+          provider: "apple_health",
+          sourceId: "healthkit",
+          kind: "workout",
+          observedAt: "2025-01-01T10:00:00.000Z",
+          timeZone: "America/New_York",
+          payload: {
+            start: "2025-01-01T10:00:00.000Z",
+            end: "2025-01-01T11:00:00.000Z",
+            timezone: "America/New_York",
+            sport: "Running",
+            durationMinutes: 60,
+            distanceMeters: 1609.344,
+          },
+        }),
+      });
+
+      expect(res.status).toBe(202);
+      const json = (await res.json()) as {
+        ok: boolean;
+        idempotentReplay?: boolean;
+        payloadEnriched?: boolean;
+      };
+      expect(json.ok).toBe(true);
+      expect(json.idempotentReplay).toBe(true);
+      expect(json.payloadEnriched).toBe(true);
+      expect(mockUpdate).toHaveBeenCalledWith({
+        payload: expect.objectContaining({ distanceMeters: 1609.344 }),
+      });
+    } finally {
+      server.close();
+    }
+  });
+
+  it("does not call update on replay when distance already present", async () => {
+    mockDocRef.get.mockResolvedValue({
+      exists: true,
+      data: () => ({
+        ...existingDoc,
+        payload: { ...existingDoc.payload, distanceMeters: 100 },
+      }),
+    });
+
+    const app = createIngestApp();
+    const server = app.listen(0);
+    const addr = server.address();
+    if (!addr || typeof addr === "string") {
+      server.close();
+      throw new Error("Failed to bind");
+    }
+
+    try {
+      const res = await fetch(`http://127.0.0.1:${addr.port}/ingest`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "Idempotency-Key": "appleHealth:v2:workout:idem_run_1",
+        },
+        body: JSON.stringify({
+          provider: "apple_health",
+          sourceId: "healthkit",
+          kind: "workout",
+          observedAt: "2025-01-01T10:00:00.000Z",
+          timeZone: "America/New_York",
+          payload: {
+            start: "2025-01-01T10:00:00.000Z",
+            end: "2025-01-01T11:00:00.000Z",
+            timezone: "America/New_York",
+            sport: "Running",
+            durationMinutes: 60,
+            distanceMeters: 1609.344,
+          },
+        }),
+      });
+
+      expect(res.status).toBe(202);
+      const json = (await res.json()) as { payloadEnriched?: boolean };
+      expect(json.payloadEnriched).toBeUndefined();
+      expect(mockUpdate).not.toHaveBeenCalled();
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/services/api/src/routes/events.ts
+++ b/services/api/src/routes/events.ts
@@ -5,6 +5,7 @@ import { rawEventDocSchema } from "@oli/contracts";
 import type { AuthedRequest } from "../middleware/auth";
 import type { RequestWithRid } from "../lib/logger";
 import { writeFailure } from "../lib/writeFailure";
+import { mergeDistanceIntoExistingAppleHealthWorkoutIfNeeded } from "../lib/mergeAppleHealthWorkoutDistance";
 import { ingestRawEventSchema, type IngestRawEventBody } from "../types/events";
 import { userCollection } from "../db";
 
@@ -331,11 +332,17 @@ router.post("/", async (req: AuthedRequest, res: Response) => {
     try {
       const existing = await docRef.get();
       if (existing.exists) {
+        const enriched = await mergeDistanceIntoExistingAppleHealthWorkoutIfNeeded({
+          body,
+          existingData: existing.data(),
+          update: (payload) => docRef.update({ payload }),
+        });
         return res.status(202).json({
           ok: true as const,
           rawEventId,
           day,
           idempotentReplay: true as const,
+          ...(enriched ? { payloadEnriched: true as const } : {}),
           requestId,
         });
       }


### PR DESCRIPTION
## Summary
- enrich existing Apple Health workout raw events with distanceMeters on idempotent replay
- enable historical Distance display for cardio workouts
- unlock Avg Pace via existing derivation logic
- bump workout bootstrap build ID to trigger one-time replay for existing users

## Why
Historical Apple Health cardio workouts were missing distance, causing Distance and Avg Pace to show as unavailable.

## Safety
- no duplicate workouts (same deterministic id)
- payload-only merge, no destructive changes
- restricted to apple_health workouts
- fail-closed on schema mismatch

## Validation
- npm run typecheck
- npm run lint
- npm test
- npm run check:invariants