### PR TITLE
Standardize module headers and overview UI

### DIFF
--- a/app/(app)/_layout.tsx
+++ b/app/(app)/_layout.tsx
@@ -43,6 +43,10 @@ export default function AppLayout() {
           />
           <Stack.Screen name="body/overview" options={{ headerTitle: "" }} />
           <Stack.Screen name="body/dexa" options={{ headerTitle: "" }} />
+          <Stack.Screen
+            name="body/settings"
+            options={{ title: "Body settings", ...workoutsStackNavigationOptions("detail") }}
+          />
 
           {/* Keep native headers for the rest */}
           <Stack.Screen
@@ -128,6 +132,10 @@ export default function AppLayout() {
             options={{ title: "Add exercise", ...workoutsStackNavigationOptions("task") }}
           />
           <Stack.Screen name="workouts/exercise-history" options={{ headerShown: false }} />
+          <Stack.Screen
+            name="workouts/settings"
+            options={{ title: "Strength settings", ...workoutsStackNavigationOptions("detail") }}
+          />
 
           <Stack.Screen
             name="cardio/index"
@@ -158,10 +166,36 @@ export default function AppLayout() {
             name="cardio/recent-workouts-full"
             options={{ title: "All cardio sessions", ...workoutsStackNavigationOptions("detail") }}
           />
+          <Stack.Screen
+            name="cardio/settings"
+            options={{ title: "Cardio settings", ...workoutsStackNavigationOptions("detail") }}
+          />
 
           <Stack.Screen name="recovery/index" options={{ title: "Recovery" }} />
-          <Stack.Screen name="recovery/sleep" options={{ title: "Sleep" }} />
-          <Stack.Screen name="recovery/readiness" options={{ title: "Readiness" }} />
+          <Stack.Screen
+            name="recovery/sleep"
+            options={{ title: "Sleep", ...workoutsStackNavigationOptions("module") }}
+          />
+          <Stack.Screen
+            name="recovery/sleep/settings"
+            options={{ title: "Sleep settings", ...workoutsStackNavigationOptions("detail") }}
+          />
+          <Stack.Screen
+            name="recovery/sleep/calendar"
+            options={{ title: "Sleep calendar", ...workoutsStackNavigationOptions("detail") }}
+          />
+          <Stack.Screen
+            name="recovery/readiness"
+            options={{ title: "Readiness", ...workoutsStackNavigationOptions("module") }}
+          />
+          <Stack.Screen
+            name="recovery/readiness/settings"
+            options={{ title: "Readiness settings", ...workoutsStackNavigationOptions("detail") }}
+          />
+          <Stack.Screen
+            name="recovery/readiness/calendar"
+            options={{ title: "Readiness calendar", ...workoutsStackNavigationOptions("detail") }}
+          />
           <Stack.Screen name="failures/index" options={{ title: "Failures" }} />
           <Stack.Screen name="settings/index" options={{ title: "Settings" }} />
           <Stack.Screen name="settings/devices" options={{ title: "Devices" }} />

--- a/app/(app)/body/__tests__/weight-screen.test.tsx
+++ b/app/(app)/body/__tests__/weight-screen.test.tsx
@@ -296,6 +296,43 @@ describe("Body Composition main screen", () => {
     expect(text).not.toContain("RMR");
     expect(text).not.toContain("1780 kcal/day");
     expect(text).toMatch(/Fair|Good|Optimal|Out of range|No data/);
+    expect(text).not.toMatch(/\bWHO\b/);
+  });
+
+  it("does not render long interpretation subtitle paragraphs as visible overview copy", () => {
+    const day = "2026-03-31";
+    mockHook.mockReturnValue(
+      buildBody({
+        overview: {
+          overviewDay: day,
+          weightKg: 80,
+          bodyFatPercent: 18.2,
+          bmi: 24.2,
+          leanBodyMassKg: 60,
+          restingMetabolicRateKcal: 1780,
+          hasAnyMetric: true,
+        },
+        byDay: new Map([[day, [buildPoint(day)]]]),
+        weekDays: [{ day, meta: { hasMeasurement: true } }],
+        series: { status: "ready", data: { points: [buildPoint(day)], latest: buildPoint(day) }, refetch: jest.fn() },
+      }),
+    );
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(React.createElement(Screen));
+    });
+    const text = collectText(tree);
+    expect(text).not.toMatch(/Mifflin/i);
+    expect(text).not.toMatch(/World Health Organization/i);
+    const weightRow = tree.root
+      .findAllByType("Pressable")
+      .find(
+        (p) =>
+          typeof p.props.accessibilityLabel === "string" &&
+          p.props.accessibilityLabel.startsWith("Open weight details"),
+      );
+    expect(weightRow).toBeDefined();
+    expect(String(weightRow!.props.accessibilityLabel)).toContain("interpretation");
   });
 
   it("routes to body day from weekly strip tap", () => {

--- a/app/(app)/body/index.tsx
+++ b/app/(app)/body/index.tsx
@@ -2,14 +2,13 @@ import React, { useEffect, useMemo, useState } from "react";
 import { Platform, Pressable, StyleSheet, Text, View, type GestureResponderEvent } from "react-native";
 import { useNavigation, useRouter } from "expo-router";
 import { HeaderBackButton } from "@/lib/ui/HeaderBackButton";
-import { HeaderIconButton } from "@/lib/ui/HeaderIconButton";
-import { WorkoutsHeaderRightRow } from "@/lib/ui/headers/WorkoutsHeaderRightRow";
+import { HeaderControls } from "@/lib/ui/HeaderControls";
 import { workoutsStackNavigationOptions } from "@/lib/ui/headers/workoutsStackHeader";
 import { ModuleScreenShell } from "@/lib/ui/ModuleScreenShell";
 import { EmptyState, ErrorState, LoadingState } from "@/lib/ui/ScreenStates";
 import { BodyWeeklyStrip } from "@/lib/ui/body/BodyWeeklyStrip";
 import { BODY_INDIGO } from "@/lib/ui/body/BodyDayRing";
-import { SYSTEM_ACCENT, SYSTEM_ACCENT_OVERLAY_10 } from "@/lib/ui/theme/systemAccent";
+import { SYSTEM_ACCENT_OVERLAY_10 } from "@/lib/ui/theme/systemAccent";
 import { BodyLogActionSheet, type BodyLogActionAnchor } from "@/lib/ui/body/BodyLogActionSheet";
 import { formatBodyDayLabel } from "@/lib/ui/body/formatBodyDayLabel";
 import { formatOverviewAsOfLabel } from "@/lib/ui/body/formatOverviewAsOfLabel";
@@ -23,6 +22,7 @@ import {
   interpretationBarAccessibilityLabel,
 } from "@/lib/ui/body/InterpretationQualityBar";
 import { InterpretationRatingPill } from "@/lib/ui/body/InterpretationRatingPill";
+import { moduleOverviewMetricLayoutStyles } from "@/lib/ui/overview/moduleOverviewMetricLayout";
 import { workoutOverviewInCardHeaderStyles } from "@/lib/ui/workouts/workoutOverviewInCardHeaderStyles";
 import { useBodyOverviewData } from "@/lib/data/body/useBodyOverviewData";
 import { useBodyCompositionInterpretation } from "@/lib/data/body/useBodyCompositionInterpretation";
@@ -43,7 +43,6 @@ export const BODY_METRIC_DETAIL_HREFS = {
 export default function BodyOverviewScreen() {
   const router = useRouter();
   const navigation = useNavigation();
-  const [menuOpen, setMenuOpen] = useState(false);
   const [recentActionOpen, setRecentActionOpen] = useState(false);
   const [recentActionAnchor, setRecentActionAnchor] = useState<BodyLogActionAnchor | null>(null);
   const [selectedRecentDay, setSelectedRecentDay] = useState<string | null>(null);
@@ -87,20 +86,13 @@ export default function BodyOverviewScreen() {
       title: "Body Composition",
       headerLeft: () => <HeaderBackButton onPress={() => navigation.goBack()} />,
       headerRight: () => (
-        <WorkoutsHeaderRightRow gap={10}>
-          <HeaderIconButton
-            iconName="calendar-outline"
-            iconSize={24}
-            color={SYSTEM_ACCENT}
-            accessibilityLabel="Open body calendar"
-            onPress={() => router.push("/(app)/body/calendar")}
-          />
-          <HeaderIconButton
-            label="•••"
-            accessibilityLabel="Body menu"
-            onPress={() => setMenuOpen(true)}
-          />
-        </WorkoutsHeaderRightRow>
+        <HeaderControls
+          gap={10}
+          calendarAccessibilityLabel="Open body calendar"
+          onCalendarPress={() => router.push("/(app)/body/calendar")}
+          overflowAccessibilityLabel="Body settings"
+          onOverflowPress={() => router.push("/(app)/body/settings")}
+        />
       ),
     });
   }, [navigation, router]);
@@ -232,24 +224,6 @@ export default function BodyOverviewScreen() {
             ) : null}
           </View>
         </ModuleScreenShell>
-        {menuOpen ? (
-          <Pressable style={styles.menuOverlay} onPress={() => setMenuOpen(false)} accessibilityLabel="Close body menu">
-            <View style={styles.menuCard}>
-              <Text style={styles.menuTitle}>Body Composition</Text>
-              <Pressable
-                onPress={() => {
-                  setMenuOpen(false);
-                  router.push("/(app)/settings/devices");
-                }}
-                style={styles.menuAction}
-                accessibilityRole="button"
-                accessibilityLabel="Open devices"
-              >
-                <Text style={styles.menuActionText}>Devices</Text>
-              </Pressable>
-            </View>
-          </Pressable>
-        ) : null}
       </View>
     );
   }
@@ -301,7 +275,7 @@ export default function BodyOverviewScreen() {
                 }
               />
             ) : (
-              <View style={styles.todayRows}>
+              <View style={moduleOverviewMetricLayoutStyles.metricGroups}>
                 {overviewRows.map((row) => (
                   <Pressable
                     key={row.id}
@@ -310,27 +284,25 @@ export default function BodyOverviewScreen() {
                     accessibilityRole="button"
                     accessibilityLabel={row.a11y}
                   >
-                    <View style={styles.todayRow}>
-                      <View style={styles.todayRowTop}>
-                        <View style={styles.metricTitleRow}>
-                          <Text style={styles.metricLabel} numberOfLines={1}>
+                    <View style={moduleOverviewMetricLayoutStyles.metricBlock}>
+                      <View style={moduleOverviewMetricLayoutStyles.topRow}>
+                        <View style={moduleOverviewMetricLayoutStyles.titlePillCluster}>
+                          <Text style={moduleOverviewMetricLayoutStyles.primaryLabel} numberOfLines={1}>
                             {row.label}
                           </Text>
                           <InterpretationRatingPill bar={row.bar} />
                         </View>
                         <Text
                           style={[
-                            styles.metricValue,
-                            row.value === "—" ? styles.metricValueEmpty : null,
+                            moduleOverviewMetricLayoutStyles.trailingValue,
+                            row.value === "—" ? styles.trailingValueEmpty : null,
                           ]}
+                          numberOfLines={1}
                         >
                           {row.value}
                         </Text>
                       </View>
                       <InterpretationQualityBar bar={row.bar} />
-                      {row.subtitle != null ? (
-                        <Text style={styles.metricSubtitle}>{row.subtitle}</Text>
-                      ) : null}
                     </View>
                   </Pressable>
                 ))}
@@ -394,24 +366,6 @@ export default function BodyOverviewScreen() {
           closeRecentActionSheet();
         }}
       />
-      {menuOpen ? (
-        <Pressable style={styles.menuOverlay} onPress={() => setMenuOpen(false)} accessibilityLabel="Close body menu">
-          <View style={styles.menuCard}>
-            <Text style={styles.menuTitle}>Body Composition</Text>
-            <Pressable
-              onPress={() => {
-                setMenuOpen(false);
-                router.push("/(app)/settings/devices");
-              }}
-              style={styles.menuAction}
-              accessibilityRole="button"
-              accessibilityLabel="Open devices"
-            >
-              <Text style={styles.menuActionText}>Devices</Text>
-            </Pressable>
-          </View>
-        </Pressable>
-      ) : null}
     </View>
   );
 }
@@ -432,22 +386,9 @@ const styles = StyleSheet.create({
   },
   cardTitle: { fontSize: 17, fontWeight: "700", color: "#1C1C1E" },
   asOfLabel: { fontSize: 14, fontWeight: "600", color: "#6E6E73" },
-  todayRows: { gap: 10 },
   metricRowPressable: { borderRadius: 8 },
   metricRowPressed: { opacity: 0.75 },
-  todayRow: { gap: 6 },
-  todayRowTop: { flexDirection: "row", justifyContent: "space-between", alignItems: "center", gap: 8 },
-  metricTitleRow: {
-    flex: 1,
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 8,
-    minWidth: 0,
-  },
-  metricLabel: { flexShrink: 1, fontSize: 14, fontWeight: "600", color: "#3C3C43" },
-  metricValue: { fontSize: 14, fontWeight: "700", color: "#1C1C1E" },
-  metricValueEmpty: { color: "#AEAEB2", fontWeight: "600" },
-  metricSubtitle: { fontSize: 12, fontWeight: "500", color: "#6E6E73", lineHeight: 16 },
+  trailingValueEmpty: { color: "#AEAEB2", fontWeight: "600" },
   recentHeader: { flexDirection: "row", alignItems: "center", justifyContent: "space-between" },
   placeholder: { fontSize: 15, color: "#8E8E93" },
   recentRow: {
@@ -463,16 +404,6 @@ const styles = StyleSheet.create({
   recentValue: { fontSize: 15, fontWeight: "500", color: "#1C1C1E", letterSpacing: -0.2 },
   rowMenuBtn: { paddingHorizontal: 10, paddingVertical: 6, marginTop: -2 },
   rowMenuText: { fontSize: 18, color: "#6E6E73", fontWeight: "700" },
-  menuOverlay: {
-    ...StyleSheet.absoluteFillObject,
-    backgroundColor: "rgba(0,0,0,0.4)",
-    justifyContent: "flex-end",
-    padding: 24,
-  },
-  menuCard: { backgroundColor: "#FFFFFF", borderRadius: 16, padding: 20, gap: 12 },
-  menuTitle: { fontSize: 18, fontWeight: "700", color: "#1C1C1E" },
-  menuAction: { paddingVertical: 10 },
-  menuActionText: { fontSize: 16, fontWeight: "600", color: BODY_INDIGO },
   syncBanner: {
     backgroundColor: SYSTEM_ACCENT_OVERLAY_10,
     borderRadius: 10,

--- a/app/(app)/body/settings.tsx
+++ b/app/(app)/body/settings.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { Platform, Pressable, StyleSheet, Text } from "react-native";
+import { useRouter } from "expo-router";
+
+import { BODY_INDIGO } from "@/lib/ui/body/BodyDayRing";
+import { ModuleSettingsPlaceholderScreen } from "@/lib/ui/ModuleSettingsPlaceholderScreen";
+
+export default function BodySettingsScreen() {
+  const router = useRouter();
+
+  return (
+    <ModuleSettingsPlaceholderScreen
+      title="Body Composition settings"
+      description="Preferences for body measurements and sources will live here. Open Devices to manage connected sources, or return to your overview."
+      overviewHref="/(app)/body"
+      overviewButtonLabel="Open Body overview"
+      overviewAccessibilityLabel="Go to Body Composition overview"
+      extraActions={
+        <>
+          <Pressable
+            onPress={() => router.push("/(app)/settings/devices")}
+            style={({ pressed }) => [styles.linkRow, pressed && styles.linkPressed]}
+            accessibilityRole="button"
+            accessibilityLabel="Open devices"
+          >
+            <Text style={styles.linkText}>Devices</Text>
+          </Pressable>
+          {Platform.OS === "ios" ? (
+            <Pressable
+              onPress={() => router.push("/(app)/settings/devices/apple_health")}
+              style={({ pressed }) => [styles.linkRow, pressed && styles.linkPressed]}
+              accessibilityRole="button"
+              accessibilityLabel="Open Apple Health device settings"
+            >
+              <Text style={styles.linkText}>Apple Health in Settings</Text>
+            </Pressable>
+          ) : null}
+        </>
+      }
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  linkRow: {
+    paddingVertical: 10,
+  },
+  linkPressed: { opacity: 0.72 },
+  linkText: { fontSize: 16, fontWeight: "600", color: BODY_INDIGO },
+});

--- a/app/(app)/cardio/settings.tsx
+++ b/app/(app)/cardio/settings.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+import { ModuleSettingsPlaceholderScreen } from "@/lib/ui/ModuleSettingsPlaceholderScreen";
+
+export default function CardioSettingsScreen() {
+  return (
+    <ModuleSettingsPlaceholderScreen
+      title="Cardio settings"
+      description="Cardio preferences and display options will appear here. For now, return to Cardio overview."
+      overviewHref="/(app)/cardio"
+      overviewButtonLabel="Open Cardio overview"
+      overviewAccessibilityLabel="Go to Cardio overview"
+    />
+  );
+}

--- a/app/(app)/nutrition/overview.tsx
+++ b/app/(app)/nutrition/overview.tsx
@@ -1,39 +1,19 @@
 import React, { useLayoutEffect } from "react";
-import { View, StyleSheet, Pressable, Text } from "react-native";
+import { View, StyleSheet } from "react-native";
 import { useNavigation, useRouter } from "expo-router";
 import { useAuth } from "@/lib/auth/AuthProvider";
 import { useNutritionOverviewScreenData } from "@/lib/hooks/useNutritionOverviewScreenData";
 import { ModuleScreenShell } from "@/lib/ui/ModuleScreenShell";
 import { EmptyState, LoadingState } from "@/lib/ui/ScreenStates";
 import { HeaderBackButton } from "@/lib/ui/HeaderBackButton";
-import { HeaderIconButton } from "@/lib/ui/HeaderIconButton";
-import { WorkoutsHeaderRightRow } from "@/lib/ui/headers/WorkoutsHeaderRightRow";
+import { HeaderControls } from "@/lib/ui/HeaderControls";
 import { NutritionWeeklyStrip } from "@/lib/ui/nutrition/NutritionWeeklyStrip";
-import { NUTRITION_ACCENT } from "@/lib/ui/nutrition/nutritionOverviewTheme";
+import { NUTRITION_SCREEN_CONTENT_BG } from "@/lib/ui/nutrition/nutritionOverviewTheme";
 import { NutritionTodayCard } from "@/lib/ui/nutrition/NutritionTodayCard";
 import { NutritionRecentCard } from "@/lib/ui/nutrition/NutritionRecentCard";
 import { NutritionWeeklyInsightsCard } from "@/lib/ui/nutrition/NutritionWeeklyInsightsCard";
 import { NutritionOverviewBottomNav } from "@/lib/ui/nutrition/NutritionOverviewBottomNav";
-import { NUTRITION_SCREEN_CONTENT_BG } from "@/lib/ui/nutrition/nutritionOverviewTheme";
 import { workoutsStackNavigationOptions } from "@/lib/ui/headers/workoutsStackHeader";
-
-function NutritionHeaderOverflowButton({ onPress }: { onPress: () => void }) {
-  return (
-    <Pressable
-      onPress={onPress}
-      style={headerMenuStyles.btn}
-      accessibilityRole="button"
-      accessibilityLabel="Nutrition menu"
-    >
-      <Text style={headerMenuStyles.text}>•••</Text>
-    </Pressable>
-  );
-}
-
-const headerMenuStyles = StyleSheet.create({
-  btn: { padding: 12 },
-  text: { fontSize: 18, color: "#1C1C1E", fontWeight: "700" },
-});
 
 export default function NutritionOverviewScreen() {
   const navigation = useNavigation();
@@ -46,16 +26,12 @@ export default function NutritionOverviewScreen() {
       ...workoutsStackNavigationOptions("module"),
       headerLeft: () => <HeaderBackButton onPress={() => navigation.goBack()} />,
       headerRight: () => (
-        <WorkoutsHeaderRightRow>
-          <HeaderIconButton
-            iconName="calendar-outline"
-            iconSize={24}
-            color={NUTRITION_ACCENT}
-            accessibilityLabel="Open nutrition calendar"
-            onPress={() => router.push("/(app)/nutrition/calendar")}
-          />
-          <NutritionHeaderOverflowButton onPress={() => router.push("/(app)/nutrition/settings")} />
-        </WorkoutsHeaderRightRow>
+        <HeaderControls
+          calendarAccessibilityLabel="Open nutrition calendar"
+          onCalendarPress={() => router.push("/(app)/nutrition/calendar")}
+          overflowAccessibilityLabel="Nutrition menu"
+          onOverflowPress={() => router.push("/(app)/nutrition/settings")}
+        />
       ),
       title: "Nutrition",
     });

--- a/app/(app)/recovery/__tests__/readiness-screen.test.tsx
+++ b/app/(app)/recovery/__tests__/readiness-screen.test.tsx
@@ -1,0 +1,124 @@
+import React from "react";
+import renderer, { act } from "react-test-renderer";
+
+const mockRouterPush = jest.fn();
+let navigationOptions: { headerRight?: () => React.ReactElement } = {};
+
+jest.mock("expo-router", () => ({
+  useNavigation: () => ({
+    setOptions: (opts: typeof navigationOptions) => {
+      navigationOptions = opts;
+    },
+    goBack: jest.fn(),
+  }),
+  useRouter: () => ({ push: mockRouterPush }),
+}));
+
+jest.mock("@react-navigation/native", () => ({
+  useFocusEffect: jest.fn(),
+}));
+
+jest.mock("react-native-safe-area-context", () => ({
+  SafeAreaView: "SafeAreaView",
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock("@/lib/ui/calendar/dateUtils", () => ({
+  ...jest.requireActual("@/lib/ui/calendar/dateUtils"),
+  getTodayDayKeyLocal: () => "2026-04-06",
+  getWeekDaysForAnchor: () => [
+    "2026-04-05",
+    "2026-04-06",
+    "2026-04-07",
+    "2026-04-08",
+    "2026-04-09",
+    "2026-04-10",
+    "2026-04-11",
+  ],
+}));
+
+jest.mock("@/lib/data/useReadinessView", () => ({
+  useReadinessView: () => ({
+    status: "ready" as const,
+    data: {
+      requestedDay: "2026-04-06",
+      resolvedDay: "2026-04-06",
+      isFallback: false,
+      day: "2026-04-06",
+      score: 80,
+      contributors: {},
+    },
+    refetch: jest.fn(),
+  }),
+}));
+
+jest.mock("@/lib/data/oura/useOuraViewWeekSnapshotPresence", () => ({
+  useOuraViewWeekSnapshotPresence: () => ({
+    status: "ready" as const,
+    hasSnapshotByDay: {
+      "2026-04-05": false,
+      "2026-04-06": true,
+      "2026-04-07": false,
+      "2026-04-08": true,
+      "2026-04-09": false,
+      "2026-04-10": false,
+      "2026-04-11": false,
+    },
+    refetch: jest.fn(),
+  }),
+}));
+
+jest.mock("@/lib/data/useOuraPresence", () => ({
+  useOuraPresence: () => ({
+    status: "ready" as const,
+    data: {
+      connected: false,
+      lastSnapshotAt: null,
+      backfillStatus: null,
+    },
+  }),
+}));
+
+import ReadinessScreen from "../readiness";
+
+describe("ReadinessScreen", () => {
+  beforeEach(() => {
+    mockRouterPush.mockClear();
+    navigationOptions = {};
+  });
+
+  it("header exposes calendar and settings routes via HeaderControls", async () => {
+    await act(async () => {
+      renderer.create(<ReadinessScreen />);
+      await Promise.resolve();
+    });
+    expect(navigationOptions.headerRight).toBeDefined();
+    let header!: renderer.ReactTestRenderer;
+    await act(async () => {
+      header = renderer.create(navigationOptions.headerRight!());
+    });
+    const calendar = header.root.findByProps({ accessibilityLabel: "Open readiness calendar" });
+    await act(async () => {
+      calendar.props.onPress();
+    });
+    expect(mockRouterPush).toHaveBeenCalledWith("/(app)/recovery/readiness/calendar");
+
+    const settings = header.root.findByProps({ accessibilityLabel: "Readiness settings" });
+    await act(async () => {
+      settings.props.onPress();
+    });
+    expect(mockRouterPush).toHaveBeenCalledWith("/(app)/recovery/readiness/settings");
+  });
+
+  it("weekly strip marks days that have snapshot presence from the week hook", async () => {
+    let tree!: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<ReadinessScreen />);
+      await Promise.resolve();
+    });
+    const str = JSON.stringify(tree!.toJSON());
+    expect(str).toContain("readiness-weekly-ring-2026-04-06");
+    expect(str).toContain("readiness-weekly-ring-2026-04-08");
+    expect(str).not.toContain("readiness-weekly-ring-2026-04-07");
+  });
+});

--- a/app/(app)/recovery/__tests__/recovery-settings-placeholders.test.tsx
+++ b/app/(app)/recovery/__tests__/recovery-settings-placeholders.test.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import renderer, { act } from "react-test-renderer";
+
+jest.mock("expo-router", () => ({
+  useNavigation: () => ({ setOptions: jest.fn(), goBack: jest.fn() }),
+  useRouter: () => ({ replace: jest.fn() }),
+}));
+
+jest.mock("react-native-safe-area-context", () => ({
+  SafeAreaView: "SafeAreaView",
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+import SleepSettingsScreen from "../sleep/settings";
+import ReadinessSettingsScreen from "../readiness/settings";
+
+describe("Recovery module settings placeholders", () => {
+  it("Sleep settings screen renders placeholder title", async () => {
+    let tree!: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<SleepSettingsScreen />);
+      await Promise.resolve();
+    });
+    const str = JSON.stringify(tree!.toJSON());
+    expect(str).toContain("Sleep settings");
+  });
+
+  it("Readiness settings screen renders placeholder title", async () => {
+    let tree!: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<ReadinessSettingsScreen />);
+      await Promise.resolve();
+    });
+    const str = JSON.stringify(tree!.toJSON());
+    expect(str).toContain("Readiness settings");
+  });
+});

--- a/app/(app)/recovery/__tests__/sleep-screen.test.tsx
+++ b/app/(app)/recovery/__tests__/sleep-screen.test.tsx
@@ -1,0 +1,124 @@
+import React from "react";
+import renderer, { act } from "react-test-renderer";
+
+const mockRouterPush = jest.fn();
+let navigationOptions: { headerRight?: () => React.ReactElement } = {};
+
+jest.mock("expo-router", () => ({
+  useNavigation: () => ({
+    setOptions: (opts: typeof navigationOptions) => {
+      navigationOptions = opts;
+    },
+    goBack: jest.fn(),
+  }),
+  useRouter: () => ({ push: mockRouterPush }),
+}));
+
+jest.mock("@react-navigation/native", () => ({
+  useFocusEffect: jest.fn(),
+}));
+
+jest.mock("react-native-safe-area-context", () => ({
+  SafeAreaView: "SafeAreaView",
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock("@/lib/ui/calendar/dateUtils", () => ({
+  ...jest.requireActual("@/lib/ui/calendar/dateUtils"),
+  getTodayDayKeyLocal: () => "2026-04-06",
+  getWeekDaysForAnchor: () => [
+    "2026-04-05",
+    "2026-04-06",
+    "2026-04-07",
+    "2026-04-08",
+    "2026-04-09",
+    "2026-04-10",
+    "2026-04-11",
+  ],
+}));
+
+jest.mock("@/lib/data/useSleepView", () => ({
+  useSleepView: () => ({
+    status: "ready" as const,
+    data: {
+      requestedDay: "2026-04-06",
+      resolvedDay: "2026-04-06",
+      isFallback: false,
+      day: "2026-04-06",
+      score: 72,
+      contributors: {},
+    },
+    refetch: jest.fn(),
+  }),
+}));
+
+jest.mock("@/lib/data/oura/useOuraViewWeekSnapshotPresence", () => ({
+  useOuraViewWeekSnapshotPresence: () => ({
+    status: "ready" as const,
+    hasSnapshotByDay: {
+      "2026-04-05": false,
+      "2026-04-06": true,
+      "2026-04-07": true,
+      "2026-04-08": false,
+      "2026-04-09": false,
+      "2026-04-10": false,
+      "2026-04-11": false,
+    },
+    refetch: jest.fn(),
+  }),
+}));
+
+jest.mock("@/lib/data/useOuraPresence", () => ({
+  useOuraPresence: () => ({
+    status: "ready" as const,
+    data: {
+      connected: false,
+      lastSnapshotAt: null,
+      backfillStatus: null,
+    },
+  }),
+}));
+
+import SleepScreen from "../sleep";
+
+describe("SleepScreen", () => {
+  beforeEach(() => {
+    mockRouterPush.mockClear();
+    navigationOptions = {};
+  });
+
+  it("header exposes calendar and settings routes via HeaderControls", async () => {
+    await act(async () => {
+      renderer.create(<SleepScreen />);
+      await Promise.resolve();
+    });
+    expect(navigationOptions.headerRight).toBeDefined();
+    let header!: renderer.ReactTestRenderer;
+    await act(async () => {
+      header = renderer.create(navigationOptions.headerRight!());
+    });
+    const calendar = header.root.findByProps({ accessibilityLabel: "Open sleep calendar" });
+    await act(async () => {
+      calendar.props.onPress();
+    });
+    expect(mockRouterPush).toHaveBeenCalledWith("/(app)/recovery/sleep/calendar");
+
+    const settings = header.root.findByProps({ accessibilityLabel: "Sleep settings" });
+    await act(async () => {
+      settings.props.onPress();
+    });
+    expect(mockRouterPush).toHaveBeenCalledWith("/(app)/recovery/sleep/settings");
+  });
+
+  it("weekly strip marks days that have snapshot presence from the week hook", async () => {
+    let tree!: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<SleepScreen />);
+      await Promise.resolve();
+    });
+    const str = JSON.stringify(tree!.toJSON());
+    expect(str).toContain("sleep-weekly-ring-2026-04-06");
+    expect(str).toContain("sleep-weekly-ring-2026-04-07");
+    expect(str).not.toContain("sleep-weekly-ring-2026-04-05");
+  });
+});

--- a/app/(app)/recovery/readiness.tsx
+++ b/app/(app)/recovery/readiness.tsx
@@ -1,15 +1,21 @@
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useLayoutEffect, useMemo, useState } from "react";
 import { View, Text, StyleSheet, ActivityIndicator } from "react-native";
 import { useFocusEffect } from "@react-navigation/native";
+import { useNavigation, useRouter } from "expo-router";
+import { HeaderBackButton } from "@/lib/ui/HeaderBackButton";
+import { HeaderControls } from "@/lib/ui/HeaderControls";
+import { workoutsStackNavigationOptions } from "@/lib/ui/headers/workoutsStackHeader";
 import { ModuleScreenShell } from "@/lib/ui/ModuleScreenShell";
 import { useReadinessView } from "@/lib/data/useReadinessView";
 import { useOuraPresence } from "@/lib/data/useOuraPresence";
+import { useOuraViewWeekSnapshotPresence } from "@/lib/data/oura/useOuraViewWeekSnapshotPresence";
 import { deriveOuraImportState } from "@/lib/integrations/oura/importState";
 import { RecoveryScoreCard } from "@/lib/ui/recovery/RecoveryScoreCard";
 import {
   RecoveryContributorsCard,
   type ContributorRowProps,
 } from "@/lib/ui/recovery/RecoveryContributorsCard";
+import { RecoveryOuraWeeklyStrip } from "@/lib/ui/recovery/RecoveryOuraWeeklyStrip";
 import {
   scoreToRatingLabel,
   contributorValueToProgress,
@@ -17,11 +23,8 @@ import {
   formatContributorDisplayValue,
   READINESS_CONTRIBUTOR_KEYS,
 } from "@/lib/format/ouraScore";
-
-function toTodayYmd(): string {
-  const d = new Date();
-  return d.toISOString().slice(0, 10);
-}
+import { getTodayDayKeyLocal, getWeekDaysForAnchor } from "@/lib/ui/calendar/dateUtils";
+import type { CalendarDay } from "@/lib/ui/calendar/types";
 
 /** Format YYYY-MM-DD as "Mar 13" for fallback banner. */
 function formatResolvedDay(day: string): string {
@@ -35,25 +38,83 @@ function formatResolvedDay(day: string): string {
   }
 }
 
+function RecoveryShell({
+  title,
+  headerContent,
+  children,
+}: {
+  title: string;
+  headerContent: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <ModuleScreenShell title={title} hideTitleChrome compactHeader headerContent={headerContent}>
+      {children}
+    </ModuleScreenShell>
+  );
+}
+
 export default function ReadinessScreen() {
-  const day = useMemo(() => toTodayYmd(), []);
-  const { refetch, ...readinessState } = useReadinessView(day);
+  const navigation = useNavigation();
+  const router = useRouter();
+  const [selectedDay, setSelectedDay] = useState(() => getTodayDayKeyLocal());
+  const weekDayKeys = useMemo(() => getWeekDaysForAnchor(selectedDay), [selectedDay]);
+  const weekStripPresence = useOuraViewWeekSnapshotPresence(weekDayKeys, "readiness");
+  const refetchWeekStrip = weekStripPresence.refetch;
+  const { refetch: refetchReadiness, ...readinessState } = useReadinessView(selectedDay);
   const ouraPresence = useOuraPresence();
+
+  const stripDays: CalendarDay<{ hasOuraSnapshot: boolean }>[] = useMemo(() => {
+    const map =
+      weekStripPresence.status === "ready" ? weekStripPresence.hasSnapshotByDay : {};
+    return weekDayKeys.map((day) => ({
+      day,
+      meta: { hasOuraSnapshot: map[day] === true },
+    }));
+  }, [weekDayKeys, weekStripPresence]);
+
+  const headerStrip = (
+    <RecoveryOuraWeeklyStrip
+      days={stripDays}
+      selectedDay={selectedDay}
+      onDayPress={setSelectedDay}
+      categoryLabel="readiness"
+      testIDPrefix="readiness-weekly"
+    />
+  );
 
   useFocusEffect(
     useCallback(() => {
-      refetch({ cacheBust: `readiness:${Date.now()}` });
-    }, [refetch]),
+      const bust = Date.now();
+      void refetchReadiness({ cacheBust: `readiness:${bust}` });
+      void refetchWeekStrip();
+    }, [refetchReadiness, refetchWeekStrip]),
   );
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      ...workoutsStackNavigationOptions("module"),
+      title: "Readiness",
+      headerLeft: () => <HeaderBackButton onPress={() => navigation.goBack()} />,
+      headerRight: () => (
+        <HeaderControls
+          calendarAccessibilityLabel="Open readiness calendar"
+          onCalendarPress={() => router.push("/(app)/recovery/readiness/calendar")}
+          overflowAccessibilityLabel="Readiness settings"
+          onOverflowPress={() => router.push("/(app)/recovery/readiness/settings")}
+        />
+      ),
+    });
+  }, [navigation, router]);
 
   if (readinessState.status === "partial") {
     return (
-      <ModuleScreenShell title="Readiness" hideTitleChrome>
+      <RecoveryShell title="Readiness" headerContent={headerStrip}>
         <View style={styles.centered}>
           <ActivityIndicator size="large" />
           <Text style={styles.loadingText}>Loading readiness data…</Text>
         </View>
-      </ModuleScreenShell>
+      </RecoveryShell>
     );
   }
 
@@ -74,38 +135,38 @@ export default function ReadinessScreen() {
       subtitle2 = "Oura import failed. Pull to refresh and try again.";
     } else if (importState === "connected_no_data" || importState === "ready") {
       subtitle2 =
-        "Oura is connected, but recent readiness data has not been imported yet.";
+        "Oura is connected, but there is no readiness snapshot stored for this day yet.";
     } else {
       subtitle2 =
         "Connect Oura in Settings → Devices and sync to see your readiness score and contributors here.";
     }
     return (
-      <ModuleScreenShell title="Readiness" hideTitleChrome>
+      <RecoveryShell title="Readiness" headerContent={headerStrip}>
         <View style={styles.messageCard}>
-          <Text style={styles.emptyTitle}>No readiness data in the last 7 days</Text>
+          <Text style={styles.emptyTitle}>No Oura readiness for {formatResolvedDay(selectedDay)}</Text>
           <Text style={styles.emptySubtitle}>{subtitle2}</Text>
         </View>
-      </ModuleScreenShell>
+      </RecoveryShell>
     );
   }
 
   if (readinessState.status === "error") {
     return (
-      <ModuleScreenShell title="Readiness" hideTitleChrome>
+      <RecoveryShell title="Readiness" headerContent={headerStrip}>
         <View style={styles.messageCard}>
           <Text style={styles.errorText}>Could not load readiness data. Try again later.</Text>
         </View>
-      </ModuleScreenShell>
+      </RecoveryShell>
     );
   }
 
   if (readinessState.status !== "ready") {
     return (
-      <ModuleScreenShell title="Readiness" hideTitleChrome>
+      <RecoveryShell title="Readiness" headerContent={headerStrip}>
         <View style={styles.messageCard}>
           <Text style={styles.emptySubtitle}>No readiness data available.</Text>
         </View>
-      </ModuleScreenShell>
+      </RecoveryShell>
     );
   }
 
@@ -129,7 +190,7 @@ export default function ReadinessScreen() {
     : null;
 
   return (
-    <ModuleScreenShell title="Readiness" hideTitleChrome>
+    <RecoveryShell title="Readiness" headerContent={headerStrip}>
       <View style={styles.content}>
         <RecoveryScoreCard
           score={score}
@@ -143,7 +204,7 @@ export default function ReadinessScreen() {
           </View>
         )}
       </View>
-    </ModuleScreenShell>
+    </RecoveryShell>
   );
 }
 

--- a/app/(app)/recovery/readiness/calendar.tsx
+++ b/app/(app)/recovery/readiness/calendar.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+import { ModuleCalendarPlaceholderScreen } from "@/lib/ui/ModuleCalendarPlaceholderScreen";
+
+export default function ReadinessCalendarScreen() {
+  return (
+    <ModuleCalendarPlaceholderScreen
+      title="Readiness calendar"
+      description="A day-by-day readiness calendar will appear here when this module is expanded. For now, use Readiness overview for your latest score."
+    />
+  );
+}

--- a/app/(app)/recovery/readiness/settings.tsx
+++ b/app/(app)/recovery/readiness/settings.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+import { ModuleSettingsPlaceholderScreen } from "@/lib/ui/ModuleSettingsPlaceholderScreen";
+
+export default function ReadinessSettingsScreen() {
+  return (
+    <ModuleSettingsPlaceholderScreen
+      title="Readiness settings"
+      description="Readiness display and integration preferences will appear here. For now, return to Readiness."
+      overviewHref="/(app)/recovery/readiness"
+      overviewButtonLabel="Open Readiness"
+      overviewAccessibilityLabel="Go to Readiness overview"
+    />
+  );
+}

--- a/app/(app)/recovery/sleep.tsx
+++ b/app/(app)/recovery/sleep.tsx
@@ -1,15 +1,21 @@
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useLayoutEffect, useMemo, useState } from "react";
 import { View, Text, StyleSheet, ActivityIndicator } from "react-native";
 import { useFocusEffect } from "@react-navigation/native";
+import { useNavigation, useRouter } from "expo-router";
+import { HeaderBackButton } from "@/lib/ui/HeaderBackButton";
+import { HeaderControls } from "@/lib/ui/HeaderControls";
+import { workoutsStackNavigationOptions } from "@/lib/ui/headers/workoutsStackHeader";
 import { ModuleScreenShell } from "@/lib/ui/ModuleScreenShell";
 import { useSleepView } from "@/lib/data/useSleepView";
 import { useOuraPresence } from "@/lib/data/useOuraPresence";
+import { useOuraViewWeekSnapshotPresence } from "@/lib/data/oura/useOuraViewWeekSnapshotPresence";
 import { deriveOuraImportState } from "@/lib/integrations/oura/importState";
 import { RecoveryScoreCard } from "@/lib/ui/recovery/RecoveryScoreCard";
 import {
   RecoveryContributorsCard,
   type ContributorRowProps,
 } from "@/lib/ui/recovery/RecoveryContributorsCard";
+import { RecoveryOuraWeeklyStrip } from "@/lib/ui/recovery/RecoveryOuraWeeklyStrip";
 import {
   scoreToRatingLabel,
   contributorValueToProgress,
@@ -18,11 +24,8 @@ import {
   formatSleepDurationMinutes,
   SLEEP_CONTRIBUTOR_KEYS,
 } from "@/lib/format/ouraScore";
-
-function toTodayYmd(): string {
-  const d = new Date();
-  return d.toISOString().slice(0, 10);
-}
+import { getTodayDayKeyLocal, getWeekDaysForAnchor } from "@/lib/ui/calendar/dateUtils";
+import type { CalendarDay } from "@/lib/ui/calendar/types";
 
 /** Format YYYY-MM-DD as "Mar 13" for fallback banner. */
 function formatResolvedDay(day: string): string {
@@ -36,25 +39,83 @@ function formatResolvedDay(day: string): string {
   }
 }
 
+function RecoveryShell({
+  title,
+  headerContent,
+  children,
+}: {
+  title: string;
+  headerContent: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <ModuleScreenShell title={title} hideTitleChrome compactHeader headerContent={headerContent}>
+      {children}
+    </ModuleScreenShell>
+  );
+}
+
 export default function SleepScreen() {
-  const day = useMemo(() => toTodayYmd(), []);
-  const { refetch, ...sleepState } = useSleepView(day);
+  const navigation = useNavigation();
+  const router = useRouter();
+  const [selectedDay, setSelectedDay] = useState(() => getTodayDayKeyLocal());
+  const weekDayKeys = useMemo(() => getWeekDaysForAnchor(selectedDay), [selectedDay]);
+  const weekStripPresence = useOuraViewWeekSnapshotPresence(weekDayKeys, "sleep");
+  const refetchWeekStrip = weekStripPresence.refetch;
+  const { refetch: refetchSleep, ...sleepState } = useSleepView(selectedDay);
   const ouraPresence = useOuraPresence();
+
+  const stripDays: CalendarDay<{ hasOuraSnapshot: boolean }>[] = useMemo(() => {
+    const map =
+      weekStripPresence.status === "ready" ? weekStripPresence.hasSnapshotByDay : {};
+    return weekDayKeys.map((day) => ({
+      day,
+      meta: { hasOuraSnapshot: map[day] === true },
+    }));
+  }, [weekDayKeys, weekStripPresence]);
+
+  const headerStrip = (
+    <RecoveryOuraWeeklyStrip
+      days={stripDays}
+      selectedDay={selectedDay}
+      onDayPress={setSelectedDay}
+      categoryLabel="sleep"
+      testIDPrefix="sleep-weekly"
+    />
+  );
 
   useFocusEffect(
     useCallback(() => {
-      refetch({ cacheBust: `sleep:${Date.now()}` });
-    }, [refetch]),
+      const bust = Date.now();
+      void refetchSleep({ cacheBust: `sleep:${bust}` });
+      void refetchWeekStrip();
+    }, [refetchSleep, refetchWeekStrip]),
   );
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      ...workoutsStackNavigationOptions("module"),
+      title: "Sleep",
+      headerLeft: () => <HeaderBackButton onPress={() => navigation.goBack()} />,
+      headerRight: () => (
+        <HeaderControls
+          calendarAccessibilityLabel="Open sleep calendar"
+          onCalendarPress={() => router.push("/(app)/recovery/sleep/calendar")}
+          overflowAccessibilityLabel="Sleep settings"
+          onOverflowPress={() => router.push("/(app)/recovery/sleep/settings")}
+        />
+      ),
+    });
+  }, [navigation, router]);
 
   if (sleepState.status === "partial") {
     return (
-      <ModuleScreenShell title="Sleep" hideTitleChrome>
+      <RecoveryShell title="Sleep" headerContent={headerStrip}>
         <View style={styles.centered}>
           <ActivityIndicator size="large" />
           <Text style={styles.loadingText}>Loading sleep data…</Text>
         </View>
-      </ModuleScreenShell>
+      </RecoveryShell>
     );
   }
 
@@ -75,38 +136,38 @@ export default function SleepScreen() {
       subtitle2 = "Oura import failed. Pull to refresh and try again.";
     } else if (importState === "connected_no_data" || importState === "ready") {
       subtitle2 =
-        "Oura is connected, but recent sleep data has not been imported yet.";
+        "Oura is connected, but there is no sleep snapshot stored for this day yet.";
     } else {
       subtitle2 =
         "Connect Oura in Settings → Devices and sync to see your sleep score and contributors here.";
     }
     return (
-      <ModuleScreenShell title="Sleep" hideTitleChrome>
+      <RecoveryShell title="Sleep" headerContent={headerStrip}>
         <View style={styles.messageCard}>
-          <Text style={styles.emptyTitle}>No sleep data in the last 7 days</Text>
+          <Text style={styles.emptyTitle}>No Oura sleep for {formatResolvedDay(selectedDay)}</Text>
           <Text style={styles.emptySubtitle}>{subtitle2}</Text>
         </View>
-      </ModuleScreenShell>
+      </RecoveryShell>
     );
   }
 
   if (sleepState.status === "error") {
     return (
-      <ModuleScreenShell title="Sleep" hideTitleChrome>
+      <RecoveryShell title="Sleep" headerContent={headerStrip}>
         <View style={styles.messageCard}>
           <Text style={styles.errorText}>Could not load sleep data. Try again later.</Text>
         </View>
-      </ModuleScreenShell>
+      </RecoveryShell>
     );
   }
 
   if (sleepState.status !== "ready") {
     return (
-      <ModuleScreenShell title="Sleep" hideTitleChrome>
+      <RecoveryShell title="Sleep" headerContent={headerStrip}>
         <View style={styles.messageCard}>
           <Text style={styles.emptySubtitle}>No sleep data available.</Text>
         </View>
-      </ModuleScreenShell>
+      </RecoveryShell>
     );
   }
 
@@ -133,7 +194,7 @@ export default function SleepScreen() {
     : null;
 
   return (
-    <ModuleScreenShell title="Sleep" hideTitleChrome>
+    <RecoveryShell title="Sleep" headerContent={headerStrip}>
       <View style={styles.content}>
         <RecoveryScoreCard
           score={score}
@@ -147,7 +208,7 @@ export default function SleepScreen() {
           </View>
         )}
       </View>
-    </ModuleScreenShell>
+    </RecoveryShell>
   );
 }
 

--- a/app/(app)/recovery/sleep/calendar.tsx
+++ b/app/(app)/recovery/sleep/calendar.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+import { ModuleCalendarPlaceholderScreen } from "@/lib/ui/ModuleCalendarPlaceholderScreen";
+
+export default function SleepCalendarScreen() {
+  return (
+    <ModuleCalendarPlaceholderScreen
+      title="Sleep calendar"
+      description="A day-by-day sleep calendar will appear here when this module is expanded. For now, use Sleep overview for your latest score."
+    />
+  );
+}

--- a/app/(app)/recovery/sleep/settings.tsx
+++ b/app/(app)/recovery/sleep/settings.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+import { ModuleSettingsPlaceholderScreen } from "@/lib/ui/ModuleSettingsPlaceholderScreen";
+
+export default function SleepSettingsScreen() {
+  return (
+    <ModuleSettingsPlaceholderScreen
+      title="Sleep settings"
+      description="Sleep display and integration preferences will appear here. For now, return to Sleep."
+      overviewHref="/(app)/recovery/sleep"
+      overviewButtonLabel="Open Sleep"
+      overviewAccessibilityLabel="Go to Sleep overview"
+    />
+  );
+}

--- a/app/(app)/workouts/__tests__/overview-recent-after-backfill.test.tsx
+++ b/app/(app)/workouts/__tests__/overview-recent-after-backfill.test.tsx
@@ -323,7 +323,7 @@ it("renders formatted recent workout title and summary metadata", async () => {
   expect(json).not.toContain("Apple Health");
 });
 
-it("renders up to 14 recent workouts and supports lower-row interactions", async () => {
+it("renders up to five recent workouts on the overview and supports fifth-row interactions", async () => {
   mockUseWorkoutsCalendarRange.mockImplementation(() => ({
     status: "ready",
     durableTitlesByWorkoutId: {},
@@ -354,10 +354,10 @@ it("renders up to 14 recent workouts and supports lower-row interactions", async
       typeof n.props?.accessibilityLabel === "string" &&
       n.props.accessibilityLabel.startsWith("Open workout details r"),
   );
-  expect(rows).toHaveLength(8);
+  expect(rows).toHaveLength(5);
 
   act(() => {
-    test.root.findByProps({ accessibilityLabel: "Open workout details r8" }).props.onPress();
+    test.root.findByProps({ accessibilityLabel: "Open workout details r5" }).props.onPress();
   });
   expect(mockPush).toHaveBeenCalledWith({
     pathname: "/(app)/workouts/day/[day]",
@@ -365,7 +365,7 @@ it("renders up to 14 recent workouts and supports lower-row interactions", async
   });
 
   act(() => {
-    test.root.findByProps({ accessibilityLabel: "Workout actions r8" }).props.onPress();
+    test.root.findByProps({ accessibilityLabel: "Workout actions r5" }).props.onPress();
   });
   act(() => {
     test.root.findByProps({ accessibilityLabel: "View details" }).props.onPress();

--- a/app/(app)/workouts/__tests__/overview-strength-main-layout.test.tsx
+++ b/app/(app)/workouts/__tests__/overview-strength-main-layout.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Strength overview main body: Today above Recent; analytics cards live on analytics-detail.
+ * Strength overview main body: Overview above Recent Workouts; analytics cards live on analytics-detail.
  */
 import React from "react";
 import renderer, { act } from "react-test-renderer";
@@ -153,11 +153,19 @@ jest.mock("@react-navigation/native", () => ({
   useFocusEffect: jest.fn(),
 }));
 
-const mockRouterPush = jest.fn();
-jest.mock("expo-router", () => ({
-  useNavigation: () => ({ setOptions: jest.fn() }),
-  useRouter: () => ({ push: mockRouterPush }),
-}));
+jest.mock("expo-router", () => {
+  const w = { push: jest.fn(), setOptions: jest.fn() };
+  (globalThis as unknown as { __oliWorkoutsOverviewExpo?: typeof w }).__oliWorkoutsOverviewExpo = w;
+  return {
+    useNavigation: () => ({ setOptions: w.setOptions, goBack: jest.fn() }),
+    useRouter: () => ({ push: w.push }),
+  };
+});
+
+function workoutsOverviewExpoMocks() {
+  return (globalThis as unknown as { __oliWorkoutsOverviewExpo: { push: jest.Mock; setOptions: jest.Mock } })
+    .__oliWorkoutsOverviewExpo;
+}
 
 jest.mock("react-native-safe-area-context", () => ({
   SafeAreaView: "SafeAreaView",
@@ -168,31 +176,59 @@ import StrengthTrainingOverviewScreen from "../overview";
 
 describe("Strength overview main layout", () => {
   beforeEach(() => {
-    mockRouterPush.mockClear();
+    workoutsOverviewExpoMocks().push.mockClear();
+    workoutsOverviewExpoMocks().setOptions.mockClear();
   });
 
-  it("renders Today before Recent and omits weekly/monthly analytics cards", async () => {
+  it("renders Overview before Recent Workouts and omits weekly/monthly analytics cards", async () => {
     let tree!: renderer.ReactTestRenderer;
     await act(async () => {
       tree = renderer.create(<StrengthTrainingOverviewScreen />);
     });
     const json = JSON.stringify(tree.toJSON());
-    const iToday = json.indexOf('"Today"');
-    const iRecent = json.indexOf('"Recent"');
+    const iOverview = json.indexOf('"Overview"');
+    const iRecent = json.indexOf('"Recent Workouts"');
     const iWeeklyInsights = json.indexOf('"Weekly Insights"');
-    expect(iToday).toBeGreaterThan(-1);
+    expect(iOverview).toBeGreaterThan(-1);
     expect(iRecent).toBeGreaterThan(-1);
     expect(iWeeklyInsights).toBeGreaterThan(-1);
-    expect(iToday).toBeLessThan(iRecent);
+    expect(iOverview).toBeLessThan(iRecent);
     expect(iRecent).toBeLessThan(iWeeklyInsights);
     expect(json).not.toContain("Weekly Strength");
     expect(json).not.toContain("Weekly Muscle Group");
     expect(json).not.toContain("Monthly Workouts");
     expect(json).not.toContain("Yearly Workouts");
     expect(json).toContain("Weekly Insights");
+    expect(json).toContain("YTD");
+    expect(json).toContain("3 Month");
+    expect(json).toContain("MTD");
+    expect(json).toContain("This Week");
   });
 
-  it("Today View More navigates to Strength Analytics", async () => {
+  it("overflow opens Strength settings route (dedicated settings, not in-popup menu)", async () => {
+    let tree!: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<StrengthTrainingOverviewScreen />);
+    });
+    const { setOptions, push } = workoutsOverviewExpoMocks();
+    expect(setOptions.mock.calls.length).toBeGreaterThan(0);
+    const lastOpts = setOptions.mock.calls[setOptions.mock.calls.length - 1]![0] as {
+      headerRight?: () => React.ReactElement;
+    };
+    expect(lastOpts.headerRight).toBeDefined();
+    let header!: renderer.ReactTestRenderer;
+    await act(async () => {
+      header = renderer.create(lastOpts.headerRight!());
+    });
+    const overflow = header.root.findByProps({ accessibilityLabel: "Strength settings" });
+    await act(async () => {
+      overflow.props.onPress();
+    });
+    expect(push).toHaveBeenCalledWith("/(app)/workouts/settings");
+    void tree;
+  });
+
+  it("Overview View More navigates to Strength Analytics", async () => {
     let tree!: renderer.ReactTestRenderer;
     await act(async () => {
       tree = renderer.create(<StrengthTrainingOverviewScreen />);
@@ -202,6 +238,6 @@ describe("Strength overview main layout", () => {
     await act(async () => {
       viewMoreLinks[0]!.props.onPress();
     });
-    expect(mockRouterPush).toHaveBeenCalledWith("/(app)/workouts/analytics-detail");
+    expect(workoutsOverviewExpoMocks().push).toHaveBeenCalledWith("/(app)/workouts/analytics-detail");
   });
 });

--- a/app/(app)/workouts/__tests__/overview-workout-actions.test.tsx
+++ b/app/(app)/workouts/__tests__/overview-workout-actions.test.tsx
@@ -264,34 +264,34 @@ describe("overview workout actions", () => {
     expect(json).not.toContain("Manual");
   });
 
-  it("lists every recent session when count is below the 14-session cap", async () => {
+  it("shows at most five recent strength sessions on the overview (newest first)", async () => {
     const test = await mountTrainingOverview();
     const rowButtons = test.root.findAll(
       (n) =>
         typeof n.props?.accessibilityLabel === "string" &&
         n.props.accessibilityLabel.startsWith("Open workout details "),
     );
-    expect(rowButtons).toHaveLength(8);
+    expect(rowButtons).toHaveLength(5);
   });
 
-  it("lower row still supports row tap and action menu", async () => {
+  it("fifth visible row still supports row tap and action menu", async () => {
     const test = await mountTrainingOverview();
     act(() => {
-      test.root.findByProps({ accessibilityLabel: "Open workout details w8" }).props.onPress();
+      test.root.findByProps({ accessibilityLabel: "Open workout details w5" }).props.onPress();
     });
     expect(mockPush).toHaveBeenCalledWith({
       pathname: "/(app)/workouts/day/[day]",
       params: { day: "2026-03-10" },
     });
     act(() => {
-      test.root.findByProps({ accessibilityLabel: "Workout actions w8" }).props.onPress();
+      test.root.findByProps({ accessibilityLabel: "Workout actions w5" }).props.onPress();
     });
     act(() => {
       test.root.findByProps({ accessibilityLabel: "Edit workout type" }).props.onPress();
     });
     expect(mockPush).toHaveBeenCalledWith({
       pathname: "/(app)/workouts/edit/type",
-      params: expect.objectContaining({ workoutId: "w8" }),
+      params: expect.objectContaining({ workoutId: "w5" }),
     });
   });
 

--- a/app/(app)/workouts/__tests__/workouts-settings-screen.test.tsx
+++ b/app/(app)/workouts/__tests__/workouts-settings-screen.test.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import renderer, { act } from "react-test-renderer";
+
+jest.mock("expo-router", () => ({
+  useNavigation: () => ({ setOptions: jest.fn(), goBack: jest.fn() }),
+  useRouter: () => ({ replace: jest.fn() }),
+}));
+
+jest.mock("react-native-safe-area-context", () => ({
+  SafeAreaView: "SafeAreaView",
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock("@/lib/preferences/PreferencesProvider", () => ({
+  usePreferences: () => ({
+    state: {
+      status: "ready" as const,
+      preferences: {
+        units: { mass: "lb" as const },
+        timezone: { mode: "recorded" as const },
+        selectedGymId: null,
+      },
+    },
+    refresh: jest.fn(),
+    setMassUnit: jest.fn(),
+    setSelectedGymId: jest.fn(),
+    setMetricSourcePreference: jest.fn(),
+  }),
+}));
+
+import WorkoutsSettingsScreen from "../settings";
+
+describe("WorkoutsSettingsScreen", () => {
+  it("renders Strength settings copy and gym section", async () => {
+    let tree!: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<WorkoutsSettingsScreen />);
+      await Promise.resolve();
+    });
+    const str = JSON.stringify(tree!.toJSON());
+    expect(str).toContain("Strength settings");
+    expect(str).toContain("Gym");
+  });
+});

--- a/app/(app)/workouts/history.tsx
+++ b/app/(app)/workouts/history.tsx
@@ -9,7 +9,7 @@ import { useNavigation, useRouter } from "expo-router";
 import { useAuth } from "@/lib/auth/AuthProvider";
 import { ModuleScreenShell } from "@/lib/ui/ModuleScreenShell";
 import { HeaderBackButton } from "@/lib/ui/HeaderBackButton";
-import { WorkoutsHeaderRightRow } from "@/lib/ui/headers/WorkoutsHeaderRightRow";
+import { HeaderControls } from "@/lib/ui/HeaderControls";
 import { workoutsStackNavigationOptions } from "@/lib/ui/headers/workoutsStackHeader";
 import { ErrorState, LoadingState, EmptyState } from "@/lib/ui/ScreenStates";
 import { useWorkoutsHistory } from "@/lib/data/useWorkoutsHistory";
@@ -37,19 +37,6 @@ function formatDateTime(iso: string | null): string {
   } catch {
     return "—";
   }
-}
-
-function OverflowMenuButton({ onPress }: { onPress: () => void }) {
-  return (
-    <Pressable
-      onPress={onPress}
-      style={styles.headerMenuBtn}
-      accessibilityRole="button"
-      accessibilityLabel="Strength history menu"
-    >
-      <Text style={styles.headerMenuText}>•••</Text>
-    </Pressable>
-  );
 }
 
 function StatusChip({
@@ -106,9 +93,10 @@ export default function WorkoutHistoryScreen() {
       ...workoutsStackNavigationOptions("detail"),
       headerLeft: () => <HeaderBackButton onPress={() => navigation.goBack()} />,
       headerRight: () => (
-        <WorkoutsHeaderRightRow>
-          <OverflowMenuButton onPress={menuPlaceholder} />
-        </WorkoutsHeaderRightRow>
+        <HeaderControls
+          onOverflowPress={menuPlaceholder}
+          overflowAccessibilityLabel="Strength history menu"
+        />
       ),
       title: SHELL_TITLE,
     });
@@ -258,11 +246,6 @@ const styles = StyleSheet.create({
   },
   chipTitle: { fontSize: 12, color: "#6E6E73" },
   chipStatus: { fontSize: 13, fontWeight: "600", color: "#3C3C43" },
-  headerMenuBtn: {
-    padding: 8,
-    marginRight: 4,
-  },
-  headerMenuText: { fontSize: 18, fontWeight: "700", color: "#1C1C1E" },
   overviewBtn: {
     alignSelf: "flex-start",
     paddingVertical: 10,

--- a/app/(app)/workouts/overview.tsx
+++ b/app/(app)/workouts/overview.tsx
@@ -1,7 +1,7 @@
 /**
  * Workouts Overview — W1 Apple Health integration.
- * Connection status, today metrics (steps, active minutes, active energy, resting HR),
- * recent workouts, last sync, manual "Sync now". Fail-closed: requestId on all API failures.
+ * Connection status, Strength Overview / Cardio analytics summary, recent workouts, last sync,
+ * manual "Sync now". Fail-closed: requestId on all API failures.
  *
  * INGESTION: Steps and workouts only (existing kinds). Resting HR, active energy, exercise time:
  * contract kind="incomplete" allows only payload.note (no structured fields); we show them in UI only and do NOT ingest.
@@ -21,18 +21,14 @@ import {
 import { useNavigation, useRouter } from "expo-router";
 import { useFocusEffect } from "@react-navigation/native";
 import { useAuth } from "@/lib/auth/AuthProvider";
-import { usePreferences } from "@/lib/preferences/PreferencesProvider";
-import { getGymMenuOptions } from "@/lib/workouts/gymRegistry";
 import { ModuleScreenShell } from "@/lib/ui/ModuleScreenShell";
 import { LoadingState, EmptyState } from "@/lib/ui/ScreenStates";
 import { HeaderBackButton } from "@/lib/ui/HeaderBackButton";
-import { HeaderIconButton } from "@/lib/ui/HeaderIconButton";
-import { WorkoutsHeaderRightRow } from "@/lib/ui/headers/WorkoutsHeaderRightRow";
+import { HeaderControls } from "@/lib/ui/HeaderControls";
 import {
   WORKOUTS_SCREEN_CONTENT_BG,
   workoutsStackNavigationOptions,
 } from "@/lib/ui/headers/workoutsStackHeader";
-import { SYSTEM_ACCENT, SYSTEM_ACCENT_OVERLAY_08 } from "@/lib/ui/theme/systemAccent";
 import { WeeklyStrip } from "@/lib/ui/calendar/WeeklyStrip";
 import { addCalendarDaysToDayKey, getTodayDayKeyLocal, getWeekDaysForAnchor } from "@/lib/ui/calendar/dateUtils";
 import type { CalendarDay, WorkoutDayMarker } from "@/lib/ui/calendar/types";
@@ -49,7 +45,6 @@ import {
 import {
   filterWorkoutCalendarDaysInclusive,
   overviewSharedRangeBounds,
-  overviewStrengthMainTabCalendarBounds,
 } from "@/lib/data/workouts/overviewCalendarRangeSlices";
 import {
   buildWorkoutOverviewAnalyticsFromCalendarDays,
@@ -68,7 +63,6 @@ import {
   toHealthKitIso8601,
   stepsIdempotencyKey,
   workoutIdempotencyKey,
-  type TodaySnapshot,
 } from "@/lib/integrations/appleHealth";
 import {
   shouldRequestHistoricalBootstrapRange,
@@ -124,8 +118,8 @@ import { buildWeeklyInsightsCardModel } from "@/lib/data/workouts/weeklyInsights
 import { WorkoutAnalyticsChart } from "@/lib/ui/workouts/WorkoutAnalyticsChart";
 import { workoutOverviewInCardHeaderStyles } from "@/lib/ui/workouts/workoutOverviewInCardHeaderStyles";
 import { WorkoutsOverviewBottomNav } from "@/lib/ui/workouts/WorkoutsOverviewBottomNav";
-import { buildTodayOverviewModel } from "@/lib/data/workouts/todayOverviewModel";
-import { TodayCard } from "@/lib/ui/workouts/TodayCard";
+import { buildStrengthOverviewCardModel } from "@/lib/data/workouts/strengthOverviewCardModel";
+import { StrengthOverviewCard } from "@/lib/ui/workouts/StrengthOverviewCard";
 import { WeeklyInsightsCard } from "@/lib/ui/workouts/WeeklyInsightsCard";
 import { serializeStrengthAnalyticsFocusParams } from "@/lib/workouts/navigation/strengthAnalyticsNavigationIntent";
 
@@ -146,6 +140,9 @@ const WORKOUT_DEEP_BACKFILL_VERSION = "v13m";
 const WORKOUT_DEEP_BACKFILL_IN_PROGRESS = "v13m:in_progress";
 const CARD_BG = "#FFFFFF";
 const RADIUS = 12;
+
+/** Strength overview “Recent Workouts” list: max visible rows (newest-first; source list still uses WORKOUT_OVERVIEW_RECENT_SESSION_CAP). */
+const STRENGTH_OVERVIEW_RECENT_DISPLAY_COUNT = 5;
 
 const WEEKDAY_SHORT = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
@@ -204,19 +201,6 @@ function getHistoricalBootstrapRange(monthsBack = 12): { startDate: string; endD
   return { startDate: toHealthKitIso8601(start), endDate: toHealthKitIso8601(end) };
 }
 
-function OverflowMenuButton({ onPress, label }: { onPress: () => void; label: string }) {
-  return (
-    <Pressable
-      onPress={onPress}
-      style={styles.headerMenuBtn}
-      accessibilityRole="button"
-      accessibilityLabel={label}
-    >
-      <Text style={styles.headerMenuText}>•••</Text>
-    </Pressable>
-  );
-}
-
 export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomain }) {
   const navigation = useNavigation();
   const router = useRouter();
@@ -224,10 +208,7 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
   const shellTitle = shellTitleForDomain(domain);
   const shellSubtitle = shellSubtitleForDomain(domain);
   const { user, initializing, getIdToken } = useAuth();
-  const { state: prefState, setSelectedGymId } = usePreferences();
   const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>("loading");
-  const [snapshot, setSnapshot] = useState<TodaySnapshot | null>(null);
-  const [menuOpen, setMenuOpen] = useState(false);
   const [workoutMenuOpen, setWorkoutMenuOpen] = useState(false);
   const [selectedWorkoutForMenu, setSelectedWorkoutForMenu] = useState<{
     day: string;
@@ -255,30 +236,15 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
   const analyticsRangeEnd = WORKOUT_OVERVIEW_ANALYTICS_RANGE_END;
   const { start: overviewRangeStart, end: overviewRangeEnd } = useMemo(
     () =>
-      domain === "strength"
-        ? overviewStrengthMainTabCalendarBounds({
-            weekStart,
-            weekEnd,
-            recentStart: recentRangeStart,
-            recentEnd: recentRangeEnd,
-          })
-        : overviewSharedRangeBounds({
-            weekStart,
-            weekEnd,
-            recentStart: recentRangeStart,
-            recentEnd: recentRangeEnd,
-            analyticsStart: analyticsRangeStart,
-            analyticsEnd: analyticsRangeEnd,
-          }),
-    [
-      domain,
-      weekStart,
-      weekEnd,
-      recentRangeStart,
-      recentRangeEnd,
-      analyticsRangeStart,
-      analyticsRangeEnd,
-    ],
+      overviewSharedRangeBounds({
+        weekStart,
+        weekEnd,
+        recentStart: recentRangeStart,
+        recentEnd: recentRangeEnd,
+        analyticsStart: analyticsRangeStart,
+        analyticsEnd: analyticsRangeEnd,
+      }),
+    [weekStart, weekEnd, recentRangeStart, recentRangeEnd, analyticsRangeStart, analyticsRangeEnd],
   );
 
   const calendarRangeOptionsShared = useMemo(
@@ -436,6 +402,11 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
     return getRecentWorkoutSessionsFromCalendarDays(recentDaysSlice, WORKOUT_OVERVIEW_RECENT_SESSION_CAP);
   }, [overviewSharedRange.status, recentDaysSlice]);
 
+  const recentSessionsShownOnOverview = useMemo(() => {
+    if (domain !== "strength") return recentWorkouts;
+    return recentWorkouts.slice(0, STRENGTH_OVERVIEW_RECENT_DISPLAY_COUNT);
+  }, [domain, recentWorkouts]);
+
   const weekWorkoutIds = useMemo(
     () =>
       weekDaysSlice.flatMap((d) =>
@@ -445,8 +416,8 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
   );
 
   const recentWorkoutIds = useMemo(
-    () => recentWorkouts.flatMap((entry) => entry.session.workouts.map((w) => w.id)),
-    [recentWorkouts],
+    () => recentSessionsShownOnOverview.flatMap((entry) => entry.session.workouts.map((w) => w.id)),
+    [recentSessionsShownOnOverview],
   );
 
   const workoutIdsForOverrides = useMemo(() => {
@@ -458,28 +429,22 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
 
   const { overridesByWorkoutId, reload } = useWorkoutOverrides(workoutIdsForOverrides);
 
-  /** Strength main tab does not render the yearly chart; skip scanning the analytics year slice. */
-  const strengthPlaceholderOverviewAnalytics = useMemo(() => {
-    const bundle = buildWorkoutOverviewAnalyticsFromCalendarDays([], { todayDayKey: today });
-    return {
-      chartPoints: bundle.chartPointsByTab.strength,
-      metrics: bundle.metricsByTab.strength,
-    };
-  }, [today]);
-
-  const cardioOverviewAnalyticsFromCalendar = useMemo(() => {
+  const workoutOverviewAnalyticsBundle = useMemo(() => {
     const bundle =
       overviewSharedRange.status === "ready"
         ? buildWorkoutOverviewAnalyticsFromCalendarDays(analyticsDaysSlice, { todayDayKey: today })
         : buildWorkoutOverviewAnalyticsFromCalendarDays([], { todayDayKey: today });
     return {
-      chartPoints: bundle.chartPointsByTab.cardio,
-      metrics: bundle.metricsByTab.cardio,
+      strength: {
+        chartPoints: bundle.chartPointsByTab.strength,
+        metrics: bundle.metricsByTab.strength,
+      },
+      cardio: {
+        chartPoints: bundle.chartPointsByTab.cardio,
+        metrics: bundle.metricsByTab.cardio,
+      },
     };
   }, [overviewSharedRange.status, analyticsDaysSlice, today]);
-
-  const rawOverviewAnalyticsSingle =
-    domain === "strength" ? strengthPlaceholderOverviewAnalytics : cardioOverviewAnalyticsFromCalendar;
 
   const weeklyInsightsCardModel = useMemo(() => {
     if (domain !== "strength") return null;
@@ -501,8 +466,31 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
     return buildWeeklyInsightsCardModel(currentWeek, previousWeek);
   }, [domain, manualWorkoutSummaries, weekStart, weekEnd, prevWeekStart, prevWeekEnd, customExerciseById]);
 
-  const overviewAnalytics = rawOverviewAnalyticsSingle;
-  const todayModel = useMemo(() => buildTodayOverviewModel(snapshot), [snapshot]);
+  const overviewAnalytics =
+    domain === "strength" ? workoutOverviewAnalyticsBundle.strength : workoutOverviewAnalyticsBundle.cardio;
+
+  const strengthOverviewModel = useMemo(() => {
+    if (domain !== "strength") return null;
+    if (overviewSharedRange.status !== "ready") return null;
+    return buildStrengthOverviewCardModel({
+      strengthCalendarDays: domainSharedDays,
+      analyticsDaysSlice,
+      todayDayKey: today,
+      weekStartDay: weekStart,
+      weekEndDay: weekEnd,
+      manualWorkoutSummaries,
+    });
+  }, [
+    domain,
+    overviewSharedRange.status,
+    domainSharedDays,
+    analyticsDaysSlice,
+    today,
+    weekStart,
+    weekEnd,
+    manualWorkoutSummaries,
+  ]);
+
   useEffect(() => {
     if (!__DEV__ || process.env.JEST_WORKER_ID) return;
     if (overviewSharedRange.status !== "ready") return;
@@ -581,27 +569,27 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
       ...workoutsStackNavigationOptions("module"),
       headerLeft: () => <HeaderBackButton onPress={() => navigation.goBack()} />,
       headerRight: () => (
-        <WorkoutsHeaderRightRow>
-          <HeaderIconButton
-            iconName="calendar-outline"
-            iconSize={24}
-            color={SYSTEM_ACCENT}
-            accessibilityLabel={`Open ${shellTitle.toLowerCase()} calendar`}
-            onPress={() =>
-              router.push(domain === "strength" ? "/(app)/workouts/calendar" : "/(app)/cardio/calendar")
-            }
-          />
-          {domain === "strength" ? (
-            <OverflowMenuButton
-              onPress={() => setMenuOpen(true)}
-              label="Strength training menu"
-            />
-          ) : null}
-        </WorkoutsHeaderRightRow>
+        <HeaderControls
+          calendarAccessibilityLabel={`Open ${shellTitle.toLowerCase()} calendar`}
+          onCalendarPress={() =>
+            router.push(domain === "strength" ? "/(app)/workouts/calendar" : "/(app)/cardio/calendar")
+          }
+          {...(domain === "strength"
+            ? {
+                onOverflowPress: () => router.push("/(app)/workouts/settings"),
+                overflowAccessibilityLabel: "Strength settings" as const,
+              }
+            : domain === "cardio"
+              ? {
+                  onOverflowPress: () => router.push("/(app)/cardio/settings"),
+                  overflowAccessibilityLabel: "Cardio settings" as const,
+                }
+              : {})}
+        />
       ),
       title: shellTitle,
     });
-  }, [navigation, router, setMenuOpen, domain, shellTitle]);
+  }, [navigation, router, domain, shellTitle]);
 
   const loadStored = useCallback(async (skipNotAvailableCheck?: boolean) => {
     const [sync, checked, connected, notAvailable] = await Promise.all([
@@ -672,16 +660,6 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
       cancelled = true;
     };
   }, [loadStored]);
-
-  const refetchSnapshot = useCallback(async () => {
-    const result = await pullTodaySnapshot();
-    if (result.ok) setSnapshot(result.data);
-    else setSnapshot(null);
-  }, []);
-
-  useEffect(() => {
-    if (connectionStatus === "connected") refetchSnapshot();
-  }, [connectionStatus, refetchSnapshot]);
 
   const maybeAutoAppleSync = useCallback(
     async (reason: "focus" | "foreground") => {
@@ -798,18 +776,12 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
         const atIso = nowIso();
         await setAppleHealthLastCheckedAt(atIso);
         await setLastSyncAt(atIso);
-        await refetchSnapshot();
         setWorkoutsCalendarRefreshEpoch((n) => n + 1);
       } finally {
         workoutBackfillInFlightRef.current = false;
       }
     },
-    [
-      connectionStatus,
-      user,
-      getIdToken,
-      refetchSnapshot,
-    ],
+    [connectionStatus, user, getIdToken],
   );
 
   useFocusEffect(
@@ -888,7 +860,7 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
     <View style={styles.card}>
       <View style={workoutOverviewInCardHeaderStyles.row}>
         <Text style={workoutOverviewInCardHeaderStyles.title}>
-          {domain === "strength" ? "Recent" : "Recent cardio sessions"}
+          {domain === "strength" ? "Recent Workouts" : "Recent cardio sessions"}
         </Text>
         <Pressable
           onPress={() => router.push(`${basePath}/recent-workouts-full`)}
@@ -908,7 +880,7 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
           {domain === "strength" ? "No strength workouts yet" : "No cardio sessions yet"}
         </Text>
       ) : (
-        recentWorkouts.map(({ day, session }) => {
+        recentSessionsShownOnOverview.map(({ day, session }) => {
           const representative = session.workouts[0];
           if (!representative) return null;
           const journalSummary =
@@ -991,8 +963,9 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
     <View style={styles.pageBody}>
       {domain === "strength" ? (
         <>
-          <TodayCard
-            model={todayModel}
+          <StrengthOverviewCard
+            loading={overviewSharedRange.status !== "ready"}
+            model={strengthOverviewModel}
             onViewMore={() => router.push(`${basePath}/analytics-detail`)}
           />
           {recentCard}
@@ -1090,45 +1063,6 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
         {content}
       </ModuleScreenShell>
       <WorkoutsOverviewBottomNav basePath={basePath} />
-      {domain === "strength" && menuOpen && (
-        <Pressable
-          style={styles.menuOverlay}
-          onPress={() => setMenuOpen(false)}
-          accessibilityLabel="Close menu"
-        >
-          <View style={styles.menuCard} onStartShouldSetResponder={() => true}>
-            <Text style={styles.menuTitle}>{shellTitle}</Text>
-            <Text style={styles.menuSectionLabel}>Gym</Text>
-            {getGymMenuOptions().map((opt) => {
-              const selected =
-                (opt.value === null && prefState.preferences.selectedGymId === null) ||
-                (opt.value !== null && prefState.preferences.selectedGymId === opt.value);
-              return (
-                <Pressable
-                  key={opt.value ?? "none"}
-                  onPress={() => {
-                    setSelectedGymId(opt.value);
-                  }}
-                  style={[styles.menuOptionRow, selected && styles.menuOptionRowSelected]}
-                  accessibilityRole="button"
-                  accessibilityLabel={`Gym: ${opt.label}${selected ? ", selected" : ""}`}
-                >
-                  <Text style={styles.menuOptionLabel}>{opt.label}</Text>
-                  {selected ? <Text style={styles.menuOptionCheck}>✓</Text> : null}
-                </Pressable>
-              );
-            })}
-            <Pressable
-              onPress={() => setMenuOpen(false)}
-              style={styles.primaryBtn}
-              accessibilityRole="button"
-              accessibilityLabel="Close"
-            >
-              <Text style={styles.primaryBtnText}>Close</Text>
-            </Pressable>
-          </View>
-        </Pressable>
-      )}
     </View>
   );
 }
@@ -1157,14 +1091,6 @@ const styles = StyleSheet.create({
     gap: 12,
   },
   placeholder: { fontSize: 15, fontWeight: "400", color: "#8E8E93", letterSpacing: -0.1 },
-  primaryBtn: {
-    alignSelf: "flex-start",
-    paddingVertical: 10,
-    paddingHorizontal: 16,
-    backgroundColor: SYSTEM_ACCENT,
-    borderRadius: 10,
-  },
-  primaryBtnText: { fontSize: 15, fontWeight: "600", color: "#FFFFFF" },
   metricRow: { flexDirection: "row", justifyContent: "space-between", alignItems: "center" },
   metricLabel: { fontSize: 15, color: "#3C3C43" },
   metricValue: { fontSize: 15, fontWeight: "600", color: "#1C1C1E" },
@@ -1184,35 +1110,6 @@ const styles = StyleSheet.create({
   recentMeta: { fontSize: 12, fontWeight: "400", color: "#AEAEB2", letterSpacing: -0.05 },
   rowMenuBtn: { paddingHorizontal: 10, paddingVertical: 6, marginTop: -2 },
   rowMenuText: { fontSize: 18, color: "#6E6E73", fontWeight: "700" },
-  headerMenuBtn: { padding: 12 },
-  headerMenuText: { fontSize: 18, color: "#1C1C1E", fontWeight: "700" },
-  menuOverlay: {
-    ...StyleSheet.absoluteFillObject,
-    backgroundColor: "rgba(0,0,0,0.4)",
-    justifyContent: "flex-end",
-    padding: 24,
-  },
-  menuCard: {
-    backgroundColor: "#FFFFFF",
-    borderRadius: 16,
-    padding: 24,
-    gap: 12,
-  },
-  menuTitle: { fontSize: 20, fontWeight: "700", color: "#1C1C1E", textAlign: "center" },
-  menuSectionLabel: { fontSize: 13, fontWeight: "600", color: "#6E6E73", marginTop: 4, marginBottom: 6 },
-  menuOptionRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-    paddingVertical: 12,
-    paddingHorizontal: 14,
-    borderRadius: 10,
-    borderWidth: 1,
-    borderColor: "rgba(0,0,0,0.2)",
-  },
-  menuOptionRowSelected: { borderColor: SYSTEM_ACCENT, backgroundColor: SYSTEM_ACCENT_OVERLAY_08 },
-  menuOptionLabel: { fontSize: 16, fontWeight: "500", color: "#1C1C1E" },
-  menuOptionCheck: { fontSize: 16, fontWeight: "700", color: SYSTEM_ACCENT },
   editorInput: {
     backgroundColor: WORKOUTS_SCREEN_CONTENT_BG,
     borderRadius: 12,

--- a/app/(app)/workouts/settings.tsx
+++ b/app/(app)/workouts/settings.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+import { ModuleSettingsPlaceholderScreen } from "@/lib/ui/ModuleSettingsPlaceholderScreen";
+import { StrengthGymSettingsSection } from "@/lib/ui/workouts/StrengthGymSettingsSection";
+
+export default function WorkoutsSettingsScreen() {
+  return (
+    <ModuleSettingsPlaceholderScreen
+      title="Strength settings"
+      description="Training preferences and defaults will appear here. For now, return to Strength overview."
+      overviewHref="/(app)/workouts/overview"
+      overviewButtonLabel="Open Strength overview"
+      overviewAccessibilityLabel="Go to Strength overview"
+      extraActions={<StrengthGymSettingsSection />}
+    />
+  );
+}

--- a/lib/body/__tests__/bodyOverviewBarDisplay.test.ts
+++ b/lib/body/__tests__/bodyOverviewBarDisplay.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "@jest/globals";
+import type { InterpretationBarModel } from "../bodyOverviewInterpretationBar";
+import {
+  BODY_ZONE_TO_VISUAL_SEGMENT_INDEX,
+  bodyInterpretationZoneQuartileBand,
+  computeBodyOverviewDisplayMarker01,
+  getBodyOverviewBarDisplay,
+} from "../bodyOverviewBarDisplay";
+import { MODULE_OVERVIEW_STRENGTH_TIER_PILL_CHROME } from "@/lib/ui/overview/moduleOverviewStrengthTierPillChrome";
+
+const SEG = 5;
+
+function assertMarkerInsideSegment(bar: InterpretationBarModel): void {
+  const idx = BODY_ZONE_TO_VISUAL_SEGMENT_INDEX[bar.zone];
+  const d = computeBodyOverviewDisplayMarker01(bar);
+  const start = idx / SEG;
+  const end = (idx + 1) / SEG;
+  expect(d).toBeGreaterThanOrEqual(start);
+  expect(d).toBeLessThanOrEqual(end);
+}
+
+describe("bodyOverviewBarDisplay", () => {
+  it("maps each Body zone to the expected shared visual segment index (orange unused)", () => {
+    expect(BODY_ZONE_TO_VISUAL_SEGMENT_INDEX).toEqual({
+      out_of_range: 0,
+      fair: 1,
+      good: 3,
+      optimal: 4,
+    });
+  });
+
+  it("keeps quartile bands aligned with interpretationZoneFromMarker01", () => {
+    expect(bodyInterpretationZoneQuartileBand("out_of_range")).toEqual({ lo: 0, hi: 0.25 });
+    expect(bodyInterpretationZoneQuartileBand("fair")).toEqual({ lo: 0.25, hi: 0.5 });
+    expect(bodyInterpretationZoneQuartileBand("good")).toEqual({ lo: 0.5, hi: 0.75 });
+    expect(bodyInterpretationZoneQuartileBand("optimal")).toEqual({ lo: 0.75, hi: 1 });
+  });
+
+  it("places display marker inside the mapped segment for every zone at band extremes", () => {
+    assertMarkerInsideSegment({
+      marker01: 0,
+      zone: "out_of_range",
+      displayLabel: "Out of range",
+      hasValue: true,
+    });
+    assertMarkerInsideSegment({
+      marker01: 0.249,
+      zone: "out_of_range",
+      displayLabel: "Out of range",
+      hasValue: true,
+    });
+    assertMarkerInsideSegment({
+      marker01: 0.25,
+      zone: "fair",
+      displayLabel: "Fair",
+      hasValue: true,
+    });
+    assertMarkerInsideSegment({
+      marker01: 0.499,
+      zone: "fair",
+      displayLabel: "Fair",
+      hasValue: true,
+    });
+    assertMarkerInsideSegment({
+      marker01: 0.5,
+      zone: "good",
+      displayLabel: "Good",
+      hasValue: true,
+    });
+    assertMarkerInsideSegment({
+      marker01: 0.749,
+      zone: "good",
+      displayLabel: "Good",
+      hasValue: true,
+    });
+    assertMarkerInsideSegment({
+      marker01: 0.75,
+      zone: "optimal",
+      displayLabel: "Optimal",
+      hasValue: true,
+    });
+    assertMarkerInsideSegment({
+      marker01: 1,
+      zone: "optimal",
+      displayLabel: "Optimal",
+      hasValue: true,
+    });
+  });
+
+  it("maps optimal at raw 0.76 into the blue segment (not green)", () => {
+    const bar: InterpretationBarModel = {
+      marker01: 0.76,
+      zone: "optimal",
+      displayLabel: "Optimal",
+      hasValue: true,
+    };
+    const d = computeBodyOverviewDisplayMarker01(bar);
+    expect(d).toBeGreaterThanOrEqual(0.8);
+    expect(d).toBeLessThanOrEqual(1);
+  });
+
+  it("derives pill and marker colors from the same Strength chrome row as the visual segment", () => {
+    const zones = ["out_of_range", "fair", "good", "optimal"] as const;
+    for (const zone of zones) {
+      const bar: InterpretationBarModel = {
+        marker01: 0.5,
+        zone,
+        displayLabel: "x",
+        hasValue: true,
+      };
+      const idx = BODY_ZONE_TO_VISUAL_SEGMENT_INDEX[zone];
+      const chrome = MODULE_OVERVIEW_STRENGTH_TIER_PILL_CHROME[idx];
+      const d = getBodyOverviewBarDisplay(bar);
+      expect(d.pillBg).toBe(chrome.pillBg);
+      expect(d.pillFg).toBe(chrome.pillFg);
+      expect(d.markerDotColor).toBe(chrome.pillFg);
+      expect(d.visualSegmentIndex).toBe(idx);
+    }
+  });
+
+  it("uses neutral pill when there is no measurement", () => {
+    const d = getBodyOverviewBarDisplay({
+      marker01: 0.5,
+      zone: "fair",
+      displayLabel: "No data",
+      hasValue: false,
+    });
+    expect(d.visualSegmentIndex).toBeNull();
+    expect(d.pillBg).toBe("#E5E5EA");
+    expect(d.pillFg).toBe("#636366");
+  });
+});

--- a/lib/body/bodyOverviewBarDisplay.ts
+++ b/lib/body/bodyOverviewBarDisplay.ts
@@ -1,0 +1,86 @@
+// Display-only mapping: Body’s 4 interpretation zones → shared 5-segment overview chrome + marker position.
+// Does not change {@link buildInterpretationBarModels} output; use only in overview UI.
+
+import type { InterpretationBarModel, InterpretationQualityZone } from "./bodyOverviewInterpretationBar";
+import { MODULE_OVERVIEW_STRENGTH_TIER_PILL_CHROME } from "@/lib/ui/overview/moduleOverviewStrengthTierPillChrome";
+
+/** Must match {@link interpretationZoneFromMarker01} quartile bands on raw marker01. */
+export function bodyInterpretationZoneQuartileBand(zone: InterpretationQualityZone): { lo: number; hi: number } {
+  switch (zone) {
+    case "out_of_range":
+      return { lo: 0, hi: 0.25 };
+    case "fair":
+      return { lo: 0.25, hi: 0.5 };
+    case "good":
+      return { lo: 0.5, hi: 0.75 };
+    case "optimal":
+      return { lo: 0.75, hi: 1 };
+  }
+}
+
+/**
+ * Body zone → shared visual segment index (0=red … 4=blue). Segment 2 (orange) is unused so
+ * “good” maps to green (Strength “Strong”) and “optimal” to blue (Strength “Optimal”).
+ */
+export const BODY_ZONE_TO_VISUAL_SEGMENT_INDEX: Record<InterpretationQualityZone, 0 | 1 | 2 | 3 | 4> = {
+  out_of_range: 0,
+  fair: 1,
+  good: 3,
+  optimal: 4,
+};
+
+const SEGMENT_COUNT = 5;
+
+const NEUTRAL_PILL = { pillBg: "#E5E5EA", pillFg: "#636366" } as const;
+
+function clamp01(x: number): number {
+  if (!Number.isFinite(x)) return 0.5;
+  return Math.min(1, Math.max(0, x));
+}
+
+/**
+ * Maps raw interpretation marker01 within the zone’s quartile band onto the mapped segment’s span
+ * so the dot stays inside the correct colored stripe.
+ */
+export function computeBodyOverviewDisplayMarker01(bar: InterpretationBarModel): number {
+  if (!bar.hasValue) return 0.5;
+  const { lo, hi } = bodyInterpretationZoneQuartileBand(bar.zone);
+  const span = hi - lo;
+  const idx = BODY_ZONE_TO_VISUAL_SEGMENT_INDEX[bar.zone];
+  const segStart = idx / SEGMENT_COUNT;
+  const segEnd = (idx + 1) / SEGMENT_COUNT;
+  const segWidth = segEnd - segStart;
+  const t = span > 0 ? clamp01((bar.marker01 - lo) / span) : 0.5;
+  return segStart + t * segWidth;
+}
+
+export type BodyOverviewBarDisplay = {
+  /** 0–1 along the shared track for {@link SegmentedZoneTrack} only. */
+  displayMarker01: number;
+  pillBg: string;
+  pillFg: string;
+  markerDotColor: string;
+  /** Shared segment index, or null when there is no measurement. */
+  visualSegmentIndex: 0 | 1 | 2 | 3 | 4 | null;
+};
+
+export function getBodyOverviewBarDisplay(bar: InterpretationBarModel): BodyOverviewBarDisplay {
+  if (!bar.hasValue) {
+    return {
+      displayMarker01: 0.5,
+      pillBg: NEUTRAL_PILL.pillBg,
+      pillFg: NEUTRAL_PILL.pillFg,
+      markerDotColor: NEUTRAL_PILL.pillFg,
+      visualSegmentIndex: null,
+    };
+  }
+  const visualSegmentIndex = BODY_ZONE_TO_VISUAL_SEGMENT_INDEX[bar.zone];
+  const chrome = MODULE_OVERVIEW_STRENGTH_TIER_PILL_CHROME[visualSegmentIndex];
+  return {
+    displayMarker01: computeBodyOverviewDisplayMarker01(bar),
+    pillBg: chrome.pillBg,
+    pillFg: chrome.pillFg,
+    markerDotColor: chrome.pillFg,
+    visualSegmentIndex,
+  };
+}

--- a/lib/data/oura/__tests__/useOuraViewWeekSnapshotPresence.test.ts
+++ b/lib/data/oura/__tests__/useOuraViewWeekSnapshotPresence.test.ts
@@ -1,0 +1,317 @@
+/**
+ * Contract: week-strip rings use GET /users/me/oura-*-view per day.
+ * Presence is `truthOutcomeFromApiResult(res).status === "ready"` (200 + DTO), not score fields.
+ * Future days (day > local today YYYY-MM-DD): never fetch, never ring.
+ */
+import React from "react";
+import renderer, { act } from "react-test-renderer";
+
+import { truthOutcomeFromApiResult } from "@/lib/data/truthOutcome";
+import {
+  mergeOuraWeekPresenceMaps,
+  partitionOuraWeekPresenceDayKeys,
+  useOuraViewWeekSnapshotPresence,
+} from "@/lib/data/oura/useOuraViewWeekSnapshotPresence";
+
+describe("partitionOuraWeekPresenceDayKeys", () => {
+  const today = "2026-04-06";
+
+  it("puts only today in daysToFetch when rest of week is future (e.g. Sunday start of week)", () => {
+    const week = [
+      "2026-04-06",
+      "2026-04-07",
+      "2026-04-08",
+      "2026-04-09",
+      "2026-04-10",
+      "2026-04-11",
+      "2026-04-12",
+    ];
+    const { noSnapshotFutureDays, daysToFetch } = partitionOuraWeekPresenceDayKeys(week, today);
+    expect(daysToFetch).toEqual(["2026-04-06"]);
+    expect(noSnapshotFutureDays).toEqual({
+      "2026-04-07": false,
+      "2026-04-08": false,
+      "2026-04-09": false,
+      "2026-04-10": false,
+      "2026-04-11": false,
+      "2026-04-12": false,
+    });
+  });
+
+  it("includes past and today in daysToFetch; marks only strictly future days", () => {
+    const todayMidWeek = "2026-04-09";
+    const week = [
+      "2026-04-06",
+      "2026-04-07",
+      "2026-04-08",
+      "2026-04-09",
+      "2026-04-10",
+      "2026-04-11",
+      "2026-04-12",
+    ];
+    const { noSnapshotFutureDays, daysToFetch } = partitionOuraWeekPresenceDayKeys(week, todayMidWeek);
+    expect(daysToFetch).toEqual(["2026-04-06", "2026-04-07", "2026-04-08", "2026-04-09"]);
+    expect(noSnapshotFutureDays).toEqual({
+      "2026-04-10": false,
+      "2026-04-11": false,
+      "2026-04-12": false,
+    });
+  });
+
+  it("when every day is past or today, nothing is forced false for future", () => {
+    const todayEnd = "2026-04-12";
+    const week = [
+      "2026-04-06",
+      "2026-04-07",
+      "2026-04-08",
+      "2026-04-09",
+      "2026-04-10",
+      "2026-04-11",
+      "2026-04-12",
+    ];
+    const { noSnapshotFutureDays, daysToFetch } = partitionOuraWeekPresenceDayKeys(week, todayEnd);
+    expect(daysToFetch).toEqual(week);
+    expect(Object.keys(noSnapshotFutureDays).length).toBe(0);
+  });
+});
+
+describe("mergeOuraWeekPresenceMaps", () => {
+  it("keeps future-day false entries and overlays API results", () => {
+    const merged = mergeOuraWeekPresenceMaps(
+      { "2026-04-10": false, "2026-04-11": false },
+      [
+        ["2026-04-08", true],
+        ["2026-04-09", false],
+      ],
+    );
+    expect(merged).toEqual({
+      "2026-04-08": true,
+      "2026-04-09": false,
+      "2026-04-10": false,
+      "2026-04-11": false,
+    });
+  });
+});
+
+describe("useOuraViewWeekSnapshotPresence (contract)", () => {
+  it("treats 200 JSON as snapshot present", () => {
+    const o = truthOutcomeFromApiResult({
+      ok: true,
+      status: 200,
+      requestId: null,
+      json: {
+        requestedDay: "2026-04-06",
+        resolvedDay: "2026-04-06",
+        isFallback: false,
+        day: "2026-04-06",
+        score: null,
+        contributors: {},
+      },
+    });
+    expect(o.status).toBe("ready");
+  });
+
+  it("treats 404 as no snapshot for that day", () => {
+    const o = truthOutcomeFromApiResult({
+      ok: false,
+      kind: "http",
+      status: 404,
+      error: "nf",
+      requestId: null,
+    });
+    expect(o.status).toBe("missing");
+  });
+});
+
+jest.mock("@/lib/auth/AuthProvider", () => ({
+  useAuth: () => ({
+    user: { uid: "u1" },
+    initializing: false,
+    getIdToken: (...args: unknown[]) =>
+      (globalThis as { __oliOuraPresenceGetIdToken?: jest.Mock }).__oliOuraPresenceGetIdToken!(...args),
+  }),
+}));
+
+jest.mock("@/lib/api/usersMe", () => ({
+  getOuraSleepView: (day: string, token: string) =>
+    (globalThis as { __oliOuraPresenceSleepMock?: jest.Mock }).__oliOuraPresenceSleepMock!(day, token),
+  getOuraReadinessView: jest.fn(),
+}));
+
+jest.mock("@/lib/ui/calendar/dateUtils", () => ({
+  ...jest.requireActual<typeof import("@/lib/ui/calendar/dateUtils")>("@/lib/ui/calendar/dateUtils"),
+  getTodayDayKeyLocal: jest.fn(),
+}));
+
+import { getTodayDayKeyLocal } from "@/lib/ui/calendar/dateUtils";
+
+describe("useOuraViewWeekSnapshotPresence (hook)", () => {
+  const weekStartingSunday = [
+    "2026-04-06",
+    "2026-04-07",
+    "2026-04-08",
+    "2026-04-09",
+    "2026-04-10",
+    "2026-04-11",
+    "2026-04-12",
+  ];
+
+  beforeEach(() => {
+    const gt = globalThis as { __oliOuraPresenceSleepMock?: jest.Mock; __oliOuraPresenceGetIdToken?: jest.Mock };
+    gt.__oliOuraPresenceSleepMock = jest.fn();
+    gt.__oliOuraPresenceGetIdToken = jest.fn().mockResolvedValue("token");
+    (getTodayDayKeyLocal as jest.Mock).mockReset();
+  });
+
+  function sleepMock() {
+    return (globalThis as { __oliOuraPresenceSleepMock?: jest.Mock }).__oliOuraPresenceSleepMock!;
+  }
+
+  function getIdTokenMock() {
+    return (globalThis as { __oliOuraPresenceGetIdToken?: jest.Mock }).__oliOuraPresenceGetIdToken!;
+  }
+
+  function Capture({
+    days,
+    stateRef,
+  }: {
+    days: readonly string[];
+    stateRef: { current: ReturnType<typeof useOuraViewWeekSnapshotPresence> | null };
+  }) {
+    stateRef.current = useOuraViewWeekSnapshotPresence(days, "sleep");
+    return null;
+  }
+
+  it("does not call Oura API for future days; future days are never marked hasSnapshot", async () => {
+    (getTodayDayKeyLocal as jest.Mock).mockReturnValue("2026-04-06");
+    sleepMock().mockResolvedValue({
+      ok: true,
+      status: 200,
+      requestId: null,
+      json: {
+        requestedDay: "2026-04-06",
+        resolvedDay: "2026-04-06",
+        isFallback: false,
+        day: "2026-04-06",
+        score: 80,
+        contributors: {},
+      },
+    });
+
+    const stateRef: { current: ReturnType<typeof useOuraViewWeekSnapshotPresence> | null } = {
+      current: null,
+    };
+    await act(async () => {
+      renderer.create(React.createElement(Capture, { days: weekStartingSunday, stateRef }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const last = stateRef.current;
+    expect(sleepMock()).toHaveBeenCalledTimes(1);
+    expect(sleepMock()).toHaveBeenCalledWith("2026-04-06", "token");
+    expect(last?.status).toBe("ready");
+    if (last?.status === "ready") {
+      expect(last.hasSnapshotByDay["2026-04-06"]).toBe(true);
+      expect(last.hasSnapshotByDay["2026-04-07"]).toBe(false);
+      expect(last.hasSnapshotByDay["2026-04-12"]).toBe(false);
+    }
+  });
+
+  it("today with no data (404) → no ring for today; future days still false", async () => {
+    (getTodayDayKeyLocal as jest.Mock).mockReturnValue("2026-04-06");
+    sleepMock().mockResolvedValue({
+      ok: false,
+      kind: "http",
+      status: 404,
+      error: "nf",
+      requestId: null,
+    });
+
+    const stateRef: { current: ReturnType<typeof useOuraViewWeekSnapshotPresence> | null } = {
+      current: null,
+    };
+    await act(async () => {
+      renderer.create(React.createElement(Capture, { days: weekStartingSunday, stateRef }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const last = stateRef.current;
+    expect(last?.status).toBe("ready");
+    if (last?.status === "ready") {
+      expect(last.hasSnapshotByDay["2026-04-06"]).toBe(false);
+      expect(last.hasSnapshotByDay["2026-04-07"]).toBe(false);
+    }
+  });
+
+  it("past days with data → ring; past days without → no ring", async () => {
+    (getTodayDayKeyLocal as jest.Mock).mockReturnValue("2026-04-12");
+    sleepMock().mockImplementation(async (day: string) => {
+      if (day === "2026-04-08") {
+        return {
+          ok: true,
+          status: 200,
+          requestId: null,
+          json: {
+            requestedDay: day,
+            resolvedDay: day,
+            isFallback: false,
+            day,
+            score: 70,
+            contributors: {},
+          },
+        };
+      }
+      return { ok: false, kind: "http" as const, status: 404, error: "nf", requestId: null };
+    });
+
+    const stateRef: { current: ReturnType<typeof useOuraViewWeekSnapshotPresence> | null } = {
+      current: null,
+    };
+    await act(async () => {
+      renderer.create(React.createElement(Capture, { days: weekStartingSunday, stateRef }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const last = stateRef.current;
+    expect(sleepMock()).toHaveBeenCalledTimes(7);
+    expect(last?.status).toBe("ready");
+    if (last?.status === "ready") {
+      expect(last.hasSnapshotByDay["2026-04-08"]).toBe(true);
+      expect(last.hasSnapshotByDay["2026-04-09"]).toBe(false);
+    }
+  });
+
+  it("when all strip days are future, performs zero API calls and all days false", async () => {
+    (getTodayDayKeyLocal as jest.Mock).mockReturnValue("2026-04-05");
+    const onlyFutureWeek = [
+      "2026-04-06",
+      "2026-04-07",
+      "2026-04-08",
+      "2026-04-09",
+      "2026-04-10",
+      "2026-04-11",
+      "2026-04-12",
+    ];
+
+    const stateRef: { current: ReturnType<typeof useOuraViewWeekSnapshotPresence> | null } = {
+      current: null,
+    };
+    await act(async () => {
+      renderer.create(React.createElement(Capture, { days: onlyFutureWeek, stateRef }));
+      await Promise.resolve();
+    });
+
+    const last = stateRef.current;
+    expect(sleepMock()).not.toHaveBeenCalled();
+    expect(getIdTokenMock()).not.toHaveBeenCalled();
+    expect(last?.status).toBe("ready");
+    if (last?.status === "ready") {
+      for (const d of onlyFutureWeek) {
+        expect(last.hasSnapshotByDay[d]).toBe(false);
+      }
+    }
+  });
+});

--- a/lib/data/oura/useOuraViewWeekSnapshotPresence.ts
+++ b/lib/data/oura/useOuraViewWeekSnapshotPresence.ts
@@ -1,0 +1,117 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { useAuth } from "@/lib/auth/AuthProvider";
+import { getOuraReadinessView, getOuraSleepView } from "@/lib/api/usersMe";
+import { truthOutcomeFromApiResult } from "@/lib/data/truthOutcome";
+import { getTodayDayKeyLocal } from "@/lib/ui/calendar/dateUtils";
+
+export type OuraRecoveryViewKind = "sleep" | "readiness";
+
+/**
+ * Split week strip days: future (local calendar) → no snapshot, no fetch; today and past → query API.
+ * YYYY-MM-DD string order matches chronological order.
+ */
+export function partitionOuraWeekPresenceDayKeys(
+  dayKeys: readonly string[],
+  todayDayKey: string,
+): { noSnapshotFutureDays: Record<string, boolean>; daysToFetch: string[] } {
+  const noSnapshotFutureDays: Record<string, boolean> = {};
+  const daysToFetch: string[] = [];
+  for (const day of dayKeys) {
+    if (day > todayDayKey) {
+      noSnapshotFutureDays[day] = false;
+    } else {
+      daysToFetch.push(day);
+    }
+  }
+  return { noSnapshotFutureDays, daysToFetch };
+}
+
+export function mergeOuraWeekPresenceMaps(
+  noSnapshotFutureDays: Record<string, boolean>,
+  fetched: readonly (readonly [string, boolean])[],
+): Record<string, boolean> {
+  const out: Record<string, boolean> = { ...noSnapshotFutureDays };
+  for (const [day, has] of fetched) {
+    out[day] = has;
+  }
+  return out;
+}
+
+type State =
+  | { status: "partial" }
+  | {
+      status: "ready";
+      /** True when GET oura-*-view returned 200 with a valid DTO (synced snapshot exists for that day). */
+      hasSnapshotByDay: Record<string, boolean>;
+    };
+
+/**
+ * Per-day Oura snapshot presence for a week strip. Uses existing per-day view endpoints only (no new API).
+ */
+export function useOuraViewWeekSnapshotPresence(
+  dayKeys: readonly string[],
+  kind: OuraRecoveryViewKind,
+): State & { refetch: () => void } {
+  const { user, initializing, getIdToken } = useAuth();
+  const dayKeysRef = useRef(dayKeys);
+  dayKeysRef.current = dayKeys;
+  const kindRef = useRef(kind);
+  kindRef.current = kind;
+  const requestSeq = useRef(0);
+
+  /** Stable across renders; read inside async fetch to avoid unstable useCallback deps (e.g. mock useAuth). */
+  const authRef = useRef({ initializing, userUid: user?.uid, getIdToken });
+  authRef.current = { initializing, userUid: user?.uid, getIdToken };
+
+  const [state, setState] = useState<State>({ status: "partial" });
+
+  const fetchAll = useCallback(async () => {
+    const seq = ++requestSeq.current;
+    const keys = [...dayKeysRef.current];
+    const k = kindRef.current;
+    const { initializing: init, userUid, getIdToken: getToken } = authRef.current;
+
+    const safeSet = (next: State) => {
+      if (seq === requestSeq.current) setState(next);
+    };
+
+    if (init || !userUid || keys.length === 0) {
+      safeSet({ status: "ready", hasSnapshotByDay: {} });
+      return;
+    }
+
+    const todayDayKey = getTodayDayKeyLocal();
+    const { noSnapshotFutureDays, daysToFetch } = partitionOuraWeekPresenceDayKeys(keys, todayDayKey);
+
+    if (daysToFetch.length === 0) {
+      safeSet({ status: "ready", hasSnapshotByDay: { ...noSnapshotFutureDays } });
+      return;
+    }
+
+    safeSet({ status: "partial" });
+
+    const token = await getToken(false);
+    if (!token || seq !== requestSeq.current) return;
+
+    const results = await Promise.all(
+      daysToFetch.map(async (day) => {
+        const res =
+          k === "sleep" ? await getOuraSleepView(day, token) : await getOuraReadinessView(day, token);
+        const outcome = truthOutcomeFromApiResult(res);
+        return [day, outcome.status === "ready"] as const;
+      }),
+    );
+
+    if (seq !== requestSeq.current) return;
+
+    const hasSnapshotByDay = mergeOuraWeekPresenceMaps(noSnapshotFutureDays, results);
+    safeSet({ status: "ready", hasSnapshotByDay });
+  }, []);
+
+  useEffect(() => {
+    void fetchAll();
+  }, [fetchAll, kind, user?.uid, dayKeys.join(",")]);
+
+  return useMemo(() => ({ ...state, refetch: fetchAll }), [state, fetchAll]);
+}

--- a/lib/data/useReadinessView.ts
+++ b/lib/data/useReadinessView.ts
@@ -54,11 +54,9 @@ export function useReadinessView(day: string): State & { refetch: (opts?: TruthG
         return;
       }
       if (outcome.status === "missing") {
-        if (stateRef.current.status === "ready") return;
         safeSet({ status: "missing" });
         return;
       }
-      if (stateRef.current.status === "ready") return;
       safeSet({ status: "error", error: outcome.error, requestId: outcome.requestId });
     },
     [getIdToken, initializing, user],

--- a/lib/data/useSleepView.ts
+++ b/lib/data/useSleepView.ts
@@ -54,11 +54,9 @@ export function useSleepView(day: string): State & { refetch: (opts?: TruthGetOp
         return;
       }
       if (outcome.status === "missing") {
-        if (stateRef.current.status === "ready") return;
         safeSet({ status: "missing" });
         return;
       }
-      if (stateRef.current.status === "ready") return;
       safeSet({ status: "error", error: outcome.error, requestId: outcome.requestId });
     },
     [getIdToken, initializing, user],

--- a/lib/data/workouts/__tests__/strengthOverviewCardModel.test.ts
+++ b/lib/data/workouts/__tests__/strengthOverviewCardModel.test.ts
@@ -1,0 +1,244 @@
+import { addCalendarDaysToDayKey } from "@/lib/ui/calendar/dateUtils";
+import { reconcileWorkoutSessionsForDay } from "@/lib/data/workouts/workoutSessionReconciliation";
+import {
+  buildStrengthOverviewCardModel,
+  formatStrengthOverviewCompactStatsLine,
+  STRENGTH_OVERVIEW_THREE_MONTH_ROLLING_DAYS,
+} from "../strengthOverviewCardModel";
+import {
+  buildWorkoutOverviewAnalyticsFromCalendarDays,
+  monthKeyFromDay,
+} from "../workoutsCalendarModel";
+
+describe("buildStrengthOverviewCardModel", () => {
+  const today = "2026-04-04" as const;
+  const weekStart = "2026-03-30" as const;
+  const weekEnd = "2026-04-05" as const;
+
+  function baseInput(overrides?: Partial<Parameters<typeof buildStrengthOverviewCardModel>[0]>) {
+    return {
+      strengthCalendarDays: [] as const,
+      analyticsDaysSlice: [] as const,
+      todayDayKey: today,
+      weekStartDay: weekStart,
+      weekEndDay: weekEnd,
+      manualWorkoutSummaries: [] as const,
+      ...overrides,
+    };
+  }
+
+  it("returns four timeframes in YTD → 3 Month → MTD → This Week order", () => {
+    const m = buildStrengthOverviewCardModel(baseInput());
+    expect(m.timeframes.map((t) => t.key)).toEqual(["ytd", "threeMonth", "mtd", "thisWeek"]);
+    expect(m.timeframes.map((t) => t.label)).toEqual(["YTD", "3 Month", "MTD", "This Week"]);
+  });
+
+  it("YTD strength metrics match buildWorkoutOverviewAnalyticsFromCalendarDays", () => {
+    const analyticsDaysSlice = [
+      {
+        day: "2026-03-10" as const,
+        workouts: [
+          {
+            id: "a",
+            observedAt: "2026-03-10T10:00:00.000Z",
+            sourceId: "apple_health",
+            title: "Lift",
+            workoutType: "strength" as const,
+            start: "2026-03-10T10:00:00.000Z",
+            end: "2026-03-10T10:30:00.000Z",
+            durationMinutes: 30,
+            calories: null,
+          },
+        ],
+      },
+    ];
+    const direct = buildWorkoutOverviewAnalyticsFromCalendarDays(analyticsDaysSlice, { todayDayKey: today });
+    const m = buildStrengthOverviewCardModel(
+      baseInput({ strengthCalendarDays: analyticsDaysSlice, analyticsDaysSlice }),
+    );
+    const ytd = m.timeframes.find((t) => t.key === "ytd")!;
+    expect(ytd.totalWorkouts).toBe(direct.metricsByTab.strength.totalWorkouts);
+    expect(ytd.avgWorkoutsPerWeek).toBe(direct.metricsByTab.strength.avgPerWeek);
+    expect(ytd.compactStatsSummary).toBe(
+      formatStrengthOverviewCompactStatsLine(ytd.totalWorkouts, ytd.avgWorkoutsPerWeek),
+    );
+  });
+
+  it("MTD uses current month only for totals vs YTD", () => {
+    const days = [
+      {
+        day: "2026-03-28" as const,
+        workouts: [
+          {
+            id: "mar",
+            observedAt: "2026-03-28T10:00:00.000Z",
+            sourceId: "apple_health",
+            title: "Lift",
+            workoutType: "strength" as const,
+            start: "2026-03-28T10:00:00.000Z",
+            end: "2026-03-28T10:30:00.000Z",
+            durationMinutes: 30,
+            calories: null,
+          },
+        ],
+      },
+      {
+        day: "2026-04-02" as const,
+        workouts: [
+          {
+            id: "apr",
+            observedAt: "2026-04-02T10:00:00.000Z",
+            sourceId: "apple_health",
+            title: "Lift",
+            workoutType: "strength" as const,
+            start: "2026-04-02T10:00:00.000Z",
+            end: "2026-04-02T10:45:00.000Z",
+            durationMinutes: 45,
+            calories: null,
+          },
+        ],
+      },
+    ];
+    const m = buildStrengthOverviewCardModel(baseInput({ strengthCalendarDays: days, analyticsDaysSlice: days }));
+    expect(monthKeyFromDay(today)).toBe("2026-04");
+    const mtd = m.timeframes.find((t) => t.key === "mtd")!;
+    const ytd = m.timeframes.find((t) => t.key === "ytd")!;
+    expect(mtd.totalWorkouts).toBe(1);
+    expect(ytd.totalWorkouts).toBe(2);
+  });
+
+  it("3 Month window uses rolling 90 calendar days through today", () => {
+    const threeStartExpected = addCalendarDaysToDayKey(today, -(STRENGTH_OVERVIEW_THREE_MONTH_ROLLING_DAYS - 1));
+    const days = [
+      {
+        day: threeStartExpected,
+        workouts: [
+          {
+            id: "edge",
+            observedAt: "2026-01-05T12:00:00.000Z",
+            sourceId: "apple_health",
+            title: "Lift",
+            workoutType: "strength" as const,
+            start: "2026-01-05T12:00:00.000Z",
+            end: "2026-01-05T12:30:00.000Z",
+            durationMinutes: 30,
+            calories: null,
+          },
+        ],
+      },
+    ];
+    const m = buildStrengthOverviewCardModel(baseInput({ strengthCalendarDays: days, analyticsDaysSlice: days }));
+    const tm = m.timeframes.find((t) => t.key === "threeMonth")!;
+    expect(tm.totalWorkouts).toBe(1);
+  });
+
+  it("excludes mixed reconciled sessions everywhere (reconciled session truth)", () => {
+    const dayKey = "2026-07-15" as const;
+    const mixedDay = {
+      day: dayKey,
+      workouts: [
+        {
+          id: "str",
+          observedAt: "2026-07-15T10:00:00.000Z",
+          sourceId: "apple_health",
+          title: "Strength Training",
+          workoutType: "strength" as const,
+          start: "2026-07-15T10:00:00.000Z",
+          end: "2026-07-15T10:45:00.000Z",
+          durationMinutes: 45,
+          calories: null,
+        },
+        {
+          id: "bridge",
+          observedAt: "2026-07-15T10:08:00.000Z",
+          sourceId: "manual",
+          title: "",
+          start: "2026-07-15T10:08:00.000Z",
+          end: null,
+          durationMinutes: null,
+          calories: null,
+        },
+        {
+          id: "car",
+          observedAt: "2026-07-15T10:15:00.000Z",
+          sourceId: "apple_health",
+          title: "Running",
+          workoutType: "cardio" as const,
+          start: "2026-07-15T10:15:00.000Z",
+          end: "2026-07-15T10:50:00.000Z",
+          durationMinutes: 35,
+          calories: null,
+        },
+      ],
+    };
+    expect(reconcileWorkoutSessionsForDay(dayKey, mixedDay.workouts)[0]?.sessionType).toBe("mixed");
+
+    const m = buildStrengthOverviewCardModel(
+      baseInput({
+        strengthCalendarDays: [mixedDay],
+        analyticsDaysSlice: [mixedDay],
+        todayDayKey: dayKey,
+        weekStartDay: "2026-07-12" as const,
+        weekEndDay: "2026-07-18" as const,
+      }),
+    );
+    for (const tf of m.timeframes) {
+      expect(tf.totalWorkouts).toBe(0);
+    }
+  });
+
+  it("This Week counts only strength sessions in the calendar week slice", () => {
+    const days = [
+      {
+        day: weekStart,
+        workouts: [
+          {
+            id: "w",
+            observedAt: "2026-03-30T10:00:00.000Z",
+            sourceId: "apple_health",
+            title: "Lift",
+            workoutType: "strength" as const,
+            start: "2026-03-30T10:00:00.000Z",
+            end: "2026-03-30T10:30:00.000Z",
+            durationMinutes: 30,
+            calories: null,
+          },
+        ],
+      },
+    ];
+    const m = buildStrengthOverviewCardModel(baseInput({ strengthCalendarDays: days, analyticsDaysSlice: days }));
+    const w = m.timeframes.find((t) => t.key === "thisWeek")!;
+    expect(w.totalWorkouts).toBe(1);
+    expect(w.avgWorkoutsPerWeek).not.toBeNull();
+  });
+
+  it("each timeframe includes rating with label, microcopy, progress in 0..1, and finite scoringAvg", () => {
+    const m = buildStrengthOverviewCardModel(baseInput());
+    for (const tf of m.timeframes) {
+      expect(tf.rating.label.length).toBeGreaterThan(0);
+      expect(tf.rating.microcopy.length).toBeGreaterThan(0);
+      expect(tf.rating.progress).toBeGreaterThanOrEqual(0);
+      expect(tf.rating.progress).toBeLessThanOrEqual(1);
+      expect(Number.isFinite(tf.rating.scoringAvg)).toBe(true);
+      expect(tf.rating.scoringAvg).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("documents 3-month rolling span constant", () => {
+    expect(STRENGTH_OVERVIEW_THREE_MONTH_ROLLING_DAYS).toBe(90);
+  });
+});
+
+describe("formatStrengthOverviewCompactStatsLine", () => {
+  it("uses plural workouts and fixed decimal avg", () => {
+    expect(formatStrengthOverviewCompactStatsLine(64, 4.8)).toBe("64 workouts · 4.8 / week");
+  });
+
+  it("uses singular workout for 1", () => {
+    expect(formatStrengthOverviewCompactStatsLine(1, 2.5)).toBe("1 workout · 2.5 / week");
+  });
+
+  it("shows em dash when avg is null", () => {
+    expect(formatStrengthOverviewCompactStatsLine(0, null)).toBe("0 workouts · — / week");
+  });
+});

--- a/lib/data/workouts/__tests__/strengthOverviewTimeframeRating.test.ts
+++ b/lib/data/workouts/__tests__/strengthOverviewTimeframeRating.test.ts
@@ -1,0 +1,159 @@
+import type { StrengthOverviewTimeframeRatingTier } from "../strengthOverviewTimeframeRating";
+import {
+  computeStrengthOverviewMarkerPosition01,
+  getStrengthOverviewTierSegmentBounds01,
+  STRENGTH_OVERVIEW_TF_PROGRESS_SCALE,
+  STRENGTH_OVERVIEW_TF_RATING_DEVELOPING_MIN,
+  STRENGTH_OVERVIEW_TF_RATING_OPTIMAL_MIN,
+  STRENGTH_OVERVIEW_TF_RATING_SOLID_MIN,
+  STRENGTH_OVERVIEW_TF_RATING_STRONG_MIN,
+  strengthOverviewTimeframeConsistencyRating,
+} from "../strengthOverviewTimeframeRating";
+
+describe("strengthOverviewTimeframeConsistencyRating", () => {
+  it("returns Low and zero progress when no workouts", () => {
+    const r = strengthOverviewTimeframeConsistencyRating({
+      timeframe: "ytd",
+      avgWorkoutsPerWeek: null,
+      totalWorkouts: 0,
+      elapsedCalendarDays: 100,
+    });
+    expect(r.tier).toBe("low");
+    expect(r.label).toBe("Low");
+    expect(r.progress).toBe(0);
+    expect(r.scoringAvg).toBe(0);
+  });
+
+  it("tier boundaries on ytd match avg/week thresholds when density is saturated", () => {
+    const mk = (avg: number) =>
+      strengthOverviewTimeframeConsistencyRating({
+        timeframe: "ytd",
+        avgWorkoutsPerWeek: avg,
+        totalWorkouts: 50,
+        elapsedCalendarDays: 100,
+      });
+
+    expect(mk(STRENGTH_OVERVIEW_TF_RATING_DEVELOPING_MIN - 0.001).tier).toBe("low");
+    expect(mk(STRENGTH_OVERVIEW_TF_RATING_DEVELOPING_MIN).tier).toBe("developing");
+    expect(mk(STRENGTH_OVERVIEW_TF_RATING_SOLID_MIN - 0.001).tier).toBe("developing");
+    expect(mk(STRENGTH_OVERVIEW_TF_RATING_SOLID_MIN).tier).toBe("solid");
+    expect(mk(STRENGTH_OVERVIEW_TF_RATING_STRONG_MIN - 0.001).tier).toBe("solid");
+    expect(mk(STRENGTH_OVERVIEW_TF_RATING_STRONG_MIN).tier).toBe("strong");
+    expect(mk(STRENGTH_OVERVIEW_TF_RATING_OPTIMAL_MIN - 0.001).tier).toBe("strong");
+    expect(mk(STRENGTH_OVERVIEW_TF_RATING_OPTIMAL_MIN).tier).toBe("optimal");
+  });
+
+  it("progress clamps to 1 and scales with scoring average", () => {
+    const r = strengthOverviewTimeframeConsistencyRating({
+      timeframe: "mtd",
+      avgWorkoutsPerWeek: 20,
+      totalWorkouts: 40,
+      elapsedCalendarDays: 30,
+    });
+    expect(r.progress).toBe(1);
+    const r2 = strengthOverviewTimeframeConsistencyRating({
+      timeframe: "mtd",
+      avgWorkoutsPerWeek: STRENGTH_OVERVIEW_TF_RATING_OPTIMAL_MIN,
+      totalWorkouts: 20,
+      elapsedCalendarDays: 30,
+    });
+    expect(r2.progress).toBeCloseTo(STRENGTH_OVERVIEW_TF_RATING_OPTIMAL_MIN / STRENGTH_OVERVIEW_TF_PROGRESS_SCALE, 5);
+  });
+
+  it("thisWeek dampens partial-week extrapolation so one workout day-1 is not Optimal", () => {
+    const r = strengthOverviewTimeframeConsistencyRating({
+      timeframe: "thisWeek",
+      avgWorkoutsPerWeek: 7,
+      totalWorkouts: 1,
+      elapsedCalendarDays: 1,
+    });
+    expect(r.tier).not.toBe("optimal");
+    expect(r.tier).toBe("developing");
+  });
+
+  it("low total workouts reduces scoring via density for the same avg/week", () => {
+    const highDensity = strengthOverviewTimeframeConsistencyRating({
+      timeframe: "threeMonth",
+      avgWorkoutsPerWeek: 3,
+      totalWorkouts: 20,
+      elapsedCalendarDays: 90,
+    });
+    const lowDensity = strengthOverviewTimeframeConsistencyRating({
+      timeframe: "threeMonth",
+      avgWorkoutsPerWeek: 3,
+      totalWorkouts: 1,
+      elapsedCalendarDays: 90,
+    });
+    expect(lowDensity.progress).toBeLessThan(highDensity.progress);
+    expect(lowDensity.tier).not.toBe("optimal");
+  });
+});
+
+function assertMarkerWithinTier(tier: StrengthOverviewTimeframeRatingTier, scoringAvg: number): number {
+  const m = computeStrengthOverviewMarkerPosition01({ tier, scoringAvg });
+  const { start, end } = getStrengthOverviewTierSegmentBounds01(tier);
+  expect(m).toBeGreaterThanOrEqual(start);
+  expect(m).toBeLessThanOrEqual(end);
+  return m;
+}
+
+describe("computeStrengthOverviewMarkerPosition01", () => {
+  it("Strong high-end score stays inside Strong segment, not in Optimal (global progress would spill)", () => {
+    const strongEnd = assertMarkerWithinTier("strong", STRENGTH_OVERVIEW_TF_RATING_OPTIMAL_MIN - 1e-6);
+    const optimalStart = getStrengthOverviewTierSegmentBounds01("optimal").start;
+    expect(strongEnd).toBeLessThan(optimalStart);
+  });
+
+  it("Strong low-end score stays inside Strong segment", () => {
+    const m = assertMarkerWithinTier("strong", STRENGTH_OVERVIEW_TF_RATING_STRONG_MIN);
+    expect(m).toBeCloseTo(getStrengthOverviewTierSegmentBounds01("strong").start, 10);
+  });
+
+  it("Optimal tier stays inside Optimal segment including capped upper score", () => {
+    assertMarkerWithinTier("optimal", STRENGTH_OVERVIEW_TF_RATING_OPTIMAL_MIN);
+    assertMarkerWithinTier("optimal", STRENGTH_OVERVIEW_TF_PROGRESS_SCALE);
+    assertMarkerWithinTier("optimal", 99);
+  });
+
+  const tierCases: { tier: StrengthOverviewTimeframeRatingTier; score: number }[] = [
+    { tier: "low", score: 0.4 },
+    { tier: "developing", score: 1.2 },
+    { tier: "solid", score: 2.5 },
+    { tier: "strong", score: 3.7 },
+    { tier: "optimal", score: 5.3 },
+  ];
+
+  it("maps all five tiers to positions inside their own segment bounds", () => {
+    for (const { tier, score } of tierCases) {
+      assertMarkerWithinTier(tier, score);
+    }
+  });
+
+  it("boundary scores at each tier threshold sit at segment starts (deterministic)", () => {
+    expect(computeStrengthOverviewMarkerPosition01({ tier: "developing", scoringAvg: 1 })).toBeCloseTo(0.2, 10);
+    expect(computeStrengthOverviewMarkerPosition01({ tier: "solid", scoringAvg: 2 })).toBeCloseTo(0.4, 10);
+    expect(computeStrengthOverviewMarkerPosition01({ tier: "strong", scoringAvg: 3 })).toBeCloseTo(0.6, 10);
+    expect(computeStrengthOverviewMarkerPosition01({ tier: "optimal", scoringAvg: 5 })).toBeCloseTo(0.8, 10);
+  });
+
+  it("invalid scoringAvg falls back safely for marker math", () => {
+    const m = computeStrengthOverviewMarkerPosition01({ tier: "low", scoringAvg: Number.NaN });
+    expect(m).toBe(0);
+  });
+
+  it("rating + marker helper: every tier from consistency rating keeps marker inside that tier segment", () => {
+    const mk = (avg: number) =>
+      strengthOverviewTimeframeConsistencyRating({
+        timeframe: "ytd",
+        avgWorkoutsPerWeek: avg,
+        totalWorkouts: 50,
+        elapsedCalendarDays: 100,
+      });
+
+    const samples = [0.2, 1.1, 2.2, 3.5, 5.2, 8];
+    for (const avg of samples) {
+      const r = mk(avg);
+      assertMarkerWithinTier(r.tier, r.scoringAvg);
+    }
+  });
+});

--- a/lib/data/workouts/strengthOverviewCardModel.ts
+++ b/lib/data/workouts/strengthOverviewCardModel.ts
@@ -1,0 +1,240 @@
+import type { DayKey } from "@/lib/ui/calendar/types";
+import type { MonthYear } from "@/lib/ui/calendar/dateUtils";
+import {
+  addCalendarDaysToDayKey,
+  enumerateDaysInclusive,
+  getMonthFirstDay,
+  getMonthLastDay,
+} from "@/lib/ui/calendar/dateUtils";
+import {
+  filterWorkoutCalendarDaysInclusive,
+  maxDayKey,
+  minDayKey,
+} from "@/lib/data/workouts/overviewCalendarRangeSlices";
+import { buildStrengthMonthOverviewFromCalendarDays } from "@/lib/data/workouts/strengthOverviewMonthAnalytics";
+import {
+  buildWorkoutOverviewAnalyticsFromCalendarDays,
+  elapsedDaysForWorkoutOverviewAnalyticsYear,
+  monthKeyFromDay,
+  sessionMatchesOverviewStrengthTab,
+  type WorkoutCalendarDayLike,
+} from "@/lib/data/workouts/workoutsCalendarModel";
+import { reconcileWorkoutSessionsForDay, type ReconciledWorkoutSession } from "@/lib/data/workouts/workoutSessionReconciliation";
+import type { ManualWorkoutDaySummary } from "@/lib/workouts/journal/manualWorkoutSummary";
+import {
+  strengthOverviewTimeframeConsistencyRating,
+  type StrengthOverviewTimeframeKey,
+  type StrengthOverviewTimeframeRatingResult,
+} from "@/lib/data/workouts/strengthOverviewTimeframeRating";
+
+export type { StrengthOverviewTimeframeKey };
+
+/** Rolling inclusive day span for the "3 Month" window (today and 89 prior days = 90). */
+export const STRENGTH_OVERVIEW_THREE_MONTH_ROLLING_DAYS = 90;
+
+export type StrengthOverviewTimeframeModel = {
+  key: StrengthOverviewTimeframeKey;
+  label: string;
+  totalWorkouts: number;
+  avgWorkoutsPerWeek: number | null;
+  /** Display line: "{n} workout(s) · {avg} / week" for the card header. */
+  compactStatsSummary: string;
+  rating: StrengthOverviewTimeframeRatingResult;
+};
+
+/** Pure formatter for Strength Overview compact stats (UI copy contract). */
+export function formatStrengthOverviewCompactStatsLine(
+  totalWorkouts: number,
+  avgWorkoutsPerWeek: number | null,
+): string {
+  const n = Math.max(0, Math.round(totalWorkouts));
+  const w = n === 1 ? "workout" : "workouts";
+  const avg =
+    typeof avgWorkoutsPerWeek === "number" && Number.isFinite(avgWorkoutsPerWeek)
+      ? avgWorkoutsPerWeek.toFixed(1)
+      : "—";
+  return `${n} ${w} · ${avg} / week`;
+}
+
+export type StrengthOverviewCardModel = {
+  timeframes: StrengthOverviewTimeframeModel[];
+};
+
+function monthYearFromMonthKey(monthKey: string): MonthYear | null {
+  const m = /^(\d{4})-(\d{2})$/.exec(monthKey);
+  if (!m) return null;
+  const year = Number(m[1]);
+  const month = Number(m[2]);
+  if (!Number.isFinite(year) || !Number.isFinite(month)) return null;
+  return { year, month };
+}
+
+function collectStrengthTabSessions(days: readonly WorkoutCalendarDayLike[]): ReconciledWorkoutSession[] {
+  const out: ReconciledWorkoutSession[] = [];
+  for (const d of days) {
+    for (const s of reconcileWorkoutSessionsForDay(d.day, d.workouts)) {
+      if (sessionMatchesOverviewStrengthTab(s)) out.push(s);
+    }
+  }
+  return out;
+}
+
+function computeAvgPerWeekFromTotals(totalWorkouts: number, elapsedCalendarDays: number): number | null {
+  if (totalWorkouts <= 0) return null;
+  if (!Number.isFinite(elapsedCalendarDays) || elapsedCalendarDays <= 0) return null;
+  return (totalWorkouts * 7) / elapsedCalendarDays;
+}
+
+function metricsForSessions(
+  sessions: ReconciledWorkoutSession[],
+  elapsedCalendarDays: number,
+): {
+  totalWorkouts: number;
+  avgWorkoutsPerWeek: number | null;
+} {
+  const totalWorkouts = sessions.length;
+  return {
+    totalWorkouts,
+    avgWorkoutsPerWeek: computeAvgPerWeekFromTotals(totalWorkouts, elapsedCalendarDays),
+  };
+}
+
+function elapsedDaysInCurrentMonthThroughToday(todayDayKey: DayKey): number {
+  const mk = monthKeyFromDay(todayDayKey);
+  const my = monthYearFromMonthKey(mk);
+  if (!my) return 0;
+  const monthStart = getMonthFirstDay(my);
+  const monthEnd = getMonthLastDay(my);
+  const coverageEnd = minDayKey(maxDayKey(monthStart, todayDayKey), monthEnd);
+  if (coverageEnd < monthStart) return 0;
+  return enumerateDaysInclusive(monthStart, coverageEnd).length;
+}
+
+export function buildStrengthOverviewCardModel(input: {
+  /** Strength-domain rows across the full overview hydrate (week ∪ recent ∪ analytics). */
+  strengthCalendarDays: readonly WorkoutCalendarDayLike[];
+  analyticsDaysSlice: readonly WorkoutCalendarDayLike[];
+  todayDayKey: DayKey;
+  weekStartDay: DayKey;
+  weekEndDay: DayKey;
+  manualWorkoutSummaries: readonly ManualWorkoutDaySummary[];
+}): StrengthOverviewCardModel {
+  const { todayDayKey, weekStartDay, weekEndDay, manualWorkoutSummaries } = input;
+
+  const ytdBundle = buildWorkoutOverviewAnalyticsFromCalendarDays([...input.analyticsDaysSlice], {
+    todayDayKey,
+  });
+  const ytdStrength = ytdBundle.metricsByTab.strength;
+  const ytdElapsed = elapsedDaysForWorkoutOverviewAnalyticsYear(todayDayKey);
+
+  const focusMonthKey = monthKeyFromDay(todayDayKey);
+  const mtdOverview = buildStrengthMonthOverviewFromCalendarDays(
+    [...input.analyticsDaysSlice],
+    focusMonthKey,
+    {
+      todayDayKey,
+      manualJournalSummaries: manualWorkoutSummaries,
+    },
+  );
+  const mtdStrength = mtdOverview.metrics;
+  const mtdElapsed = elapsedDaysInCurrentMonthThroughToday(todayDayKey);
+
+  const threeStart = addCalendarDaysToDayKey(todayDayKey, -(STRENGTH_OVERVIEW_THREE_MONTH_ROLLING_DAYS - 1));
+  const threeDays = filterWorkoutCalendarDaysInclusive(
+    [...input.strengthCalendarDays],
+    threeStart,
+    todayDayKey,
+  );
+  const threeSessions = collectStrengthTabSessions(threeDays);
+  const threeElapsed = enumerateDaysInclusive(threeStart, todayDayKey).length;
+  const threeMetrics = metricsForSessions(threeSessions, threeElapsed);
+
+  const weekDays = filterWorkoutCalendarDaysInclusive(
+    [...input.strengthCalendarDays],
+    weekStartDay,
+    weekEndDay,
+  );
+  const weekSessions = collectStrengthTabSessions(weekDays);
+  const weekCoverageEnd = maxDayKey(weekStartDay, minDayKey(todayDayKey, weekEndDay));
+  const weekElapsedDays =
+    weekCoverageEnd < weekStartDay ? 0 : enumerateDaysInclusive(weekStartDay, weekCoverageEnd).length;
+  const weekElapsedForMetrics = Math.max(weekElapsedDays, 1);
+  const weekMetrics = metricsForSessions(weekSessions, weekElapsedForMetrics);
+
+  const ytdRating = strengthOverviewTimeframeConsistencyRating({
+    timeframe: "ytd",
+    avgWorkoutsPerWeek: ytdStrength.avgPerWeek,
+    totalWorkouts: ytdStrength.totalWorkouts,
+    elapsedCalendarDays: ytdElapsed > 0 ? ytdElapsed : 1,
+  });
+
+  const threeRating = strengthOverviewTimeframeConsistencyRating({
+    timeframe: "threeMonth",
+    avgWorkoutsPerWeek: threeMetrics.avgWorkoutsPerWeek,
+    totalWorkouts: threeMetrics.totalWorkouts,
+    elapsedCalendarDays: threeElapsed > 0 ? threeElapsed : 1,
+  });
+
+  const mtdRating = strengthOverviewTimeframeConsistencyRating({
+    timeframe: "mtd",
+    avgWorkoutsPerWeek: mtdStrength.avgPerWeek,
+    totalWorkouts: mtdStrength.totalWorkouts,
+    elapsedCalendarDays: mtdElapsed > 0 ? mtdElapsed : 1,
+  });
+
+  const weekRating = strengthOverviewTimeframeConsistencyRating({
+    timeframe: "thisWeek",
+    avgWorkoutsPerWeek: weekMetrics.avgWorkoutsPerWeek,
+    totalWorkouts: weekMetrics.totalWorkouts,
+    elapsedCalendarDays: weekElapsedForMetrics,
+  });
+
+  const timeframes: StrengthOverviewTimeframeModel[] = [
+    {
+      key: "ytd",
+      label: "YTD",
+      totalWorkouts: ytdStrength.totalWorkouts,
+      avgWorkoutsPerWeek: ytdStrength.avgPerWeek,
+      compactStatsSummary: formatStrengthOverviewCompactStatsLine(
+        ytdStrength.totalWorkouts,
+        ytdStrength.avgPerWeek,
+      ),
+      rating: ytdRating,
+    },
+    {
+      key: "threeMonth",
+      label: "3 Month",
+      totalWorkouts: threeMetrics.totalWorkouts,
+      avgWorkoutsPerWeek: threeMetrics.avgWorkoutsPerWeek,
+      compactStatsSummary: formatStrengthOverviewCompactStatsLine(
+        threeMetrics.totalWorkouts,
+        threeMetrics.avgWorkoutsPerWeek,
+      ),
+      rating: threeRating,
+    },
+    {
+      key: "mtd",
+      label: "MTD",
+      totalWorkouts: mtdStrength.totalWorkouts,
+      avgWorkoutsPerWeek: mtdStrength.avgPerWeek,
+      compactStatsSummary: formatStrengthOverviewCompactStatsLine(
+        mtdStrength.totalWorkouts,
+        mtdStrength.avgPerWeek,
+      ),
+      rating: mtdRating,
+    },
+    {
+      key: "thisWeek",
+      label: "This Week",
+      totalWorkouts: weekMetrics.totalWorkouts,
+      avgWorkoutsPerWeek: weekMetrics.avgWorkoutsPerWeek,
+      compactStatsSummary: formatStrengthOverviewCompactStatsLine(
+        weekMetrics.totalWorkouts,
+        weekMetrics.avgWorkoutsPerWeek,
+      ),
+      rating: weekRating,
+    },
+  ];
+
+  return { timeframes };
+}

--- a/lib/data/workouts/strengthOverviewTimeframeRating.ts
+++ b/lib/data/workouts/strengthOverviewTimeframeRating.ts
@@ -1,0 +1,173 @@
+/**
+ * Per-timeframe training consistency rating for Strength Overview.
+ * Primary signal: avg workouts/week. Secondary: total workouts vs expected density for elapsed days.
+ * Duration is not part of the score (v1). Deterministic thresholds — tune here only.
+ */
+
+export type StrengthOverviewTimeframeKey = "ytd" | "threeMonth" | "mtd" | "thisWeek";
+
+export type StrengthOverviewTimeframeRatingLabel = "Low" | "Developing" | "Solid" | "Strong" | "Optimal";
+
+export type StrengthOverviewTimeframeRatingTier = "low" | "developing" | "solid" | "strong" | "optimal";
+
+export type StrengthOverviewTimeframeRatingResult = {
+  label: StrengthOverviewTimeframeRatingLabel;
+  microcopy: string;
+  /** 0..1 fill for a single consistency bar (not per-metric). */
+  progress: number;
+  tier: StrengthOverviewTimeframeRatingTier;
+  /**
+   * Blended score used for tier selection (avg/week + density). Used for bar marker position within tier segment.
+   */
+  scoringAvg: number;
+};
+
+/** Tier boundaries on the scoring average (workouts/week equivalent after dampening + density). */
+export const STRENGTH_OVERVIEW_TF_RATING_DEVELOPING_MIN = 1;
+export const STRENGTH_OVERVIEW_TF_RATING_SOLID_MIN = 2;
+export const STRENGTH_OVERVIEW_TF_RATING_STRONG_MIN = 3;
+export const STRENGTH_OVERVIEW_TF_RATING_OPTIMAL_MIN = 5;
+
+/** `scoringAvg / PROGRESS_SCALE` clamped → bar fill (Optimal at 5+ lands near full). */
+export const STRENGTH_OVERVIEW_TF_PROGRESS_SCALE = 5.5;
+
+/**
+ * Expected-session baseline: ~one strength session every 14 elapsed calendar days (normalization only).
+ */
+export const STRENGTH_OVERVIEW_TF_REFERENCE_SESSION_DAYS = 14;
+
+/** Blend: 65% time-dampened avg/week + 35% volume-density factor. */
+export const STRENGTH_OVERVIEW_TF_AVG_WEIGHT = 0.65;
+export const STRENGTH_OVERVIEW_TF_DENSITY_WEIGHT = 0.35;
+
+function clamp01(x: number): number {
+  if (!Number.isFinite(x) || x <= 0) return 0;
+  if (x >= 1) return 1;
+  return x;
+}
+
+/** Five equal UI segments left → right; indices match {@link tierFromScoringAvg} order. */
+export const STRENGTH_OVERVIEW_MARKER_SEGMENT_COUNT = 5;
+
+const TIER_TO_SEGMENT_INDEX: Record<StrengthOverviewTimeframeRatingTier, number> = {
+  low: 0,
+  developing: 1,
+  solid: 2,
+  strong: 3,
+  optimal: 4,
+};
+
+export function getStrengthOverviewTierSegmentBounds01(
+  tier: StrengthOverviewTimeframeRatingTier,
+): { start: number; end: number } {
+  const i = TIER_TO_SEGMENT_INDEX[tier];
+  const n = STRENGTH_OVERVIEW_MARKER_SEGMENT_COUNT;
+  return { start: i / n, end: (i + 1) / n };
+}
+
+/**
+ * Normalized horizontal position (0–1) for the Strength Overview marker so it always lies in the segment
+ * for {@link tier}, with intra-tier placement from {@link scoringAvg} vs that tier’s score bounds.
+ */
+export function computeStrengthOverviewMarkerPosition01(input: {
+  tier: StrengthOverviewTimeframeRatingTier;
+  scoringAvg: number;
+}): number {
+  const sRaw = input.scoringAvg;
+  const s = Number.isFinite(sRaw) && sRaw > 0 ? sRaw : 0;
+
+  const { start: segStart, end: segEnd } = getStrengthOverviewTierSegmentBounds01(input.tier);
+  const segWidth = segEnd - segStart;
+
+  let intra = 0;
+  switch (input.tier) {
+    case "low":
+      intra = s / STRENGTH_OVERVIEW_TF_RATING_DEVELOPING_MIN;
+      break;
+    case "developing":
+      intra =
+        (s - STRENGTH_OVERVIEW_TF_RATING_DEVELOPING_MIN) /
+        (STRENGTH_OVERVIEW_TF_RATING_SOLID_MIN - STRENGTH_OVERVIEW_TF_RATING_DEVELOPING_MIN);
+      break;
+    case "solid":
+      intra =
+        (s - STRENGTH_OVERVIEW_TF_RATING_SOLID_MIN) /
+        (STRENGTH_OVERVIEW_TF_RATING_STRONG_MIN - STRENGTH_OVERVIEW_TF_RATING_SOLID_MIN);
+      break;
+    case "strong":
+      intra =
+        (s - STRENGTH_OVERVIEW_TF_RATING_STRONG_MIN) /
+        (STRENGTH_OVERVIEW_TF_RATING_OPTIMAL_MIN - STRENGTH_OVERVIEW_TF_RATING_STRONG_MIN);
+      break;
+    case "optimal":
+      intra =
+        (Math.min(s, STRENGTH_OVERVIEW_TF_PROGRESS_SCALE) - STRENGTH_OVERVIEW_TF_RATING_OPTIMAL_MIN) /
+        (STRENGTH_OVERVIEW_TF_PROGRESS_SCALE - STRENGTH_OVERVIEW_TF_RATING_OPTIMAL_MIN);
+      break;
+  }
+
+  intra = clamp01(intra);
+  let marker01 = segStart + intra * segWidth;
+  if (marker01 < segStart) marker01 = segStart;
+  if (marker01 > segEnd) marker01 = segEnd;
+  return marker01;
+}
+
+const TIER_COPY: Record<
+  StrengthOverviewTimeframeRatingTier,
+  { label: StrengthOverviewTimeframeRatingLabel; microcopy: string }
+> = {
+  low: { label: "Low", microcopy: "Limited training consistency" },
+  developing: { label: "Developing", microcopy: "Establishing consistency" },
+  solid: { label: "Solid", microcopy: "Good training rhythm" },
+  strong: { label: "Strong", microcopy: "Highly consistent" },
+  optimal: { label: "Optimal", microcopy: "Peak consistency" },
+};
+
+function tierFromScoringAvg(scoringAvg: number): StrengthOverviewTimeframeRatingTier {
+  if (scoringAvg < STRENGTH_OVERVIEW_TF_RATING_DEVELOPING_MIN) return "low";
+  if (scoringAvg < STRENGTH_OVERVIEW_TF_RATING_SOLID_MIN) return "developing";
+  if (scoringAvg < STRENGTH_OVERVIEW_TF_RATING_STRONG_MIN) return "solid";
+  if (scoringAvg < STRENGTH_OVERVIEW_TF_RATING_OPTIMAL_MIN) return "strong";
+  return "optimal";
+}
+
+/**
+ * @param elapsedCalendarDays — inclusive calendar length of the timeframe (≥1 when workouts exist; use ≥1 for scoring when total>0).
+ */
+export function strengthOverviewTimeframeConsistencyRating(input: {
+  timeframe: StrengthOverviewTimeframeKey;
+  avgWorkoutsPerWeek: number | null;
+  totalWorkouts: number;
+  elapsedCalendarDays: number;
+}): StrengthOverviewTimeframeRatingResult {
+  const total = input.totalWorkouts;
+  const elapsedRaw = input.elapsedCalendarDays;
+  const elapsed = Number.isFinite(elapsedRaw) && elapsedRaw > 0 ? elapsedRaw : 0;
+
+  if (total <= 0 || elapsed <= 0) {
+    const tier: StrengthOverviewTimeframeRatingTier = "low";
+    const { label, microcopy } = TIER_COPY[tier];
+    return { label, microcopy, progress: 0, tier, scoringAvg: 0 };
+  }
+
+  const avg = typeof input.avgWorkoutsPerWeek === "number" && Number.isFinite(input.avgWorkoutsPerWeek)
+    ? input.avgWorkoutsPerWeek
+    : 0;
+
+  let timeDampenedAvg = avg;
+  if (input.timeframe === "thisWeek" && elapsed < 7) {
+    timeDampenedAvg = avg * (elapsed / 7);
+  }
+
+  const referenceSessions = Math.max(1, elapsed / STRENGTH_OVERVIEW_TF_REFERENCE_SESSION_DAYS);
+  const density = Math.min(1, total / referenceSessions);
+  const scoringAvg =
+    timeDampenedAvg * (STRENGTH_OVERVIEW_TF_AVG_WEIGHT + STRENGTH_OVERVIEW_TF_DENSITY_WEIGHT * density);
+
+  const tier = tierFromScoringAvg(scoringAvg);
+  const { label, microcopy } = TIER_COPY[tier];
+  const progress = clamp01(scoringAvg / STRENGTH_OVERVIEW_TF_PROGRESS_SCALE);
+
+  return { label, microcopy, progress, tier, scoringAvg };
+}

--- a/lib/ui/HeaderBackButton.tsx
+++ b/lib/ui/HeaderBackButton.tsx
@@ -2,9 +2,12 @@ import React from "react";
 import { Pressable, StyleSheet, type ViewStyle } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 
+import { headerChromeCircleShell } from "@/lib/ui/headerChrome";
+import { UI_HEADER_CHROME_BG, UI_TEXT_PRIMARY } from "@/lib/ui/theme/uiTokens";
+
 /** Neutral header chrome (card-surface family), not primary CTA black. */
-export const HEADER_BACK_BUTTON_BG = "#F2F2F7";
-export const HEADER_BACK_BUTTON_ICON = "#1C1C1E";
+export const HEADER_BACK_BUTTON_BG = UI_HEADER_CHROME_BG;
+export const HEADER_BACK_BUTTON_ICON = UI_TEXT_PRIMARY;
 
 const VISUAL_SIZE = 40;
 const ICON_SIZE = 20;
@@ -47,9 +50,9 @@ const styles = StyleSheet.create({
     height: VISUAL_SIZE,
     borderRadius: VISUAL_SIZE / 2,
     marginLeft: 12,
-    backgroundColor: HEADER_BACK_BUTTON_BG,
     alignItems: "center",
     justifyContent: "center",
+    ...headerChromeCircleShell,
   },
   pressed: { opacity: 0.72, transform: [{ scale: 0.96 }] },
 });

--- a/lib/ui/HeaderControls.tsx
+++ b/lib/ui/HeaderControls.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { View, Pressable, type ViewStyle } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+
+import {
+  headerChromeCapsuleDivider,
+  headerChromeCapsuleSegmentBase,
+  headerChromeCapsuleSegmentPressed,
+  headerChromeCapsuleShell,
+} from "@/lib/ui/headerChrome";
+import { WorkoutsHeaderRightRow } from "@/lib/ui/headers/WorkoutsHeaderRightRow";
+import { HeaderOverflowMenuButton } from "@/lib/ui/HeaderOverflowMenuButton";
+import { UI_TEXT_PRIMARY } from "@/lib/ui/theme/uiTokens";
+
+export type HeaderControlsProps = {
+  /** Default matches historical `WorkoutsHeaderRightRow` spacing (single capsule child). */
+  gap?: number;
+  onCalendarPress?: () => void;
+  calendarAccessibilityLabel?: string;
+  /** Defaults to primary label color (same family as back chevron). */
+  calendarIconColor?: string;
+  calendarIconSize?: number;
+  onOverflowPress?: () => void;
+  overflowAccessibilityLabel?: string;
+};
+
+/**
+ * Trailing header cluster: one shared capsule with individually tappable calendar + overflow segments.
+ * Handlers and labels are owned by the screen; this component is chrome only.
+ */
+export function HeaderControls({
+  gap = 12,
+  onCalendarPress,
+  calendarAccessibilityLabel,
+  calendarIconColor = UI_TEXT_PRIMARY,
+  calendarIconSize = 24,
+  onOverflowPress,
+  overflowAccessibilityLabel,
+}: HeaderControlsProps) {
+  const showCalendar = onCalendarPress != null && calendarAccessibilityLabel != null;
+  const showOverflow = onOverflowPress != null && overflowAccessibilityLabel != null;
+
+  if (!showCalendar && !showOverflow) {
+    return null;
+  }
+
+  return (
+    <WorkoutsHeaderRightRow gap={gap}>
+      <View style={headerChromeCapsuleShell as ViewStyle}>
+        {showCalendar ? (
+          <Pressable
+            onPress={onCalendarPress}
+            accessibilityRole="button"
+            accessibilityLabel={calendarAccessibilityLabel}
+            hitSlop={8}
+            style={({ pressed }) => [
+              headerChromeCapsuleSegmentBase,
+              pressed && headerChromeCapsuleSegmentPressed,
+            ]}
+          >
+            <Ionicons name="calendar-outline" size={calendarIconSize} color={calendarIconColor} />
+          </Pressable>
+        ) : null}
+        {showCalendar && showOverflow ? <View style={headerChromeCapsuleDivider} /> : null}
+        {showOverflow ? (
+          <HeaderOverflowMenuButton onPress={onOverflowPress} accessibilityLabel={overflowAccessibilityLabel} />
+        ) : null}
+      </View>
+    </WorkoutsHeaderRightRow>
+  );
+}

--- a/lib/ui/HeaderOverflowMenuButton.tsx
+++ b/lib/ui/HeaderOverflowMenuButton.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { Pressable, StyleSheet, Text } from "react-native";
+
+import {
+  headerChromeCapsuleSegmentBase,
+  headerChromeCapsuleSegmentPressed,
+} from "@/lib/ui/headerChrome";
+import { UI_TEXT_PRIMARY } from "@/lib/ui/theme/uiTokens";
+
+export type HeaderOverflowMenuButtonProps = {
+  onPress: () => void;
+  accessibilityLabel: string;
+};
+
+/**
+ * Overflow segment for use inside {@link HeaderControls} capsule (or same metrics if reused).
+ */
+export function HeaderOverflowMenuButton({ onPress, accessibilityLabel }: HeaderOverflowMenuButtonProps) {
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      hitSlop={8}
+      style={({ pressed }) => [
+        headerChromeCapsuleSegmentBase,
+        pressed && headerChromeCapsuleSegmentPressed,
+      ]}
+    >
+      <Text style={styles.dots}>•••</Text>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  dots: {
+    fontSize: 18,
+    fontWeight: "700",
+    color: UI_TEXT_PRIMARY,
+  },
+});

--- a/lib/ui/HeaderToolbarPillButton.tsx
+++ b/lib/ui/HeaderToolbarPillButton.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { Pressable, StyleSheet, type ViewStyle } from "react-native";
+
+import { headerChromeCircleShell } from "@/lib/ui/headerChrome";
+
+export const HEADER_TOOLBAR_PILL_SIZE = 40;
+
+export type HeaderToolbarPillButtonProps = {
+  onPress: () => void;
+  accessibilityLabel: string;
+  children: React.ReactNode;
+  testID?: string;
+  style?: ViewStyle;
+};
+
+/**
+ * Standalone circular header action — same border + shadow family as {@link HeaderBackButton}.
+ * Prefer {@link HeaderControls} for trailing calendar/overflow on module screens.
+ */
+export function HeaderToolbarPillButton({
+  onPress,
+  accessibilityLabel,
+  children,
+  testID,
+  style,
+}: HeaderToolbarPillButtonProps) {
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      hitSlop={8}
+      testID={testID}
+      style={({ pressed }) => [styles.base, pressed && styles.pressed, style]}
+    >
+      {children}
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  base: {
+    width: HEADER_TOOLBAR_PILL_SIZE,
+    height: HEADER_TOOLBAR_PILL_SIZE,
+    borderRadius: HEADER_TOOLBAR_PILL_SIZE / 2,
+    alignItems: "center",
+    justifyContent: "center",
+    ...headerChromeCircleShell,
+  },
+  pressed: { opacity: 0.72, transform: [{ scale: 0.96 }] },
+});

--- a/lib/ui/ModuleCalendarPlaceholderScreen.tsx
+++ b/lib/ui/ModuleCalendarPlaceholderScreen.tsx
@@ -1,0 +1,50 @@
+import React, { useLayoutEffect } from "react";
+import { View, Text, StyleSheet } from "react-native";
+import { useNavigation } from "expo-router";
+
+import { ScreenContainer } from "@/lib/ui/ScreenStates";
+import { HeaderBackButton } from "@/lib/ui/HeaderBackButton";
+import { workoutsStackNavigationOptions } from "@/lib/ui/headers/workoutsStackHeader";
+
+export type ModuleCalendarPlaceholderScreenProps = {
+  title: string;
+  description: string;
+};
+
+/** Placeholder until module-specific sleep/readiness calendar UX is defined (no data hooks). */
+export function ModuleCalendarPlaceholderScreen({ title, description }: ModuleCalendarPlaceholderScreenProps) {
+  const navigation = useNavigation();
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      ...workoutsStackNavigationOptions("detail"),
+      headerLeft: () => <HeaderBackButton onPress={() => navigation.goBack()} />,
+    });
+  }, [navigation]);
+
+  return (
+    <ScreenContainer>
+      <View style={styles.body}>
+        <Text style={styles.title}>{title}</Text>
+        <Text style={styles.bodyText}>{description}</Text>
+      </View>
+    </ScreenContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  body: {
+    paddingTop: 24,
+    gap: 12,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: "700",
+    color: "#1C1C1E",
+  },
+  bodyText: {
+    fontSize: 16,
+    lineHeight: 22,
+    color: "#3C3C43",
+  },
+});

--- a/lib/ui/ModuleSettingsPlaceholderScreen.tsx
+++ b/lib/ui/ModuleSettingsPlaceholderScreen.tsx
@@ -1,0 +1,94 @@
+import React, { useLayoutEffect } from "react";
+import { View, Text, StyleSheet, Pressable } from "react-native";
+import { useNavigation, useRouter } from "expo-router";
+
+import { ScreenContainer } from "@/lib/ui/ScreenStates";
+import { HeaderBackButton } from "@/lib/ui/HeaderBackButton";
+import { workoutsStackNavigationOptions } from "@/lib/ui/headers/workoutsStackHeader";
+import { SYSTEM_ACCENT } from "@/lib/ui/theme/systemAccent";
+
+export type ModuleSettingsPlaceholderScreenProps = {
+  title: string;
+  description: string;
+  overviewHref: string;
+  overviewButtonLabel: string;
+  overviewAccessibilityLabel: string;
+  /** Secondary actions (e.g. Devices) rendered between description and primary CTA. */
+  extraActions?: React.ReactNode;
+};
+
+/**
+ * Shared placeholder for module-scoped settings (no backend; navigation-only).
+ */
+export function ModuleSettingsPlaceholderScreen({
+  title,
+  description,
+  overviewHref,
+  overviewButtonLabel,
+  overviewAccessibilityLabel,
+  extraActions,
+}: ModuleSettingsPlaceholderScreenProps) {
+  const navigation = useNavigation();
+  const router = useRouter();
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      ...workoutsStackNavigationOptions("detail"),
+      headerLeft: () => <HeaderBackButton onPress={() => navigation.goBack()} />,
+    });
+  }, [navigation]);
+
+  return (
+    <ScreenContainer>
+      <View style={styles.body}>
+        <Text style={styles.title}>{title}</Text>
+        <Text style={styles.bodyText}>{description}</Text>
+        {extraActions != null ? <View style={styles.extraWrap}>{extraActions}</View> : null}
+        <Pressable
+          style={({ pressed }) => [styles.primaryBtn, pressed && styles.primaryBtnPressed]}
+          onPress={() => router.replace(overviewHref as never)}
+          accessibilityRole="button"
+          accessibilityLabel={overviewAccessibilityLabel}
+        >
+          <Text style={styles.primaryBtnText}>{overviewButtonLabel}</Text>
+        </Pressable>
+      </View>
+    </ScreenContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  body: {
+    paddingTop: 24,
+    gap: 16,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: "700",
+    color: "#1C1C1E",
+  },
+  bodyText: {
+    fontSize: 16,
+    lineHeight: 22,
+    color: "#3C3C43",
+  },
+  extraWrap: {
+    gap: 12,
+  },
+  primaryBtn: {
+    alignSelf: "flex-start",
+    marginTop: 8,
+    paddingVertical: 12,
+    paddingHorizontal: 20,
+    borderRadius: 12,
+    backgroundColor: SYSTEM_ACCENT,
+  },
+  primaryBtnPressed: {
+    opacity: 0.85,
+  },
+  primaryBtnText: {
+    fontSize: 16,
+    fontWeight: "600",
+    color: "#FFFFFF",
+  },
+});

--- a/lib/ui/body/BodyWeeklyStrip.tsx
+++ b/lib/ui/body/BodyWeeklyStrip.tsx
@@ -1,7 +1,10 @@
 import React from "react";
-import { Pressable, StyleSheet, Text, View } from "react-native";
+import { View } from "react-native";
+
+import { CalendarDayCell } from "@/lib/ui/calendar/CalendarDayCell";
+import { calendarStripDayOfMonth, calendarStripDayOfWeekLabel } from "@/lib/ui/calendar/calendarWeeklyStripDayUtils";
+import { calendarWeeklyStripStyles } from "@/lib/ui/calendar/calendarWeeklyStripStyles";
 import type { CalendarDay } from "@/lib/ui/calendar/types";
-import { WEEKLY_STRIP_SELECTED_DAY_CIRCLE_FILL } from "@/lib/ui/calendar/weeklyCalendarStripTheme";
 import { BodyDayRing } from "./BodyDayRing";
 
 export type BodyDayMarker = {
@@ -14,76 +17,35 @@ type BodyWeeklyStripProps = {
   onDayPress: (day: string) => void;
 };
 
-const DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-
-function getDayOfWeekLabel(dayKey: string): string {
-  const d = new Date(`${dayKey}T12:00:00.000Z`);
-  return DAY_LABELS[d.getUTCDay()] ?? "";
-}
-
-function getDayOfMonth(dayKey: string): string {
-  return String(new Date(`${dayKey}T12:00:00.000Z`).getUTCDate());
-}
-
 export function BodyWeeklyStrip({ days, selectedDay, onDayPress }: BodyWeeklyStripProps) {
   return (
-    <View style={styles.container}>
-      <View style={styles.row}>
+    <View style={calendarWeeklyStripStyles.container}>
+      <View style={calendarWeeklyStripStyles.row}>
         {days.map((d) => {
           const hasMeasurement = d.meta?.hasMeasurement === true;
           const isSelected = selectedDay === d.day;
           return (
-            <Pressable
+            <CalendarDayCell
               key={d.day}
+              dayOfWeekLabel={calendarStripDayOfWeekLabel(d.day)}
+              dayOfMonthLabel={calendarStripDayOfMonth(d.day)}
+              isSelected={isSelected}
               onPress={() => onDayPress(d.day)}
-              accessibilityRole="button"
               accessibilityLabel={
                 hasMeasurement ? `${d.day}, has body measurement` : `${d.day}, no body measurement`
               }
-              hitSlop={8}
-              style={({ pressed }) => [
-                styles.dayCell,
-                isSelected && styles.dayCellSelected,
-                pressed && styles.dayCellPressed,
-              ]}
-            >
-              <Text style={styles.dayOfWeek}>{getDayOfWeekLabel(d.day)}</Text>
-              <View style={[styles.dayCircle, isSelected && styles.dayCircleSelected]}>
-                <View style={styles.dayRingBackdrop} pointerEvents="none">
-                  <BodyDayRing
-                    size={40}
-                    hasMeasurement={hasMeasurement}
-                    emphasized={isSelected}
-                    testID={`body-weekly-ring-${d.day}`}
-                  />
-                </View>
-                <Text style={[styles.dayNumber, isSelected && styles.dayNumberSelected]}>
-                  {getDayOfMonth(d.day)}
-                </Text>
-              </View>
-            </Pressable>
+              ring={
+                <BodyDayRing
+                  size={40}
+                  hasMeasurement={hasMeasurement}
+                  emphasized={isSelected}
+                  testID={`body-weekly-ring-${d.day}`}
+                />
+              }
+            />
           );
         })}
       </View>
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: { width: "100%", paddingHorizontal: 0, paddingBottom: 2, paddingTop: 0 },
-  row: { flexDirection: "row", width: "100%", alignItems: "flex-start", justifyContent: "space-between" },
-  dayCell: { flex: 1, minWidth: 0, alignItems: "center", justifyContent: "flex-start" },
-  dayCellSelected: {},
-  dayCellPressed: { opacity: 0.7 },
-  dayOfWeek: { fontSize: 13, color: "#8E8E93", marginBottom: 2 },
-  dayCircle: { width: 40, height: 40, borderRadius: 20, alignItems: "center", justifyContent: "center" },
-  dayCircleSelected: { backgroundColor: WEEKLY_STRIP_SELECTED_DAY_CIRCLE_FILL },
-  dayRingBackdrop: {
-    ...StyleSheet.absoluteFillObject,
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  dayNumber: { fontSize: 18, fontWeight: "600", color: "#1C1C1E" },
-  dayNumberSelected: { color: "#FFFFFF" },
-});
-

--- a/lib/ui/body/InterpretationQualityBar.tsx
+++ b/lib/ui/body/InterpretationQualityBar.tsx
@@ -1,19 +1,17 @@
 // lib/ui/body/InterpretationQualityBar.tsx
-// Four-zone interpretation track with value marker (Body Composition overview).
-import React, { useState } from "react";
-import { LayoutChangeEvent, View, StyleSheet } from "react-native";
+// Body Composition overview track: shared 5-segment palette + display-mapped marker (see bodyOverviewBarDisplay).
+import React from "react";
 
 import type { InterpretationBarModel } from "@/lib/body/bodyOverviewInterpretationBar";
-
-import { clampedDotLeftPx } from "./interpretationBarDotLayout";
-
-const ZONE_BG = ["#DCDCE3", "#D0D0D8", "#C4CEC8", "#B0C9B8"] as const;
-const TRACK_RADIUS = 5;
-const DOT_SIZE = 10;
+import { getBodyOverviewBarDisplay } from "@/lib/body/bodyOverviewBarDisplay";
+import { MODULE_OVERVIEW_SEGMENT_ZONE_FILLS } from "@/lib/ui/overview/moduleOverviewSegmentZoneFills";
+import { MODULE_OVERVIEW_SEGMENTED_TRACK } from "@/lib/ui/overview/moduleOverviewSegmentedTrackMetrics";
+import { SegmentedZoneTrack } from "@/lib/ui/primitives/SegmentedZoneTrack";
 
 export function interpretationBarAccessibilityLabel(bar: InterpretationBarModel, metricLabel: string): string {
-  const pct = Math.round(bar.marker01 * 100);
   if (bar.hasValue) {
+    const d = getBodyOverviewBarDisplay(bar);
+    const pct = Math.round(d.displayMarker01 * 100);
     return `${metricLabel} interpretation: ${bar.displayLabel}. Marker at ${pct} percent along the quality scale.`;
   }
   return `${metricLabel}: no measurement; interpretation not available.`;
@@ -24,70 +22,21 @@ export type InterpretationQualityBarProps = {
 };
 
 export function InterpretationQualityBar({ bar }: InterpretationQualityBarProps) {
-  const [trackW, setTrackW] = useState(0);
-
-  const onTrackLayout = (e: LayoutChangeEvent) => {
-    const w = e.nativeEvent.layout.width;
-    if (w > 0 && Math.abs(w - trackW) > 0.5) setTrackW(w);
-  };
-
-  const dotLeft =
-    bar.hasValue && trackW > 0 ? clampedDotLeftPx(trackW, bar.marker01, DOT_SIZE) : undefined;
-
+  const d = getBodyOverviewBarDisplay(bar);
   return (
-    <View
-      style={styles.wrap}
-      accessibilityRole="none"
-      accessible={false}
-      importantForAccessibility="no"
-      onLayout={onTrackLayout}
-    >
-      <View style={styles.zonesClip} importantForAccessibility="no">
-        <View style={styles.zonesRow}>
-          {ZONE_BG.map((color, i) => (
-            <View key={i} style={[styles.zone, { backgroundColor: color }]} />
-          ))}
-        </View>
-      </View>
-      {bar.hasValue && dotLeft != null ? (
-        <View
-          style={[
-            styles.dot,
-            {
-              left: dotLeft,
-            },
-          ]}
-          importantForAccessibility="no"
-        />
-      ) : null}
-    </View>
+    <SegmentedZoneTrack
+      zoneColors={MODULE_OVERVIEW_SEGMENT_ZONE_FILLS}
+      markerPosition01={d.displayMarker01}
+      showMarker={bar.hasValue}
+      markerBackgroundColor={d.markerDotColor}
+      dotSize={MODULE_OVERVIEW_SEGMENTED_TRACK.dotSize}
+      barHeight={MODULE_OVERVIEW_SEGMENTED_TRACK.barHeight}
+      trackRadius={MODULE_OVERVIEW_SEGMENTED_TRACK.trackRadius}
+      wrapperProps={{
+        accessibilityRole: "none",
+        accessible: false,
+        importantForAccessibility: "no",
+      }}
+    />
   );
 }
-
-const styles = StyleSheet.create({
-  wrap: {
-    height: 10,
-    position: "relative",
-    justifyContent: "center",
-  },
-  zonesClip: {
-    borderRadius: TRACK_RADIUS,
-    overflow: "hidden",
-    height: 10,
-  },
-  zonesRow: {
-    flexDirection: "row",
-    height: 10,
-  },
-  zone: { flex: 1, marginHorizontal: StyleSheet.hairlineWidth },
-  dot: {
-    position: "absolute",
-    top: 0,
-    width: DOT_SIZE,
-    height: DOT_SIZE,
-    borderRadius: DOT_SIZE / 2,
-    backgroundColor: "#3A3A3C",
-    borderWidth: StyleSheet.hairlineWidth,
-    borderColor: "rgba(255,255,255,0.85)",
-  },
-});

--- a/lib/ui/body/InterpretationRatingPill.tsx
+++ b/lib/ui/body/InterpretationRatingPill.tsx
@@ -1,52 +1,27 @@
 // Compact zone label beside metric title (Body Composition overview).
 import React from "react";
-import { StyleSheet, Text, View } from "react-native";
+import { Text, View } from "react-native";
 
-import type { InterpretationBarModel, InterpretationQualityZone } from "@/lib/body/bodyOverviewInterpretationBar";
-
-const ZONE_STYLES: Record<
-  InterpretationQualityZone,
-  { bg: string; fg: string }
-> = {
-  out_of_range: { bg: "#FCE8E8", fg: "#9E2F2F" },
-  fair: { bg: "#FFF3D6", fg: "#8A6116" },
-  good: { bg: "#E3EDF5", fg: "#2F5F8A" },
-  optimal: { bg: "#E4EFE6", fg: "#2F6B42" },
-};
-
-const NEUTRAL = { bg: "#E5E5EA", fg: "#636366" };
+import type { InterpretationBarModel } from "@/lib/body/bodyOverviewInterpretationBar";
+import { getBodyOverviewBarDisplay } from "@/lib/body/bodyOverviewBarDisplay";
+import { moduleOverviewMetricLayoutStyles } from "@/lib/ui/overview/moduleOverviewMetricLayout";
 
 export type InterpretationRatingPillProps = {
   bar: InterpretationBarModel;
 };
 
 export function InterpretationRatingPill({ bar }: InterpretationRatingPillProps) {
-  const colors = bar.hasValue ? ZONE_STYLES[bar.zone] : NEUTRAL;
+  const d = getBodyOverviewBarDisplay(bar);
+  const colors = { bg: d.pillBg, fg: d.pillFg };
   return (
     <View
-      style={[styles.pill, { backgroundColor: colors.bg }]}
+      style={[moduleOverviewMetricLayoutStyles.ratingPillShell, { backgroundColor: colors.bg }]}
       accessibilityElementsHidden
       importantForAccessibility="no"
     >
-      <Text style={[styles.text, { color: colors.fg }]} numberOfLines={1}>
+      <Text style={[moduleOverviewMetricLayoutStyles.ratingPillLabel, { color: colors.fg }]} numberOfLines={1}>
         {bar.displayLabel}
       </Text>
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  pill: {
-    flexShrink: 0,
-    paddingHorizontal: 8,
-    paddingVertical: 3,
-    borderRadius: 8,
-    alignSelf: "center",
-    maxWidth: "48%",
-  },
-  text: {
-    fontSize: 11,
-    fontWeight: "600",
-    letterSpacing: 0.15,
-  },
-});

--- a/lib/ui/body/__tests__/InterpretationQualityBar.test.tsx
+++ b/lib/ui/body/__tests__/InterpretationQualityBar.test.tsx
@@ -2,13 +2,16 @@ import React from "react";
 import renderer, { act } from "react-test-renderer";
 import { describe, expect, it } from "@jest/globals";
 import { View } from "react-native";
+import { MODULE_OVERVIEW_SEGMENT_ZONE_FILLS } from "@/lib/ui/overview/moduleOverviewSegmentZoneFills";
+import { SegmentedZoneTrack } from "@/lib/ui/primitives/SegmentedZoneTrack";
+import { STRENGTH_OVERVIEW_TIER_ZONE_BG } from "@/lib/ui/workouts/StrengthOverviewCard";
 import {
   InterpretationQualityBar,
   interpretationBarAccessibilityLabel,
 } from "../InterpretationQualityBar";
 
 describe("interpretationBarAccessibilityLabel", () => {
-  it("describes interpretation and marker percent when valued", () => {
+  it("describes interpretation and display marker percent when valued", () => {
     const label = interpretationBarAccessibilityLabel(
       {
         marker01: 0.62,
@@ -19,7 +22,7 @@ describe("interpretationBarAccessibilityLabel", () => {
       "Weight",
     );
     expect(label).toContain("Weight interpretation: Good");
-    expect(label).toMatch(/62 percent/);
+    expect(label).toMatch(/70 percent/);
   });
 
   it("uses no-measurement copy when hasValue is false", () => {
@@ -38,6 +41,29 @@ describe("interpretationBarAccessibilityLabel", () => {
 });
 
 describe("InterpretationQualityBar", () => {
+  it("uses the same five segment fills as Strength Overview (shared palette)", () => {
+    expect(STRENGTH_OVERVIEW_TIER_ZONE_BG).toBe(MODULE_OVERVIEW_SEGMENT_ZONE_FILLS);
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(
+        <InterpretationQualityBar
+          bar={{
+            marker01: 0.62,
+            zone: "good",
+            displayLabel: "Good",
+            hasValue: true,
+          }}
+        />,
+      );
+    });
+    const track = tree.root.findByType(SegmentedZoneTrack);
+    expect(track.props.zoneColors).toBe(MODULE_OVERVIEW_SEGMENT_ZONE_FILLS);
+    expect(track.props.zoneColors).toHaveLength(5);
+    expect(track.props.markerPosition01).toBeGreaterThanOrEqual(0.6);
+    expect(track.props.markerPosition01).toBeLessThanOrEqual(0.8);
+    expect(track.props.markerBackgroundColor).toBe("#5EC08C");
+  });
+
   it("does not render a separate rating label under the track", () => {
     let tree!: renderer.ReactTestRenderer;
     act(() => {

--- a/lib/ui/body/__tests__/InterpretationRatingPill.test.tsx
+++ b/lib/ui/body/__tests__/InterpretationRatingPill.test.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import renderer, { act } from "react-test-renderer";
 import { describe, expect, it } from "@jest/globals";
-import { Text } from "react-native";
+import { Text, View } from "react-native";
+import { MODULE_OVERVIEW_STRENGTH_TIER_PILL_CHROME } from "@/lib/ui/overview/moduleOverviewStrengthTierPillChrome";
 import { InterpretationRatingPill } from "../InterpretationRatingPill";
 
 describe("InterpretationRatingPill", () => {
@@ -20,6 +21,10 @@ describe("InterpretationRatingPill", () => {
       );
     });
     expect(tree.root.findAllByType(Text).some((n) => n.props.children === "Optimal")).toBe(true);
+    const shell = tree.root.findByType(View);
+    expect(shell.props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining({ backgroundColor: MODULE_OVERVIEW_STRENGTH_TIER_PILL_CHROME[4].pillBg })]),
+    );
   });
 
   it("renders No data when metric has no value", () => {

--- a/lib/ui/calendar/CalendarDayCell.tsx
+++ b/lib/ui/calendar/CalendarDayCell.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { Pressable, Text, View } from "react-native";
+
+import { calendarWeeklyStripStyles } from "@/lib/ui/calendar/calendarWeeklyStripStyles";
+
+export type CalendarDayCellProps = {
+  dayOfWeekLabel: string;
+  dayOfMonthLabel: string;
+  isSelected: boolean;
+  onPress: () => void;
+  accessibilityLabel: string;
+  /** Ring layer (workout / body / nutrition); `null` when the day has no ring. */
+  ring: React.ReactNode;
+};
+
+/**
+ * Single day column for module weekly strips — shared chrome, domain-specific `ring`.
+ */
+export function CalendarDayCell({
+  dayOfWeekLabel,
+  dayOfMonthLabel,
+  isSelected,
+  onPress,
+  accessibilityLabel,
+  ring,
+}: CalendarDayCellProps) {
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      hitSlop={8}
+      style={({ pressed }) => [
+        calendarWeeklyStripStyles.dayCell,
+        isSelected && calendarWeeklyStripStyles.dayCellSelected,
+        pressed && calendarWeeklyStripStyles.dayCellPressed,
+      ]}
+    >
+      <Text style={calendarWeeklyStripStyles.dayOfWeek}>{dayOfWeekLabel}</Text>
+      <View
+        style={[
+          calendarWeeklyStripStyles.dayCircle,
+          isSelected && calendarWeeklyStripStyles.dayCircleSelected,
+        ]}
+      >
+        <View style={calendarWeeklyStripStyles.dayRingBackdrop} pointerEvents="none">
+          {ring}
+        </View>
+        <Text style={calendarWeeklyStripStyles.dayNumber}>{dayOfMonthLabel}</Text>
+      </View>
+    </Pressable>
+  );
+}

--- a/lib/ui/calendar/WeeklyStrip.tsx
+++ b/lib/ui/calendar/WeeklyStrip.tsx
@@ -1,7 +1,10 @@
 import React from "react";
-import { Pressable, StyleSheet, Text, View } from "react-native";
+import { View } from "react-native";
+
+import { CalendarDayCell } from "@/lib/ui/calendar/CalendarDayCell";
+import { calendarStripDayOfMonth, calendarStripDayOfWeekLabel } from "@/lib/ui/calendar/calendarWeeklyStripDayUtils";
+import { calendarWeeklyStripStyles } from "@/lib/ui/calendar/calendarWeeklyStripStyles";
 import type { CalendarDay, WorkoutDayMarker } from "./types";
-import { WEEKLY_STRIP_SELECTED_DAY_CIRCLE_FILL } from "./weeklyCalendarStripTheme";
 import { WorkoutDayRing } from "./WorkoutDayRing";
 
 export type WeeklyStripProps = {
@@ -10,22 +13,10 @@ export type WeeklyStripProps = {
   onDayPress: (day: string) => void;
 };
 
-const DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-function getDayOfWeekLabel(dayKey: string): string {
-  const d = new Date(`${dayKey}T12:00:00.000Z`);
-  const dow = d.getUTCDay();
-  return DAY_LABELS[dow] ?? "";
-}
-
-function getDayOfMonth(dayKey: string): string {
-  const d = new Date(`${dayKey}T12:00:00.000Z`);
-  return String(d.getUTCDate());
-}
-
 export function WeeklyStrip({ days, selectedDay, onDayPress }: WeeklyStripProps) {
   return (
-    <View style={styles.container}>
-      <View style={styles.row}>
+    <View style={calendarWeeklyStripStyles.container}>
+      <View style={calendarWeeklyStripStyles.row}>
         {days.map((d) => {
           const marker = d.meta;
           const isSelected = selectedDay === d.day;
@@ -33,109 +24,29 @@ export function WeeklyStrip({ days, selectedDay, onDayPress }: WeeklyStripProps)
           const hasStrength = marker?.hasStrength === true;
           const hasCardio = marker?.hasCardio === true;
           return (
-            <Pressable
+            <CalendarDayCell
               key={d.day}
+              dayOfWeekLabel={calendarStripDayOfWeekLabel(d.day)}
+              dayOfMonthLabel={calendarStripDayOfMonth(d.day)}
+              isSelected={isSelected}
               onPress={() => onDayPress(d.day)}
-              accessibilityRole="button"
               accessibilityLabel={
-                hasWorkouts
-                  ? `${d.day}, has workouts`
-                  : `${d.day}, no workouts`
+                hasWorkouts ? `${d.day}, has workouts` : `${d.day}, no workouts`
               }
-              style={({ pressed }) => [
-                styles.dayCell,
-                isSelected && styles.dayCellSelected,
-                pressed && styles.dayCellPressed,
-              ]}
-              hitSlop={8}
-            >
-              <Text style={styles.dayOfWeek}>{getDayOfWeekLabel(d.day)}</Text>
-              <View
-                style={[
-                  styles.dayCircle,
-                  isSelected && styles.dayCircleSelected,
-                ]}
-              >
-                <View style={styles.dayRingBackdrop} pointerEvents="none">
-                  <WorkoutDayRing
-                    size={40}
-                    hasStrength={hasStrength}
-                    hasCardio={hasCardio}
-                    emphasized={isSelected}
-                    outerTestID={`weekly-outer-ring-${d.day}`}
-                    innerTestID={`weekly-cardio-inner-ring-${d.day}`}
-                  />
-                </View>
-                <Text
-                  style={[
-                    styles.dayNumber,
-                    isSelected && styles.dayNumberSelected,
-                  ]}
-                >
-                  {getDayOfMonth(d.day)}
-                </Text>
-              </View>
-            </Pressable>
+              ring={
+                <WorkoutDayRing
+                  size={40}
+                  hasStrength={hasStrength}
+                  hasCardio={hasCardio}
+                  emphasized={isSelected}
+                  outerTestID={`weekly-outer-ring-${d.day}`}
+                  innerTestID={`weekly-cardio-inner-ring-${d.day}`}
+                />
+              }
+            />
           );
         })}
       </View>
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  /** No horizontal padding: parent (e.g. ModuleScreenShell header) already applies page gutter (16). */
-  container: {
-    width: "100%",
-    paddingHorizontal: 0,
-    paddingBottom: 2,
-    paddingTop: 0,
-  },
-  row: {
-    flexDirection: "row",
-    width: "100%",
-    alignItems: "flex-start",
-    justifyContent: "space-between",
-  },
-  dayCell: {
-    flex: 1,
-    minWidth: 0,
-    alignItems: "center",
-    justifyContent: "flex-start",
-  },
-  dayCellSelected: {},
-  dayCellPressed: {
-    opacity: 0.7,
-  },
-  dayOfWeek: {
-    fontSize: 13,
-    color: "#8E8E93",
-    marginBottom: 2,
-  },
-  dayCircle: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    position: "relative",
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  /** Ring + fill are absolutely positioned so the day numeral stays centered in the circle. */
-  dayRingBackdrop: {
-    ...StyleSheet.absoluteFillObject,
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  dayCircleSelected: {
-    backgroundColor: WEEKLY_STRIP_SELECTED_DAY_CIRCLE_FILL,
-  },
-  dayNumber: {
-    fontSize: 18,
-    fontWeight: "600",
-    color: "#1C1C1E",
-  },
-  dayNumberSelected: {
-    color: "#FFFFFF",
-  },
-});
-

--- a/lib/ui/calendar/calendarWeeklyStripDayUtils.ts
+++ b/lib/ui/calendar/calendarWeeklyStripDayUtils.ts
@@ -1,0 +1,10 @@
+const DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
+
+export function calendarStripDayOfWeekLabel(dayKey: string): string {
+  const d = new Date(`${dayKey}T12:00:00.000Z`);
+  return DAY_LABELS[d.getUTCDay()] ?? "";
+}
+
+export function calendarStripDayOfMonth(dayKey: string): string {
+  return String(new Date(`${dayKey}T12:00:00.000Z`).getUTCDate());
+}

--- a/lib/ui/calendar/calendarWeeklyStripStyles.ts
+++ b/lib/ui/calendar/calendarWeeklyStripStyles.ts
@@ -1,0 +1,56 @@
+import { StyleSheet } from "react-native";
+
+import { UI_TEXT_PRIMARY, UI_TEXT_TERTIARY_LABEL } from "@/lib/ui/theme/uiTokens";
+import { WEEKLY_STRIP_SELECTED_DAY_CIRCLE_FILL } from "@/lib/ui/calendar/weeklyCalendarStripTheme";
+
+/** Shared layout for {@link WeeklyStrip}, {@link BodyWeeklyStrip}, {@link NutritionWeeklyStrip}. */
+export const calendarWeeklyStripStyles = StyleSheet.create({
+  container: {
+    width: "100%",
+    paddingHorizontal: 0,
+    paddingBottom: 2,
+    paddingTop: 0,
+  },
+  row: {
+    flexDirection: "row",
+    width: "100%",
+    alignItems: "flex-start",
+    justifyContent: "space-between",
+  },
+  dayCell: {
+    flex: 1,
+    minWidth: 0,
+    alignItems: "center",
+    justifyContent: "flex-start",
+  },
+  dayCellSelected: {},
+  dayCellPressed: {
+    opacity: 0.7,
+  },
+  dayOfWeek: {
+    fontSize: 13,
+    color: UI_TEXT_TERTIARY_LABEL,
+    marginBottom: 2,
+  },
+  dayCircle: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    position: "relative",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  dayRingBackdrop: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  dayCircleSelected: {
+    backgroundColor: WEEKLY_STRIP_SELECTED_DAY_CIRCLE_FILL,
+  },
+  dayNumber: {
+    fontSize: 18,
+    fontWeight: "600",
+    color: UI_TEXT_PRIMARY,
+  },
+});

--- a/lib/ui/calendar/weeklyCalendarStripTheme.ts
+++ b/lib/ui/calendar/weeklyCalendarStripTheme.ts
@@ -1,5 +1,7 @@
+import { UI_HEADER_CHROME_BG } from "@/lib/ui/theme/uiTokens";
+
 /**
  * Weekly calendar strip (see {@link WeeklyStrip}): selected-day `dayCircle` background.
- * This is the center fill behind `WorkoutDayRing` when `isSelected` is true.
+ * Matches header pill chrome ({@link UI_HEADER_CHROME_BG}) for a unified calendar + nav system.
  */
-export const WEEKLY_STRIP_SELECTED_DAY_CIRCLE_FILL = "#2C2C2E";
+export const WEEKLY_STRIP_SELECTED_DAY_CIRCLE_FILL = UI_HEADER_CHROME_BG;

--- a/lib/ui/headerChrome.ts
+++ b/lib/ui/headerChrome.ts
@@ -1,0 +1,75 @@
+import { Platform, StyleSheet, type ViewStyle } from "react-native";
+
+import {
+  UI_HEADER_CHROME_BG,
+  UI_HEADER_CHROME_BORDER,
+  UI_HEADER_CAPSULE_DIVIDER,
+  UI_HEADER_CAPSULE_PADDING_H,
+  UI_HEADER_CAPSULE_SEGMENT_GAP,
+} from "@/lib/ui/theme/uiTokens";
+
+/** iOS shadow aligned with nutrition dock “slot” treatment — softer than the full dock. */
+const HEADER_CHROME_SHADOW_IOS = {
+  shadowColor: "#000000",
+  shadowOpacity: 0.06,
+  shadowRadius: 8,
+  shadowOffset: { width: 0, height: 2 },
+} as const;
+
+const HEADER_CHROME_SHADOW_ANDROID = {
+  elevation: 2,
+} as const;
+
+/** `Platform` can be undefined under partial Jest mocks — fall back to no shadow. */
+const platformOs = Platform?.OS;
+
+export const headerChromeShadow = (
+  platformOs === "ios"
+    ? HEADER_CHROME_SHADOW_IOS
+    : platformOs === "android"
+      ? HEADER_CHROME_SHADOW_ANDROID
+      : {}
+) as ViewStyle;
+
+/** Circular controls (back). */
+export const headerChromeCircleShell = {
+  backgroundColor: UI_HEADER_CHROME_BG,
+  borderWidth: StyleSheet.hairlineWidth,
+  borderColor: UI_HEADER_CHROME_BORDER,
+  ...headerChromeShadow,
+};
+
+/** Grouped trailing capsule (calendar + overflow). */
+export const headerChromeCapsuleShell = {
+  flexDirection: "row" as const,
+  alignItems: "center" as const,
+  backgroundColor: UI_HEADER_CHROME_BG,
+  borderRadius: 20,
+  borderWidth: StyleSheet.hairlineWidth,
+  borderColor: UI_HEADER_CHROME_BORDER,
+  paddingHorizontal: UI_HEADER_CAPSULE_PADDING_H,
+  gap: UI_HEADER_CAPSULE_SEGMENT_GAP,
+  ...headerChromeShadow,
+};
+
+/** One tappable region inside the trailing capsule (40×40 target). */
+export const headerChromeCapsuleSegmentBase = {
+  minWidth: 40,
+  minHeight: 40,
+  alignItems: "center" as const,
+  justifyContent: "center" as const,
+};
+
+export const headerChromeCapsuleSegmentPressed = {
+  opacity: 0.72,
+};
+
+/** ~65% of 40pt capsule height, centered; 1px for crisp separation. */
+const HEADER_CAPSULE_DIVIDER_HEIGHT = 26;
+
+export const headerChromeCapsuleDivider = {
+  width: 1,
+  height: HEADER_CAPSULE_DIVIDER_HEIGHT,
+  alignSelf: "center" as const,
+  backgroundColor: UI_HEADER_CAPSULE_DIVIDER,
+};

--- a/lib/ui/nutrition/NutritionTodayCard.tsx
+++ b/lib/ui/nutrition/NutritionTodayCard.tsx
@@ -3,6 +3,7 @@ import { Pressable, StyleSheet, Text, View } from "react-native";
 import type { NutritionTodayCardModel } from "@/lib/data/nutrition/nutritionTodayCardModel";
 import type { NutritionTodayFactsUi } from "@/lib/data/nutrition/nutritionOverviewUi";
 import { workoutOverviewInCardHeaderStyles } from "@/lib/ui/workouts/workoutOverviewInCardHeaderStyles";
+import { LinearProgressBar } from "@/lib/ui/primitives/LinearProgressBar";
 import { NUTRITION_ACCENT, NUTRITION_PROGRESS_TRACK_BG } from "@/lib/ui/nutrition/nutritionOverviewTheme";
 import { ErrorState, LoadingState } from "@/lib/ui/ScreenStates";
 
@@ -55,9 +56,11 @@ export function NutritionTodayCard({ model, todayFacts, onRetryFacts, onViewMore
                   <Text style={styles.label}>{row.label}</Text>
                   <Text style={styles.value}>{row.valueLabel}</Text>
                 </View>
-                <View style={styles.track}>
-                  <View style={[styles.fill, { width: `${Math.round(row.progress * 100)}%` }]} />
-                </View>
+                <LinearProgressBar
+                  progress={row.progress}
+                  trackColor={NUTRITION_PROGRESS_TRACK_BG}
+                  fillColor={NUTRITION_ACCENT}
+                />
               </View>
             ))}
           </View>
@@ -102,17 +105,5 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: "700",
     color: "#1C1C1E",
-  },
-  track: {
-    width: "100%",
-    height: 8,
-    borderRadius: 999,
-    backgroundColor: NUTRITION_PROGRESS_TRACK_BG,
-    overflow: "hidden",
-  },
-  fill: {
-    height: "100%",
-    borderRadius: 999,
-    backgroundColor: NUTRITION_ACCENT,
   },
 });

--- a/lib/ui/nutrition/NutritionWeeklyStrip.tsx
+++ b/lib/ui/nutrition/NutritionWeeklyStrip.tsx
@@ -1,22 +1,12 @@
 import React from "react";
-import { Pressable, StyleSheet, Text, View } from "react-native";
+import { View } from "react-native";
+
+import { CalendarDayCell } from "@/lib/ui/calendar/CalendarDayCell";
+import { calendarStripDayOfMonth, calendarStripDayOfWeekLabel } from "@/lib/ui/calendar/calendarWeeklyStripDayUtils";
+import { calendarWeeklyStripStyles } from "@/lib/ui/calendar/calendarWeeklyStripStyles";
 import type { CalendarDay } from "@/lib/ui/calendar/types";
 import type { NutritionDayStripMeta } from "@/lib/data/nutrition/nutritionWeeklyStripMeta";
-import { WEEKLY_STRIP_SELECTED_DAY_CIRCLE_FILL } from "@/lib/ui/calendar/weeklyCalendarStripTheme";
 import { NutritionDayRing } from "@/lib/ui/calendar/NutritionDayRing";
-
-const DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-
-function getDayOfWeekLabel(dayKey: string): string {
-  const d = new Date(`${dayKey}T12:00:00.000Z`);
-  const dow = d.getUTCDay();
-  return DAY_LABELS[dow] ?? "";
-}
-
-function getDayOfMonth(dayKey: string): string {
-  const d = new Date(`${dayKey}T12:00:00.000Z`);
-  return String(d.getUTCDate());
-}
 
 export type NutritionWeeklyStripProps = {
   days: CalendarDay<NutritionDayStripMeta>[];
@@ -25,98 +15,37 @@ export type NutritionWeeklyStripProps = {
 };
 
 /**
- * Week strip aligned with {@link WeeklyStrip} (Strength): typography, spacing, selection; accent rings when logged.
+ * Week strip aligned with Strength / Body modules; accent rings when nutrition is logged.
  */
 export function NutritionWeeklyStrip({ days, selectedDay, onDayPress }: NutritionWeeklyStripProps) {
   return (
-    <View style={styles.container}>
-      <View style={styles.row}>
+    <View style={calendarWeeklyStripStyles.container}>
+      <View style={calendarWeeklyStripStyles.row}>
         {days.map((d) => {
           const hasNutrition = d.meta?.hasNutrition === true;
           const isSelected = selectedDay === d.day;
           return (
-            <Pressable
+            <CalendarDayCell
               key={d.day}
+              dayOfWeekLabel={calendarStripDayOfWeekLabel(d.day)}
+              dayOfMonthLabel={calendarStripDayOfMonth(d.day)}
+              isSelected={isSelected}
               onPress={() => onDayPress(d.day)}
-              accessibilityRole="button"
-              accessibilityLabel={hasNutrition ? `${d.day}, nutrition logged` : `${d.day}, no nutrition log`}
-              style={({ pressed }) => [
-                styles.dayCell,
-                isSelected && styles.dayCellSelected,
-                pressed && styles.dayCellPressed,
-              ]}
-              hitSlop={8}
-            >
-              <Text style={styles.dayOfWeek}>{getDayOfWeekLabel(d.day)}</Text>
-              <View style={[styles.dayCircle, isSelected && styles.dayCircleSelected]}>
-                <View style={styles.dayRingBackdrop} pointerEvents="none">
-                  <NutritionDayRing
-                    size={40}
-                    hasNutrition={hasNutrition}
-                    emphasized={isSelected}
-                    outerTestID={`nutrition-weekly-outer-ring-${d.day}`}
-                  />
-                </View>
-                <Text style={[styles.dayNumber, isSelected && styles.dayNumberSelected]}>{getDayOfMonth(d.day)}</Text>
-              </View>
-            </Pressable>
+              accessibilityLabel={
+                hasNutrition ? `${d.day}, nutrition logged` : `${d.day}, no nutrition log`
+              }
+              ring={
+                <NutritionDayRing
+                  size={40}
+                  hasNutrition={hasNutrition}
+                  emphasized={isSelected}
+                  outerTestID={`nutrition-weekly-outer-ring-${d.day}`}
+                />
+              }
+            />
           );
         })}
       </View>
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    width: "100%",
-    paddingHorizontal: 0,
-    paddingBottom: 2,
-    paddingTop: 0,
-  },
-  row: {
-    flexDirection: "row",
-    width: "100%",
-    alignItems: "flex-start",
-    justifyContent: "space-between",
-  },
-  dayCell: {
-    flex: 1,
-    minWidth: 0,
-    alignItems: "center",
-    justifyContent: "flex-start",
-  },
-  dayCellSelected: {},
-  dayCellPressed: {
-    opacity: 0.7,
-  },
-  dayOfWeek: {
-    fontSize: 13,
-    color: "#8E8E93",
-    marginBottom: 2,
-  },
-  dayCircle: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    position: "relative",
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  dayRingBackdrop: {
-    ...StyleSheet.absoluteFillObject,
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  dayCircleSelected: {
-    backgroundColor: WEEKLY_STRIP_SELECTED_DAY_CIRCLE_FILL,
-  },
-  dayNumber: {
-    fontSize: 18,
-    fontWeight: "600",
-    color: "#1C1C1E",
-  },
-  dayNumberSelected: {
-    color: "#FFFFFF",
-  },
-});

--- a/lib/ui/overview/moduleOverviewMetricLayout.ts
+++ b/lib/ui/overview/moduleOverviewMetricLayout.ts
@@ -1,0 +1,54 @@
+import { StyleSheet } from "react-native";
+
+/**
+ * Shared vertical rhythm for overview metric blocks (label + pill cluster, trailing value, bar below).
+ * Used by Strength Overview card and Body Composition Overview card.
+ */
+export const moduleOverviewMetricLayoutStyles = StyleSheet.create({
+  metricGroups: {
+    gap: 20,
+  },
+  metricBlock: {
+    gap: 8,
+  },
+  topRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 10,
+  },
+  titlePillCluster: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    flex: 1,
+    minWidth: 0,
+  },
+  primaryLabel: {
+    fontSize: 15,
+    fontWeight: "700",
+    color: "#1C1C1E",
+    flexShrink: 0,
+  },
+  trailingValue: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: "#3C3C43",
+    letterSpacing: -0.15,
+    flexShrink: 0,
+    maxWidth: "42%",
+    textAlign: "right",
+  },
+  ratingPillShell: {
+    flexShrink: 1,
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 8,
+    maxWidth: "46%",
+  },
+  ratingPillLabel: {
+    fontSize: 11,
+    fontWeight: "600",
+    letterSpacing: 0.15,
+  },
+});

--- a/lib/ui/overview/moduleOverviewSegmentZoneFills.ts
+++ b/lib/ui/overview/moduleOverviewSegmentZoneFills.ts
@@ -1,0 +1,11 @@
+/**
+ * Five segment fills for {@link SegmentedZoneTrack} on module overview cards (Strength + Body).
+ * Same RGB at ~35% alpha on white as Strength tier chroma: Low → Optimal (red → blue).
+ */
+export const MODULE_OVERVIEW_SEGMENT_ZONE_FILLS = [
+  "rgba(229, 115, 115, 0.35)",
+  "rgba(242, 208, 107, 0.35)",
+  "rgba(230, 161, 92, 0.35)",
+  "rgba(94, 192, 140, 0.35)",
+  "rgba(92, 143, 230, 0.35)",
+] as const;

--- a/lib/ui/overview/moduleOverviewSegmentedTrackMetrics.ts
+++ b/lib/ui/overview/moduleOverviewSegmentedTrackMetrics.ts
@@ -1,0 +1,9 @@
+/**
+ * Shared geometry for {@link SegmentedZoneTrack} on module overview cards (Strength consistency,
+ * Body interpretation). Domain-specific zone colors stay at call sites.
+ */
+export const MODULE_OVERVIEW_SEGMENTED_TRACK = {
+  barHeight: 10,
+  trackRadius: 5,
+  dotSize: 10,
+} as const;

--- a/lib/ui/overview/moduleOverviewStrengthTierPillChrome.ts
+++ b/lib/ui/overview/moduleOverviewStrengthTierPillChrome.ts
@@ -1,0 +1,11 @@
+/**
+ * Full-opacity pill chrome per shared overview segment index (Low → Optimal).
+ * Order matches {@link MODULE_OVERVIEW_SEGMENT_ZONE_FILLS} and Strength tier indices 0–4.
+ */
+export const MODULE_OVERVIEW_STRENGTH_TIER_PILL_CHROME = [
+  { pillBg: "#FDEBEB", pillFg: "#E57373" },
+  { pillBg: "#F5ECD8", pillFg: "#F2D06B" },
+  { pillBg: "#FFF4E8", pillFg: "#E6A15C" },
+  { pillBg: "#E8F6EF", pillFg: "#5EC08C" },
+  { pillBg: "#E9F0FC", pillFg: "#5C8FE6" },
+] as const;

--- a/lib/ui/primitives/LinearProgressBar.tsx
+++ b/lib/ui/primitives/LinearProgressBar.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { StyleSheet, View, type DimensionValue } from "react-native";
+
+export type LinearProgressBarProps = {
+  /** 0–1; values outside range are clamped. */
+  progress: number;
+  trackColor: string;
+  fillColor: string;
+  height?: number;
+  borderRadius?: number;
+  testID?: string;
+};
+
+function clamp01(x: number): number {
+  if (!Number.isFinite(x) || x <= 0) return 0;
+  if (x >= 1) return 1;
+  return x;
+}
+
+/**
+ * Simple horizontal progress (filled width), shared by overview cards and similar rows.
+ */
+export function LinearProgressBar({
+  progress,
+  trackColor,
+  fillColor,
+  height = 8,
+  borderRadius = 999,
+  testID,
+}: LinearProgressBarProps) {
+  const p = clamp01(progress);
+  const widthPct = `${Math.round(p * 100)}%` as DimensionValue;
+
+  return (
+    <View
+      style={[styles.track, { height, borderRadius, backgroundColor: trackColor }]}
+      testID={testID}
+    >
+      <View style={[styles.fill, { width: widthPct, borderRadius, backgroundColor: fillColor }]} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  track: {
+    width: "100%",
+    overflow: "hidden",
+  },
+  fill: {
+    height: "100%",
+  },
+});

--- a/lib/ui/primitives/SegmentedZoneTrack.tsx
+++ b/lib/ui/primitives/SegmentedZoneTrack.tsx
@@ -1,0 +1,129 @@
+import React, { useState } from "react";
+import { LayoutChangeEvent, StyleSheet, View, type ViewProps } from "react-native";
+
+import { clampedDotLeftPx } from "@/lib/ui/body/interpretationBarDotLayout";
+import { MODULE_OVERVIEW_SEGMENTED_TRACK } from "@/lib/ui/overview/moduleOverviewSegmentedTrackMetrics";
+
+const DEFAULT_DOT_SIZE = MODULE_OVERVIEW_SEGMENTED_TRACK.dotSize;
+const DEFAULT_BAR_HEIGHT = MODULE_OVERVIEW_SEGMENTED_TRACK.barHeight;
+const DEFAULT_TRACK_RADIUS = MODULE_OVERVIEW_SEGMENTED_TRACK.trackRadius;
+
+function clamp01(x: number): number {
+  if (!Number.isFinite(x) || x <= 0) return 0;
+  if (x >= 1) return 1;
+  return x;
+}
+
+export type SegmentedZoneTrackProps = {
+  zoneColors: readonly string[];
+  testID?: string;
+  /** Clamped 0–1 along full track width. */
+  markerPosition01: number;
+  /** When false, zones render but no marker (e.g. Body with no measurement). */
+  showMarker: boolean;
+  markerBackgroundColor: string;
+  dotSize?: number;
+  barHeight?: number;
+  trackRadius?: number;
+  /** Applied to the outer wrapper (layout + testID are owned by this component). */
+  wrapperProps?: Omit<ViewProps, "children" | "onLayout" | "testID" | "style"> & {
+    style?: ViewProps["style"];
+  };
+};
+
+/**
+ * Shared layout for multi-segment quality / consistency tracks with an optional position marker.
+ * Domain colors, accessibility, and semantics stay at call sites.
+ */
+export function SegmentedZoneTrack({
+  zoneColors,
+  testID,
+  markerPosition01,
+  showMarker,
+  markerBackgroundColor,
+  dotSize = DEFAULT_DOT_SIZE,
+  barHeight = DEFAULT_BAR_HEIGHT,
+  trackRadius = DEFAULT_TRACK_RADIUS,
+  wrapperProps,
+}: SegmentedZoneTrackProps) {
+  const [trackW, setTrackW] = useState(0);
+
+  const onTrackLayout = (e: LayoutChangeEvent) => {
+    const w = e.nativeEvent.layout.width;
+    if (w > 0 && Math.abs(w - trackW) > 0.5) setTrackW(w);
+  };
+
+  const marker01 = clamp01(markerPosition01);
+
+  const dotLeft =
+    showMarker && trackW > 0 ? clampedDotLeftPx(trackW, marker01, dotSize) : undefined;
+
+  const zonesTestID = testID != null ? `${testID}-zones` : undefined;
+  const markerTestID = testID != null ? `${testID}-marker` : undefined;
+  const { style: wrapperStyle, ...wrapperRest } = wrapperProps ?? {};
+
+  return (
+    <View
+      {...wrapperRest}
+      {...(testID != null ? { testID } : {})}
+      style={[styles.trackWrap, { height: barHeight }, wrapperStyle]}
+      onLayout={onTrackLayout}
+    >
+      <View
+        style={[styles.zonesClip, { borderRadius: trackRadius, height: barHeight }]}
+        {...(zonesTestID != null ? { testID: zonesTestID } : {})}
+        importantForAccessibility="no"
+      >
+        <View style={[styles.zonesRow, { height: barHeight }]} importantForAccessibility="no">
+          {zoneColors.map((color, i) => (
+            <View
+              key={i}
+              style={[styles.zone, { backgroundColor: color }]}
+              importantForAccessibility="no"
+            />
+          ))}
+        </View>
+      </View>
+      {dotLeft != null ? (
+        <View
+          style={[
+            styles.markerDot,
+            {
+              left: dotLeft,
+              width: dotSize,
+              height: dotSize,
+              borderRadius: dotSize / 2,
+              backgroundColor: markerBackgroundColor,
+            },
+          ]}
+          importantForAccessibility="no"
+          {...(markerTestID != null ? { testID: markerTestID } : {})}
+        />
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  trackWrap: {
+    width: "100%",
+    position: "relative",
+    justifyContent: "center",
+  },
+  zonesClip: {
+    overflow: "hidden",
+  },
+  zonesRow: {
+    flexDirection: "row",
+  },
+  zone: {
+    flex: 1,
+    marginHorizontal: StyleSheet.hairlineWidth,
+  },
+  markerDot: {
+    position: "absolute",
+    top: 0,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: "rgba(255,255,255,0.85)",
+  },
+});

--- a/lib/ui/recovery/RecoveryContributorsCard.tsx
+++ b/lib/ui/recovery/RecoveryContributorsCard.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { View, Text, StyleSheet } from "react-native";
 
+import { LinearProgressBar } from "@/lib/ui/primitives/LinearProgressBar";
+
 export type ContributorRowProps = {
   label: string;
   valueDisplay: string;
@@ -24,9 +26,13 @@ export function RecoveryContributorsCard({ title = "Contributors", rows }: Props
               <Text style={styles.label}>{row.label}</Text>
               <Text style={styles.value}>{row.valueDisplay}</Text>
             </View>
-            <View style={styles.barTrack}>
-              <View style={[styles.barFill, { width: `${Math.max(0, Math.min(1, row.progress)) * 100}%` }]} />
-            </View>
+            <LinearProgressBar
+              progress={row.progress}
+              height={6}
+              borderRadius={3}
+              trackColor="#E5E5EA"
+              fillColor="#1C1C1E"
+            />
             <Text style={styles.rating}>{row.rating}</Text>
           </View>
         ))}
@@ -67,17 +73,6 @@ const styles = StyleSheet.create({
     fontSize: 15,
     fontWeight: "600",
     color: "#1C1C1E",
-  },
-  barTrack: {
-    height: 6,
-    backgroundColor: "#E5E5EA",
-    borderRadius: 3,
-    overflow: "hidden",
-  },
-  barFill: {
-    height: "100%",
-    backgroundColor: "#1C1C1E",
-    borderRadius: 3,
   },
   rating: {
     fontSize: 13,

--- a/lib/ui/recovery/RecoveryOuraWeeklyStrip.tsx
+++ b/lib/ui/recovery/RecoveryOuraWeeklyStrip.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { View } from "react-native";
+
+import { CalendarDayCell } from "@/lib/ui/calendar/CalendarDayCell";
+import { calendarStripDayOfMonth, calendarStripDayOfWeekLabel } from "@/lib/ui/calendar/calendarWeeklyStripDayUtils";
+import { calendarWeeklyStripStyles } from "@/lib/ui/calendar/calendarWeeklyStripStyles";
+import type { CalendarDay } from "@/lib/ui/calendar/types";
+import { BodyDayRing } from "@/lib/ui/body/BodyDayRing";
+
+export type RecoveryOuraDayMarker = {
+  hasOuraSnapshot: boolean;
+};
+
+export type RecoveryOuraWeeklyStripProps = {
+  days: CalendarDay<RecoveryOuraDayMarker>[];
+  selectedDay?: string;
+  onDayPress: (day: string) => void;
+  /** Used for accessibility strings only. */
+  categoryLabel: "sleep" | "readiness";
+  testIDPrefix?: string;
+};
+
+export function RecoveryOuraWeeklyStrip({
+  days,
+  selectedDay,
+  onDayPress,
+  categoryLabel,
+  testIDPrefix = "recovery-oura-weekly",
+}: RecoveryOuraWeeklyStripProps) {
+  return (
+    <View style={calendarWeeklyStripStyles.container}>
+      <View style={calendarWeeklyStripStyles.row}>
+        {days.map((d) => {
+          const hasOuraSnapshot = d.meta?.hasOuraSnapshot === true;
+          const isSelected = selectedDay === d.day;
+          const noun = categoryLabel === "sleep" ? "sleep data" : "readiness data";
+          return (
+            <CalendarDayCell
+              key={d.day}
+              dayOfWeekLabel={calendarStripDayOfWeekLabel(d.day)}
+              dayOfMonthLabel={calendarStripDayOfMonth(d.day)}
+              isSelected={isSelected}
+              onPress={() => onDayPress(d.day)}
+              accessibilityLabel={
+                hasOuraSnapshot
+                  ? `${d.day}, has Oura ${noun}`
+                  : `${d.day}, no Oura ${noun}`
+              }
+              ring={
+                <BodyDayRing
+                  size={40}
+                  hasMeasurement={hasOuraSnapshot}
+                  emphasized={isSelected}
+                  testID={`${testIDPrefix}-ring-${d.day}`}
+                />
+              }
+            />
+          );
+        })}
+      </View>
+    </View>
+  );
+}

--- a/lib/ui/theme/uiTokens.ts
+++ b/lib/ui/theme/uiTokens.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared neutral / chrome tokens for cross-module UI consistency.
+ * Accent colors stay in {@link systemAccent} and domain themes.
+ */
+export const UI_TEXT_PRIMARY = "#1C1C1E";
+export const UI_TEXT_SECONDARY = "#3C3C43";
+export const UI_TEXT_MUTED = "#6E6E73";
+export const UI_TEXT_TERTIARY_LABEL = "#8E8E93";
+
+/** Header back / toolbar pill fill (iOS grouped background family). */
+export const UI_HEADER_CHROME_BG = "#F2F2F7";
+
+/** Hairline border for header chrome (capsule, back circle) — subtle separation from white nav bar. */
+export const UI_HEADER_CHROME_BORDER = "rgba(60, 60, 67, 0.12)";
+
+/** Horizontal inset inside grouped header capsule (calendar + overflow). */
+export const UI_HEADER_CAPSULE_PADDING_H = 9;
+
+/**
+ * Flex `gap` between capsule segments (calendar | divider | overflow).
+ * With a ~1px divider, total air between segment centers reads ~14–16px.
+ */
+export const UI_HEADER_CAPSULE_SEGMENT_GAP = 7;
+
+/** Vertical rule between capsule actions — lighter than outer chrome border. */
+export const UI_HEADER_CAPSULE_DIVIDER = "rgba(60, 60, 67, 0.08)";
+
+/** Secondary inline actions (e.g. in-card “View More”) — neutral, not accent CTA. */
+export const UI_LINK_SECONDARY = UI_TEXT_SECONDARY;
+
+export const UI_BORDER_HAIRLINE = "#E5E5EA";
+export const UI_SCREEN_BG = "#F2F2F7";
+export const UI_CARD_SURFACE = "#FFFFFF";

--- a/lib/ui/workouts/StrengthGymSettingsSection.tsx
+++ b/lib/ui/workouts/StrengthGymSettingsSection.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { View, Text, Pressable, StyleSheet } from "react-native";
+
+import { usePreferences } from "@/lib/preferences/PreferencesProvider";
+import { getGymMenuOptions } from "@/lib/workouts/gymRegistry";
+import { SYSTEM_ACCENT, SYSTEM_ACCENT_OVERLAY_08 } from "@/lib/ui/theme/systemAccent";
+
+/**
+ * Gym picker for Strength settings (moved from overview overflow menu).
+ */
+export function StrengthGymSettingsSection() {
+  const { state: prefState, setSelectedGymId } = usePreferences();
+
+  return (
+    <View style={styles.wrap}>
+      <Text style={styles.sectionLabel}>Gym</Text>
+      {getGymMenuOptions().map((opt) => {
+        const selected =
+          (opt.value === null && prefState.preferences.selectedGymId === null) ||
+          (opt.value !== null && prefState.preferences.selectedGymId === opt.value);
+        return (
+          <Pressable
+            key={opt.value ?? "none"}
+            onPress={() => {
+              setSelectedGymId(opt.value);
+            }}
+            style={[styles.optionRow, selected && styles.optionRowSelected]}
+            accessibilityRole="button"
+            accessibilityLabel={`Gym: ${opt.label}${selected ? ", selected" : ""}`}
+          >
+            <Text style={styles.optionLabel}>{opt.label}</Text>
+            {selected ? <Text style={styles.optionCheck}>✓</Text> : null}
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: { gap: 8 },
+  sectionLabel: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: "#6E6E73",
+    marginBottom: 4,
+  },
+  optionRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: "rgba(0,0,0,0.2)",
+  },
+  optionRowSelected: {
+    borderColor: SYSTEM_ACCENT,
+    backgroundColor: SYSTEM_ACCENT_OVERLAY_08,
+  },
+  optionLabel: { fontSize: 16, fontWeight: "500", color: "#1C1C1E" },
+  optionCheck: { fontSize: 16, fontWeight: "700", color: SYSTEM_ACCENT },
+});

--- a/lib/ui/workouts/StrengthOverviewCard.tsx
+++ b/lib/ui/workouts/StrengthOverviewCard.tsx
@@ -1,0 +1,199 @@
+import React from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import type { StrengthOverviewCardModel } from "@/lib/data/workouts/strengthOverviewCardModel";
+import type {
+  StrengthOverviewTimeframeRatingLabel,
+  StrengthOverviewTimeframeRatingTier,
+} from "@/lib/data/workouts/strengthOverviewTimeframeRating";
+import { computeStrengthOverviewMarkerPosition01 } from "@/lib/data/workouts/strengthOverviewTimeframeRating";
+import { moduleOverviewMetricLayoutStyles } from "@/lib/ui/overview/moduleOverviewMetricLayout";
+import { MODULE_OVERVIEW_SEGMENT_ZONE_FILLS } from "@/lib/ui/overview/moduleOverviewSegmentZoneFills";
+import { MODULE_OVERVIEW_STRENGTH_TIER_PILL_CHROME } from "@/lib/ui/overview/moduleOverviewStrengthTierPillChrome";
+import { MODULE_OVERVIEW_SEGMENTED_TRACK } from "@/lib/ui/overview/moduleOverviewSegmentedTrackMetrics";
+import { SegmentedZoneTrack } from "@/lib/ui/primitives/SegmentedZoneTrack";
+import { workoutOverviewInCardHeaderStyles } from "@/lib/ui/workouts/workoutOverviewInCardHeaderStyles";
+import { LoadingState } from "@/lib/ui/ScreenStates";
+
+type StrengthOverviewCardProps = {
+  loading: boolean;
+  model: StrengthOverviewCardModel | null;
+  onViewMore?: () => void;
+};
+
+/**
+ * Strength-only tier palette (not Body interpretation zones).
+ * Tier chroma: Low #E57373, Developing #F2D06B, Solid #E6A15C, Strong #5EC08C, Optimal #5C8FE6.
+ * Bar segments: same RGB at ~35% alpha on white. Pill fg + marker: full-opacity tier hex. Pill bg: soft opaque tints.
+ */
+const STRENGTH_OVERVIEW_TIER_COLORS: Record<
+  StrengthOverviewTimeframeRatingTier,
+  { pillBg: string; pillFg: string; segmentFill: string }
+> = {
+  low: {
+    pillBg: MODULE_OVERVIEW_STRENGTH_TIER_PILL_CHROME[0].pillBg,
+    pillFg: MODULE_OVERVIEW_STRENGTH_TIER_PILL_CHROME[0].pillFg,
+    segmentFill: MODULE_OVERVIEW_SEGMENT_ZONE_FILLS[0],
+  },
+  developing: {
+    pillBg: MODULE_OVERVIEW_STRENGTH_TIER_PILL_CHROME[1].pillBg,
+    pillFg: MODULE_OVERVIEW_STRENGTH_TIER_PILL_CHROME[1].pillFg,
+    segmentFill: MODULE_OVERVIEW_SEGMENT_ZONE_FILLS[1],
+  },
+  solid: {
+    pillBg: MODULE_OVERVIEW_STRENGTH_TIER_PILL_CHROME[2].pillBg,
+    pillFg: MODULE_OVERVIEW_STRENGTH_TIER_PILL_CHROME[2].pillFg,
+    segmentFill: MODULE_OVERVIEW_SEGMENT_ZONE_FILLS[2],
+  },
+  strong: {
+    pillBg: MODULE_OVERVIEW_STRENGTH_TIER_PILL_CHROME[3].pillBg,
+    pillFg: MODULE_OVERVIEW_STRENGTH_TIER_PILL_CHROME[3].pillFg,
+    segmentFill: MODULE_OVERVIEW_SEGMENT_ZONE_FILLS[3],
+  },
+  optimal: {
+    pillBg: MODULE_OVERVIEW_STRENGTH_TIER_PILL_CHROME[4].pillBg,
+    pillFg: MODULE_OVERVIEW_STRENGTH_TIER_PILL_CHROME[4].pillFg,
+    segmentFill: MODULE_OVERVIEW_SEGMENT_ZONE_FILLS[4],
+  },
+};
+
+const RATING_PILL_STYLES: Record<StrengthOverviewTimeframeRatingTier, { bg: string; fg: string }> =
+  (Object.keys(STRENGTH_OVERVIEW_TIER_COLORS) as StrengthOverviewTimeframeRatingTier[]).reduce(
+    (acc, tier) => {
+      const t = STRENGTH_OVERVIEW_TIER_COLORS[tier];
+      acc[tier] = { bg: t.pillBg, fg: t.pillFg };
+      return acc;
+    },
+    {} as Record<StrengthOverviewTimeframeRatingTier, { bg: string; fg: string }>,
+  );
+
+const TIER_FOR_RATING_LABEL: Record<StrengthOverviewTimeframeRatingLabel, StrengthOverviewTimeframeRatingTier> = {
+  Low: "low",
+  Developing: "developing",
+  Solid: "solid",
+  Strong: "strong",
+  Optimal: "optimal",
+};
+
+/** Marker fill matches rating pill foreground for the tier (not bar position / segment under the dot). */
+export function getStrengthOverviewMarkerColorForRatingLabel(
+  label: StrengthOverviewTimeframeRatingLabel,
+): string {
+  return RATING_PILL_STYLES[TIER_FOR_RATING_LABEL[label]].fg;
+}
+
+/**
+ * Bar segment fills (Low → Optimal); same tuple as {@link MODULE_OVERVIEW_SEGMENT_ZONE_FILLS}.
+ */
+export const STRENGTH_OVERVIEW_TIER_ZONE_BG = MODULE_OVERVIEW_SEGMENT_ZONE_FILLS;
+
+function clamp01(x: number): number {
+  if (!Number.isFinite(x) || x <= 0) return 0;
+  if (x >= 1) return 1;
+  return x;
+}
+
+function StrengthOverviewConsistencyTrack({
+  testID,
+  markerPosition01,
+  ratingLabel,
+}: {
+  testID: string;
+  /** 0–1 along full track; must already lie inside the tier segment (see {@link computeStrengthOverviewMarkerPosition01}). */
+  markerPosition01: number;
+  ratingLabel: StrengthOverviewTimeframeRatingLabel;
+}) {
+  const marker01 = clamp01(markerPosition01);
+  const pct = Math.round(marker01 * 100);
+  const markerColor = getStrengthOverviewMarkerColorForRatingLabel(ratingLabel);
+
+  return (
+    <SegmentedZoneTrack
+      zoneColors={STRENGTH_OVERVIEW_TIER_ZONE_BG}
+      testID={testID}
+      markerPosition01={marker01}
+      showMarker
+      markerBackgroundColor={markerColor}
+      dotSize={MODULE_OVERVIEW_SEGMENTED_TRACK.dotSize}
+      barHeight={MODULE_OVERVIEW_SEGMENTED_TRACK.barHeight}
+      trackRadius={MODULE_OVERVIEW_SEGMENTED_TRACK.trackRadius}
+      wrapperProps={{
+        accessibilityRole: "progressbar",
+        accessibilityValue: { now: pct, min: 0, max: 100 },
+      }}
+    />
+  );
+}
+
+export function StrengthOverviewCard({ loading, model, onViewMore }: StrengthOverviewCardProps) {
+  return (
+    <View style={styles.card}>
+      <View style={[styles.headerRow, workoutOverviewInCardHeaderStyles.row]}>
+        <Text style={workoutOverviewInCardHeaderStyles.title}>Overview</Text>
+        {onViewMore != null ? (
+          <Pressable
+            onPress={onViewMore}
+            accessibilityRole="button"
+            accessibilityLabel="View more"
+            hitSlop={8}
+            style={({ pressed }) => [
+              workoutOverviewInCardHeaderStyles.linkHit,
+              pressed && workoutOverviewInCardHeaderStyles.linkPressed,
+            ]}
+          >
+            <Text style={workoutOverviewInCardHeaderStyles.link}>View More</Text>
+          </Pressable>
+        ) : null}
+      </View>
+
+      {loading ? (
+        <LoadingState variant="inline" message="Loading workouts…" />
+      ) : model != null ? (
+        <View style={moduleOverviewMetricLayoutStyles.metricGroups}>
+          {model.timeframes.map((tf) => {
+            const pill = RATING_PILL_STYLES[tf.rating.tier];
+            const a11y = `${tf.label}. ${tf.rating.label}. ${tf.compactStatsSummary}.`;
+            return (
+              <View key={tf.key} style={moduleOverviewMetricLayoutStyles.metricBlock} accessibilityLabel={a11y} accessible>
+                <View style={moduleOverviewMetricLayoutStyles.topRow}>
+                  <View style={moduleOverviewMetricLayoutStyles.titlePillCluster}>
+                    <Text style={moduleOverviewMetricLayoutStyles.primaryLabel} numberOfLines={1}>
+                      {tf.label}
+                    </Text>
+                    <View style={[moduleOverviewMetricLayoutStyles.ratingPillShell, { backgroundColor: pill.bg }]}>
+                      <Text style={[moduleOverviewMetricLayoutStyles.ratingPillLabel, { color: pill.fg }]} numberOfLines={1}>
+                        {tf.rating.label}
+                      </Text>
+                    </View>
+                  </View>
+                  <Text style={moduleOverviewMetricLayoutStyles.trailingValue} numberOfLines={1}>
+                    {tf.compactStatsSummary}
+                  </Text>
+                </View>
+                <StrengthOverviewConsistencyTrack
+                  testID={`strength-overview-consistency-bar-${tf.key}`}
+                  markerPosition01={computeStrengthOverviewMarkerPosition01({
+                    tier: tf.rating.tier,
+                    scoringAvg: tf.rating.scoringAvg,
+                  })}
+                  ratingLabel={tf.rating.label}
+                />
+              </View>
+            );
+          })}
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: "#FFFFFF",
+    borderRadius: 12,
+    padding: 16,
+    gap: 12,
+  },
+  headerRow: {
+    alignItems: "flex-start",
+  },
+});

--- a/lib/ui/workouts/TodayCard.tsx
+++ b/lib/ui/workouts/TodayCard.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Pressable, StyleSheet, Text, View } from "react-native";
 import type { TodayOverviewModel } from "@/lib/data/workouts/todayOverviewModel";
 import { workoutOverviewInCardHeaderStyles } from "@/lib/ui/workouts/workoutOverviewInCardHeaderStyles";
+import { LinearProgressBar } from "@/lib/ui/primitives/LinearProgressBar";
 import {
   WORKOUT_STRENGTH_OVERVIEW_PROGRESS_FILL,
   WORKOUT_STRENGTH_PROGRESS_TRACK_BG,
@@ -39,9 +40,11 @@ export function TodayCard({ model, onViewMore }: TodayCardProps) {
               <Text style={styles.label}>{row.label}</Text>
               <Text style={styles.value}>{row.valueLabel}</Text>
             </View>
-            <View style={styles.track}>
-              <View style={[styles.fill, { width: `${Math.round(row.progress * 100)}%` }]} />
-            </View>
+            <LinearProgressBar
+              progress={row.progress}
+              trackColor={WORKOUT_STRENGTH_PROGRESS_TRACK_BG}
+              fillColor={WORKOUT_STRENGTH_OVERVIEW_PROGRESS_FILL}
+            />
           </View>
         ))}
       </View>
@@ -77,17 +80,5 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: "700",
     color: "#1C1C1E",
-  },
-  track: {
-    width: "100%",
-    height: 8,
-    borderRadius: 999,
-    backgroundColor: WORKOUT_STRENGTH_PROGRESS_TRACK_BG,
-    overflow: "hidden",
-  },
-  fill: {
-    height: "100%",
-    borderRadius: 999,
-    backgroundColor: WORKOUT_STRENGTH_OVERVIEW_PROGRESS_FILL,
   },
 });

--- a/lib/ui/workouts/WeeklyMuscleGroupCard.tsx
+++ b/lib/ui/workouts/WeeklyMuscleGroupCard.tsx
@@ -3,6 +3,7 @@ import { Pressable, StyleSheet, Text, View } from "react-native";
 import type { MuscleGroup } from "@/lib/workouts/exercises/taxonomy";
 import type { WeeklyStrengthCardModel } from "@/lib/data/workouts/weeklyStrengthCardModel";
 import { kgToLbs } from "@/lib/metrics/metricUnits";
+import { LinearProgressBar } from "@/lib/ui/primitives/LinearProgressBar";
 import {
   overviewAccentForTab,
   WORKOUT_STRENGTH_OVERVIEW_PROGRESS_FILL,
@@ -112,7 +113,6 @@ export function WeeklyMuscleGroupCard({ model, initialTab }: WeeklyMuscleGroupCa
             <Text style={styles.placeholder}>{placeholder}</Text>
           ) : (
             model.muscleGroups.map((row) => {
-              const widthPct = Math.max(0, Math.min(100, (row.totalVolume / volumeMax) * 100));
               return (
                 <View key={row.muscleGroup} style={styles.row}>
                   <View style={styles.rowTop}>
@@ -121,9 +121,11 @@ export function WeeklyMuscleGroupCard({ model, initialTab }: WeeklyMuscleGroupCa
                     </Text>
                     <Text style={styles.rowValue}>{formatVolumeLabelKgAsLb(row.totalVolume)}</Text>
                   </View>
-                  <View style={styles.progressTrack}>
-                    <View style={[styles.progressFill, { width: `${widthPct}%` }]} />
-                  </View>
+                  <LinearProgressBar
+                    progress={row.totalVolume / volumeMax}
+                    trackColor={WORKOUT_STRENGTH_PROGRESS_TRACK_BG}
+                    fillColor={WORKOUT_STRENGTH_OVERVIEW_PROGRESS_FILL}
+                  />
                 </View>
               );
             })
@@ -132,7 +134,6 @@ export function WeeklyMuscleGroupCard({ model, initialTab }: WeeklyMuscleGroupCa
           <Text style={styles.placeholder}>{placeholder}</Text>
         ) : (
           model.muscleGroupsSets.map((row) => {
-            const widthPct = Math.max(0, Math.min(100, (row.totalSets / setsMax) * 100));
             return (
               <View key={row.muscleGroup} style={styles.row}>
                 <View style={styles.rowTop}>
@@ -141,9 +142,11 @@ export function WeeklyMuscleGroupCard({ model, initialTab }: WeeklyMuscleGroupCa
                   </Text>
                   <Text style={styles.rowValue}>{formatSetCount(row.totalSets)}</Text>
                 </View>
-                <View style={styles.progressTrack}>
-                  <View style={[styles.progressFill, { width: `${widthPct}%` }]} />
-                </View>
+                <LinearProgressBar
+                  progress={row.totalSets / setsMax}
+                  trackColor={WORKOUT_STRENGTH_PROGRESS_TRACK_BG}
+                  fillColor={WORKOUT_STRENGTH_OVERVIEW_PROGRESS_FILL}
+                />
               </View>
             );
           })
@@ -208,18 +211,6 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: "600",
     color: "#3C3C43",
-  },
-  progressTrack: {
-    width: "100%",
-    height: 8,
-    borderRadius: 999,
-    backgroundColor: WORKOUT_STRENGTH_PROGRESS_TRACK_BG,
-    overflow: "hidden",
-  },
-  progressFill: {
-    height: "100%",
-    borderRadius: 999,
-    backgroundColor: WORKOUT_STRENGTH_OVERVIEW_PROGRESS_FILL,
   },
   placeholder: {
     fontSize: 14,

--- a/lib/ui/workouts/WeeklyStrengthCard.tsx
+++ b/lib/ui/workouts/WeeklyStrengthCard.tsx
@@ -3,6 +3,7 @@ import { StyleSheet, Text, View } from "react-native";
 import type { WeeklyStrengthCardModel } from "@/lib/data/workouts/weeklyStrengthCardModel";
 import { kgToLbs } from "@/lib/metrics/metricUnits";
 import { workoutOverviewInCardHeaderStyles } from "@/lib/ui/workouts/workoutOverviewInCardHeaderStyles";
+import { LinearProgressBar } from "@/lib/ui/primitives/LinearProgressBar";
 import {
   WORKOUT_STRENGTH_OVERVIEW_PROGRESS_FILL,
   WORKOUT_STRENGTH_PROGRESS_TRACK_BG,
@@ -43,7 +44,6 @@ export function WeeklyStrengthCard({ model }: WeeklyStrengthCardProps) {
           <Text style={styles.placeholder}>No strength workouts this week yet.</Text>
         ) : (
           model.workouts.map((row) => {
-            const widthPct = Math.max(0, Math.min(100, (row.totalVolume / workoutMax) * 100));
             return (
               <View key={row.workoutId} style={styles.row}>
                 <View style={styles.rowTop}>
@@ -52,9 +52,11 @@ export function WeeklyStrengthCard({ model }: WeeklyStrengthCardProps) {
                   </Text>
                   <Text style={styles.rowValue}>{formatVolumeLabelKgAsLb(row.totalVolume)}</Text>
                 </View>
-                <View style={styles.progressTrack}>
-                  <View style={[styles.progressFill, { width: `${widthPct}%` }]} />
-                </View>
+                <LinearProgressBar
+                  progress={row.totalVolume / workoutMax}
+                  trackColor={WORKOUT_STRENGTH_PROGRESS_TRACK_BG}
+                  fillColor={WORKOUT_STRENGTH_OVERVIEW_PROGRESS_FILL}
+                />
               </View>
             );
           })
@@ -121,18 +123,6 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: "600",
     color: "#3C3C43",
-  },
-  progressTrack: {
-    width: "100%",
-    height: 8,
-    borderRadius: 999,
-    backgroundColor: WORKOUT_STRENGTH_PROGRESS_TRACK_BG,
-    overflow: "hidden",
-  },
-  progressFill: {
-    height: "100%",
-    borderRadius: 999,
-    backgroundColor: WORKOUT_STRENGTH_OVERVIEW_PROGRESS_FILL,
   },
   placeholder: {
     fontSize: 14,

--- a/lib/ui/workouts/__tests__/StrengthOverviewCard.test.tsx
+++ b/lib/ui/workouts/__tests__/StrengthOverviewCard.test.tsx
@@ -1,0 +1,163 @@
+import React from "react";
+import renderer, { act } from "react-test-renderer";
+import { addCalendarDaysToDayKey } from "@/lib/ui/calendar/dateUtils";
+import { buildStrengthOverviewCardModel } from "@/lib/data/workouts/strengthOverviewCardModel";
+import {
+  STRENGTH_OVERVIEW_TF_RATING_OPTIMAL_MIN,
+  computeStrengthOverviewMarkerPosition01,
+  getStrengthOverviewTierSegmentBounds01,
+} from "@/lib/data/workouts/strengthOverviewTimeframeRating";
+import {
+  getStrengthOverviewMarkerColorForRatingLabel,
+  STRENGTH_OVERVIEW_TIER_ZONE_BG,
+  StrengthOverviewCard,
+} from "@/lib/ui/workouts/StrengthOverviewCard";
+
+describe("STRENGTH_OVERVIEW_TIER_ZONE_BG", () => {
+  it("defines five segments Low through Optimal", () => {
+    expect(STRENGTH_OVERVIEW_TIER_ZONE_BG).toHaveLength(5);
+  });
+});
+
+describe("getStrengthOverviewMarkerColorForRatingLabel", () => {
+  it("Strong uses pill-matched green, not Optimal blue, regardless of score position semantics", () => {
+    expect(getStrengthOverviewMarkerColorForRatingLabel("Strong")).toBe("#5EC08C");
+    expect(getStrengthOverviewMarkerColorForRatingLabel("Optimal")).toBe("#5C8FE6");
+    expect(getStrengthOverviewMarkerColorForRatingLabel("Strong")).not.toBe(
+      getStrengthOverviewMarkerColorForRatingLabel("Optimal"),
+    );
+  });
+});
+
+describe("Strength Overview bar marker (tier segment + color)", () => {
+  it("Strong + near-Optimal scoringAvg keeps marker before Optimal segment; color stays Strong green", () => {
+    const optimalStart = getStrengthOverviewTierSegmentBounds01("optimal").start;
+    const marker01 = computeStrengthOverviewMarkerPosition01({
+      tier: "strong",
+      scoringAvg: STRENGTH_OVERVIEW_TF_RATING_OPTIMAL_MIN - 1e-6,
+    });
+    expect(marker01).toBeLessThan(optimalStart);
+    expect(getStrengthOverviewMarkerColorForRatingLabel("Strong")).toBe("#5EC08C");
+  });
+});
+
+describe("StrengthOverviewCard", () => {
+  const today = "2026-04-04";
+  const weekStart = "2026-03-30";
+  const weekEnd = "2026-04-05";
+
+  function minimalModel() {
+    return buildStrengthOverviewCardModel({
+      strengthCalendarDays: [],
+      analyticsDaysSlice: [],
+      todayDayKey: today,
+      weekStartDay: weekStart,
+      weekEndDay: weekEnd,
+      manualWorkoutSummaries: [],
+    });
+  }
+
+  it("renders four timeframes with compact stats, pills, and bars", () => {
+    const model = minimalModel();
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(
+        <StrengthOverviewCard loading={false} model={model} onViewMore={jest.fn()} />,
+      );
+    });
+    const json = JSON.stringify(tree.toJSON());
+    expect(json).toContain("Overview");
+    expect(json).toContain("YTD");
+    expect(json).toContain("3 Month");
+    expect(json).toContain("MTD");
+    expect(json).toContain("This Week");
+    expect(json).toContain("0 workouts · — / week");
+    expect(json).not.toContain("Limited training consistency");
+    expect(json).not.toContain("Total workouts");
+    expect(json).not.toContain("Avg per week");
+    expect(json).not.toContain("Avg duration");
+
+    const barWrapRe = /^strength-overview-consistency-bar-(ytd|threeMonth|mtd|thisWeek)$/;
+    const bars = tree.root.findAll(
+      (n) => typeof n.props?.testID === "string" && barWrapRe.test(n.props.testID as string),
+    );
+    const barTestIds = new Set(bars.map((n) => n.props.testID as string));
+    expect(barTestIds.size).toBe(4);
+    expect(barTestIds.has("strength-overview-consistency-bar-ytd")).toBe(true);
+    expect(barTestIds.has("strength-overview-consistency-bar-threeMonth")).toBe(true);
+    expect(barTestIds.has("strength-overview-consistency-bar-mtd")).toBe(true);
+    expect(barTestIds.has("strength-overview-consistency-bar-thisWeek")).toBe(true);
+
+    const ytdBar = tree.root
+      .findAllByProps({ testID: "strength-overview-consistency-bar-ytd" })
+      .find((n) => typeof n.props.onLayout === "function");
+    expect(ytdBar).toBeDefined();
+    expect(typeof ytdBar!.props.onLayout).toBe("function");
+    expect(
+      tree.root.findAllByProps({ testID: "strength-overview-consistency-bar-ytd-zones" }).length,
+    ).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows loading state when loading", () => {
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<StrengthOverviewCard loading model={null} onViewMore={jest.fn()} />);
+    });
+    expect(JSON.stringify(tree.toJSON())).toContain("Loading workouts");
+  });
+
+  it("invokes onViewMore from header link", () => {
+    const onViewMore = jest.fn();
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(
+        <StrengthOverviewCard loading={false} model={minimalModel()} onViewMore={onViewMore} />,
+      );
+    });
+    const link = tree.root.findByProps({ accessibilityLabel: "View more" });
+    act(() => {
+      link.props.onPress();
+    });
+    expect(onViewMore).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders compact stats when threeMonth has workouts", () => {
+    const threeStart = addCalendarDaysToDayKey(today, -(90 - 1));
+    const days = [
+      {
+        day: threeStart,
+        workouts: [
+          {
+            id: "s",
+            observedAt: `${threeStart}T12:00:00.000Z`,
+            sourceId: "apple_health",
+            title: "Lift",
+            workoutType: "strength" as const,
+            start: `${threeStart}T12:00:00.000Z`,
+            end: `${threeStart}T12:30:00.000Z`,
+            durationMinutes: 30,
+            calories: null,
+          },
+        ],
+      },
+    ];
+    const model = buildStrengthOverviewCardModel({
+      strengthCalendarDays: days,
+      analyticsDaysSlice: days,
+      todayDayKey: today,
+      weekStartDay: weekStart,
+      weekEndDay: weekEnd,
+      manualWorkoutSummaries: [],
+    });
+    const tm = model.timeframes.find((t) => t.key === "threeMonth")!;
+    expect(tm.rating.progress).toBeGreaterThan(0);
+    expect(tm.compactStatsSummary).toContain("workout");
+    expect(tm.compactStatsSummary).toContain("/ week");
+
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<StrengthOverviewCard loading={false} model={model} />);
+    });
+    expect(JSON.stringify(tree.toJSON())).toContain(tm.compactStatsSummary);
+  });
+});

--- a/lib/ui/workouts/workoutOverviewInCardHeaderStyles.ts
+++ b/lib/ui/workouts/workoutOverviewInCardHeaderStyles.ts
@@ -1,5 +1,6 @@
 import { StyleSheet } from "react-native";
-import { SYSTEM_ACCENT } from "@/lib/ui/theme/systemAccent";
+
+import { UI_LINK_SECONDARY } from "@/lib/ui/theme/uiTokens";
 
 /**
  * Shared title row for Workouts Overview in-card section headers:
@@ -18,7 +19,7 @@ export const workoutOverviewInCardHeaderStyles = StyleSheet.create({
     letterSpacing: -0.35,
   },
   linkHit: { paddingVertical: 4, paddingLeft: 8 },
-  link: { fontSize: 15, fontWeight: "600", color: SYSTEM_ACCENT, letterSpacing: -0.2 },
-  /** Matches HeaderIconButton / link rows: quiet opacity on press. */
-  linkPressed: { opacity: 0.55 },
+  link: { fontSize: 15, fontWeight: "600", color: UI_LINK_SECONDARY, letterSpacing: -0.2 },
+  /** Secondary action — subtle press without accent flash. */
+  linkPressed: { opacity: 0.62 },
 });


### PR DESCRIPTION
- Unified header controls across modules (calendar + overflow capsule)
- Added settings routes for workouts, body, cardio, recovery
- Added weekly strip for sleep and readiness (Oura-backed)
- Fixed future-day ring bug in Oura week presence hook
- Standardized overview card layout (Strength → Body)
- Introduced shared segmented progress bar + layout primitives
- Renamed Recent → Recent Workouts and limited to 5 items
- Removed overview microcopy for cleaner UI

No backend or schema changes