### PR TITLE
feat(dash): implement Daily Recap + Stacks UI system with shared head…

### DIFF
--- a/app/(app)/(tabs)/__tests__/dash-accessibility.test.tsx
+++ b/app/(app)/(tabs)/__tests__/dash-accessibility.test.tsx
@@ -4,11 +4,16 @@
 import React, { act } from "react";
 import renderer from "react-test-renderer";
 
+jest.mock("@/lib/data/dash/useDashRecapData", () => ({
+  useDashRecapData: () => ({ kind: "loading" as const }),
+}));
+
 jest.mock("react-native", () => ({
   View: "View",
   Text: "Text",
   Pressable: "Pressable",
   ScrollView: "ScrollView",
+  ActivityIndicator: "ActivityIndicator",
   StyleSheet: { create: (s: unknown) => s },
   Animated: {
     View: "Animated.View",
@@ -85,7 +90,7 @@ describe("Dash accessibility", () => {
     expect(cardio.length).toBeGreaterThanOrEqual(1);
   });
 
-  it("shows Manage your data section label", () => {
+  it("shows Stacks section heading", () => {
     let test!: renderer.ReactTestRenderer;
     act(() => {
       test = renderer.create(<DashScreen />);
@@ -96,7 +101,7 @@ describe("Dash accessibility", () => {
         (n.children as (string | number)[]).filter((c) => typeof c === "string" || typeof c === "number").join("")
       )
       .join(" ");
-    expect(text).toContain("Manage your data");
+    expect(text).toContain("Stacks");
   });
 
   it("exposes accessibilityRole button on Settings and all cards", () => {

--- a/app/(app)/(tabs)/__tests__/dash-provenance.test.tsx
+++ b/app/(app)/(tabs)/__tests__/dash-provenance.test.tsx
@@ -4,11 +4,16 @@
 import React, { act } from "react";
 import renderer from "react-test-renderer";
 
+jest.mock("@/lib/data/dash/useDashRecapData", () => ({
+  useDashRecapData: () => ({ kind: "loading" as const }),
+}));
+
 jest.mock("react-native", () => ({
   View: "View",
   Text: "Text",
   Pressable: "Pressable",
   ScrollView: "ScrollView",
+  ActivityIndicator: "ActivityIndicator",
   StyleSheet: { create: (s: unknown) => s },
   Animated: {
     View: "Animated.View",
@@ -64,23 +69,26 @@ describe("Dash provenance", () => {
     mockPush.mockClear();
   });
 
-  it("shows Oli title and manage-your-health subtitle", () => {
+  it("shows Oli title and Stacks tagline", () => {
     let test!: renderer.ReactTestRenderer;
     act(() => {
       test = renderer.create(<DashScreen />);
     });
     const text = collectAllText(test);
     expect(text).toContain("Oli");
-    expect(text).toContain("Manage your health and fitness — all in one place.");
+    expect(text).toContain("Optimize your health and fitness — all in one place.");
+    expect(text).toContain("Daily Recap");
+    expect(text).toContain("View More");
   });
 
-  it("shows Manage your data section label and cards", () => {
+  it("shows Stacks section heading, tagline, and cards", () => {
     let test!: renderer.ReactTestRenderer;
     act(() => {
       test = renderer.create(<DashScreen />);
     });
     const text = collectAllText(test);
-    expect(text).toContain("Manage your data");
+    expect(text).toContain("Stacks");
+    expect(text).toContain("Optimize your health and fitness — all in one place.");
     expect(text).toContain("Body Composition");
     expect(text).toContain("Strength");
     expect(text).toContain("Cardio");

--- a/app/(app)/(tabs)/__tests__/dash-recap.test.tsx
+++ b/app/(app)/(tabs)/__tests__/dash-recap.test.tsx
@@ -1,0 +1,156 @@
+// app/(app)/(tabs)/__tests__/dash-recap.test.tsx
+import React, { act } from "react";
+import renderer from "react-test-renderer";
+
+jest.mock("react-native", () => ({
+  View: "View",
+  Text: "Text",
+  Pressable: "Pressable",
+  ScrollView: "ScrollView",
+  StyleSheet: { create: (s: unknown) => s },
+  ActivityIndicator: "ActivityIndicator",
+  Animated: {
+    View: "Animated.View",
+    Value: function (initial: number) {
+      return { _value: initial };
+    },
+    timing: function () {
+      return { start: jest.fn() };
+    },
+  },
+}));
+
+jest.mock("react-native-safe-area-context", () => ({
+  SafeAreaView: "SafeAreaView",
+}));
+
+const mockPush = jest.fn();
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock("@expo/vector-icons", () => ({
+  Ionicons: () => require("react").createElement("View", { "data-testid": "icon" }),
+}));
+
+const mockUseDashRecapData = jest.fn();
+jest.mock("@/lib/data/dash/useDashRecapData", () => ({
+  useDashRecapData: () => mockUseDashRecapData(),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const DashScreen = require("../dash").default;
+
+function collectAllText(test: renderer.ReactTestRenderer): string {
+  const nodes = test.root.findAllByType("Text");
+  const parts: string[] = [];
+  for (const n of nodes) {
+    for (const child of n.children) {
+      if (typeof child === "string" || typeof child === "number") parts.push(String(child));
+    }
+  }
+  return parts.join(" ");
+}
+
+function findPressableWithA11y(root: renderer.ReactTestInstance, label: string): renderer.ReactTestInstance | null {
+  const pressables = root.findAllByType("Pressable");
+  for (const p of pressables) {
+    if ((p.props as { accessibilityLabel?: string }).accessibilityLabel === label) return p;
+  }
+  return null;
+}
+
+describe("Dash Recap card", () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+    mockUseDashRecapData.mockReset();
+  });
+
+  it("renders Daily Recap before Stacks and tagline when model is ready", () => {
+    mockUseDashRecapData.mockReturnValue({
+      kind: "ready",
+      dayKey: "2026-04-05",
+      rows: [
+        {
+          id: "weight",
+          label: "Weight",
+          valueText: "176.4 lb",
+          isPlaceholder: false,
+          bar: { kind: "none" },
+        },
+        {
+          id: "cardioSessions",
+          label: "Cardio Sessions",
+          valueText: "2",
+          isPlaceholder: false,
+          bar: { kind: "placement", markerPosition01: 0.33 },
+        },
+      ],
+    });
+
+    let test!: renderer.ReactTestRenderer;
+    act(() => {
+      test = renderer.create(<DashScreen />);
+    });
+    const text = collectAllText(test);
+    const idxRecap = text.indexOf("Daily Recap");
+    const idxStacks = text.indexOf("Stacks");
+    const idxTagline = text.indexOf("Optimize your health and fitness — all in one place.");
+    expect(idxRecap).toBeGreaterThan(-1);
+    expect(text).toContain("View More");
+    expect(idxStacks).toBeGreaterThan(-1);
+    expect(idxTagline).toBeGreaterThan(-1);
+    expect(idxStacks).toBeGreaterThan(idxRecap);
+    expect(idxTagline).toBeGreaterThan(idxStacks);
+    expect(text).toContain("176.4 lb");
+    expect(text).toContain("Cardio Sessions");
+    expect(text).toContain("2");
+
+    const vm = findPressableWithA11y(test.root, "View more daily recap");
+    expect(vm).not.toBeNull();
+    act(() => {
+      (vm as renderer.ReactTestInstance).props.onPress();
+    });
+    expect(mockPush).toHaveBeenCalledWith("/(app)/dash/daily-recap");
+  });
+
+  it("shows loading copy when recap model is loading", () => {
+    mockUseDashRecapData.mockReturnValue({ kind: "loading" });
+
+    let test!: renderer.ReactTestRenderer;
+    act(() => {
+      test = renderer.create(<DashScreen />);
+    });
+    const text = collectAllText(test);
+    expect(text).toContain("Daily Recap");
+    expect(text).toContain("Loading yesterday's summary");
+  });
+
+  it("shows missing-doc hint when model is missing_doc", () => {
+    mockUseDashRecapData.mockReturnValue({
+      kind: "missing_doc",
+      dayKey: "2026-04-05",
+      rows: [
+        { id: "weight", label: "Weight", valueText: "—", isPlaceholder: true, bar: { kind: "none" } },
+        { id: "sleep", label: "Sleep", valueText: "—", isPlaceholder: true, bar: { kind: "none" } },
+        { id: "steps", label: "Steps", valueText: "—", isPlaceholder: true, bar: { kind: "none" } },
+        {
+          id: "strengthWorkouts",
+          label: "Strength Workouts",
+          valueText: "—",
+          isPlaceholder: true,
+          bar: { kind: "none" },
+        },
+        { id: "cardioSessions", label: "Cardio Sessions", valueText: "—", isPlaceholder: true, bar: { kind: "none" } },
+        { id: "calories", label: "Calories", valueText: "—", isPlaceholder: true, bar: { kind: "none" } },
+      ],
+    });
+
+    let test!: renderer.ReactTestRenderer;
+    act(() => {
+      test = renderer.create(<DashScreen />);
+    });
+    const text = collectAllText(test);
+    expect(text).toContain("No daily rollup for yesterday yet");
+  });
+});

--- a/app/(app)/(tabs)/dash.tsx
+++ b/app/(app)/(tabs)/dash.tsx
@@ -1,5 +1,5 @@
 // app/(app)/(tabs)/dash.tsx
-// Oli — Dash: title, subtitle, and "Manage your data" cards to real screens only.
+// Oli — Dash: tab header, Daily Recap, Stacks + subtitle, category cards to real screens only.
 import React, { useRef } from "react";
 import {
   ScrollView,
@@ -12,8 +12,21 @@ import {
 import { useRouter } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import { ScreenContainer } from "@/lib/ui/ScreenStates";
-import { PageTitleRow } from "@/lib/ui/PageTitleRow";
+import { TabRootScreenHeader } from "@/lib/ui/TabRootScreenHeader";
 import { SettingsGearButton } from "@/lib/ui/SettingsGearButton";
+import { DashRecapCard } from "@/lib/ui/dash/DashRecapCard";
+import { useDashRecapData } from "@/lib/data/dash/useDashRecapData";
+import {
+  UI_APP_SCREEN_BG,
+  UI_CARD_SURFACE,
+  UI_DASH_CATEGORY_CARD_RADIUS,
+  UI_HEADER_CHROME_BG,
+  UI_TAB_ROOT_INSET,
+  UI_TEXT_MUTED,
+  UI_TEXT_PRIMARY,
+  UI_TEXT_SECONDARY,
+  UI_TEXT_SLATE_COOL,
+} from "@/lib/ui/theme/uiTokens";
 
 /** Cards that navigate to existing routes only. */
 const MANAGE_DATA_CARDS = [
@@ -26,8 +39,15 @@ const MANAGE_DATA_CARDS = [
   { id: "labs", title: "Labs", subtitle: "Lab results and biomarkers", route: "/(app)/labs" as const },
 ] as const;
 
+const CATEGORY_CARD_PRESSED_BG = UI_HEADER_CHROME_BG;
+
 const SCALE_PRESSED = 0.98;
 const ANIM_DURATION = 100;
+
+const STACKS_TAGLINE = "Optimize your health and fitness — all in one place.";
+
+/** Must match `styles.card` `paddingHorizontal` so Stacks copy aligns with card title text. */
+const DASH_CARD_PADDING_HORIZONTAL = 18;
 
 type DashCardProps = {
   title: string;
@@ -57,7 +77,10 @@ function DashCard({ title, subtitle, onPress, accessibilityLabel }: DashCardProp
 
   return (
     <Pressable
-      style={({ pressed }) => [styles.card, pressed && styles.cardPressed]}
+      style={({ pressed }) => [
+        styles.card,
+        { backgroundColor: pressed ? CATEGORY_CARD_PRESSED_BG : UI_CARD_SURFACE },
+      ]}
       onPress={onPress}
       onPressIn={pressIn}
       onPressOut={pressOut}
@@ -70,7 +93,9 @@ function DashCard({ title, subtitle, onPress, accessibilityLabel }: DashCardProp
             <Text style={styles.cardTitle}>{title}</Text>
             <Text style={styles.cardSubtitle}>{subtitle}</Text>
           </View>
-          <Ionicons name="chevron-forward" size={20} color="#8E8E93" />
+          <View style={styles.cardChevronWrap}>
+            <Ionicons name="chevron-forward" size={21} color={UI_TEXT_SECONDARY} />
+          </View>
         </View>
       </Animated.View>
     </Pressable>
@@ -79,63 +104,116 @@ function DashCard({ title, subtitle, onPress, accessibilityLabel }: DashCardProp
 
 export default function DashScreen() {
   const router = useRouter();
+  const recapModel = useDashRecapData();
 
   return (
-    <ScreenContainer>
-      <ScrollView contentContainerStyle={styles.scroll}>
-        <PageTitleRow
-          title="Oli"
-          subtitle="Manage your health and fitness — all in one place."
-          rightSlot={<SettingsGearButton />}
-        />
+    <ScreenContainer padded={false}>
+      <View style={styles.root}>
+        <TabRootScreenHeader title="Oli" rightSlot={<SettingsGearButton />} />
+        <ScrollView
+          style={styles.scrollView}
+          contentContainerStyle={styles.scroll}
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+        >
+          <View style={styles.recapWrap}>
+            <DashRecapCard model={recapModel} onViewMore={() => router.push("/(app)/dash/daily-recap")} />
+          </View>
 
-        <Text style={styles.sectionLabel}>Manage your data</Text>
-
-        <View style={styles.cards}>
-          {MANAGE_DATA_CARDS.map((card) => (
-            <DashCard
-              key={card.id}
-              title={card.title}
-              subtitle={card.subtitle}
-              onPress={() => router.push(card.route)}
-              accessibilityLabel={`${card.title}. ${card.subtitle}`}
-            />
-          ))}
-        </View>
-      </ScrollView>
+          <View style={styles.stacksSection}>
+            <View style={styles.stacksHeaderInset}>
+              <Text style={styles.sectionHeading} accessibilityRole="header">
+                Stacks
+              </Text>
+              <Text style={styles.stacksTagline}>{STACKS_TAGLINE}</Text>
+            </View>
+            <View style={styles.cards}>
+              {MANAGE_DATA_CARDS.map((card) => (
+                <DashCard
+                  key={card.id}
+                  title={card.title}
+                  subtitle={card.subtitle}
+                  onPress={() => router.push(card.route)}
+                  accessibilityLabel={`${card.title}. ${card.subtitle}`}
+                />
+              ))}
+            </View>
+          </View>
+        </ScrollView>
+      </View>
     </ScreenContainer>
   );
 }
 
 const styles = StyleSheet.create({
-  scroll: { padding: 16, paddingBottom: 40 },
-  sectionLabel: {
-    marginTop: 18,
-    marginBottom: 10,
-    fontSize: 13,
-    fontWeight: "600",
-    color: "#8E8E93",
-    textTransform: "uppercase",
+  root: {
+    flex: 1,
+    backgroundColor: UI_APP_SCREEN_BG,
+  },
+  scrollView: {
+    flex: 1,
+    backgroundColor: UI_APP_SCREEN_BG,
+  },
+  scroll: {
+    paddingHorizontal: UI_TAB_ROOT_INSET,
+    paddingTop: 8,
+    paddingBottom: 40,
+    flexGrow: 1,
+    backgroundColor: UI_APP_SCREEN_BG,
+  },
+  recapWrap: { marginTop: 4 },
+  /** Groups Stacks header + cards; cards share full width with scroll content inset. */
+  stacksSection: {},
+  /** Inset matches card inner padding so “Stacks” / tagline align with category row titles. */
+  stacksHeaderInset: {
+    paddingHorizontal: DASH_CARD_PADDING_HORIZONTAL,
+  },
+  /** Below Oli (28 / 900): smaller size + bold 700 preserves Oli > Stacks hierarchy. */
+  sectionHeading: {
+    marginTop: 28,
+    marginBottom: 0,
+    fontSize: 24,
+    fontWeight: "700",
+    color: UI_TEXT_PRIMARY,
+    letterSpacing: 0.25,
+  },
+  stacksTagline: {
+    fontSize: 17,
+    fontWeight: "400",
+    color: UI_TEXT_SLATE_COOL,
+    marginTop: 5,
+    marginBottom: 12,
+    lineHeight: 26,
+    letterSpacing: 0.2,
   },
   cards: {
     gap: 14,
   },
   card: {
     width: "100%",
-    backgroundColor: "#F2F2F7",
-    borderRadius: 20,
-    padding: 20,
-    minHeight: 88,
+    borderRadius: UI_DASH_CATEGORY_CARD_RADIUS,
+    paddingVertical: 16,
+    paddingHorizontal: DASH_CARD_PADDING_HORIZONTAL,
+    minHeight: 68,
     justifyContent: "center",
   },
-  cardPressed: { backgroundColor: "#EAEAEE" },
   cardInner: {},
   cardRow: {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",
   },
-  cardTextBlock: { flex: 1, minWidth: 0 },
-  cardTitle: { fontSize: 18, fontWeight: "700", color: "#1C1C1E" },
-  cardSubtitle: { fontSize: 14, color: "#6E6E73", marginTop: 4, lineHeight: 20 },
+  cardTextBlock: { flex: 1, minWidth: 0, paddingRight: 10 },
+  cardChevronWrap: {
+    justifyContent: "center",
+    alignSelf: "center",
+    paddingRight: 4,
+  },
+  cardTitle: { fontSize: 17, fontWeight: "700", color: UI_TEXT_PRIMARY },
+  cardSubtitle: {
+    fontSize: 13,
+    color: UI_TEXT_MUTED,
+    marginTop: 4,
+    lineHeight: 19,
+  },
 });

--- a/app/(app)/(tabs)/library/index.tsx
+++ b/app/(app)/(tabs)/library/index.tsx
@@ -2,8 +2,9 @@
 import { ScrollView, View, Text, StyleSheet, Pressable } from "react-native";
 import { useRouter } from "expo-router";
 import { ScreenContainer } from "@/lib/ui/ScreenStates";
-import { PageTitleRow } from "@/lib/ui/PageTitleRow";
+import { TabRootScreenHeader } from "@/lib/ui/TabRootScreenHeader";
 import { SettingsGearButton } from "@/lib/ui/SettingsGearButton";
+import { UI_APP_SCREEN_BG, UI_TAB_ROOT_INSET } from "@/lib/ui/theme/uiTokens";
 import { useFailuresRange } from "@/lib/data/useFailuresRange";
 import { useUploadsPresence } from "@/lib/data/useUploadsPresence";
 import { useMemo } from "react";
@@ -72,14 +73,19 @@ export default function LibraryIndexScreen() {
   };
 
   return (
-    <ScreenContainer>
-      <ScrollView contentContainerStyle={styles.scroll}>
-        <PageTitleRow
+    <ScreenContainer padded={false}>
+      <View style={styles.tabRoot}>
+        <TabRootScreenHeader
           title="Library"
           subtitle="Category list with presence and counts"
           rightSlot={<SettingsGearButton />}
         />
-
+        <ScrollView
+          style={styles.scrollView}
+          contentContainerStyle={styles.scroll}
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+        >
         <View style={styles.quickLenses}>
           {QUICK_LENSES.map((l) => (
             <Pressable
@@ -122,13 +128,20 @@ export default function LibraryIndexScreen() {
           ))}
         </View>
       </ScrollView>
+      </View>
     </ScreenContainer>
   );
 }
 
 const styles = StyleSheet.create({
-  scroll: { padding: 16, paddingBottom: 40 },
-  quickLenses: { flexDirection: "row", gap: 8, marginTop: 16, flexWrap: "wrap" },
+  tabRoot: { flex: 1, backgroundColor: UI_APP_SCREEN_BG },
+  scrollView: { flex: 1, backgroundColor: UI_APP_SCREEN_BG },
+  scroll: {
+    paddingHorizontal: UI_TAB_ROOT_INSET,
+    paddingTop: 8,
+    paddingBottom: 40,
+  },
+  quickLenses: { flexDirection: "row", gap: 8, marginTop: 8, flexWrap: "wrap" },
   lensBtn: {
     paddingVertical: 8,
     paddingHorizontal: 14,

--- a/app/(app)/(tabs)/manage.tsx
+++ b/app/(app)/(tabs)/manage.tsx
@@ -6,8 +6,9 @@ import React, { useEffect, useMemo, useState } from "react";
 import { ScrollView, View, Text, StyleSheet, Pressable } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { ScreenContainer } from "@/lib/ui/ScreenStates";
-import { PageTitleRow } from "@/lib/ui/PageTitleRow";
+import { TabRootScreenHeader } from "@/lib/ui/TabRootScreenHeader";
 import { SettingsGearButton } from "@/lib/ui/SettingsGearButton";
+import { UI_APP_SCREEN_BG, UI_TAB_ROOT_INSET } from "@/lib/ui/theme/uiTokens";
 import { getTodayDayKey } from "@/lib/time/dayKey";
 import { useDailyFacts } from "@/lib/data/useDailyFacts";
 import { useLabResults } from "@/lib/data/useLabResults";
@@ -568,23 +569,36 @@ export default function ManageScreen() {
   );
 
   return (
-    <ScreenContainer>
-      <ScrollView contentContainerStyle={styles.scroll}>
-        <PageTitleRow
+    <ScreenContainer padded={false}>
+      <View style={styles.tabRoot}>
+        <TabRootScreenHeader
           title="Manage"
           subtitle="Your health record — tracked and missing."
           rightSlot={<SettingsGearButton />}
         />
-        {renderSection("HEALTH SYSTEMS", healthSystems)}
-        {renderSection("CLINICAL RECORDS", clinicalRecords)}
-        {renderSection("RECORD INTEGRITY", recordIntegrity)}
-      </ScrollView>
+        <ScrollView
+          style={styles.scrollView}
+          contentContainerStyle={styles.scroll}
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+        >
+          {renderSection("HEALTH SYSTEMS", healthSystems)}
+          {renderSection("CLINICAL RECORDS", clinicalRecords)}
+          {renderSection("RECORD INTEGRITY", recordIntegrity)}
+        </ScrollView>
+      </View>
     </ScreenContainer>
   );
 }
 
 const styles = StyleSheet.create({
-  scroll: { padding: 16, paddingBottom: 40 },
+  tabRoot: { flex: 1, backgroundColor: UI_APP_SCREEN_BG },
+  scrollView: { flex: 1, backgroundColor: UI_APP_SCREEN_BG },
+  scroll: {
+    paddingHorizontal: UI_TAB_ROOT_INSET,
+    paddingTop: 8,
+    paddingBottom: 40,
+  },
   section: { marginTop: 24 },
   sectionLabel: {
     marginBottom: 10,

--- a/app/(app)/(tabs)/timeline/index.tsx
+++ b/app/(app)/(tabs)/timeline/index.tsx
@@ -5,8 +5,9 @@ import { ScreenContainer, EmptyState } from "@/lib/ui/ScreenStates";
 import { FailClosed } from "@/lib/ui/FailClosed";
 import { OfflineBanner } from "@/lib/ui/OfflineBanner";
 import { TruthIndicator } from "@/lib/ui/TruthIndicators";
-import { PageTitleRow } from "@/lib/ui/PageTitleRow";
+import { TabRootScreenHeader } from "@/lib/ui/TabRootScreenHeader";
 import { SettingsGearButton } from "@/lib/ui/SettingsGearButton";
+import { UI_APP_SCREEN_BG, UI_TAB_ROOT_INSET } from "@/lib/ui/theme/uiTokens";
 import { useTimeline } from "@/lib/data/useTimeline";
 import { useMemo, useState, useCallback } from "react";
 import {
@@ -75,15 +76,14 @@ export default function TimelineIndexScreen() {
   }, [jumpInput]);
 
   return (
-    <ScreenContainer>
+    <ScreenContainer padded={false}>
       <View style={styles.main}>
-        <View style={styles.header}>
-          <PageTitleRow
-            title="Timeline"
-            subtitle="Day list with presence and light counts"
-            rightSlot={<SettingsGearButton />}
-          />
-        </View>
+        <TabRootScreenHeader
+          title="Timeline"
+          subtitle="Day list with presence and light counts"
+          rightSlot={<SettingsGearButton />}
+        />
+        <View style={styles.failClosedWrap}>
         <FailClosed
           outcome={outcome}
           onRetry={() => timeline.refetch()}
@@ -250,15 +250,22 @@ export default function TimelineIndexScreen() {
             );
           }}
         </FailClosed>
+        </View>
       </View>
     </ScreenContainer>
   );
 }
 
 const styles = StyleSheet.create({
-  main: { flex: 1 },
-  header: { paddingHorizontal: 16, paddingTop: 16, paddingBottom: 8 },
-  scroll: { flex: 1, padding: 16, paddingBottom: 40 },
+  main: { flex: 1, backgroundColor: UI_APP_SCREEN_BG },
+  failClosedWrap: { flex: 1, backgroundColor: UI_APP_SCREEN_BG },
+  scroll: {
+    flex: 1,
+    paddingHorizontal: UI_TAB_ROOT_INSET,
+    paddingTop: 8,
+    paddingBottom: 40,
+    backgroundColor: UI_APP_SCREEN_BG,
+  },
   listHeader: { height: 16 },
   listFooter: { height: 40 },
   listGap: { height: 6 },
@@ -266,7 +273,7 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
-    marginTop: 16,
+    marginTop: 8,
     marginBottom: 8,
   },
   viewModeRow: { flexDirection: "row", gap: 4 },

--- a/app/(app)/_layout.tsx
+++ b/app/(app)/_layout.tsx
@@ -17,6 +17,8 @@ export default function AppLayout() {
           {/* Sprint 3 — Phase 1 tabs (Library, Manage, Timeline, Profile, Dash) */}
           <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
 
+          <Stack.Screen name="dash/daily-recap" options={{ title: "Daily Recap" }} />
+
           {/* Event detail (from Library / Timeline) */}
           <Stack.Screen name="event/[id]" options={{ title: "Event" }} />
 

--- a/app/(app)/dash/daily-recap.tsx
+++ b/app/(app)/dash/daily-recap.tsx
@@ -1,0 +1,48 @@
+// app/(app)/dash/daily-recap.tsx
+// Placeholder — full Daily Recap experience will ship later.
+import React, { useLayoutEffect } from "react";
+import { View, Text, StyleSheet } from "react-native";
+import { useNavigation } from "expo-router";
+import { ScreenContainer } from "@/lib/ui/ScreenStates";
+import { HeaderBackButton } from "@/lib/ui/HeaderBackButton";
+
+export default function DailyRecapPlaceholderScreen() {
+  const navigation = useNavigation();
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      title: "Daily Recap",
+      headerBackButtonDisplayMode: "minimal",
+      headerShadowVisible: false,
+      headerLeft: () => <HeaderBackButton onPress={() => navigation.goBack()} />,
+    });
+  }, [navigation]);
+
+  return (
+    <ScreenContainer>
+      <View style={styles.body}>
+        <Text style={styles.title}>Coming soon</Text>
+        <Text style={styles.copy}>
+          A dedicated Daily Recap screen will open from here. For now, see your snapshot on the Dash tab.
+        </Text>
+      </View>
+    </ScreenContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  body: {
+    paddingTop: 24,
+    gap: 12,
+  },
+  title: {
+    fontSize: 22,
+    fontWeight: "700",
+    color: "#1C1C1E",
+  },
+  copy: {
+    fontSize: 16,
+    color: "#6E6E73",
+    lineHeight: 22,
+  },
+});

--- a/lib/contracts/__tests__/workoutDaySummaryItemDtoSchema.test.ts
+++ b/lib/contracts/__tests__/workoutDaySummaryItemDtoSchema.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "@jest/globals";
+import { workoutDaySummaryItemDtoSchema } from "@/lib/contracts/retrieval";
+import { WORKOUT_DAY_SUMMARY_SCHEMA_VERSION } from "@/lib/contracts/workoutDaySummary";
+
+describe("workoutDaySummaryItemDtoSchema", () => {
+  it("accepts v2 items with tab session counts", () => {
+    const row = {
+      schemaVersion: WORKOUT_DAY_SUMMARY_SCHEMA_VERSION,
+      day: "2026-03-10",
+      computedAt: "2026-03-10T12:00:00.000Z",
+      reconcileVersion: "2",
+      hasStrength: true,
+      hasCardio: true,
+      rawWorkoutCount: 3,
+      strengthSessionCount: 1,
+      cardioSessionCount: 2,
+    };
+    const parsed = workoutDaySummaryItemDtoSchema.safeParse(row);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.strengthSessionCount).toBe(1);
+      expect(parsed.data.cardioSessionCount).toBe(2);
+    }
+  });
+
+  it("rejects v1-shaped docs without session counts", () => {
+    const legacy = {
+      schemaVersion: 1,
+      day: "2026-03-10",
+      computedAt: "2026-03-10T12:00:00.000Z",
+      reconcileVersion: "1",
+      hasStrength: false,
+      hasCardio: false,
+      rawWorkoutCount: 0,
+    };
+    expect(workoutDaySummaryItemDtoSchema.safeParse(legacy).success).toBe(false);
+  });
+});

--- a/lib/contracts/retrieval.ts
+++ b/lib/contracts/retrieval.ts
@@ -308,6 +308,10 @@ export const workoutDaySummaryItemDtoSchema = z
     hasStrength: z.boolean(),
     hasCardio: z.boolean(),
     rawWorkoutCount: z.number().int().nonnegative(),
+    /** Overview Strength tab: reconciled sessions with sessionType "strength" only. */
+    strengthSessionCount: z.number().int().nonnegative(),
+    /** Overview Cardio tab: reconciled sessions with sessionType "cardio" only. */
+    cardioSessionCount: z.number().int().nonnegative(),
   })
   .strip();
 

--- a/lib/contracts/workoutDaySummary.ts
+++ b/lib/contracts/workoutDaySummary.ts
@@ -1,8 +1,15 @@
-/** Written to Firestore `workoutDaySummaries` and validated on read (API + client). */
-export const WORKOUT_DAY_SUMMARY_SCHEMA_VERSION = 1 as const;
+/**
+ * Written to Firestore `workoutDaySummaries` and validated on read (API + client).
+ *
+ * Changelog:
+ * - v1 / reconcile "1": hasStrength, hasCardio, rawWorkoutCount
+ * - v2 / reconcile "2": adds strengthSessionCount & cardioSessionCount (overview-tab session counts;
+ *   same rules as Strength/Cardio overview tabs in lib/data/workouts/workoutsCalendarModel.ts)
+ */
+export const WORKOUT_DAY_SUMMARY_SCHEMA_VERSION = 2 as const;
 
-/** Bump when server/client reconciliation rules for markers diverge. */
-export const WORKOUT_DAY_SUMMARY_RECONCILE_VERSION = "1";
+/** Bump when server/client reconciliation rules for markers or tab counts diverge. */
+export const WORKOUT_DAY_SUMMARY_RECONCILE_VERSION = "2";
 
 export const WORKOUT_DAY_SUMMARY_EXPECTED = {
   schemaVersion: WORKOUT_DAY_SUMMARY_SCHEMA_VERSION,

--- a/lib/data/dash/__tests__/dashRecapA11y.test.ts
+++ b/lib/data/dash/__tests__/dashRecapA11y.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "@jest/globals";
+import { dashRecapRowAccessibilityLabel } from "../dashRecapA11y";
+import type { DashRecapRow } from "../dashRecapViewModel";
+
+describe("dashRecapRowAccessibilityLabel", () => {
+  it("appends placement disclaimer when bar is placement", () => {
+    const row: DashRecapRow = {
+      id: "steps",
+      label: "Steps",
+      valueText: "5000",
+      isPlaceholder: false,
+      bar: { kind: "placement", markerPosition01: 0.5 },
+    };
+    expect(dashRecapRowAccessibilityLabel(row)).toContain("Not a health rating");
+    expect(dashRecapRowAccessibilityLabel(row)).toContain("50 percent");
+  });
+
+  it("omits placement line when bar is none", () => {
+    const row: DashRecapRow = {
+      id: "weight",
+      label: "Weight",
+      valueText: "70 kg",
+      isPlaceholder: false,
+      bar: { kind: "none" },
+    };
+    expect(dashRecapRowAccessibilityLabel(row)).not.toContain("Not a health rating");
+  });
+});

--- a/lib/data/dash/__tests__/dashRecapDisplayPlacement.test.ts
+++ b/lib/data/dash/__tests__/dashRecapDisplayPlacement.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "@jest/globals";
+import { DASH_RECAP_DISPLAY_PLACEMENT_CAPS, dashRecapPlacementMarker01 } from "../dashRecapDisplayPlacement";
+
+describe("dashRecapPlacementMarker01", () => {
+  it("clamps to 0–1", () => {
+    expect(dashRecapPlacementMarker01(6000, DASH_RECAP_DISPLAY_PLACEMENT_CAPS.steps)).toBe(0.5);
+    expect(dashRecapPlacementMarker01(12000, DASH_RECAP_DISPLAY_PLACEMENT_CAPS.steps)).toBe(1);
+    expect(dashRecapPlacementMarker01(24000, DASH_RECAP_DISPLAY_PLACEMENT_CAPS.steps)).toBe(1);
+    expect(dashRecapPlacementMarker01(0, DASH_RECAP_DISPLAY_PLACEMENT_CAPS.steps)).toBe(0);
+  });
+});

--- a/lib/data/dash/__tests__/dashRecapViewModel.test.ts
+++ b/lib/data/dash/__tests__/dashRecapViewModel.test.ts
@@ -1,0 +1,122 @@
+import {
+  buildDashRecapPlaceholderRows,
+  buildDashRecapRows,
+  dashRecapRowsAllPlaceholders,
+  DASH_RECAP_VALUE_PLACEHOLDER,
+  mergeCardioSessionsIntoDashRecapRows,
+} from "../dashRecapViewModel";
+import type { DailyFactsDto } from "@/lib/contracts/dailyFacts";
+
+function baseFacts(overrides: Partial<DailyFactsDto> = {}): DailyFactsDto {
+  return {
+    schemaVersion: 1,
+    userId: "u1",
+    date: "2026-04-05",
+    computedAt: "2026-04-06T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("buildDashRecapPlaceholderRows", () => {
+  it("returns five labeled placeholder rows", () => {
+    const rows = buildDashRecapPlaceholderRows();
+    expect(rows).toHaveLength(5);
+    expect(rows.map((r) => r.id)).toEqual([
+      "weight",
+      "sleep",
+      "steps",
+      "strengthWorkouts",
+      "calories",
+    ]);
+    expect(rows.every((r) => r.valueText === DASH_RECAP_VALUE_PLACEHOLDER && r.isPlaceholder)).toBe(true);
+    expect(rows.every((r) => r.bar.kind === "none")).toBe(true);
+  });
+});
+
+describe("buildDashRecapRows", () => {
+  it("formats populated DailyFacts fields", () => {
+    const rows = buildDashRecapRows({
+      facts: baseFacts({
+        body: { weightKg: 80 },
+        sleep: { totalMinutes: 450 },
+        activity: { steps: 8421 },
+        strength: { workoutsCount: 2, totalSets: 8, totalReps: 40, totalVolumeByUnit: { kg: 1000 } },
+        nutrition: { totalKcal: 2100.4, proteinG: 100, carbsG: 200, fatG: 60 },
+      }),
+      massUnit: "kg",
+    });
+    const byId = Object.fromEntries(rows.map((r) => [r.id, r]));
+    expect(byId.weight?.isPlaceholder).toBe(false);
+    expect(byId.weight?.valueText).toContain("kg");
+    expect(byId.sleep?.valueText).toMatch(/7h/);
+    expect(byId.steps?.valueText).toBe("8421");
+    expect(byId.strengthWorkouts?.valueText).toBe("2");
+    expect(byId.calories?.valueText).toBe("2100");
+    expect(byId.weight?.bar.kind).toBe("none");
+    expect(byId.sleep?.bar.kind).toBe("placement");
+    expect(byId.steps?.bar.kind).toBe("placement");
+    expect(byId.strengthWorkouts?.bar.kind).toBe("placement");
+    expect(byId.calories?.bar.kind).toBe("placement");
+  });
+
+  it("uses placeholders for absent optional slices", () => {
+    const rows = buildDashRecapRows({ facts: baseFacts(), massUnit: "lb" });
+    expect(dashRecapRowsAllPlaceholders(rows)).toBe(true);
+  });
+
+  it("shows zero strength workouts when strength object is present", () => {
+    const rows = buildDashRecapRows({
+      facts: baseFacts({
+        strength: { workoutsCount: 0, totalSets: 0, totalReps: 0, totalVolumeByUnit: {} },
+      }),
+      massUnit: "lb",
+    });
+    const s = rows.find((r) => r.id === "strengthWorkouts");
+    expect(s?.valueText).toBe("0");
+    expect(s?.isPlaceholder).toBe(false);
+    expect(s?.bar).toMatchObject({ kind: "placement", markerPosition01: 0 });
+  });
+});
+
+describe("dashRecapRowsAllPlaceholders", () => {
+  it("is false when any row has a value", () => {
+    const rows = buildDashRecapRows({
+      facts: baseFacts({ activity: { steps: 1 } }),
+      massUnit: "kg",
+    });
+    expect(dashRecapRowsAllPlaceholders(rows)).toBe(false);
+  });
+
+  it("ignores cardio row when checking DailyFacts placeholders", () => {
+    const factRows = buildDashRecapRows({
+      facts: baseFacts(),
+      massUnit: "kg",
+    });
+    const merged = mergeCardioSessionsIntoDashRecapRows(factRows, { kind: "ready", count: 2 });
+    expect(dashRecapRowsAllPlaceholders(merged)).toBe(true);
+  });
+});
+
+describe("mergeCardioSessionsIntoDashRecapRows", () => {
+  it("inserts cardio before calories", () => {
+    const factRows = buildDashRecapRows({
+      facts: baseFacts({ nutrition: { totalKcal: 100, proteinG: 1, carbsG: 1, fatG: 1 } }),
+      massUnit: "kg",
+    });
+    const merged = mergeCardioSessionsIntoDashRecapRows(factRows, { kind: "ready", count: 3 });
+    const ids = merged.map((r) => r.id);
+    expect(ids.indexOf("cardioSessions")).toBe(ids.indexOf("calories") - 1);
+    expect(merged.find((r) => r.id === "cardioSessions")?.valueText).toBe("3");
+    expect(merged.find((r) => r.id === "cardioSessions")?.bar.kind).toBe("placement");
+  });
+
+  it("uses placeholder when unavailable", () => {
+    const merged = mergeCardioSessionsIntoDashRecapRows(buildDashRecapPlaceholderRows(), {
+      kind: "unavailable",
+    });
+    const c = merged.find((r) => r.id === "cardioSessions");
+    expect(c?.valueText).toBe(DASH_RECAP_VALUE_PLACEHOLDER);
+    expect(c?.isPlaceholder).toBe(true);
+    expect(c?.bar.kind).toBe("none");
+  });
+});

--- a/lib/data/dash/__tests__/workoutDaySummaryRecapPick.test.ts
+++ b/lib/data/dash/__tests__/workoutDaySummaryRecapPick.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "@jest/globals";
+import { pickWorkoutDaySummaryItemForDay } from "../workoutDaySummaryRecapPick";
+import type { WorkoutDaySummariesResponseDto } from "@oli/contracts";
+
+describe("pickWorkoutDaySummaryItemForDay", () => {
+  it("returns the item for the requested day", () => {
+    const res: WorkoutDaySummariesResponseDto = {
+      start: "2026-04-05",
+      end: "2026-04-05",
+      expectedDayCount: 1,
+      complete: true,
+      items: [
+        {
+          schemaVersion: 2,
+          day: "2026-04-05",
+          computedAt: "2026-04-06T00:00:00.000Z",
+          reconcileVersion: "2",
+          hasStrength: false,
+          hasCardio: true,
+          rawWorkoutCount: 1,
+          strengthSessionCount: 0,
+          cardioSessionCount: 1,
+        },
+      ],
+    };
+    expect(pickWorkoutDaySummaryItemForDay(res, "2026-04-05")?.cardioSessionCount).toBe(1);
+  });
+
+  it("returns null when the day is absent", () => {
+    const res: WorkoutDaySummariesResponseDto = {
+      start: "2026-04-05",
+      end: "2026-04-05",
+      expectedDayCount: 1,
+      complete: false,
+      items: [],
+    };
+    expect(pickWorkoutDaySummaryItemForDay(res, "2026-04-05")).toBeNull();
+  });
+});

--- a/lib/data/dash/dashRecapA11y.ts
+++ b/lib/data/dash/dashRecapA11y.ts
@@ -1,0 +1,11 @@
+// lib/data/dash/dashRecapA11y.ts
+import type { DashRecapRow } from "@/lib/data/dash/dashRecapViewModel";
+
+export function dashRecapRowAccessibilityLabel(row: DashRecapRow): string {
+  let label = `${row.label}. ${row.valueText}.`;
+  if (row.bar.kind === "placement") {
+    const pct = Math.round(row.bar.markerPosition01 * 100);
+    label += ` Visual placement along scale at ${pct} percent. Not a health rating.`;
+  }
+  return label;
+}

--- a/lib/data/dash/dashRecapDisplayPlacement.ts
+++ b/lib/data/dash/dashRecapDisplayPlacement.ts
@@ -1,0 +1,29 @@
+// lib/data/dash/dashRecapDisplayPlacement.ts
+/**
+ * Neutral **visual placement** along the shared 5-segment track (0–1 marker position).
+ * These ratios are **not** clinical bands, goals, or validated interpretation — only UI scale
+ * denominators so the Daily Recap bar can mirror Strength Overview **geometry** without implying
+ * the same semantic tiers as the Strength Overview consistency bar.
+ */
+export const DASH_RECAP_DISPLAY_PLACEMENT_CAPS = {
+  /** Steps denominator for bar fill only. */
+  steps: 12_000,
+  /** Sleep duration (minutes) denominator for bar fill only. */
+  sleepMinutes: 600,
+  /** Calorie denominator for bar fill only. */
+  caloriesKcal: 4_000,
+  /** Strength / cardio session-count denominator for bar fill only. */
+  sessionCount: 6,
+} as const;
+
+function clamp01(x: number): number {
+  if (!Number.isFinite(x) || x <= 0) return 0;
+  if (x >= 1) return 1;
+  return x;
+}
+
+/** Marker position for a nonnegative value vs an explicit display cap. */
+export function dashRecapPlacementMarker01(value: number, cap: number): number {
+  if (!Number.isFinite(value) || value < 0 || !Number.isFinite(cap) || cap <= 0) return 0;
+  return clamp01(value / cap);
+}

--- a/lib/data/dash/dashRecapViewModel.ts
+++ b/lib/data/dash/dashRecapViewModel.ts
@@ -1,0 +1,181 @@
+// lib/data/dash/dashRecapViewModel.ts
+// Dash Recap: DailyFacts + workout day summary cardio; optional neutral placement bars (not interpretation).
+import type { DailyFactsDto } from "@/lib/contracts/dailyFacts";
+import {
+  DASH_RECAP_DISPLAY_PLACEMENT_CAPS,
+  dashRecapPlacementMarker01,
+} from "@/lib/data/dash/dashRecapDisplayPlacement";
+import { formatSleepDurationMinutes } from "@/lib/format/ouraScore";
+import { formatBodyWeight } from "@/lib/ui/body/bodyMetricFormatting";
+
+/** Same empty sentinel as Body Composition overview numeric gaps. */
+export const DASH_RECAP_VALUE_PLACEHOLDER = "—" as const;
+
+export type DashRecapRowId =
+  | "weight"
+  | "sleep"
+  | "steps"
+  | "strengthWorkouts"
+  | "cardioSessions"
+  | "calories";
+
+/**
+ * `placement`: marker along shared 5-segment track for **visual scale only** (see dashRecapDisplayPlacement).
+ * `none`: no bar (missing data, or weight — no repo-safe neutral scale without user context).
+ */
+export type DashRecapRowBar = { kind: "none" } | { kind: "placement"; markerPosition01: number };
+
+export type DashRecapRow = {
+  id: DashRecapRowId;
+  label: string;
+  valueText: string;
+  isPlaceholder: boolean;
+  bar: DashRecapRowBar;
+};
+
+export type DashRecapViewModel =
+  | { kind: "loading" }
+  | {
+      kind: "error";
+      message: string;
+      requestId: string | null;
+      retry: () => void;
+    }
+  | {
+      kind: "missing_doc";
+      dayKey: string;
+      rows: readonly DashRecapRow[];
+    }
+  | {
+      kind: "empty";
+      dayKey: string;
+      rows: readonly DashRecapRow[];
+    }
+  | {
+      kind: "ready";
+      dayKey: string;
+      rows: readonly DashRecapRow[];
+    };
+
+const ROW_LABELS: Record<DashRecapRowId, string> = {
+  weight: "Weight",
+  sleep: "Sleep",
+  steps: "Steps",
+  strengthWorkouts: "Strength Workouts",
+  cardioSessions: "Cardio Sessions",
+  calories: "Calories",
+};
+
+function row(
+  id: DashRecapRowId,
+  valueText: string,
+  isPlaceholder: boolean,
+  bar: DashRecapRowBar,
+): DashRecapRow {
+  return { id, label: ROW_LABELS[id], valueText, isPlaceholder, bar };
+}
+
+const FACT_ROW_IDS = ["weight", "sleep", "steps", "strengthWorkouts", "calories"] as const;
+
+/** DailyFacts slice placeholders only (cardio comes from workout day summary merge). */
+export function buildDashRecapPlaceholderRows(): DashRecapRow[] {
+  return FACT_ROW_IDS.map((id) => row(id, DASH_RECAP_VALUE_PLACEHOLDER, true, { kind: "none" }));
+}
+
+export type DashRecapCardioSessionsMerge =
+  | { kind: "ready"; count: number }
+  | { kind: "unavailable" };
+
+/**
+ * Inserts Cardio Sessions immediately before Calories. Count uses workout day summary
+ * `cardioSessionCount` (overview Cardio tab; see `WorkoutDaySummaryItemDto`).
+ */
+export function mergeCardioSessionsIntoDashRecapRows(
+  factRows: readonly DashRecapRow[],
+  cardio: DashRecapCardioSessionsMerge,
+): DashRecapRow[] {
+  const calIdx = factRows.findIndex((r) => r.id === "calories");
+  const cardioRow: DashRecapRow =
+    cardio.kind === "ready"
+      ? row("cardioSessions", `${cardio.count}`, false, {
+          kind: "placement",
+          markerPosition01: dashRecapPlacementMarker01(
+            cardio.count,
+            DASH_RECAP_DISPLAY_PLACEMENT_CAPS.sessionCount,
+          ),
+        })
+      : row("cardioSessions", DASH_RECAP_VALUE_PLACEHOLDER, true, { kind: "none" });
+  if (calIdx < 0) {
+    return [...factRows, cardioRow];
+  }
+  return [...factRows.slice(0, calIdx), cardioRow, ...factRows.slice(calIdx)];
+}
+
+function formatSteps(steps: number): string {
+  return `${Math.round(steps)}`;
+}
+
+function formatCalories(kcal: number): string {
+  return `${Math.round(kcal)}`;
+}
+
+/**
+ * Maps DailyFacts scalars to recap rows. Absent optional slices → placeholder per metric.
+ * Weight: numeric display only — **no** placement bar (no repo-neutral scale without profile context).
+ */
+export function buildDashRecapRows(input: {
+  facts: DailyFactsDto;
+  massUnit: "kg" | "lb";
+}): DashRecapRow[] {
+  const { facts, massUnit } = input;
+
+  const weightKg = facts.body?.weightKg;
+  const weightRow =
+    typeof weightKg === "number" && Number.isFinite(weightKg)
+      ? row("weight", formatBodyWeight(weightKg, massUnit), false, { kind: "none" })
+      : row("weight", DASH_RECAP_VALUE_PLACEHOLDER, true, { kind: "none" });
+
+  const sleepMin = facts.sleep?.totalMinutes;
+  const sleepRow =
+    typeof sleepMin === "number" && Number.isFinite(sleepMin) && sleepMin >= 0
+      ? row("sleep", formatSleepDurationMinutes(sleepMin), false, {
+          kind: "placement",
+          markerPosition01: dashRecapPlacementMarker01(sleepMin, DASH_RECAP_DISPLAY_PLACEMENT_CAPS.sleepMinutes),
+        })
+      : row("sleep", DASH_RECAP_VALUE_PLACEHOLDER, true, { kind: "none" });
+
+  const steps = facts.activity?.steps;
+  const stepsRow =
+    typeof steps === "number" && Number.isFinite(steps) && steps >= 0
+      ? row("steps", formatSteps(steps), false, {
+          kind: "placement",
+          markerPosition01: dashRecapPlacementMarker01(steps, DASH_RECAP_DISPLAY_PLACEMENT_CAPS.steps),
+        })
+      : row("steps", DASH_RECAP_VALUE_PLACEHOLDER, true, { kind: "none" });
+
+  const wc = facts.strength?.workoutsCount;
+  const strengthRow =
+    typeof wc === "number" && Number.isFinite(wc) && wc >= 0
+      ? row("strengthWorkouts", `${wc}`, false, {
+          kind: "placement",
+          markerPosition01: dashRecapPlacementMarker01(wc, DASH_RECAP_DISPLAY_PLACEMENT_CAPS.sessionCount),
+        })
+      : row("strengthWorkouts", DASH_RECAP_VALUE_PLACEHOLDER, true, { kind: "none" });
+
+  const kcal = facts.nutrition?.totalKcal;
+  const calRow =
+    typeof kcal === "number" && Number.isFinite(kcal) && kcal >= 0
+      ? row("calories", formatCalories(kcal), false, {
+          kind: "placement",
+          markerPosition01: dashRecapPlacementMarker01(kcal, DASH_RECAP_DISPLAY_PLACEMENT_CAPS.caloriesKcal),
+        })
+      : row("calories", DASH_RECAP_VALUE_PLACEHOLDER, true, { kind: "none" });
+
+  return [weightRow, sleepRow, stepsRow, strengthRow, calRow];
+}
+
+/** True when every DailyFacts-backed row is a placeholder (ignores cardio row). */
+export function dashRecapRowsAllPlaceholders(rows: readonly DashRecapRow[]): boolean {
+  const factRows = rows.filter((r) => r.id !== "cardioSessions");
+  return factRows.length === FACT_ROW_IDS.length && factRows.every((r) => r.isPlaceholder);
+}

--- a/lib/data/dash/useDashRecapData.ts
+++ b/lib/data/dash/useDashRecapData.ts
@@ -1,0 +1,85 @@
+// lib/data/dash/useDashRecapData.ts
+import { useMemo } from "react";
+import { addCalendarDaysToDayKey, getTodayDayKeyLocal } from "@/lib/ui/calendar/dateUtils";
+import { useDailyFacts } from "@/lib/data/useDailyFacts";
+import { useWorkoutDaySummaryForDay } from "@/lib/data/dash/useWorkoutDaySummaryForDay";
+import { usePreferences } from "@/lib/preferences/PreferencesProvider";
+import {
+  buildDashRecapPlaceholderRows,
+  buildDashRecapRows,
+  dashRecapRowsAllPlaceholders,
+  mergeCardioSessionsIntoDashRecapRows,
+  type DashRecapCardioSessionsMerge,
+  type DashRecapRow,
+  type DashRecapViewModel,
+} from "@/lib/data/dash/dashRecapViewModel";
+
+/**
+ * Yesterday's calendar key (device-local day anchor + repo UTC calendar shift; see dateUtils).
+ */
+export function getYesterdayDayKeyLocal(): string {
+  return addCalendarDaysToDayKey(getTodayDayKeyLocal(), -1);
+}
+
+export function useDashRecapData(): DashRecapViewModel {
+  const yesterdayKey = getYesterdayDayKeyLocal();
+  const factsState = useDailyFacts(yesterdayKey);
+  const workoutSummaryState = useWorkoutDaySummaryForDay(yesterdayKey);
+  const { state: prefState } = usePreferences();
+  const massUnit = prefState.preferences?.units?.mass ?? "lb";
+
+  return useMemo((): DashRecapViewModel => {
+    const summaryLoading = workoutSummaryState.status === "partial";
+    const factsLoading = factsState.status === "partial";
+
+    if (factsLoading || summaryLoading) {
+      return { kind: "loading" };
+    }
+
+    if (factsState.status === "error") {
+      return {
+        kind: "error",
+        message: factsState.error,
+        requestId: factsState.requestId,
+        retry: () => {
+          void factsState.refetch();
+          void workoutSummaryState.refetch();
+        },
+      };
+    }
+
+    const cardioMerge: DashRecapCardioSessionsMerge =
+      workoutSummaryState.status === "ready"
+        ? { kind: "ready", count: workoutSummaryState.data.cardioSessionCount }
+        : { kind: "unavailable" };
+
+    const buildMergedRows = (factRows: readonly DashRecapRow[]) =>
+      mergeCardioSessionsIntoDashRecapRows(factRows, cardioMerge);
+
+    if (factsState.status === "missing") {
+      const factRows = buildDashRecapPlaceholderRows();
+      return {
+        kind: "missing_doc",
+        dayKey: yesterdayKey,
+        rows: buildMergedRows(factRows),
+      };
+    }
+
+    const factRows = buildDashRecapRows({ facts: factsState.data, massUnit });
+    const allFactsPlaceholder = dashRecapRowsAllPlaceholders(factRows);
+
+    if (allFactsPlaceholder && cardioMerge.kind === "unavailable") {
+      return {
+        kind: "empty",
+        dayKey: yesterdayKey,
+        rows: buildMergedRows(factRows),
+      };
+    }
+
+    return {
+      kind: "ready",
+      dayKey: yesterdayKey,
+      rows: buildMergedRows(factRows),
+    };
+  }, [factsState, massUnit, workoutSummaryState, yesterdayKey]);
+}

--- a/lib/data/dash/useWorkoutDaySummaryForDay.ts
+++ b/lib/data/dash/useWorkoutDaySummaryForDay.ts
@@ -1,0 +1,107 @@
+// lib/data/dash/useWorkoutDaySummaryForDay.ts
+// Single-day read of workoutDaySummaries via GET .../workout-day-summaries?start=&end= (same range).
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useAuth } from "@/lib/auth/AuthProvider";
+import { getWorkoutDaySummaries, type TruthGetOptions } from "@/lib/api/usersMe";
+import type { WorkoutDaySummaryItemDto } from "@oli/contracts";
+import { truthOutcomeFromApiResult } from "@/lib/data/truthOutcome";
+import { pickWorkoutDaySummaryItemForDay } from "@/lib/data/dash/workoutDaySummaryRecapPick";
+
+type State =
+  | { status: "partial" }
+  | { status: "missing" }
+  | { status: "error"; error: string; requestId: string | null }
+  | { status: "ready"; data: WorkoutDaySummaryItemDto };
+
+type RefetchOpts = TruthGetOptions;
+
+function withUniqueCacheBust(opts: RefetchOpts | undefined, seq: number): RefetchOpts | undefined {
+  const cb = opts?.cacheBust;
+  if (!cb) return opts;
+  return { ...opts, cacheBust: `${cb}:${seq}` };
+}
+
+export function useWorkoutDaySummaryForDay(
+  day: string,
+): State & { refetch: (opts?: RefetchOpts) => void } {
+  const { user, initializing, getIdToken } = useAuth();
+
+  const dayRef = useRef(day);
+  dayRef.current = day;
+
+  const requestSeq = useRef(0);
+
+  const [state, setState] = useState<State>({ status: "partial" });
+  const stateRef = useRef<State>(state);
+  useEffect(() => {
+    stateRef.current = state;
+  }, [state]);
+
+  const fetchOnce = useCallback(
+    async (opts?: RefetchOpts) => {
+      const seq = ++requestSeq.current;
+
+      const safeSet = (next: State) => {
+        if (seq === requestSeq.current) setState(next);
+      };
+
+      if (initializing || !user) {
+        if (stateRef.current.status !== "ready") safeSet({ status: "partial" });
+        return;
+      }
+
+      const token = await getIdToken(false);
+      if (!token || seq !== requestSeq.current) return;
+
+      if (stateRef.current.status !== "ready") safeSet({ status: "partial" });
+
+      const d = dayRef.current;
+      const res = await getWorkoutDaySummaries(token, {
+        start: d,
+        end: d,
+        ...withUniqueCacheBust(opts, seq),
+      });
+      if (seq !== requestSeq.current) return;
+
+      const outcome = truthOutcomeFromApiResult(res);
+
+      if (outcome.status === "error") {
+        if (stateRef.current.status === "ready") return;
+        safeSet({
+          status: "error",
+          error: outcome.error,
+          requestId: outcome.requestId,
+        });
+        return;
+      }
+
+      if (outcome.status === "missing") {
+        if (stateRef.current.status === "ready") return;
+        safeSet({ status: "missing" });
+        return;
+      }
+
+      const item = pickWorkoutDaySummaryItemForDay(outcome.data, d);
+      if (item != null) {
+        safeSet({ status: "ready", data: item });
+        return;
+      }
+
+      if (stateRef.current.status === "ready") return;
+      safeSet({ status: "missing" });
+    },
+    [getIdToken, initializing, user],
+  );
+
+  useEffect(() => {
+    void fetchOnce();
+  }, [fetchOnce, day, user?.uid]);
+
+  return useMemo(
+    () => ({
+      ...state,
+      refetch: fetchOnce,
+    }),
+    [state, fetchOnce],
+  );
+}

--- a/lib/data/dash/workoutDaySummaryRecapPick.ts
+++ b/lib/data/dash/workoutDaySummaryRecapPick.ts
@@ -1,0 +1,14 @@
+// lib/data/dash/workoutDaySummaryRecapPick.ts
+import type { WorkoutDaySummariesResponseDto, WorkoutDaySummaryItemDto } from "@oli/contracts";
+
+/**
+ * Returns the validated workout-day summary row for a single calendar day, if present in the API response.
+ * Caller must request `start === end === dayKey` for a single-day read.
+ */
+export function pickWorkoutDaySummaryItemForDay(
+  response: WorkoutDaySummariesResponseDto,
+  dayKey: string,
+): WorkoutDaySummaryItemDto | null {
+  const item = response.items.find((i) => i.day === dayKey);
+  return item ?? null;
+}

--- a/lib/data/workouts/__tests__/useWorkoutsCalendar.summaryFirst.test.tsx
+++ b/lib/data/workouts/__tests__/useWorkoutsCalendar.summaryFirst.test.tsx
@@ -59,6 +59,8 @@ describe("useWorkoutsCalendarRange summary-first", () => {
         hasStrength: false,
         hasCardio: false,
         rawWorkoutCount: 0,
+        strengthSessionCount: 0,
+        cardioSessionCount: 0,
       },
       {
         schemaVersion: WORKOUT_DAY_SUMMARY_EXPECTED.schemaVersion,
@@ -68,6 +70,8 @@ describe("useWorkoutsCalendarRange summary-first", () => {
         hasStrength: true,
         hasCardio: false,
         rawWorkoutCount: 1,
+        strengthSessionCount: 1,
+        cardioSessionCount: 0,
       },
       {
         schemaVersion: WORKOUT_DAY_SUMMARY_EXPECTED.schemaVersion,
@@ -77,6 +81,8 @@ describe("useWorkoutsCalendarRange summary-first", () => {
         hasStrength: false,
         hasCardio: false,
         rawWorkoutCount: 0,
+        strengthSessionCount: 0,
+        cardioSessionCount: 0,
       },
     ];
 
@@ -191,6 +197,8 @@ describe("useWorkoutsCalendarRange summary-first", () => {
         hasStrength: false,
         hasCardio: false,
         rawWorkoutCount: 0,
+        strengthSessionCount: 0,
+        cardioSessionCount: 0,
       },
       {
         schemaVersion: WORKOUT_DAY_SUMMARY_EXPECTED.schemaVersion,
@@ -200,6 +208,8 @@ describe("useWorkoutsCalendarRange summary-first", () => {
         hasStrength: true,
         hasCardio: false,
         rawWorkoutCount: 1,
+        strengthSessionCount: 1,
+        cardioSessionCount: 0,
       },
       {
         schemaVersion: WORKOUT_DAY_SUMMARY_EXPECTED.schemaVersion,
@@ -209,6 +219,8 @@ describe("useWorkoutsCalendarRange summary-first", () => {
         hasStrength: false,
         hasCardio: false,
         rawWorkoutCount: 0,
+        strengthSessionCount: 0,
+        cardioSessionCount: 0,
       },
     ];
 

--- a/lib/data/workouts/__tests__/workoutDaySummaryCompute.test.ts
+++ b/lib/data/workouts/__tests__/workoutDaySummaryCompute.test.ts
@@ -6,7 +6,10 @@ import {
   reconcileWorkoutSessionsForDay,
 } from "@/lib/data/workouts/workoutSessionReconciliation";
 import { parseWorkoutHistoryItem } from "@/lib/data/workouts/parseWorkoutFromRawEvent";
-import { sortWorkoutsChronologicalAsc } from "@/lib/data/workouts/workoutsCalendarModel";
+import {
+  deriveOverviewTabSessionCounts,
+  sortWorkoutsChronologicalAsc,
+} from "@/lib/data/workouts/workoutsCalendarModel";
 
 function minimalWorkoutRaw(
   id: string,
@@ -46,13 +49,19 @@ describe("computeWorkoutDaySummaryPayload", () => {
     const computedAt = "2026-03-11T12:00:00.000Z";
     const summary = computeWorkoutDaySummaryPayload(day, docs, computedAt);
     const items = sortWorkoutsChronologicalAsc(docs.map((d) => parseWorkoutHistoryItem(d)));
-    const flags = deriveSessionTypeFlags(reconcileWorkoutSessionsForDay(day, items));
+    const sessions = reconcileWorkoutSessionsForDay(day, items);
+    const flags = deriveSessionTypeFlags(sessions);
+    const tabCounts = deriveOverviewTabSessionCounts(sessions);
     expect(summary.day).toBe(day);
     expect(summary.rawWorkoutCount).toBe(1);
     expect(summary.hasStrength).toBe(flags.hasStrength);
     expect(summary.hasCardio).toBe(flags.hasCardio);
-    expect(summary.reconcileVersion).toBe("1");
-    expect(summary.schemaVersion).toBe(1);
+    expect(summary.strengthSessionCount).toBe(tabCounts.strengthSessionCount);
+    expect(summary.cardioSessionCount).toBe(tabCounts.cardioSessionCount);
+    expect(summary.cardioSessionCount).toBe(1);
+    expect(summary.strengthSessionCount).toBe(0);
+    expect(summary.reconcileVersion).toBe("2");
+    expect(summary.schemaVersion).toBe(2);
   });
 
   it("returns zero counts for empty day input", () => {
@@ -61,5 +70,28 @@ describe("computeWorkoutDaySummaryPayload", () => {
     expect(summary.rawWorkoutCount).toBe(0);
     expect(summary.hasStrength).toBe(false);
     expect(summary.hasCardio).toBe(false);
+    expect(summary.strengthSessionCount).toBe(0);
+    expect(summary.cardioSessionCount).toBe(0);
+  });
+
+  it("counts one strength session for strength_workout raw doc", () => {
+    const day = "2026-03-13";
+    const docs: RawEventDoc[] = [
+      minimalWorkoutRaw(
+        "r1",
+        "strength_workout",
+        {
+          start: `${day}T18:00:00.000Z`,
+          timezone: "UTC",
+          exercises: [{ exercise: "Squat", reps: 5, load: 100, unit: "kg" }],
+        },
+        `${day}T18:00:00.000Z`,
+      ),
+    ];
+    const summary = computeWorkoutDaySummaryPayload(day, docs, "2026-03-13T12:00:00.000Z");
+    expect(summary.rawWorkoutCount).toBe(1);
+    expect(summary.strengthSessionCount).toBe(1);
+    expect(summary.cardioSessionCount).toBe(0);
+    expect(summary.hasStrength).toBe(true);
   });
 });

--- a/lib/data/workouts/__tests__/workoutsCalendarModel.test.ts
+++ b/lib/data/workouts/__tests__/workoutsCalendarModel.test.ts
@@ -5,6 +5,7 @@ import {
   buildWorkoutOverviewAnalyticsFromCalendarDays,
   compareWorkoutsChronologicalAsc,
   countWeekBucketsInDayRangeInclusive,
+  deriveOverviewTabSessionCounts,
   getRecentWorkoutsFromCalendarDays,
   getRecentWorkoutSessionsFromCalendarDays,
   sortWorkoutsChronologicalAsc,
@@ -533,5 +534,86 @@ describe("workoutsCalendarModel", () => {
     expect(bundle.metricsByTab.cardio.totalWorkouts).toBe(0);
     expect(bundle.chartPointsByTab.strength.find((p) => p.monthKey === "2026-07")?.workouts).toBe(0);
     expect(bundle.chartPointsByTab.cardio.find((p) => p.monthKey === "2026-07")?.workouts).toBe(0);
+  });
+
+  describe("deriveOverviewTabSessionCounts", () => {
+    it("excludes mixed sessions from both tab counts (flags may still be true via deriveSessionTypeFlags)", () => {
+      const dayKey = "2026-07-15";
+      const mixedDay = {
+        day: dayKey,
+        workouts: [
+          {
+            id: "str",
+            observedAt: "2026-07-15T10:00:00.000Z",
+            sourceId: "manual",
+            title: "Lift",
+            workoutType: "strength" as const,
+            start: "2026-07-15T10:00:00.000Z",
+            end: "2026-07-15T10:45:00.000Z",
+            durationMinutes: 45,
+            calories: null,
+          },
+          {
+            id: "bridge",
+            observedAt: "2026-07-15T10:08:00.000Z",
+            sourceId: "manual",
+            title: "",
+            start: "2026-07-15T10:08:00.000Z",
+            end: null,
+            durationMinutes: null,
+            calories: null,
+          },
+          {
+            id: "car",
+            observedAt: "2026-07-15T10:15:00.000Z",
+            sourceId: "apple_health",
+            title: "Running",
+            workoutType: "cardio" as const,
+            start: "2026-07-15T10:15:00.000Z",
+            end: "2026-07-15T10:50:00.000Z",
+            durationMinutes: 35,
+            calories: null,
+          },
+        ],
+      };
+      const sessions = reconcileWorkoutSessionsForDay(dayKey, mixedDay.workouts);
+      expect(deriveOverviewTabSessionCounts(sessions)).toEqual({
+        strengthSessionCount: 0,
+        cardioSessionCount: 0,
+      });
+    });
+
+    it("counts one strength and one cardio session the same as overview tab totals", () => {
+      const day = "2026-03-20";
+      const items: WorkoutHistoryItem[] = [
+        {
+          id: "s",
+          observedAt: `${day}T17:00:00.000Z`,
+          sourceId: "manual",
+          title: "Push",
+          workoutType: "strength",
+          start: `${day}T17:00:00.000Z`,
+          end: null,
+          durationMinutes: 60,
+          calories: null,
+        },
+        {
+          id: "c",
+          observedAt: `${day}T20:00:00.000Z`,
+          sourceId: "manual",
+          title: "Run",
+          workoutType: "cardio",
+          start: `${day}T20:00:00.000Z`,
+          end: null,
+          durationMinutes: 30,
+          calories: null,
+        },
+      ];
+      const sessions = reconcileWorkoutSessionsForDay(day, items);
+      expect(deriveOverviewTabSessionCounts(sessions)).toEqual({
+        strengthSessionCount: 1,
+        cardioSessionCount: 1,
+      });
+    });
   });
 });

--- a/lib/data/workouts/workoutDaySummaryCompute.ts
+++ b/lib/data/workouts/workoutDaySummaryCompute.ts
@@ -6,7 +6,10 @@ import {
   deriveSessionTypeFlags,
   reconcileWorkoutSessionsForDay,
 } from "@/lib/data/workouts/workoutSessionReconciliation";
-import { sortWorkoutsChronologicalAsc } from "@/lib/data/workouts/workoutsCalendarModel";
+import {
+  deriveOverviewTabSessionCounts,
+  sortWorkoutsChronologicalAsc,
+} from "@/lib/data/workouts/workoutsCalendarModel";
 import {
   DEFAULT_WORKOUT_CALENDAR_RAW_EVENT_KINDS,
   type WorkoutCalendarRawEventKind,
@@ -30,10 +33,15 @@ export type WorkoutDaySummaryPayload = {
   hasStrength: boolean;
   hasCardio: boolean;
   rawWorkoutCount: number;
+  /** Count of reconciled sessions with `sessionType === "strength"` (overview Strength tab). */
+  strengthSessionCount: number;
+  /** Count of reconciled sessions with `sessionType === "cardio"` (overview Cardio tab). */
+  cardioSessionCount: number;
 };
 
 /**
  * Same marker semantics as Calendar: {@link reconcileWorkoutSessionsForDay} → {@link deriveSessionTypeFlags}.
+ * Tab session counts: {@link deriveOverviewTabSessionCounts} (strict strength vs cardio; excludes mixed/unknown).
  * `rawWorkoutCount` matches grouped raw items for that UI day (before session merge).
  */
 export function computeWorkoutDaySummaryPayload(
@@ -51,6 +59,7 @@ export function computeWorkoutDaySummaryPayload(
   const sorted = sortWorkoutsChronologicalAsc(items);
   const sessions = reconcileWorkoutSessionsForDay(uiDay, sorted);
   const flags = deriveSessionTypeFlags(sessions);
+  const tabCounts = deriveOverviewTabSessionCounts(sessions);
   return {
     schemaVersion: WORKOUT_DAY_SUMMARY_SCHEMA_VERSION,
     day: uiDay,
@@ -59,5 +68,7 @@ export function computeWorkoutDaySummaryPayload(
     hasStrength: flags.hasStrength,
     hasCardio: flags.hasCardio,
     rawWorkoutCount: sorted.length,
+    strengthSessionCount: tabCounts.strengthSessionCount,
+    cardioSessionCount: tabCounts.cardioSessionCount,
   };
 }

--- a/lib/data/workouts/workoutsCalendarModel.ts
+++ b/lib/data/workouts/workoutsCalendarModel.ts
@@ -163,6 +163,26 @@ export function sessionMatchesOverviewCardioTab(session: ReconciledWorkoutSessio
   return session.sessionType === "cardio";
 }
 
+/**
+ * Per-day session counts aligned with Strength/Cardio overview tabs: strict `sessionType` match only.
+ * `mixed` and `unknown` are excluded from both counts (same rules as {@link buildWorkoutOverviewAnalyticsFromCalendarDays}).
+ *
+ * Note: {@link deriveSessionTypeFlags} sets both `hasStrength` and `hasCardio` when any session is `mixed`,
+ * but those sessions contribute **0** to both counts here — flags are “any signal,” counts are “tab-eligible sessions.”
+ */
+export function deriveOverviewTabSessionCounts(sessions: readonly ReconciledWorkoutSession[]): {
+  strengthSessionCount: number;
+  cardioSessionCount: number;
+} {
+  let strengthSessionCount = 0;
+  let cardioSessionCount = 0;
+  for (const s of sessions) {
+    if (sessionMatchesOverviewStrengthTab(s)) strengthSessionCount += 1;
+    if (sessionMatchesOverviewCardioTab(s)) cardioSessionCount += 1;
+  }
+  return { strengthSessionCount, cardioSessionCount };
+}
+
 function buildTwelveMonthSkeleton(year: number): WorkoutAnalyticsMonthPoint[] {
   const out: WorkoutAnalyticsMonthPoint[] = [];
   for (let m = 1; m <= 12; m += 1) {

--- a/lib/ui/PageTitleRow.tsx
+++ b/lib/ui/PageTitleRow.tsx
@@ -1,14 +1,23 @@
 // Shared title row for tab pages: title (and optional subtitle) left, optional rightSlot (e.g. Settings gear) right.
 // Gear is in the same row as the title so it aligns with the title line; subtitle sits below.
 import { View, Text, StyleSheet } from "react-native";
+import { UI_TEXT_MUTED } from "@/lib/ui/theme/uiTokens";
 
 export type PageTitleRowProps = {
   title: string;
   subtitle?: string;
+  /** `soft` = light gray; `dash` = readable secondary on Dash grouped background. */
+  subtitleVariant?: "default" | "soft" | "dash";
   rightSlot?: React.ReactNode;
 };
 
-export function PageTitleRow({ title, subtitle, rightSlot }: PageTitleRowProps) {
+function subtitleStyleForVariant(variant: "default" | "soft" | "dash") {
+  if (variant === "soft") return styles.subtitleSoft;
+  if (variant === "dash") return styles.subtitleDash;
+  return styles.subtitle;
+}
+
+export function PageTitleRow({ title, subtitle, subtitleVariant = "default", rightSlot }: PageTitleRowProps) {
   return (
     <View style={styles.container}>
       <View style={styles.row}>
@@ -20,7 +29,7 @@ export function PageTitleRow({ title, subtitle, rightSlot }: PageTitleRowProps) 
         ) : null}
       </View>
       {subtitle != null && subtitle !== "" ? (
-        <Text style={styles.subtitle}>{subtitle}</Text>
+        <Text style={subtitleStyleForVariant(subtitleVariant)}>{subtitle}</Text>
       ) : null}
     </View>
   );
@@ -42,4 +51,17 @@ const styles = StyleSheet.create({
   },
   rightSlot: { marginLeft: 8 },
   subtitle: { fontSize: 15, color: "#8E8E93", marginTop: 6 },
+  subtitleSoft: {
+    fontSize: 15,
+    color: "#AEAEB2",
+    marginTop: 6,
+    lineHeight: 22,
+  },
+  subtitleDash: {
+    fontSize: 16,
+    color: UI_TEXT_MUTED,
+    marginTop: 8,
+    lineHeight: 24,
+    letterSpacing: 0.15,
+  },
 });

--- a/lib/ui/ScreenStates.tsx
+++ b/lib/ui/ScreenStates.tsx
@@ -6,6 +6,7 @@
 import React from "react";
 import { View, Text, StyleSheet, Pressable, ActivityIndicator } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+import { UI_APP_SCREEN_BG } from "@/lib/ui/theme/uiTokens";
 
 export type ScreenContainerProps = {
   children: React.ReactNode;
@@ -17,7 +18,7 @@ export type ScreenContainerProps = {
 export function ScreenContainer({
   children,
   edges = ["top"],
-  backgroundColor = "#FFFFFF",
+  backgroundColor = UI_APP_SCREEN_BG,
   padded = true,
 }: ScreenContainerProps) {
   return (

--- a/lib/ui/TabRootScreenHeader.tsx
+++ b/lib/ui/TabRootScreenHeader.tsx
@@ -1,0 +1,26 @@
+// Fixed top chrome for bottom-tab root screens: shared horizontal inset + PageTitleRow (title / optional subtitle / settings gear).
+import { View, StyleSheet } from "react-native";
+import { PageTitleRow, type PageTitleRowProps } from "@/lib/ui/PageTitleRow";
+import { UI_APP_SCREEN_BG, UI_TAB_ROOT_INSET } from "@/lib/ui/theme/uiTokens";
+
+export type TabRootScreenHeaderProps = Pick<
+  PageTitleRowProps,
+  "title" | "subtitle" | "subtitleVariant" | "rightSlot"
+>;
+
+export function TabRootScreenHeader(props: TabRootScreenHeaderProps) {
+  return (
+    <View style={styles.wrap}>
+      <PageTitleRow {...props} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: {
+    paddingHorizontal: UI_TAB_ROOT_INSET,
+    paddingTop: 16,
+    paddingBottom: 10,
+    backgroundColor: UI_APP_SCREEN_BG,
+  },
+});

--- a/lib/ui/dash/DashRecapCard.tsx
+++ b/lib/ui/dash/DashRecapCard.tsx
@@ -1,0 +1,185 @@
+// lib/ui/dash/DashRecapCard.tsx
+import React from "react";
+import { View, Text, StyleSheet, Pressable } from "react-native";
+import type { DashRecapViewModel } from "@/lib/data/dash/dashRecapViewModel";
+import { dashRecapRowAccessibilityLabel } from "@/lib/data/dash/dashRecapA11y";
+import { moduleOverviewMetricLayoutStyles } from "@/lib/ui/overview/moduleOverviewMetricLayout";
+import { MODULE_OVERVIEW_SEGMENT_ZONE_FILLS } from "@/lib/ui/overview/moduleOverviewSegmentZoneFills";
+import { MODULE_OVERVIEW_SEGMENTED_TRACK } from "@/lib/ui/overview/moduleOverviewSegmentedTrackMetrics";
+import { SegmentedZoneTrack } from "@/lib/ui/primitives/SegmentedZoneTrack";
+import { workoutOverviewInCardHeaderStyles } from "@/lib/ui/workouts/workoutOverviewInCardHeaderStyles";
+import { formatOverviewAsOfLabel } from "@/lib/ui/body/formatOverviewAsOfLabel";
+import { ErrorState, LoadingState } from "@/lib/ui/ScreenStates";
+import { UI_CARD_SURFACE, UI_DASH_RECAP_CARD_RADIUS } from "@/lib/ui/theme/uiTokens";
+
+/** Marker fill: neutral gray — does not encode Strength tier semantics. */
+const DASH_RECAP_PLACEMENT_MARKER_COLOR = "#6E6E73";
+
+export type DashRecapCardProps = {
+  model: DashRecapViewModel;
+  onViewMore?: () => void;
+};
+
+function RecapHint({ children }: { children: string }) {
+  return <Text style={styles.hint}>{children}</Text>;
+}
+
+function DailyRecapHeader({
+  showAsOf,
+  dayKey,
+  onViewMore,
+}: {
+  showAsOf: boolean;
+  dayKey?: string;
+  onViewMore?: () => void;
+}) {
+  return (
+    <>
+      <View style={[styles.headerRow, workoutOverviewInCardHeaderStyles.row]}>
+        <Text
+          style={workoutOverviewInCardHeaderStyles.title}
+          accessibilityRole="header"
+          accessibilityLabel="Daily Recap"
+        >
+          Daily Recap
+        </Text>
+        {onViewMore != null ? (
+          <Pressable
+            onPress={onViewMore}
+            accessibilityRole="button"
+            accessibilityLabel="View more daily recap"
+            hitSlop={8}
+            style={({ pressed }) => [
+              workoutOverviewInCardHeaderStyles.linkHit,
+              pressed && workoutOverviewInCardHeaderStyles.linkPressed,
+            ]}
+          >
+            <Text style={workoutOverviewInCardHeaderStyles.link}>View More</Text>
+          </Pressable>
+        ) : null}
+      </View>
+      {showAsOf && dayKey != null ? (
+        <Text style={styles.asOfLabel} accessibilityLabel={`Day ${dayKey}`}>
+          {formatOverviewAsOfLabel(dayKey)}
+        </Text>
+      ) : null}
+    </>
+  );
+}
+
+function PlacementTrack({ markerPosition01, testID }: { markerPosition01: number; testID: string }) {
+  const m = Math.max(0, Math.min(1, markerPosition01));
+  const pct = Math.round(m * 100);
+  return (
+    <SegmentedZoneTrack
+      zoneColors={MODULE_OVERVIEW_SEGMENT_ZONE_FILLS}
+      testID={testID}
+      markerPosition01={m}
+      showMarker
+      markerBackgroundColor={DASH_RECAP_PLACEMENT_MARKER_COLOR}
+      dotSize={MODULE_OVERVIEW_SEGMENTED_TRACK.dotSize}
+      barHeight={MODULE_OVERVIEW_SEGMENTED_TRACK.barHeight}
+      trackRadius={MODULE_OVERVIEW_SEGMENTED_TRACK.trackRadius}
+      wrapperProps={{
+        accessibilityRole: "progressbar",
+        accessibilityLabel: `Visual placement bar. Not a health rating. ${pct} percent along display scale.`,
+        accessibilityValue: { now: pct, min: 0, max: 100 },
+      }}
+    />
+  );
+}
+
+export function DashRecapCard({ model, onViewMore }: DashRecapCardProps) {
+  if (model.kind === "loading") {
+    return (
+      <View style={styles.card} accessibilityLabel="Daily Recap loading">
+        <DailyRecapHeader showAsOf={false} {...(onViewMore != null ? { onViewMore } : {})} />
+        <LoadingState variant="inline" message="Loading yesterday's summary…" />
+      </View>
+    );
+  }
+
+  if (model.kind === "error") {
+    return (
+      <View style={styles.card} accessibilityLabel="Daily Recap error">
+        <DailyRecapHeader showAsOf={false} {...(onViewMore != null ? { onViewMore } : {})} />
+        <ErrorState
+          variant="inline"
+          title="Could not load recap"
+          message={model.message}
+          requestId={model.requestId}
+          onRetry={model.retry}
+        />
+      </View>
+    );
+  }
+
+  const dayKey = model.dayKey;
+  const rows = model.rows;
+  const hint =
+    model.kind === "missing_doc"
+      ? "No daily rollup for yesterday yet — metrics appear after data syncs."
+      : model.kind === "empty"
+        ? "No tracked metrics for yesterday in your daily summary."
+        : null;
+
+  return (
+    <View style={styles.card} accessibilityLabel={`Daily Recap for ${dayKey}`}>
+      <DailyRecapHeader showAsOf dayKey={dayKey} {...(onViewMore != null ? { onViewMore } : {})} />
+      {hint != null ? <RecapHint>{hint}</RecapHint> : null}
+      <View style={moduleOverviewMetricLayoutStyles.metricGroups}>
+        {rows.map((r) => (
+          <View
+            key={r.id}
+            style={moduleOverviewMetricLayoutStyles.metricBlock}
+            accessibilityLabel={dashRecapRowAccessibilityLabel(r)}
+            accessible
+          >
+            <View style={moduleOverviewMetricLayoutStyles.topRow}>
+              <Text style={moduleOverviewMetricLayoutStyles.primaryLabel} numberOfLines={1}>
+                {r.label}
+              </Text>
+              <Text
+                style={[
+                  moduleOverviewMetricLayoutStyles.trailingValue,
+                  r.isPlaceholder ? styles.trailingPlaceholder : null,
+                ]}
+                numberOfLines={1}
+              >
+                {r.valueText}
+              </Text>
+            </View>
+            {r.bar.kind === "placement" ? (
+              <PlacementTrack markerPosition01={r.bar.markerPosition01} testID={`dash-daily-recap-bar-${r.id}`} />
+            ) : null}
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: UI_CARD_SURFACE,
+    borderRadius: UI_DASH_RECAP_CARD_RADIUS,
+    padding: 20,
+    gap: 12,
+  },
+  headerRow: {
+    alignItems: "flex-start",
+  },
+  asOfLabel: {
+    fontSize: 14,
+    fontWeight: "600",
+    color: "#6E6E73",
+  },
+  hint: {
+    fontSize: 14,
+    color: "#8E8E93",
+    lineHeight: 20,
+  },
+  trailingPlaceholder: {
+    color: "#AEAEB2",
+  },
+});

--- a/lib/ui/dash/__tests__/DashRecapCard.test.tsx
+++ b/lib/ui/dash/__tests__/DashRecapCard.test.tsx
@@ -1,0 +1,80 @@
+// lib/ui/dash/__tests__/DashRecapCard.test.tsx
+import React, { act } from "react";
+import renderer from "react-test-renderer";
+import { describe, expect, it, jest } from "@jest/globals";
+import { Pressable } from "react-native";
+import { DashRecapCard } from "../DashRecapCard";
+
+function findViewsWithTestIdPrefix(root: renderer.ReactTestInstance, prefix: string): renderer.ReactTestInstance[] {
+  const views = root.findAllByType("View");
+  return views.filter((v) => {
+    const id = (v.props as { testID?: string }).testID;
+    return typeof id === "string" && id.startsWith(prefix);
+  });
+}
+
+describe("DashRecapCard", () => {
+  it("renders placement bars only for rows with bar.kind placement", () => {
+    const onViewMore = jest.fn();
+    const model = {
+      kind: "ready" as const,
+      dayKey: "2026-04-05",
+      rows: [
+        {
+          id: "weight" as const,
+          label: "Weight",
+          valueText: "70 kg",
+          isPlaceholder: false,
+          bar: { kind: "none" as const },
+        },
+        {
+          id: "steps" as const,
+          label: "Steps",
+          valueText: "6000",
+          isPlaceholder: false,
+          bar: { kind: "placement" as const, markerPosition01: 0.5 },
+        },
+      ],
+    };
+
+    let test!: renderer.ReactTestRenderer;
+    act(() => {
+      test = renderer.create(<DashRecapCard model={model} onViewMore={onViewMore} />);
+    });
+
+    const bars = findViewsWithTestIdPrefix(test.root, "dash-daily-recap-bar-");
+    expect(bars.length).toBeGreaterThanOrEqual(1);
+    expect(
+      bars.some((b) => (b.props as { testID?: string }).testID === "dash-daily-recap-bar-steps"),
+    ).toBe(true);
+    expect(
+      bars.some((b) => (b.props as { testID?: string }).testID === "dash-daily-recap-bar-weight"),
+    ).toBe(false);
+  });
+
+  it("invokes onViewMore when View More is pressed", () => {
+    const onViewMore = jest.fn();
+    const model = {
+      kind: "ready" as const,
+      dayKey: "2026-04-05",
+      rows: [],
+    };
+
+    let test!: renderer.ReactTestRenderer;
+    act(() => {
+      test = renderer.create(<DashRecapCard model={model} onViewMore={onViewMore} />);
+    });
+
+    const texts = test.root.findAllByType("Text");
+    expect(
+      texts.some((t) => (t.children as unknown[]).some((c) => c === "View More")),
+    ).toBe(true);
+
+    const pressables = test.root.findAllByType(Pressable);
+    expect(pressables.length).toBeGreaterThanOrEqual(1);
+    act(() => {
+      pressables[0]!.props.onPress();
+    });
+    expect(onViewMore).toHaveBeenCalledTimes(1);
+  });
+});

--- a/lib/ui/profile/ProfileMainScreen.tsx
+++ b/lib/ui/profile/ProfileMainScreen.tsx
@@ -1,11 +1,12 @@
 // lib/ui/profile/ProfileMainScreen.tsx
-// Tab-root layout: matches Dash / other tabs — ScreenContainer + in-scroll PageTitleRow (no settings gear).
+// Tab-root layout: TabRootScreenHeader + scroll (matches other tab roots; no settings gear).
 import React from "react";
 import { View, Text, Pressable, StyleSheet, ActivityIndicator, ScrollView } from "react-native";
 import { useRouter } from "expo-router";
 
 import { ScreenContainer } from "@/lib/ui/ScreenStates";
-import { PageTitleRow } from "@/lib/ui/PageTitleRow";
+import { TabRootScreenHeader } from "@/lib/ui/TabRootScreenHeader";
+import { UI_APP_SCREEN_BG, UI_TAB_ROOT_INSET } from "@/lib/ui/theme/uiTokens";
 import type { MassUnit, UserProfileMain } from "@oli/contracts";
 import {
   formatHeightForDisplay,
@@ -26,8 +27,6 @@ const CATEGORY_PLACEHOLDERS = [
   "Health inputs",
 ] as const;
 
-/** Tab-root grays: continuous page + grouped sections (aligned with app grays, not stark white cards). */
-const PAGE_BG = "#F2F2F7";
 const GROUP_BG = "#EBEBEF";
 const GROUP_OUTLINE = "#D1D1D6";
 const ROW_DIVIDER = "#C6C6CC";
@@ -79,16 +78,16 @@ export function ProfileMainScreen({
   );
 
   return (
-    <ScreenContainer backgroundColor={PAGE_BG}>
-      <ScrollView
-        style={styles.scroll}
-        contentContainerStyle={styles.scrollContent}
-        keyboardShouldPersistTaps="handled"
-        showsVerticalScrollIndicator={false}
-        bounces
-      >
-        <PageTitleRow title="Profile" subtitle="Personalization & body context" />
-
+    <ScreenContainer padded={false}>
+      <View style={styles.tabRoot}>
+        <TabRootScreenHeader title="Profile" subtitle="Personalization & body context" />
+        <ScrollView
+          style={styles.scroll}
+          contentContainerStyle={styles.scrollContent}
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+          bounces
+        >
         {showLoadError ? <Text style={styles.errorText}>{errorMessage}</Text> : null}
 
         {hydrating ? (
@@ -213,18 +212,21 @@ export function ProfileMainScreen({
           Social Security numbers, government IDs, or payment details in Profile.
         </Text>
       </ScrollView>
+      </View>
     </ScreenContainer>
   );
 }
 
 const styles = StyleSheet.create({
+  tabRoot: { flex: 1, backgroundColor: UI_APP_SCREEN_BG },
   scroll: {
     flex: 1,
-    backgroundColor: PAGE_BG,
+    backgroundColor: UI_APP_SCREEN_BG,
   },
   scrollContent: {
     flexGrow: 1,
-    padding: 16,
+    paddingHorizontal: UI_TAB_ROOT_INSET,
+    paddingTop: 8,
     paddingBottom: 40,
   },
   sectionLabel: {

--- a/lib/ui/theme/uiTokens.ts
+++ b/lib/ui/theme/uiTokens.ts
@@ -7,6 +7,9 @@ export const UI_TEXT_SECONDARY = "#3C3C43";
 export const UI_TEXT_MUTED = "#6E6E73";
 export const UI_TEXT_TERTIARY_LABEL = "#8E8E93";
 
+/** Cool blue-gray secondary line on grouped sheets (e.g. Dash Stacks tagline) — calm, not marketing blue. */
+export const UI_TEXT_SLATE_COOL = "#5B6C8A";
+
 /** Header back / toolbar pill fill (iOS grouped background family). */
 export const UI_HEADER_CHROME_BG = "#F2F2F7";
 
@@ -31,3 +34,23 @@ export const UI_LINK_SECONDARY = UI_TEXT_SECONDARY;
 export const UI_BORDER_HAIRLINE = "#E5E5EA";
 export const UI_SCREEN_BG = "#F2F2F7";
 export const UI_CARD_SURFACE = "#FFFFFF";
+
+/** App-wide grouped page root (tab roots, ScreenContainer default). Calm blue-gray. */
+export const UI_APP_SCREEN_BG = "#EEF3F8";
+
+/** @deprecated Use UI_APP_SCREEN_BG — kept for existing imports. */
+export const UI_DASH_SCREEN_BG = UI_APP_SCREEN_BG;
+
+/**
+ * Horizontal inset for tab root headers and scroll content so title, gear, and cards share one grid.
+ */
+export const UI_TAB_ROOT_INSET = 20;
+
+/** Default corner radius for white cards on grouped backgrounds (non-Dash). */
+export const UI_GROUPED_CARD_RADIUS = 16;
+
+/** Daily Recap on Dash — crisp primary card (tighter than secondary nav rows). */
+export const UI_DASH_RECAP_CARD_RADIUS = 14;
+
+/** Dash category module rows — softer, more premium than recap. */
+export const UI_DASH_CATEGORY_CARD_RADIUS = 20;

--- a/services/api/src/routes/__tests__/workoutDaySummaries.list.test.ts
+++ b/services/api/src/routes/__tests__/workoutDaySummaries.list.test.ts
@@ -39,13 +39,15 @@ describe("GET /users/me/workout-day-summaries", () => {
 
   it("returns complete true when every day in range has a valid summary doc", async () => {
     const item = {
-      schemaVersion: 1,
+      schemaVersion: 2,
       day: "2026-03-10",
       computedAt: "2026-03-10T12:00:00.000Z",
-      reconcileVersion: "1",
+      reconcileVersion: "2",
       hasStrength: false,
       hasCardio: true,
       rawWorkoutCount: 1,
+      strengthSessionCount: 0,
+      cardioSessionCount: 1,
     };
 
     (userCollection as jest.Mock).mockImplementation((_uid: string, name: string) => {
@@ -72,6 +74,8 @@ describe("GET /users/me/workout-day-summaries", () => {
     expect(json.expectedDayCount).toBe(1);
     expect(json.items).toHaveLength(1);
     expect(json.items[0].day).toBe("2026-03-10");
+    expect(json.items[0].cardioSessionCount).toBe(1);
+    expect(json.items[0].strengthSessionCount).toBe(0);
   });
 
   it("returns complete false when a day is missing", async () => {


### PR DESCRIPTION
…er and workout summary integration

- add Daily Recap card with DailyFacts + cardio session counts
- integrate workout day summary counts (cardioSessionCount)
- introduce dash recap view-model and hooks
- implement Stacks section with improved hierarchy and typography
- upgrade Dash layout (background, spacing, card system)
- introduce shared TabRootScreenHeader for tab pages
- unify app background across tab screens
- improve alignment and premium UI polish
- add tests for recap, workout summary, and dash behavior

all checks passing (typecheck, lint, test, invariants)