### PR TITLE
feat(body): implement premium Weight Trend card and unify calendar sy…

### DIFF
--- a/app/(app)/(tabs)/__tests__/dash-recap.test.tsx
+++ b/app/(app)/(tabs)/__tests__/dash-recap.test.tsx
@@ -66,7 +66,7 @@ describe("Dash Recap card", () => {
     mockUseDashRecapData.mockReset();
   });
 
-  it("renders Daily Recap before Stacks and tagline when model is ready", () => {
+  it("renders Stacks and tagline before Daily Recap when model is ready", () => {
     mockUseDashRecapData.mockReturnValue({
       kind: "ready",
       dayKey: "2026-04-05",
@@ -100,8 +100,8 @@ describe("Dash Recap card", () => {
     expect(text).toContain("View More");
     expect(idxStacks).toBeGreaterThan(-1);
     expect(idxTagline).toBeGreaterThan(-1);
-    expect(idxStacks).toBeGreaterThan(idxRecap);
-    expect(idxTagline).toBeGreaterThan(idxStacks);
+    expect(idxStacks).toBeLessThan(idxTagline);
+    expect(idxTagline).toBeLessThan(idxRecap);
     expect(text).toContain("176.4 lb");
     expect(text).toContain("Cardio Sessions");
     expect(text).toContain("2");

--- a/app/(app)/(tabs)/dash.tsx
+++ b/app/(app)/(tabs)/dash.tsx
@@ -1,5 +1,5 @@
 // app/(app)/(tabs)/dash.tsx
-// Oli — Dash: tab header, Daily Recap, Stacks + subtitle, category cards to real screens only.
+// Oli — Dash: tab header, Stacks section (subtitle + Daily Recap + stack cards); recap reads as summary of Stacks.
 import React, { useRef } from "react";
 import {
   ScrollView,
@@ -9,6 +9,7 @@ import {
   Pressable,
   Animated,
 } from "react-native";
+import { elevatedCardSurfaceStyle } from "@/lib/ui/theme/elevatedCardSurface";
 import { useRouter } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import { ScreenContainer } from "@/lib/ui/ScreenStates";
@@ -21,6 +22,7 @@ import {
   UI_CARD_SURFACE,
   UI_DASH_CATEGORY_CARD_RADIUS,
   UI_HEADER_CHROME_BG,
+  UI_TAB_ROOT_CONTENT_GUTTER,
   UI_TAB_ROOT_INSET,
   UI_TEXT_MUTED,
   UI_TEXT_PRIMARY,
@@ -45,9 +47,6 @@ const SCALE_PRESSED = 0.98;
 const ANIM_DURATION = 100;
 
 const STACKS_TAGLINE = "Optimize your health and fitness — all in one place.";
-
-/** Must match `styles.card` `paddingHorizontal` so Stacks copy aligns with card title text. */
-const DASH_CARD_PADDING_HORIZONTAL = 18;
 
 type DashCardProps = {
   title: string;
@@ -116,16 +115,15 @@ export default function DashScreen() {
           keyboardShouldPersistTaps="handled"
           showsVerticalScrollIndicator={false}
         >
-          <View style={styles.recapWrap}>
-            <DashRecapCard model={recapModel} onViewMore={() => router.push("/(app)/dash/daily-recap")} />
-          </View>
-
           <View style={styles.stacksSection}>
             <View style={styles.stacksHeaderInset}>
               <Text style={styles.sectionHeading} accessibilityRole="header">
                 Stacks
               </Text>
               <Text style={styles.stacksTagline}>{STACKS_TAGLINE}</Text>
+            </View>
+            <View style={styles.recapInStacksSection}>
+              <DashRecapCard model={recapModel} onViewMore={() => router.push("/(app)/dash/daily-recap")} />
             </View>
             <View style={styles.cards}>
               {MANAGE_DATA_CARDS.map((card) => (
@@ -156,44 +154,47 @@ const styles = StyleSheet.create({
   },
   scroll: {
     paddingHorizontal: UI_TAB_ROOT_INSET,
-    paddingTop: 8,
+    paddingTop: 6,
     paddingBottom: 40,
     flexGrow: 1,
     backgroundColor: UI_APP_SCREEN_BG,
   },
-  recapWrap: { marginTop: 4 },
-  /** Groups Stacks header + cards; cards share full width with scroll content inset. */
+  /** Stacks = parent section: heading, tagline, Daily Recap (section summary), then module cards. */
   stacksSection: {},
   /** Inset matches card inner padding so “Stacks” / tagline align with category row titles. */
   stacksHeaderInset: {
-    paddingHorizontal: DASH_CARD_PADDING_HORIZONTAL,
+    paddingHorizontal: UI_TAB_ROOT_CONTENT_GUTTER,
   },
-  /** Below Oli (28 / 900): smaller size + bold 700 preserves Oli > Stacks hierarchy. */
   sectionHeading: {
-    marginTop: 28,
+    marginTop: 18,
     marginBottom: 0,
-    fontSize: 24,
+    fontSize: 26,
     fontWeight: "700",
     color: UI_TEXT_PRIMARY,
-    letterSpacing: 0.25,
+    letterSpacing: -0.2,
   },
   stacksTagline: {
     fontSize: 17,
     fontWeight: "400",
     color: UI_TEXT_SLATE_COOL,
-    marginTop: 5,
+    marginTop: 7,
     marginBottom: 12,
     lineHeight: 26,
-    letterSpacing: 0.2,
+    letterSpacing: 0.15,
+  },
+  /** Daily Recap sits inside Stacks — spacing after subtitle, before stack cards. */
+  recapInStacksSection: {
+    marginBottom: 16,
   },
   cards: {
     gap: 14,
   },
   card: {
     width: "100%",
+    ...elevatedCardSurfaceStyle,
     borderRadius: UI_DASH_CATEGORY_CARD_RADIUS,
     paddingVertical: 16,
-    paddingHorizontal: DASH_CARD_PADDING_HORIZONTAL,
+    paddingHorizontal: UI_TAB_ROOT_CONTENT_GUTTER,
     minHeight: 68,
     justifyContent: "center",
   },

--- a/app/(app)/(tabs)/library/index.tsx
+++ b/app/(app)/(tabs)/library/index.tsx
@@ -4,7 +4,11 @@ import { useRouter } from "expo-router";
 import { ScreenContainer } from "@/lib/ui/ScreenStates";
 import { TabRootScreenHeader } from "@/lib/ui/TabRootScreenHeader";
 import { SettingsGearButton } from "@/lib/ui/SettingsGearButton";
-import { UI_APP_SCREEN_BG, UI_TAB_ROOT_INSET } from "@/lib/ui/theme/uiTokens";
+import {
+  UI_APP_SCREEN_BG,
+  UI_TAB_ROOT_CONTENT_GUTTER_STYLE,
+  UI_TAB_ROOT_INSET,
+} from "@/lib/ui/theme/uiTokens";
 import { useFailuresRange } from "@/lib/data/useFailuresRange";
 import { useUploadsPresence } from "@/lib/data/useUploadsPresence";
 import { useMemo } from "react";
@@ -86,48 +90,50 @@ export default function LibraryIndexScreen() {
           keyboardShouldPersistTaps="handled"
           showsVerticalScrollIndicator={false}
         >
-        <View style={styles.quickLenses}>
-          {QUICK_LENSES.map((l) => (
-            <Pressable
-              key={l.id}
-              style={styles.lensBtn}
-              onPress={() =>
-                router.push({
-                  pathname: l.path as "/",
-                  params: l.params as Record<string, string>,
-                })
-              }
-            >
-              <Text style={styles.lensBtnText}>{l.label}</Text>
-            </Pressable>
-          ))}
-        </View>
+          <View style={UI_TAB_ROOT_CONTENT_GUTTER_STYLE}>
+            <View style={styles.quickLenses}>
+              {QUICK_LENSES.map((l) => (
+                <Pressable
+                  key={l.id}
+                  style={styles.lensBtn}
+                  onPress={() =>
+                    router.push({
+                      pathname: l.path as "/",
+                      params: l.params as Record<string, string>,
+                    })
+                  }
+                >
+                  <Text style={styles.lensBtnText}>{l.label}</Text>
+                </Pressable>
+              ))}
+            </View>
 
-        <View style={styles.list}>
-          {LIBRARY_CATEGORIES.map((cat) => (
-            <Pressable
-              key={cat.id}
-              style={styles.row}
-              onPress={() => {
-                if (cat.id === "search") {
-                  router.push("/(app)/(tabs)/library/search");
-                } else if (cat.id === "weight") {
-                  router.push("/(app)/body/weight");
-                } else {
-                  router.push({
-                    pathname: "/(app)/(tabs)/library/[category]",
-                    params: { category: cat.id },
-                  });
-                }
-              }}
-              accessibilityLabel={`${cat.title}, ${getCategoryCount(cat)}`}
-            >
-              <Text style={styles.rowTitle}>{cat.title}</Text>
-              <Text style={styles.rowCount}>{getCategoryCount(cat)}</Text>
-            </Pressable>
-          ))}
-        </View>
-      </ScrollView>
+            <View style={styles.list}>
+              {LIBRARY_CATEGORIES.map((cat) => (
+                <Pressable
+                  key={cat.id}
+                  style={styles.row}
+                  onPress={() => {
+                    if (cat.id === "search") {
+                      router.push("/(app)/(tabs)/library/search");
+                    } else if (cat.id === "weight") {
+                      router.push("/(app)/body/weight");
+                    } else {
+                      router.push({
+                        pathname: "/(app)/(tabs)/library/[category]",
+                        params: { category: cat.id },
+                      });
+                    }
+                  }}
+                  accessibilityLabel={`${cat.title}, ${getCategoryCount(cat)}`}
+                >
+                  <Text style={styles.rowTitle}>{cat.title}</Text>
+                  <Text style={styles.rowCount}>{getCategoryCount(cat)}</Text>
+                </Pressable>
+              ))}
+            </View>
+          </View>
+        </ScrollView>
       </View>
     </ScreenContainer>
   );
@@ -138,7 +144,7 @@ const styles = StyleSheet.create({
   scrollView: { flex: 1, backgroundColor: UI_APP_SCREEN_BG },
   scroll: {
     paddingHorizontal: UI_TAB_ROOT_INSET,
-    paddingTop: 8,
+    paddingTop: 6,
     paddingBottom: 40,
   },
   quickLenses: { flexDirection: "row", gap: 8, marginTop: 8, flexWrap: "wrap" },
@@ -154,7 +160,9 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
-    padding: 16,
+    paddingVertical: 16,
+    paddingLeft: 0,
+    paddingRight: 16,
     backgroundColor: "#FFFFFF",
   },
   rowTitle: { fontSize: 17, fontWeight: "600", color: "#1C1C1E" },

--- a/app/(app)/(tabs)/manage.tsx
+++ b/app/(app)/(tabs)/manage.tsx
@@ -8,7 +8,11 @@ import { Ionicons } from "@expo/vector-icons";
 import { ScreenContainer } from "@/lib/ui/ScreenStates";
 import { TabRootScreenHeader } from "@/lib/ui/TabRootScreenHeader";
 import { SettingsGearButton } from "@/lib/ui/SettingsGearButton";
-import { UI_APP_SCREEN_BG, UI_TAB_ROOT_INSET } from "@/lib/ui/theme/uiTokens";
+import {
+  UI_APP_SCREEN_BG,
+  UI_TAB_ROOT_CONTENT_GUTTER_STYLE,
+  UI_TAB_ROOT_INSET,
+} from "@/lib/ui/theme/uiTokens";
 import { getTodayDayKey } from "@/lib/time/dayKey";
 import { useDailyFacts } from "@/lib/data/useDailyFacts";
 import { useLabResults } from "@/lib/data/useLabResults";
@@ -582,9 +586,11 @@ export default function ManageScreen() {
           keyboardShouldPersistTaps="handled"
           showsVerticalScrollIndicator={false}
         >
-          {renderSection("HEALTH SYSTEMS", healthSystems)}
-          {renderSection("CLINICAL RECORDS", clinicalRecords)}
-          {renderSection("RECORD INTEGRITY", recordIntegrity)}
+          <View style={UI_TAB_ROOT_CONTENT_GUTTER_STYLE}>
+            {renderSection("HEALTH SYSTEMS", healthSystems)}
+            {renderSection("CLINICAL RECORDS", clinicalRecords)}
+            {renderSection("RECORD INTEGRITY", recordIntegrity)}
+          </View>
         </ScrollView>
       </View>
     </ScreenContainer>
@@ -596,7 +602,7 @@ const styles = StyleSheet.create({
   scrollView: { flex: 1, backgroundColor: UI_APP_SCREEN_BG },
   scroll: {
     paddingHorizontal: UI_TAB_ROOT_INSET,
-    paddingTop: 8,
+    paddingTop: 6,
     paddingBottom: 40,
   },
   section: { marginTop: 24 },
@@ -618,7 +624,7 @@ const styles = StyleSheet.create({
   row: {
     backgroundColor: "#FFFFFF",
     paddingVertical: 16,
-    paddingHorizontal: 16,
+    paddingHorizontal: 0,
     borderBottomWidth: StyleSheet.hairlineWidth,
     borderBottomColor: "#E5E5EA",
   },
@@ -627,6 +633,7 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",
+    paddingRight: 16,
   },
   rowLeft: { flex: 1, minWidth: 0, gap: 2 },
   rowTitle: { fontSize: 17, fontWeight: "600", color: "#1C1C1E" },

--- a/app/(app)/(tabs)/timeline/index.tsx
+++ b/app/(app)/(tabs)/timeline/index.tsx
@@ -7,7 +7,11 @@ import { OfflineBanner } from "@/lib/ui/OfflineBanner";
 import { TruthIndicator } from "@/lib/ui/TruthIndicators";
 import { TabRootScreenHeader } from "@/lib/ui/TabRootScreenHeader";
 import { SettingsGearButton } from "@/lib/ui/SettingsGearButton";
-import { UI_APP_SCREEN_BG, UI_TAB_ROOT_INSET } from "@/lib/ui/theme/uiTokens";
+import {
+  UI_APP_SCREEN_BG,
+  UI_TAB_ROOT_CONTENT_GUTTER_STYLE,
+  UI_TAB_ROOT_INSET,
+} from "@/lib/ui/theme/uiTokens";
 import { useTimeline } from "@/lib/data/useTimeline";
 import { useMemo, useState, useCallback } from "react";
 import {
@@ -99,6 +103,7 @@ export default function TimelineIndexScreen() {
               <>
                 <OfflineBanner isOffline={fromCache} />
                 <View style={styles.scroll}>
+                  <View style={[styles.scrollBody, UI_TAB_ROOT_CONTENT_GUTTER_STYLE]}>
                   <View style={styles.navRow}>
                   <View style={styles.viewModeRow}>
                     {VIEW_MODES.map((m) => (
@@ -145,6 +150,7 @@ export default function TimelineIndexScreen() {
                 />
               ) : (
                 <FlatList
+                  style={styles.listFlex}
                   data={days}
                   keyExtractor={(d) => d.day}
                   renderItem={({ item: d }) => (
@@ -244,7 +250,8 @@ export default function TimelineIndexScreen() {
                     </View>
                 </Pressable>
               </Pressable>
-            </Modal>
+              </Modal>
+                  </View>
                 </View>
               </>
             );
@@ -262,9 +269,12 @@ const styles = StyleSheet.create({
   scroll: {
     flex: 1,
     paddingHorizontal: UI_TAB_ROOT_INSET,
-    paddingTop: 8,
-    paddingBottom: 40,
+    paddingTop: 6,
     backgroundColor: UI_APP_SCREEN_BG,
+  },
+  scrollBody: {
+    flex: 1,
+    paddingBottom: 40,
   },
   listHeader: { height: 16 },
   listFooter: { height: 40 },
@@ -307,11 +317,14 @@ const styles = StyleSheet.create({
     marginTop: 16,
     gap: 6,
   },
+  listFlex: { flex: 1 },
   row: {
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
-    padding: 16,
+    paddingVertical: 16,
+    paddingLeft: 0,
+    paddingRight: 12,
     backgroundColor: "#F2F2F7",
     borderRadius: 12,
   },

--- a/app/(app)/_layout.tsx
+++ b/app/(app)/_layout.tsx
@@ -33,7 +33,7 @@ export default function AppLayout() {
           />
           <Stack.Screen
             name="body/calendar"
-            options={{ title: "Body Calendar", ...workoutsStackNavigationOptions("detail") }}
+            options={{ title: "", ...workoutsStackNavigationOptions("detail") }}
           />
           <Stack.Screen
             name="body/day/[day]"
@@ -77,7 +77,7 @@ export default function AppLayout() {
           />
           <Stack.Screen
             name="nutrition/calendar"
-            options={{ title: "Nutrition Calendar", ...workoutsStackNavigationOptions("detail") }}
+            options={{ title: "", ...workoutsStackNavigationOptions("detail") }}
           />
           <Stack.Screen
             name="nutrition/settings"
@@ -89,7 +89,7 @@ export default function AppLayout() {
           />
           <Stack.Screen
             name="workouts/calendar"
-            options={{ title: "Strength Calendar", ...workoutsStackNavigationOptions("detail") }}
+            options={{ title: "", ...workoutsStackNavigationOptions("detail") }}
           />
           <Stack.Screen
             name="workouts/day/[day]"
@@ -145,7 +145,7 @@ export default function AppLayout() {
           />
           <Stack.Screen
             name="cardio/calendar"
-            options={{ title: "Cardio Calendar", ...workoutsStackNavigationOptions("detail") }}
+            options={{ title: "", ...workoutsStackNavigationOptions("detail") }}
           />
           <Stack.Screen
             name="cardio/day/[day]"
@@ -184,7 +184,7 @@ export default function AppLayout() {
           />
           <Stack.Screen
             name="recovery/sleep/calendar"
-            options={{ title: "Sleep calendar", ...workoutsStackNavigationOptions("detail") }}
+            options={{ title: "", ...workoutsStackNavigationOptions("detail") }}
           />
           <Stack.Screen
             name="recovery/readiness"
@@ -196,7 +196,7 @@ export default function AppLayout() {
           />
           <Stack.Screen
             name="recovery/readiness/calendar"
-            options={{ title: "Readiness calendar", ...workoutsStackNavigationOptions("detail") }}
+            options={{ title: "", ...workoutsStackNavigationOptions("detail") }}
           />
           <Stack.Screen name="failures/index" options={{ title: "Failures" }} />
           <Stack.Screen name="settings/index" options={{ title: "Settings" }} />

--- a/app/(app)/body/__tests__/calendar-screen.test.tsx
+++ b/app/(app)/body/__tests__/calendar-screen.test.tsx
@@ -3,6 +3,7 @@ import renderer, { act } from "react-test-renderer";
 
 const mockPush = jest.fn();
 const mockFlatListProps = jest.fn();
+const mockSetOptions = jest.fn();
 
 jest.mock("react-native", () => {
   const ReactLib = require("react");
@@ -11,6 +12,7 @@ jest.mock("react-native", () => {
     Text: "Text",
     Pressable: "Pressable",
     StyleSheet: { create: (s: unknown) => s },
+    Platform: { OS: "ios" },
     FlatList: (props: { data: unknown[]; renderItem: (item: { item: unknown }) => React.ReactElement }) => {
       mockFlatListProps(props);
       return ReactLib.createElement(
@@ -28,7 +30,19 @@ jest.mock("react-native-safe-area-context", () => ({
 
 jest.mock("expo-router", () => ({
   useRouter: () => ({ push: mockPush }),
+  useNavigation: () => ({
+    setOptions: mockSetOptions,
+    goBack: jest.fn(),
+  }),
 }));
+
+jest.mock("@/lib/ui/calendar/dateUtils", () => {
+  const actual = jest.requireActual<typeof import("@/lib/ui/calendar/dateUtils")>("@/lib/ui/calendar/dateUtils");
+  return {
+    ...actual,
+    getTodayDayKeyLocal: jest.fn(() => "2026-04-07"),
+  };
+});
 
 const mockHook = jest.fn();
 jest.mock("@/lib/data/body/useBodyCompositionData", () => ({
@@ -41,6 +55,7 @@ describe("Body calendar screen", () => {
   beforeEach(() => {
     mockPush.mockClear();
     mockFlatListProps.mockClear();
+    mockSetOptions.mockClear();
   });
 
   it("routes to body day from month grid day tap", () => {
@@ -66,7 +81,7 @@ describe("Body calendar screen", () => {
     });
   });
 
-  it("initializes calendar around January 2026", () => {
+  it("initializes calendar around local today month and scroll index matches Strength pattern", () => {
     mockHook.mockReturnValue({
       today: "2026-03-31",
       markedDays: new Set<string>(),
@@ -82,7 +97,9 @@ describe("Body calendar screen", () => {
       .flatMap((node) => node.children)
       .filter((x) => typeof x === "string")
       .join(" ");
-    expect(text).toContain("January 2026");
+    expect(text).toContain("April 2026");
+    expect(mockSetOptions).toHaveBeenCalled();
+    const opts = mockSetOptions.mock.calls[0]?.[0] as { headerTitle?: () => React.ReactElement };
+    expect(typeof opts?.headerTitle).toBe("function");
   });
 });
-

--- a/app/(app)/body/__tests__/weight-screen.test.tsx
+++ b/app/(app)/body/__tests__/weight-screen.test.tsx
@@ -30,6 +30,14 @@ jest.mock("@/lib/preferences/PreferencesProvider", () => ({
   }),
 }));
 
+jest.mock("@/lib/ui/calendar/dateUtils", () => {
+  const actual = jest.requireActual<typeof import("@/lib/ui/calendar/dateUtils")>("@/lib/ui/calendar/dateUtils");
+  return {
+    ...actual,
+    getTodayDayKeyLocal: jest.fn(() => "2026-04-06"),
+  };
+});
+
 const mockHook = jest.fn();
 jest.mock("@/lib/data/body/useBodyOverviewData", () => ({
   useBodyOverviewData: (...args: unknown[]) => mockHook(...args),
@@ -75,11 +83,33 @@ function buildPoint(dayKey: string, observedAt = `${dayKey}T07:00:00.000Z`): Wei
   return { dayKey, observedAt, weightKg: 80, sourceId: "healthkit" };
 }
 
+function defaultTrendsV1() {
+  return {
+    latest: {
+      currentKg: null as number | null,
+      seriesStatus: "ready" as const,
+      weeklyDeltaKg: null as number | null,
+    },
+    ytd: {
+      trendYear: 2026,
+      windowLabel: "2026-01-01 → 2026-04-07",
+      trendsStatus: "ready" as const,
+      changeKg: null as number | null,
+      bandLowKg: null as number | null,
+      bandHighKg: null as number | null,
+      bandCurrentKg: null as number | null,
+      sampleCount: 0 as number | null,
+    },
+  };
+}
+
 function buildBody(overrides: Record<string, unknown> = {}) {
   return {
     today: "2026-03-31",
     peek: { status: "ready" as const, items: [] as unknown[], refetch: jest.fn() },
     snapshotDayPeek: { status: "ready" as const, items: [] as unknown[], refetch: jest.fn() },
+    trendsWeightYtd: { refetch: jest.fn(), status: "ready" as const },
+    trendsV1: defaultTrendsV1(),
     series: {
       status: "ready" as const,
       data: { points: [] as WeightPoint[], latest: null },
@@ -129,7 +159,8 @@ describe("Body Composition main screen", () => {
     const text = collectText(tree);
     expect(text).toContain("Overview");
     expect(text).toContain("No overview data yet");
-    expect(text).toContain("Recent");
+    expect(text).toContain("2026 Weight Trend");
+    expect(text).not.toContain("Recent");
   });
 
   it("shows As of label when overview snapshot day is known", () => {
@@ -159,7 +190,7 @@ describe("Body Composition main screen", () => {
       tree = renderer.create(React.createElement(Screen));
     });
     const text = collectText(tree);
-    expect(text).toContain("As of 3/31");
+    expect(text).toContain("As of Tue 3/31");
   });
 
   it("routes to weight metric detail when Weight row is pressed", () => {
@@ -362,65 +393,6 @@ describe("Body Composition main screen", () => {
       pathname: "/(app)/body/day/[day]",
       params: { day },
     });
-  });
-
-  it("routes to body day from recent row tap", () => {
-    const day = "2026-03-31";
-    mockHook.mockReturnValue(
-      buildBody({
-        today: "2026-03-31",
-        weekDays: [{ day: "2026-03-31", meta: { hasMeasurement: true } }],
-        markedDays: new Set<string>([day]),
-        byDay: new Map([[day, [buildPoint(day)]]]),
-        recent: [{ day, latest: buildPoint(day) }],
-        series: { status: "ready", data: { points: [buildPoint(day)], latest: buildPoint(day) }, refetch: jest.fn() },
-      }),
-    );
-    let tree!: renderer.ReactTestRenderer;
-    act(() => {
-      tree = renderer.create(React.createElement(Screen));
-    });
-    const recentRow = tree.root
-      .findAllByType("Pressable")
-      .find((p) => p.props.accessibilityLabel === `Open body details for ${day}`);
-    expect(recentRow).toBeDefined();
-    act(() => {
-      recentRow!.props.onPress();
-    });
-    expect(mockPush).toHaveBeenCalledWith({
-      pathname: "/(app)/body/day/[day]",
-      params: { day },
-    });
-  });
-
-  it("shows compact recent day label and row actions menu", () => {
-    const day = "2026-03-31";
-    mockHook.mockReturnValue(
-      buildBody({
-        today: day,
-        weekDays: [{ day, meta: { hasMeasurement: true } }],
-        markedDays: new Set<string>([day]),
-        byDay: new Map([[day, [buildPoint(day)]]]),
-        recent: [{ day, latest: buildPoint(day) }],
-        series: { status: "ready", data: { points: [buildPoint(day)], latest: buildPoint(day) }, refetch: jest.fn() },
-      }),
-    );
-    let tree!: renderer.ReactTestRenderer;
-    act(() => {
-      tree = renderer.create(React.createElement(Screen));
-    });
-    const text = collectText(tree);
-    expect(text).toContain("Tue 3/31");
-    const rowActions = tree.root
-      .findAllByType("Pressable")
-      .find((p) => p.props.accessibilityLabel === `Body log actions ${day}`);
-    expect(rowActions).toBeDefined();
-    act(() => {
-      rowActions!.props.onPress({ stopPropagation: jest.fn(), nativeEvent: { pageX: 100, pageY: 150 } });
-    });
-    const updatedText = collectText(tree);
-    expect(updatedText).toContain("Edit log");
-    expect(updatedText).toContain("Delete log");
   });
 
   it("shows Apple Health permission onboarding when access is not determined", () => {

--- a/app/(app)/body/calendar.tsx
+++ b/app/(app)/body/calendar.tsx
@@ -1,17 +1,24 @@
-import React, { useMemo } from "react";
-import { FlatList, StyleSheet, View } from "react-native";
-import { useRouter } from "expo-router";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { FlatList, Platform, StyleSheet, View, type ViewToken } from "react-native";
+import { useNavigation, useRouter } from "expo-router";
 import { ScreenContainer } from "@/lib/ui/ScreenStates";
 import { BodyMonthGrid } from "@/lib/ui/body/BodyMonthGrid";
-import { clampMonthYear, type MonthYear } from "@/lib/ui/calendar/dateUtils";
+import { clampMonthYear, getTodayDayKeyLocal, type MonthYear } from "@/lib/ui/calendar/dateUtils";
+import { headerYearFromViewableMonthItems } from "@/lib/ui/calendar/moduleCalendarHeaderYear";
+import { useModuleCalendarYearNavigationHeader } from "@/lib/ui/calendar/useModuleCalendarYearNavigationHeader";
 import { useBodyCompositionData } from "@/lib/data/body/useBodyCompositionData";
+import { UI_APP_SCREEN_BG } from "@/lib/ui/theme/uiTokens";
 
 type MonthModel = { key: string; monthYear: MonthYear };
 const MONTHS_BACK = 12;
+const MONTHS_FORWARD = 12;
 const CALENDAR_MONTH_ITEM_HEIGHT = 372;
 
-function initialBodyCalendarMonth(): MonthYear {
-  return { year: 2026, month: 1 };
+function monthYearFromToday(): MonthYear {
+  const d = getTodayDayKeyLocal();
+  const y = Number(d.slice(0, 4));
+  const m = Number(d.slice(5, 7));
+  return clampMonthYear({ year: y, month: m });
 }
 
 function shiftMonth(monthYear: MonthYear, delta: number): MonthYear {
@@ -20,7 +27,7 @@ function shiftMonth(monthYear: MonthYear, delta: number): MonthYear {
 
 function buildMonthRange(center: MonthYear): MonthModel[] {
   const out: MonthModel[] = [];
-  for (let i = -MONTHS_BACK; i <= 12; i += 1) {
+  for (let i = -MONTHS_BACK; i <= MONTHS_FORWARD; i += 1) {
     const m = shiftMonth(center, i);
     out.push({ key: `${m.year}-${String(m.month).padStart(2, "0")}`, monthYear: m });
   }
@@ -29,22 +36,69 @@ function buildMonthRange(center: MonthYear): MonthModel[] {
 
 export default function BodyCalendarScreen() {
   const router = useRouter();
-  const initialMonth = initialBodyCalendarMonth();
-  const months = useMemo(() => buildMonthRange(initialMonth), [initialMonth.year, initialMonth.month]);
+  const navigation = useNavigation();
+  const todayMonth = monthYearFromToday();
+  const months = useMemo(() => buildMonthRange(todayMonth), [todayMonth.year, todayMonth.month]);
+  const todayMonthIndex = MONTHS_BACK;
+  const flatListRef = useRef<FlatList<MonthModel>>(null);
+  const [headerYear, setHeaderYear] = useState(todayMonth.year);
+
   const body = useBodyCompositionData(new Date().toISOString().slice(0, 10), "5Y");
 
+  useModuleCalendarYearNavigationHeader(navigation, headerYear);
+
+  useEffect(() => {
+    if (process.env.JEST_WORKER_ID) return;
+    const id = requestAnimationFrame(() => {
+      flatListRef.current?.scrollToIndex({
+        index: todayMonthIndex,
+        animated: false,
+        viewPosition: 0,
+      });
+    });
+    return () => cancelAnimationFrame(id);
+  }, [todayMonthIndex]);
+
+  const onViewableItemsChanged = useCallback(
+    ({ viewableItems }: { viewableItems: ViewToken[] }) => {
+      const y = headerYearFromViewableMonthItems(viewableItems, months);
+      if (y != null) setHeaderYear(y);
+    },
+    [months],
+  );
+
+  const viewabilityConfig = useRef({
+    itemVisiblePercentThreshold: 20,
+  }).current;
+
+  /** Stack header sits below status bar; omit top safe-area + outer padding to avoid a band under the nav (see workouts day screen). */
+  const screenEdges = ["left", "right", "bottom"] as const;
+
   return (
-    <ScreenContainer>
+    <ScreenContainer backgroundColor={UI_APP_SCREEN_BG} padded={false} edges={[...screenEdges]}>
       <FlatList
+        ref={flatListRef}
         data={months}
         keyExtractor={(item) => item.key}
         contentContainerStyle={styles.scroll}
-        initialScrollIndex={MONTHS_BACK}
+        initialScrollIndex={todayMonthIndex}
+        initialNumToRender={5}
+        maxToRenderPerBatch={6}
+        windowSize={7}
         getItemLayout={(_, index) => ({
           length: CALENDAR_MONTH_ITEM_HEIGHT,
           offset: CALENDAR_MONTH_ITEM_HEIGHT * index,
           index,
         })}
+        viewabilityConfig={viewabilityConfig}
+        onViewableItemsChanged={onViewableItemsChanged}
+        onScrollToIndexFailed={() => {
+          flatListRef.current?.scrollToOffset({
+            offset: todayMonthIndex * CALENDAR_MONTH_ITEM_HEIGHT,
+            animated: false,
+          });
+        }}
+        {...(Platform.OS === "ios" ? { contentInsetAdjustmentBehavior: "never" as const } : {})}
         renderItem={({ item }) => (
           <View style={styles.monthItem}>
             <BodyMonthGrid
@@ -63,4 +117,3 @@ const styles = StyleSheet.create({
   scroll: { paddingBottom: 32 },
   monthItem: { height: CALENDAR_MONTH_ITEM_HEIGHT },
 });
-

--- a/app/(app)/body/index.tsx
+++ b/app/(app)/body/index.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useMemo, useState } from "react";
-import { Platform, Pressable, StyleSheet, Text, View, type GestureResponderEvent } from "react-native";
+import React, { useEffect, useMemo } from "react";
+import { Platform, Pressable, StyleSheet, Text, View } from "react-native";
 import { useNavigation, useRouter } from "expo-router";
 import { HeaderBackButton } from "@/lib/ui/HeaderBackButton";
 import { HeaderControls } from "@/lib/ui/HeaderControls";
@@ -9,9 +9,7 @@ import { EmptyState, ErrorState, LoadingState } from "@/lib/ui/ScreenStates";
 import { BodyWeeklyStrip } from "@/lib/ui/body/BodyWeeklyStrip";
 import { BODY_INDIGO } from "@/lib/ui/body/BodyDayRing";
 import { SYSTEM_ACCENT_OVERLAY_10 } from "@/lib/ui/theme/systemAccent";
-import { BodyLogActionSheet, type BodyLogActionAnchor } from "@/lib/ui/body/BodyLogActionSheet";
-import { formatBodyDayLabel } from "@/lib/ui/body/formatBodyDayLabel";
-import { formatOverviewAsOfLabel } from "@/lib/ui/body/formatOverviewAsOfLabel";
+import { formatOverviewAsOfLabel } from "@/lib/ui/calendar/dayKeyDisplayFormat";
 import {
   formatBodyBmi,
   formatBodyLeanMass,
@@ -30,6 +28,8 @@ import { useAppleHealthBodyAccessState } from "@/lib/data/body/useAppleHealthBod
 import { useAppleHealthBodyBackfill } from "@/lib/data/body/useAppleHealthBodyBackfill";
 import { usePreferences } from "@/lib/preferences/PreferencesProvider";
 import { BodyAppleHealthPermissionCard } from "@/lib/ui/body/BodyAppleHealthPermissionCard";
+import { BodyTrendsCard } from "@/lib/ui/body/BodyTrendsCard";
+import { elevatedCardSurfaceStyle } from "@/lib/ui/theme/elevatedCardSurface";
 
 /** @internal — tests assert on these hrefs */
 export const BODY_METRIC_DETAIL_HREFS = {
@@ -43,9 +43,6 @@ export const BODY_METRIC_DETAIL_HREFS = {
 export default function BodyOverviewScreen() {
   const router = useRouter();
   const navigation = useNavigation();
-  const [recentActionOpen, setRecentActionOpen] = useState(false);
-  const [recentActionAnchor, setRecentActionAnchor] = useState<BodyLogActionAnchor | null>(null);
-  const [selectedRecentDay, setSelectedRecentDay] = useState<string | null>(null);
   const { state: prefState } = usePreferences();
   const unit = prefState.preferences?.units?.mass ?? "lb";
   const body = useBodyOverviewData();
@@ -54,6 +51,7 @@ export default function BodyOverviewScreen() {
     void body.peek.refetch({ cacheBust: `bodyBackfillPeek:${Date.now()}` });
     void body.snapshotDayPeek.refetch({ cacheBust: `bodyBackfillSnapshotPeek:${Date.now()}` });
     void body.dayFacts.refetch({ cacheBust: `bodyBackfill:${Date.now()}` });
+    void body.trendsWeightYtd.refetch({ cacheBust: `bodyBackfill:${Date.now()}` });
   });
   const access = useAppleHealthBodyAccessState({
     syncAppleHealthBodyNow: body.syncAppleHealthBodyNow,
@@ -161,12 +159,6 @@ export default function BodyOverviewScreen() {
     [overview, unit, compositionIx],
   );
 
-  const closeRecentActionSheet = () => {
-    setRecentActionOpen(false);
-    setRecentActionAnchor(null);
-    setSelectedRecentDay(null);
-  };
-
   if (body.series.status === "error") {
     return (
       <ModuleScreenShell
@@ -252,7 +244,7 @@ export default function BodyOverviewScreen() {
             <View style={[styles.overviewHeader, workoutOverviewInCardHeaderStyles.row]}>
               <Text style={workoutOverviewInCardHeaderStyles.title}>Overview</Text>
               {overview.overviewDay != null ? (
-                <Text style={styles.asOfLabel} accessibilityLabel={`As of ${overview.overviewDay}`}>
+                <Text style={styles.asOfLabel} accessibilityLabel={formatOverviewAsOfLabel(overview.overviewDay)}>
                   {formatOverviewAsOfLabel(overview.overviewDay)}
                 </Text>
               ) : null}
@@ -286,21 +278,22 @@ export default function BodyOverviewScreen() {
                   >
                     <View style={moduleOverviewMetricLayoutStyles.metricBlock}>
                       <View style={moduleOverviewMetricLayoutStyles.topRow}>
-                        <View style={moduleOverviewMetricLayoutStyles.titlePillCluster}>
-                          <Text style={moduleOverviewMetricLayoutStyles.primaryLabel} numberOfLines={1}>
+                        <View style={styles.bodyMetricLeftSummary}>
+                          <Text style={styles.bodyMetricLabel} numberOfLines={1}>
                             {row.label}
                           </Text>
-                          <InterpretationRatingPill bar={row.bar} />
+                          <Text
+                            style={[
+                              styles.bodyMetricValue,
+                              row.value === "—" ? styles.bodyMetricValueEmpty : null,
+                            ]}
+                            numberOfLines={1}
+                            ellipsizeMode="tail"
+                          >
+                            {row.value}
+                          </Text>
                         </View>
-                        <Text
-                          style={[
-                            moduleOverviewMetricLayoutStyles.trailingValue,
-                            row.value === "—" ? styles.trailingValueEmpty : null,
-                          ]}
-                          numberOfLines={1}
-                        >
-                          {row.value}
-                        </Text>
+                        <InterpretationRatingPill bar={row.bar} shellStyle={styles.bodyRatingPillTrailing} />
                       </View>
                       <InterpretationQualityBar bar={row.bar} />
                     </View>
@@ -310,62 +303,9 @@ export default function BodyOverviewScreen() {
             )}
           </View>
 
-          <View style={styles.card}>
-            <View style={styles.recentHeader}>
-              <Text style={styles.cardTitle}>Recent</Text>
-            </View>
-            {body.recent.length === 0 ? (
-              <Text style={styles.placeholder}>No measurements yet</Text>
-            ) : (
-              body.recent.map((item) => (
-                <Pressable
-                  key={item.day}
-                  style={({ pressed }) => [styles.recentRow, pressed && styles.recentRowPressed]}
-                  onPress={() => router.push({ pathname: "/(app)/body/day/[day]", params: { day: item.day } })}
-                  accessibilityRole="button"
-                  accessibilityLabel={`Open body details for ${item.day}`}
-                >
-                  <Text style={styles.recentDate}>{formatBodyDayLabel(item.day)}</Text>
-                  <View style={styles.recentMain}>
-                    <Text style={styles.recentValue}>{formatBodyWeight(item.latest.weightKg, unit)}</Text>
-                  </View>
-                  <Pressable
-                    onPress={(e: GestureResponderEvent) => {
-                      e.stopPropagation();
-                      const native = e.nativeEvent;
-                      setRecentActionAnchor({
-                        x: typeof native?.pageX === "number" ? native.pageX : 320,
-                        y: typeof native?.pageY === "number" ? native.pageY : 220,
-                        width: 24,
-                        height: 24,
-                      });
-                      setSelectedRecentDay(item.day);
-                      setRecentActionOpen(true);
-                    }}
-                    accessibilityRole="button"
-                    accessibilityLabel={`Body log actions ${item.day}`}
-                    hitSlop={10}
-                    style={styles.rowMenuBtn}
-                  >
-                    <Text style={styles.rowMenuText}>•••</Text>
-                  </Pressable>
-                </Pressable>
-              ))
-            )}
-          </View>
+          <BodyTrendsCard unit={unit} trends={body.trendsV1} onRetryYtd={() => void body.trendsWeightYtd.refetch()} />
         </View>
       </ModuleScreenShell>
-      <BodyLogActionSheet
-        visible={recentActionOpen && selectedRecentDay != null}
-        anchor={recentActionAnchor}
-        onClose={closeRecentActionSheet}
-        onEditLog={() => {
-          closeRecentActionSheet();
-        }}
-        onDeleteLog={() => {
-          closeRecentActionSheet();
-        }}
-      />
     </View>
   );
 }
@@ -380,30 +320,54 @@ const styles = StyleSheet.create({
     paddingBottom: 80,
     gap: 20,
   },
-  card: { backgroundColor: "#FFFFFF", borderRadius: 12, padding: 16, gap: 12 },
+  card: {
+    backgroundColor: "#FFFFFF",
+    borderRadius: 12,
+    padding: 16,
+    gap: 12,
+    ...elevatedCardSurfaceStyle,
+  },
   overviewHeader: {
     gap: 8,
+    alignItems: "flex-start",
+    paddingBottom: 2,
   },
-  cardTitle: { fontSize: 17, fontWeight: "700", color: "#1C1C1E" },
   asOfLabel: { fontSize: 14, fontWeight: "600", color: "#6E6E73" },
   metricRowPressable: { borderRadius: 8 },
   metricRowPressed: { opacity: 0.75 },
-  trailingValueEmpty: { color: "#AEAEB2", fontWeight: "600" },
-  recentHeader: { flexDirection: "row", alignItems: "center", justifyContent: "space-between" },
-  placeholder: { fontSize: 15, color: "#8E8E93" },
-  recentRow: {
+  /** Matches Strength overview “label + result” scan line; pill trails right. */
+  bodyMetricLeftSummary: {
+    flex: 1,
+    minWidth: 0,
     flexDirection: "row",
-    alignItems: "flex-start",
-    borderTopWidth: 1,
-    borderTopColor: "#E5E5EA",
-    paddingVertical: 12,
+    alignItems: "center",
+    gap: 10,
+    paddingRight: 8,
   },
-  recentRowPressed: { opacity: 0.7 },
-  recentDate: { width: 84, fontSize: 13, fontWeight: "400", color: "#8E8E93", letterSpacing: -0.1 },
-  recentMain: { flex: 1, gap: 2 },
-  recentValue: { fontSize: 15, fontWeight: "500", color: "#1C1C1E", letterSpacing: -0.2 },
-  rowMenuBtn: { paddingHorizontal: 10, paddingVertical: 6, marginTop: -2 },
-  rowMenuText: { fontSize: 18, color: "#6E6E73", fontWeight: "700" },
+  bodyMetricLabel: {
+    fontSize: 15,
+    fontWeight: "600",
+    color: "#6E6E73",
+    letterSpacing: -0.12,
+    flexShrink: 0,
+  },
+  bodyMetricValue: {
+    flex: 1,
+    minWidth: 0,
+    fontSize: 14,
+    fontWeight: "600",
+    color: "#3C3C43",
+    letterSpacing: -0.15,
+  },
+  bodyMetricValueEmpty: {
+    color: "#AEAEB2",
+    fontWeight: "600",
+  },
+  bodyRatingPillTrailing: {
+    flexShrink: 0,
+    maxWidth: "40%",
+    alignSelf: "center",
+  },
   syncBanner: {
     backgroundColor: SYSTEM_ACCENT_OVERLAY_10,
     borderRadius: 10,

--- a/app/(app)/body/metric/[metric].tsx
+++ b/app/(app)/body/metric/[metric].tsx
@@ -12,6 +12,7 @@ import {
   formatBodyRmr,
   formatBodyWeight,
 } from "@/lib/ui/body/bodyMetricFormatting";
+import { BODY_METRIC_DETAIL_DEFAULT_RANGE } from "@/lib/data/body/bodyMetricDetailDefaults";
 import { useBodyMetricTrends, type BodyTrendMetric } from "@/lib/data/body/useBodyMetricTrends";
 import type { WeightPoint, WeightRangeKey } from "@/lib/data/useWeightSeries";
 import { usePreferences } from "@/lib/preferences/PreferencesProvider";
@@ -44,7 +45,7 @@ export default function BodyMetricDetailScreen() {
   const router = useRouter();
   const { state: prefState } = usePreferences();
   const unit = prefState.preferences?.units?.mass ?? "lb";
-  const [range, setRange] = useState<WeightRangeKey>("1Y");
+  const [range, setRange] = useState<WeightRangeKey>(BODY_METRIC_DETAIL_DEFAULT_RANGE);
 
   const metric = typeof metricParam === "string" ? PARAM_TO_METRIC[metricParam] : undefined;
 

--- a/app/(app)/nutrition/calendar.tsx
+++ b/app/(app)/nutrition/calendar.tsx
@@ -1,18 +1,25 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { View, StyleSheet, FlatList, type ViewToken } from "react-native";
+import { View, StyleSheet, FlatList, Platform, type ViewToken } from "react-native";
 import { useNavigation, useRouter } from "expo-router";
 import { useAuth } from "@/lib/auth/AuthProvider";
 import { ScreenContainer, ErrorState, EmptyState } from "@/lib/ui/ScreenStates";
-import { HeaderBackButton } from "@/lib/ui/HeaderBackButton";
-import { workoutsStackNavigationOptions } from "@/lib/ui/headers/workoutsStackHeader";
 import { NutritionMonthGrid } from "@/lib/ui/calendar/NutritionMonthGrid";
-import type { DayKey } from "@/lib/ui/calendar/types";
-import { getMonthFirstDay, getMonthLastDay, type MonthYear, clampMonthYear } from "@/lib/ui/calendar/dateUtils";
+import {
+  getMonthFirstDay,
+  getMonthLastDay,
+  getTodayDayKeyLocal,
+  type MonthYear,
+  clampMonthYear,
+} from "@/lib/ui/calendar/dateUtils";
+import { headerYearFromViewableMonthItems } from "@/lib/ui/calendar/moduleCalendarHeaderYear";
+import { useModuleCalendarYearNavigationHeader } from "@/lib/ui/calendar/useModuleCalendarYearNavigationHeader";
 import { useNutritionLoggedDaysForRange } from "@/lib/hooks/useNutritionLoggedDaysForRange";
+import type { DayKey } from "@/lib/ui/calendar/types";
+import { UI_APP_SCREEN_BG } from "@/lib/ui/theme/uiTokens";
 
 function monthYearFromToday(): MonthYear {
-  const now = new Date();
-  return { year: now.getFullYear(), month: now.getMonth() + 1 };
+  const d = getTodayDayKeyLocal();
+  return clampMonthYear({ year: Number(d.slice(0, 4)), month: Number(d.slice(5, 7)) });
 }
 
 function shiftMonth(monthYear: MonthYear, delta: number): MonthYear {
@@ -46,6 +53,7 @@ export default function NutritionCalendarScreen() {
   const router = useRouter();
   const { user } = useAuth();
   const todayMonth = monthYearFromToday();
+  const [headerYear, setHeaderYear] = useState(todayMonth.year);
   const [refreshEpoch, setRefreshEpoch] = useState(0);
   const [windowBounds, setWindowBounds] = useState(() => ({
     startIndex: MONTHS_BACK,
@@ -54,6 +62,8 @@ export default function NutritionCalendarScreen() {
   const months = useMemo(() => buildMonthRange(todayMonth), [todayMonth.year, todayMonth.month]);
   const todayMonthIndex = MONTHS_BACK;
   const flatListRef = useRef<FlatList<CalendarMonthModel>>(null);
+
+  useModuleCalendarYearNavigationHeader(navigation, headerYear);
 
   const clampedStart = Math.max(0, Math.min(windowBounds.startIndex, months.length - 1));
   const clampedEnd = Math.max(clampedStart, Math.min(windowBounds.endIndex, months.length - 1));
@@ -64,13 +74,6 @@ export default function NutritionCalendarScreen() {
     enabled: !!user,
     refreshEpoch,
   });
-
-  useEffect(() => {
-    navigation.setOptions({
-      ...workoutsStackNavigationOptions("detail"),
-      headerLeft: () => <HeaderBackButton onPress={() => navigation.goBack()} />,
-    });
-  }, [navigation]);
 
   useEffect(() => {
     if (process.env.JEST_WORKER_ID) return;
@@ -102,8 +105,11 @@ export default function NutritionCalendarScreen() {
           ? prev
           : { startIndex: nextStart, endIndex: nextEnd },
       );
+
+      const y = headerYearFromViewableMonthItems(viewableItems, months);
+      if (y != null) setHeaderYear(y);
     },
-    [months.length],
+    [months],
   );
 
   const viewabilityConfig = useRef({
@@ -135,8 +141,10 @@ export default function NutritionCalendarScreen() {
     router.push({ pathname: "/(app)/nutrition/day/[day]", params: { day } });
   };
 
+  const screenEdges = ["left", "right", "bottom"] as const;
+
   return (
-    <ScreenContainer>
+    <ScreenContainer backgroundColor={UI_APP_SCREEN_BG} padded={false} edges={[...screenEdges]}>
       <FlatList
         ref={flatListRef}
         data={months}
@@ -159,7 +167,7 @@ export default function NutritionCalendarScreen() {
             animated: false,
           });
         }}
-        ListHeaderComponent={<View style={styles.topSpacer} />}
+        {...(Platform.OS === "ios" ? { contentInsetAdjustmentBehavior: "never" as const } : {})}
         renderItem={({ item }) => (
           <View style={styles.monthItem}>
             <NutritionMonthGrid monthYear={item.monthYear} markerForDay={markerForDay} onDayPress={onDayPress} />
@@ -184,7 +192,6 @@ const styles = StyleSheet.create({
   scroll: {
     paddingBottom: 32,
   },
-  topSpacer: { height: 0 },
   monthItem: {
     height: CALENDAR_MONTH_ITEM_HEIGHT,
   },

--- a/app/(app)/workouts/__tests__/workout-log-session.test.tsx
+++ b/app/(app)/workouts/__tests__/workout-log-session.test.tsx
@@ -395,10 +395,9 @@ describe("workouts/log session UI", () => {
     const edgeOption = findByA11yLabel(test!.root, "Gym: Edge Fitness Manchester CT");
     expect(edgeOption).not.toBeNull();
 
-    act(() => {
-      edgeOption!.props.onPress();
+    await act(async () => {
+      await edgeOption!.props.onPress();
     });
-    await flushEventLoop();
 
     const errorNode = findByA11yLabel(test!.root, "Gym save error");
     expect(errorNode).not.toBeNull();

--- a/app/(app)/workouts/calendar.tsx
+++ b/app/(app)/workouts/calendar.tsx
@@ -1,11 +1,11 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { View, StyleSheet, FlatList, type ViewToken } from "react-native";
+import { View, StyleSheet, FlatList, Platform, type ViewToken } from "react-native";
 import { useNavigation, useRouter } from "expo-router";
 import { useAuth } from "@/lib/auth/AuthProvider";
 import { ScreenContainer, ErrorState, EmptyState } from "@/lib/ui/ScreenStates";
-import { HeaderBackButton } from "@/lib/ui/HeaderBackButton";
-import { workoutsStackNavigationOptions } from "@/lib/ui/headers/workoutsStackHeader";
 import { MonthGrid } from "@/lib/ui/calendar/MonthGrid";
+import { headerYearFromViewableMonthItems } from "@/lib/ui/calendar/moduleCalendarHeaderYear";
+import { useModuleCalendarYearNavigationHeader } from "@/lib/ui/calendar/useModuleCalendarYearNavigationHeader";
 import type { DayKey } from "@/lib/ui/calendar/types";
 import {
   clearWorkoutCalendarMarkerCache,
@@ -17,15 +17,22 @@ import {
   useWorkoutsCalendarRange,
 } from "@/lib/data/workouts/useWorkoutsCalendar";
 import { getWorkoutTruthTargetConfig } from "@/lib/debug/workoutTruthTargets";
-import { getMonthFirstDay, getMonthLastDay, type MonthYear, clampMonthYear } from "@/lib/ui/calendar/dateUtils";
+import { UI_APP_SCREEN_BG } from "@/lib/ui/theme/uiTokens";
+import {
+  getMonthFirstDay,
+  getMonthLastDay,
+  getTodayDayKeyLocal,
+  type MonthYear,
+  clampMonthYear,
+} from "@/lib/ui/calendar/dateUtils";
 import type { WorkoutMarkerFlags } from "@/lib/data/workouts/workoutMarkerFlags";
 import { deriveSessionTypeFlags, reconcileWorkoutSessionsForDay } from "@/lib/data/workouts/workoutSessionReconciliation";
 import type { WorkoutProductDomain } from "@/lib/data/workouts/workoutDomain";
 import { narrowWorkoutMarkerFlagsForDomain } from "@/lib/data/workouts/workoutDomain";
 
 function monthYearFromToday(): MonthYear {
-  const now = new Date();
-  return { year: now.getFullYear(), month: now.getMonth() + 1 };
+  const d = getTodayDayKeyLocal();
+  return clampMonthYear({ year: Number(d.slice(0, 4)), month: Number(d.slice(5, 7)) });
 }
 
 function shiftMonth(monthYear: MonthYear, delta: number): MonthYear {
@@ -65,9 +72,12 @@ export function WorkoutsCalendarRoute({ domain }: { domain: WorkoutProductDomain
     endIndex: MONTHS_BACK,
   }));
   const [markerMap, setMarkerMap] = useState<Map<DayKey, WorkoutMarkerFlags>>(new Map());
+  const [headerYear, setHeaderYear] = useState(todayMonth.year);
   const months = useMemo(() => buildMonthRange(todayMonth), [todayMonth.year, todayMonth.month]);
   const todayMonthIndex = MONTHS_BACK;
   const flatListRef = useRef<FlatList<CalendarMonthModel>>(null);
+
+  useModuleCalendarYearNavigationHeader(navigation, headerYear);
 
   const clampedStart = Math.max(0, Math.min(windowBounds.startIndex, months.length - 1));
   const clampedEnd = Math.max(clampedStart, Math.min(windowBounds.endIndex, months.length - 1));
@@ -175,13 +185,6 @@ export function WorkoutsCalendarRoute({ domain }: { domain: WorkoutProductDomain
     return () => cancelAnimationFrame(id);
   }, [todayMonthIndex]);
 
-  useEffect(() => {
-    navigation.setOptions({
-      ...workoutsStackNavigationOptions("detail"),
-      headerLeft: () => <HeaderBackButton onPress={() => navigation.goBack()} />,
-    });
-  }, [navigation]);
-
   const onViewableItemsChanged = useCallback(
     ({ viewableItems }: { viewableItems: ViewToken[] }) => {
       if (viewableItems.length === 0) return;
@@ -200,8 +203,11 @@ export function WorkoutsCalendarRoute({ domain }: { domain: WorkoutProductDomain
           ? prev
           : { startIndex: nextStart, endIndex: nextEnd },
       );
+
+      const y = headerYearFromViewableMonthItems(viewableItems, months);
+      if (y != null) setHeaderYear(y);
     },
-    [months.length],
+    [months],
   );
   const viewabilityConfig = useRef({
     itemVisiblePercentThreshold: 20,
@@ -280,8 +286,11 @@ export function WorkoutsCalendarRoute({ domain }: { domain: WorkoutProductDomain
     });
   };
 
+  /** Stack header below status bar; avoid top safe-area + padded container duplicating inset under nav (matches Body calendar / workouts day). */
+  const screenEdges = ["left", "right", "bottom"] as const;
+
   return (
-    <ScreenContainer>
+    <ScreenContainer backgroundColor={UI_APP_SCREEN_BG} padded={false} edges={[...screenEdges]}>
       <FlatList
         ref={flatListRef}
         data={months}
@@ -304,7 +313,7 @@ export function WorkoutsCalendarRoute({ domain }: { domain: WorkoutProductDomain
             animated: false,
           });
         }}
-        ListHeaderComponent={<View style={styles.topSpacer} />}
+        {...(Platform.OS === "ios" ? { contentInsetAdjustmentBehavior: "never" as const } : {})}
         renderItem={({ item }) => (
           <View style={styles.monthItem}>
             <MonthGrid monthYear={item.monthYear} markerForDay={markerForDay} onDayPress={onDayPress} />
@@ -333,7 +342,6 @@ const styles = StyleSheet.create({
   scroll: {
     paddingBottom: 32,
   },
-  topSpacer: { height: 0 },
   monthItem: {
     height: CALENDAR_MONTH_ITEM_HEIGHT,
   },

--- a/app/(app)/workouts/overview.tsx
+++ b/app/(app)/workouts/overview.tsx
@@ -121,6 +121,7 @@ import { WorkoutsOverviewBottomNav } from "@/lib/ui/workouts/WorkoutsOverviewBot
 import { buildStrengthOverviewCardModel } from "@/lib/data/workouts/strengthOverviewCardModel";
 import { StrengthOverviewCard } from "@/lib/ui/workouts/StrengthOverviewCard";
 import { WeeklyInsightsCard } from "@/lib/ui/workouts/WeeklyInsightsCard";
+import { elevatedCardSurfaceStyle } from "@/lib/ui/theme/elevatedCardSurface";
 import { serializeStrengthAnalyticsFocusParams } from "@/lib/workouts/navigation/strengthAnalyticsNavigationIntent";
 
 type ConnectionStatus = "loading" | "not_available" | "not_connected" | "connected";
@@ -173,6 +174,27 @@ function formatWorkoutDayLabel(dayKey: string): string {
   const month = d.getUTCMonth() + 1;
   const day = d.getUTCDate();
   return `${wd} ${month}/${day}`;
+}
+
+function countJournalSetsForDisplay(summary: ManualWorkoutDaySummary | null): number {
+  if (summary == null) return 0;
+  let n = 0;
+  for (const ex of summary.exercises) {
+    n += ex.sets.length;
+  }
+  return n;
+}
+
+/** Recent row line 3: duration; strength appends journal set count when present (display-only). */
+function formatRecentWorkoutMetaLine(
+  domain: WorkoutProductDomain,
+  durationLabel: string,
+  journalSummary: ManualWorkoutDaySummary | null,
+): string {
+  if (domain !== "strength") return durationLabel;
+  const n = countJournalSetsForDisplay(journalSummary);
+  if (n > 0) return `${durationLabel} · ${n} set${n === 1 ? "" : "s"}`;
+  return durationLabel;
 }
 
 function getDeviceTimezone(): string {
@@ -880,7 +902,7 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
           {domain === "strength" ? "No strength workouts yet" : "No cardio sessions yet"}
         </Text>
       ) : (
-        recentSessionsShownOnOverview.map(({ day, session }) => {
+        recentSessionsShownOnOverview.map(({ day, session }, rowIndex) => {
           const representative = session.workouts[0];
           if (!representative) return null;
           const journalSummary =
@@ -907,10 +929,15 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
                 surface.metricsWorkout.durationMinutes ?? session.durationMinutes,
             }),
           );
+          const metaLine = formatRecentWorkoutMetaLine(domain, durationLabel, journalSummary);
           return (
             <Pressable
               key={session.id}
-              style={({ pressed }) => [styles.recentRow, pressed && styles.recentRowPressed]}
+              style={({ pressed }) => [
+                styles.recentRow,
+                rowIndex === 0 && styles.recentRowFirst,
+                pressed && styles.recentRowPressed,
+              ]}
               onPress={() => {
                 router.push({
                   pathname:
@@ -923,13 +950,13 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
               accessibilityRole="button"
               accessibilityLabel={`Open workout details ${surface.actionWorkout.id}`}
             >
-              <Text style={styles.recentDate}>{formatWorkoutDayLabel(day)}</Text>
-              <View style={styles.recentMain}>
-                <Text style={styles.recentTitle} numberOfLines={1}>
+              <View style={styles.recentRowTextCol}>
+                <Text style={styles.recentDate}>{formatWorkoutDayLabel(day)}</Text>
+                <Text style={styles.recentTitle} numberOfLines={2} ellipsizeMode="tail">
                   {surface.displayTitle}
                 </Text>
-                <Text style={styles.recentMeta} numberOfLines={1}>
-                  {durationLabel}
+                <Text style={styles.recentMeta} numberOfLines={1} ellipsizeMode="tail">
+                  {metaLine}
                 </Text>
               </View>
               <Pressable
@@ -1087,8 +1114,9 @@ const styles = StyleSheet.create({
   card: {
     backgroundColor: CARD_BG,
     borderRadius: RADIUS,
-    padding: 16,
-    gap: 12,
+    padding: 14,
+    gap: 10,
+    ...elevatedCardSurfaceStyle,
   },
   placeholder: { fontSize: 15, fontWeight: "400", color: "#8E8E93", letterSpacing: -0.1 },
   metricRow: { flexDirection: "row", justifyContent: "space-between", alignItems: "center" },
@@ -1096,20 +1124,52 @@ const styles = StyleSheet.create({
   metricValue: { fontSize: 15, fontWeight: "600", color: "#1C1C1E" },
   recentRow: {
     flexDirection: "row",
-    alignItems: "flex-start",
-    paddingVertical: 12,
+    alignItems: "center",
+    paddingVertical: 11,
     borderTopWidth: 1,
-    borderTopColor: "#E5E5EA",
+    borderTopColor: "rgba(60, 60, 67, 0.055)",
+    gap: 2,
+  },
+  /** Most recent session: no rule above so the list reads as one block from the header. */
+  recentRowFirst: {
+    borderTopWidth: 0,
   },
   recentRowPressed: {
     opacity: 0.7,
   },
-  recentDate: { width: 84, fontSize: 13, fontWeight: "400", color: "#8E8E93", letterSpacing: -0.1 },
-  recentMain: { flex: 1, gap: 2 },
-  recentTitle: { fontSize: 15, fontWeight: "500", color: "#1C1C1E", letterSpacing: -0.2 },
-  recentMeta: { fontSize: 12, fontWeight: "400", color: "#AEAEB2", letterSpacing: -0.05 },
-  rowMenuBtn: { paddingHorizontal: 10, paddingVertical: 6, marginTop: -2 },
-  rowMenuText: { fontSize: 18, color: "#6E6E73", fontWeight: "700" },
+  recentRowTextCol: {
+    flex: 1,
+    minWidth: 0,
+    gap: 3,
+  },
+  recentDate: {
+    fontSize: 12,
+    fontWeight: "500",
+    color: "#8E8E93",
+    letterSpacing: -0.05,
+  },
+  recentTitle: {
+    fontSize: 17,
+    fontWeight: "600",
+    color: "#1C1C1E",
+    letterSpacing: -0.28,
+    lineHeight: 21,
+  },
+  recentMeta: {
+    fontSize: 13,
+    fontWeight: "500",
+    color: "#6E6E73",
+    letterSpacing: -0.1,
+  },
+  rowMenuBtn: {
+    paddingHorizontal: 6,
+    paddingVertical: 6,
+    alignSelf: "center",
+    justifyContent: "center",
+    alignItems: "center",
+    minWidth: 36,
+  },
+  rowMenuText: { fontSize: 17, color: "#3C3C43", fontWeight: "700", letterSpacing: 0.5 },
   editorInput: {
     backgroundColor: WORKOUTS_SCREEN_CONTENT_BG,
     borderRadius: 12,

--- a/lib/data/body/__tests__/bodyHistoryRange.test.ts
+++ b/lib/data/body/__tests__/bodyHistoryRange.test.ts
@@ -12,6 +12,7 @@ import {
   addDaysToDayKey,
   rangeToStartEnd,
   resolveBodyHistoryQueryWindow,
+  ytdBoundsForAnchorDay,
 } from "../bodyHistoryRange";
 
 describe("bodyHistoryRange", () => {
@@ -34,5 +35,15 @@ describe("bodyHistoryRange", () => {
 
   it("rangeToStartEnd(All) is unbounded marker for legacy callers", () => {
     expect(rangeToStartEnd("All")).toBe("all");
+  });
+
+  it("YTD window is Jan 1 of anchor year through anchor + end buffer", () => {
+    expect(ytdBoundsForAnchorDay("2026-03-20")).toEqual({
+      start: "2026-01-01",
+      end: addDaysToDayKey("2026-03-20", RAW_EVENTS_QUERY_END_DAY_BUFFER),
+    });
+    expect(resolveBodyHistoryQueryWindow("YTD", { anchorDayKey: "2025-11-02" })).toEqual(
+      ytdBoundsForAnchorDay("2025-11-02"),
+    );
   });
 });

--- a/lib/data/body/__tests__/useBodyOverviewData.noHeavyTrends.test.ts
+++ b/lib/data/body/__tests__/useBodyOverviewData.noHeavyTrends.test.ts
@@ -3,13 +3,17 @@ import { join } from "node:path";
 import { describe, it, expect } from "@jest/globals";
 
 describe("useBodyOverviewData", () => {
-  it("does not reference useBodyMetricTrends (main Body avoids heavy trend pagination)", () => {
+  it("uses a single bounded YTD weight trend hook with anchorDayKey (no stacked 1Y/6M/90D/30D hooks)", () => {
     const p = join(__dirname, "../useBodyOverviewData.ts");
     const src = readFileSync(p, "utf8");
-    expect(src).not.toContain("useBodyMetricTrends");
+    expect(src).toContain('useBodyMetricTrends("YTD", "weight", { anchorDayKey: factsDay })');
+    expect(src).not.toContain('useBodyMetricTrends("6M"');
+    expect(src).not.toContain('useBodyMetricTrends("90D"');
+    expect(src).not.toContain('useBodyMetricTrends("30D"');
+    expect(src).not.toContain("BODY_METRIC_DETAIL_DEFAULT_RANGE");
   });
 
-  it("after Apple Health body sync, refetches series, global peek, snapshot-day peek, and daily facts", () => {
+  it("after Apple Health body sync, refetches series, peek, snapshot-day peek, daily facts, and YTD weight trend hook", () => {
     const p = join(__dirname, "../useBodyOverviewData.ts");
     const src = readFileSync(p, "utf8");
     expect(src).toContain("useAppleHealthBodySync(");
@@ -17,5 +21,6 @@ describe("useBodyOverviewData", () => {
     expect(src).toContain("void peek.refetch({ cacheBust:");
     expect(src).toContain("void snapshotDayPeek.refetch({ cacheBust:");
     expect(src).toContain("void dayFacts.refetch({ cacheBust:");
+    expect(src).toContain("void trendsWeightYtd.refetch({ cacheBust:");
   });
 });

--- a/lib/data/body/__tests__/useBodyOverviewData.overview-resilience.test.tsx
+++ b/lib/data/body/__tests__/useBodyOverviewData.overview-resilience.test.tsx
@@ -12,6 +12,32 @@ import { useDailyFacts } from "@/lib/data/useDailyFacts";
 import { useBodyOverviewPeek } from "../useBodyOverviewPeek";
 import { useAppleHealthBodySync } from "../useAppleHealthBodySync";
 
+jest.mock("../useBodyMetricTrends", () => ({
+  useBodyMetricTrends: jest.fn(() => {
+    const z = { change: null, avg: null, high: null, low: null };
+    return {
+      status: "ready" as const,
+      data: {
+        byMetric: {
+          weight: [],
+          body_fat_percent: [],
+          bmi: [],
+          lean_body_mass: [],
+          resting_metabolic_rate: [],
+        },
+        statsByMetric: {
+          weight: { ...z },
+          body_fat_percent: { ...z },
+          bmi: { ...z },
+          lean_body_mass: { ...z },
+          resting_metabolic_rate: { ...z },
+        },
+      },
+      refetch: jest.fn(),
+    };
+  }),
+}));
+
 jest.mock("@/lib/data/useWeightSeries", () => ({
   useWeightSeries: jest.fn(),
 }));

--- a/lib/data/body/bodyHistoryRange.ts
+++ b/lib/data/body/bodyHistoryRange.ts
@@ -8,7 +8,15 @@ import { getTodayDayKey } from "@/lib/time/dayKey";
 export const RAW_EVENTS_QUERY_END_DAY_BUFFER = 1;
 
 /** Shared with weight chart / Body trends (not Strength). */
-export type WeightRangeKey = "7D" | "30D" | "90D" | "6M" | "1Y" | "3Y" | "5Y" | "All";
+export type WeightRangeKey = "7D" | "30D" | "90D" | "6M" | "1Y" | "YTD" | "3Y" | "5Y" | "All";
+
+export type BodyHistoryQueryWindowOpts = {
+  /**
+   * When `range` is `YTD`, window is Jan 1 of this calendar year through `anchorDayKey` (+ end buffer).
+   * Omit to use {@link getTodayDayKey} (rolling “today”).
+   */
+  anchorDayKey?: string;
+};
 
 /**
  * Body chart "All" maps to the same horizon as Apple Health body backfill
@@ -35,6 +43,18 @@ export function addDaysToDayKey(dayKey: string, delta: number): string {
 }
 
 /**
+ * Calendar year-to-date window for `anchorDayKey` (local YYYY-MM-DD):
+ * `[year-01-01, anchorDay + RAW_EVENTS_QUERY_END_DAY_BUFFER]` — same end-buffer rule as other bounded ranges.
+ */
+export function ytdBoundsForAnchorDay(anchorDayKey: string): { start: string; end: string } {
+  const y = Number(anchorDayKey.slice(0, 4));
+  const year = Number.isFinite(y) && y >= 1 ? y : Number(getTodayDayKey().slice(0, 4));
+  const start = `${year}-01-01`;
+  const end = addDaysToDayKey(anchorDayKey, RAW_EVENTS_QUERY_END_DAY_BUFFER);
+  return { start, end };
+}
+
+/**
  * Calendar day window [start, end] for raw-events `start`/`end` query params, or `"all"` for legacy unbounded pagination.
  */
 export function rangeToStartEnd(range: WeightRangeKey): { start: string; end: string } | "all" {
@@ -58,6 +78,8 @@ export function rangeToStartEnd(range: WeightRangeKey): { start: string; end: st
     case "1Y":
       start = addDaysToDayKey(today, -365);
       break;
+    case "YTD":
+      return ytdBoundsForAnchorDay(today);
     case "3Y":
       start = addDaysToDayKey(today, -1095);
       break;
@@ -71,8 +93,15 @@ export function rangeToStartEnd(range: WeightRangeKey): { start: string; end: st
 }
 
 /** Finite window for Body chart/trends (never unbounded). */
-export function resolveBodyHistoryQueryWindow(range: WeightRangeKey): { start: string; end: string } {
+export function resolveBodyHistoryQueryWindow(
+  range: WeightRangeKey,
+  opts?: BodyHistoryQueryWindowOpts,
+): { start: string; end: string } {
   const effective = range === "All" ? BODY_CHART_ALL_EFFECTIVE_RANGE : range;
+  if (effective === "YTD") {
+    const anchor = opts?.anchorDayKey ?? getTodayDayKey();
+    return ytdBoundsForAnchorDay(anchor);
+  }
   const bounds = rangeToStartEnd(effective);
   if (bounds === "all") {
     return rangeToStartEnd(BODY_CHART_ALL_EFFECTIVE_RANGE) as { start: string; end: string };

--- a/lib/data/body/bodyMetricDetailDefaults.ts
+++ b/lib/data/body/bodyMetricDetailDefaults.ts
@@ -1,0 +1,4 @@
+import type { WeightRangeKey } from "@/lib/data/body/bodyHistoryRange";
+
+/** Default chart range on Body metric detail screens (`app/(app)/body/metric/[metric].tsx`). */
+export const BODY_METRIC_DETAIL_DEFAULT_RANGE: WeightRangeKey = "1Y";

--- a/lib/data/body/useBodyMetricTrends.ts
+++ b/lib/data/body/useBodyMetricTrends.ts
@@ -116,17 +116,20 @@ type TrendRow = {
  *
  * @param filterMetric — when set, only that metric is populated (and only the matching raw `kind(s)` are requested).
  * @param opts.enabled — when false, skips network (e.g. invalid route guard).
+ * @param opts.anchorDayKey — when `chartRange` is `YTD`, passed to {@link resolveBodyHistoryQueryWindow} (overview snapshot day, etc.).
  */
 export function useBodyMetricTrends(
   chartRange: WeightRangeKey,
   filterMetric?: BodyTrendMetric,
-  opts?: { enabled?: boolean },
+  opts?: { enabled?: boolean; anchorDayKey?: string },
 ): State & { refetch: (opts?: GetOptions) => void } {
   const { user, initializing, getIdToken } = useAuth();
   const rangeRef = useRef(chartRange);
   rangeRef.current = chartRange;
   const metricRef = useRef(filterMetric);
   metricRef.current = filterMetric;
+  const anchorDayKeyRef = useRef(opts?.anchorDayKey);
+  anchorDayKeyRef.current = opts?.anchorDayKey;
   const enabledRef = useRef(opts?.enabled !== false);
   enabledRef.current = opts?.enabled !== false;
   const reqSeq = useRef(0);
@@ -158,7 +161,11 @@ export function useBodyMetricTrends(
       safeSet({ status: "partial" });
       const optsUnique = withUniqueCacheBust(opts, seq);
       const tz = getDeviceTimezone();
-      const { start, end } = resolveBodyHistoryQueryWindow(rangeRef.current);
+      const anchor = anchorDayKeyRef.current;
+      const { start, end } = resolveBodyHistoryQueryWindow(
+        rangeRef.current,
+        anchor !== undefined ? { anchorDayKey: anchor } : undefined,
+      );
       const fm = metricRef.current;
       const kinds = fm ? trendKindsForMetric(fm) : (["weight", "body_composition"] as const);
 
@@ -311,12 +318,12 @@ export function useBodyMetricTrends(
       };
       safeSet({ status: "ready", data: { byMetric, statsByMetric } });
     },
-    [getIdToken, initializing, user, chartRange, filterMetric, opts?.enabled],
+    [getIdToken, initializing, user, chartRange, filterMetric, opts?.enabled, opts?.anchorDayKey],
   );
 
   useEffect(() => {
     void loadOnce();
-  }, [loadOnce, chartRange, filterMetric, opts?.enabled, user?.uid]);
+  }, [loadOnce, chartRange, filterMetric, opts?.enabled, opts?.anchorDayKey, user?.uid]);
 
   return useMemo(() => ({ ...state, refetch: loadOnce }), [state, loadOnce]);
 }

--- a/lib/data/body/useBodyOverviewData.ts
+++ b/lib/data/body/useBodyOverviewData.ts
@@ -6,6 +6,8 @@ import { useDailyFacts } from "@/lib/data/useDailyFacts";
 import { useBodyOverviewPeek } from "@/lib/data/body/useBodyOverviewPeek";
 import { useBodyOverviewSnapshotDayPeek } from "@/lib/data/body/useBodyOverviewSnapshotDayPeek";
 import { useAppleHealthBodySync } from "@/lib/data/body/useAppleHealthBodySync";
+import { ytdBoundsForAnchorDay } from "@/lib/data/body/bodyHistoryRange";
+import { useBodyMetricTrends, type BodyMetricTrendsState } from "@/lib/data/body/useBodyMetricTrends";
 import { filterToAppleHealthBodyReadSources } from "@/lib/data/body/sourceFiltering";
 import {
   bodyMarkerDays,
@@ -23,8 +25,88 @@ export type BodyRecentItem = {
 };
 
 /**
- * Main Body overview: weight series (5Y) + one-page peek + daily facts for snapshot day.
- * Does not load full multi-metric trends (detail screens only).
+ * YTD band: low/high = min/max weight (kg) in the YTD query window; current = latest sample in-window by `observedAt`.
+ * Not an interpretation / quality bar — pure placement on the min–max weight span.
+ */
+export type BodyTrendsV1WeightYtd = {
+  trendYear: number;
+  windowLabel: string;
+  trendsStatus: "partial" | "ready" | "error";
+  /** `buildStats` change (last − first by `observedAt`) in YTD window; kg. */
+  changeKg: number | null;
+  bandLowKg: number | null;
+  bandHighKg: number | null;
+  bandCurrentKg: number | null;
+  sampleCount: number | null;
+  errorMessage?: string;
+  requestId?: string | null;
+};
+
+export type BodyTrendsV1Weight = {
+  /** Overview snapshot weight + weekly delta from `useWeightSeries` 5Y view model (`weeklyDeltaKg`). */
+  latest: {
+    currentKg: number | null;
+    seriesStatus: "partial" | "ready" | "error";
+    weeklyDeltaKg: number | null;
+  };
+  ytd: BodyTrendsV1WeightYtd;
+};
+
+/** View-model for {@link BodyTrendsCard} (weight-only). */
+export type BodyTrendsV1 = BodyTrendsV1Weight;
+
+function bodyTrendsYtdFromState(anchorDayKey: string, state: BodyMetricTrendsState): BodyTrendsV1WeightYtd {
+  const win = ytdBoundsForAnchorDay(anchorDayKey);
+  const windowLabel = `${win.start} → ${win.end}`;
+  const trendYear = Number(anchorDayKey.slice(0, 4));
+  const safeYear = Number.isFinite(trendYear) && trendYear >= 1 ? trendYear : new Date().getFullYear();
+
+  if (state.status === "partial") {
+    return {
+      trendYear: safeYear,
+      windowLabel,
+      trendsStatus: "partial",
+      changeKg: null,
+      bandLowKg: null,
+      bandHighKg: null,
+      bandCurrentKg: null,
+      sampleCount: null,
+    };
+  }
+  if (state.status === "error") {
+    return {
+      trendYear: safeYear,
+      windowLabel,
+      trendsStatus: "error",
+      changeKg: null,
+      bandLowKg: null,
+      bandHighKg: null,
+      bandCurrentKg: null,
+      sampleCount: null,
+      errorMessage: state.error,
+      requestId: state.requestId,
+    };
+  }
+  const pts = state.data.byMetric.weight;
+  const sorted = [...pts].sort((a, b) => a.observedAt.localeCompare(b.observedAt));
+  const bandCurrentKg = sorted.length ? sorted[sorted.length - 1]!.weightKg : null;
+  const w = state.data.statsByMetric.weight;
+  return {
+    trendYear: safeYear,
+    windowLabel,
+    trendsStatus: "ready",
+    changeKg: w.change,
+    bandLowKg: w.low,
+    bandHighKg: w.high,
+    bandCurrentKg,
+    sampleCount: pts.length,
+  };
+}
+
+/**
+ * Main Body overview: weight series (5Y) + one-page peek + daily facts for snapshot day +
+ * `useBodyMetricTrends("YTD", "weight", { anchorDayKey })` for annual summary +
+ * `weeklyDeltaKg` from `useWeightSeries` for “this week”.
  */
 export function useBodyOverviewData() {
   const series = useWeightSeries("5Y");
@@ -48,12 +130,14 @@ export function useBodyOverviewData() {
   const factsDay = overviewDay ?? today;
   const dayFacts = useDailyFacts(factsDay);
   const snapshotDayPeek = useBodyOverviewSnapshotDayPeek(overviewDay);
+  const trendsWeightYtd = useBodyMetricTrends("YTD", "weight", { anchorDayKey: factsDay });
 
   const { isBodySyncing, syncAppleHealthBodyNow, hasSuccessfulBodySync } = useAppleHealthBodySync(() => {
     void series.refetch({ cacheBust: `appleHealthBody:${Date.now()}` });
     void peek.refetch({ cacheBust: `appleHealthPeek:${Date.now()}` });
     void snapshotDayPeek.refetch({ cacheBust: `appleHealthSnapshotPeek:${Date.now()}` });
     void dayFacts.refetch({ cacheBust: `appleHealthBody:${Date.now()}` });
+    void trendsWeightYtd.refetch({ cacheBust: `appleHealthBody:${Date.now()}` });
   });
 
   const derived = useMemo(() => {
@@ -166,9 +250,21 @@ export function useBodyOverviewData() {
     };
   }, [overviewDay, derived.byDay, peek, snapshotDayPeek, dayFacts, tz]);
 
+  const trendsV1 = useMemo((): BodyTrendsV1 => {
+    return {
+      latest: {
+        currentKg: overview.weightKg,
+        seriesStatus: series.status,
+        weeklyDeltaKg: series.status === "ready" ? series.data.weeklyDeltaKg : null,
+      },
+      ytd: bodyTrendsYtdFromState(factsDay, trendsWeightYtd),
+    };
+  }, [overview.weightKg, series, factsDay, trendsWeightYtd]);
+
   return {
     today,
     series,
+    trendsWeightYtd,
     peek,
     snapshotDayPeek,
     dayFacts,
@@ -177,5 +273,6 @@ export function useBodyOverviewData() {
     hasSuccessfulBodySync,
     ...derived,
     overview,
+    trendsV1,
   };
 }

--- a/lib/ui/ModuleCalendarPlaceholderScreen.tsx
+++ b/lib/ui/ModuleCalendarPlaceholderScreen.tsx
@@ -1,10 +1,11 @@
-import React, { useLayoutEffect } from "react";
+import React, { useMemo } from "react";
 import { View, Text, StyleSheet } from "react-native";
 import { useNavigation } from "expo-router";
 
 import { ScreenContainer } from "@/lib/ui/ScreenStates";
-import { HeaderBackButton } from "@/lib/ui/HeaderBackButton";
-import { workoutsStackNavigationOptions } from "@/lib/ui/headers/workoutsStackHeader";
+import { getTodayDayKeyLocal } from "@/lib/ui/calendar/dateUtils";
+import { useModuleCalendarYearNavigationHeader } from "@/lib/ui/calendar/useModuleCalendarYearNavigationHeader";
+import { UI_APP_SCREEN_BG } from "@/lib/ui/theme/uiTokens";
 
 export type ModuleCalendarPlaceholderScreenProps = {
   title: string;
@@ -14,16 +15,12 @@ export type ModuleCalendarPlaceholderScreenProps = {
 /** Placeholder until module-specific sleep/readiness calendar UX is defined (no data hooks). */
 export function ModuleCalendarPlaceholderScreen({ title, description }: ModuleCalendarPlaceholderScreenProps) {
   const navigation = useNavigation();
+  const headerYear = useMemo(() => Number(getTodayDayKeyLocal().slice(0, 4)), []);
 
-  useLayoutEffect(() => {
-    navigation.setOptions({
-      ...workoutsStackNavigationOptions("detail"),
-      headerLeft: () => <HeaderBackButton onPress={() => navigation.goBack()} />,
-    });
-  }, [navigation]);
+  useModuleCalendarYearNavigationHeader(navigation, headerYear);
 
   return (
-    <ScreenContainer>
+    <ScreenContainer backgroundColor={UI_APP_SCREEN_BG}>
       <View style={styles.body}>
         <Text style={styles.title}>{title}</Text>
         <Text style={styles.bodyText}>{description}</Text>

--- a/lib/ui/PageTitleRow.tsx
+++ b/lib/ui/PageTitleRow.tsx
@@ -1,7 +1,7 @@
 // Shared title row for tab pages: title (and optional subtitle) left, optional rightSlot (e.g. Settings gear) right.
 // Gear is in the same row as the title so it aligns with the title line; subtitle sits below.
 import { View, Text, StyleSheet } from "react-native";
-import { UI_TEXT_MUTED } from "@/lib/ui/theme/uiTokens";
+import { UI_TEXT_MUTED, UI_TEXT_SECONDARY } from "@/lib/ui/theme/uiTokens";
 
 export type PageTitleRowProps = {
   title: string;
@@ -45,9 +45,10 @@ const styles = StyleSheet.create({
   title: {
     flex: 1,
     minWidth: 0,
-    fontSize: 28,
-    fontWeight: "900",
-    color: "#1C1C1E",
+    fontSize: 22,
+    fontWeight: "600",
+    color: UI_TEXT_SECONDARY,
+    letterSpacing: 0.15,
   },
   rightSlot: { marginLeft: 8 },
   subtitle: { fontSize: 15, color: "#8E8E93", marginTop: 6 },

--- a/lib/ui/TabRootScreenHeader.tsx
+++ b/lib/ui/TabRootScreenHeader.tsx
@@ -1,16 +1,36 @@
 // Fixed top chrome for bottom-tab root screens: shared horizontal inset + PageTitleRow (title / optional subtitle / settings gear).
 import { View, StyleSheet } from "react-native";
 import { PageTitleRow, type PageTitleRowProps } from "@/lib/ui/PageTitleRow";
-import { UI_APP_SCREEN_BG, UI_TAB_ROOT_INSET } from "@/lib/ui/theme/uiTokens";
+import {
+  UI_APP_SCREEN_BG,
+  UI_TAB_ROOT_CONTENT_GUTTER,
+  UI_TAB_ROOT_INSET,
+} from "@/lib/ui/theme/uiTokens";
 
 export type TabRootScreenHeaderProps = Pick<
   PageTitleRowProps,
   "title" | "subtitle" | "subtitleVariant" | "rightSlot"
->;
+> & {
+  /**
+   * Override default title inset (defaults to `UI_TAB_ROOT_CONTENT_GUTTER` so tab titles align with primary body text).
+   */
+  leadingInsetExtra?: number;
+};
 
-export function TabRootScreenHeader(props: TabRootScreenHeaderProps) {
+export function TabRootScreenHeader({
+  leadingInsetExtra = UI_TAB_ROOT_CONTENT_GUTTER,
+  ...props
+}: TabRootScreenHeaderProps) {
   return (
-    <View style={styles.wrap}>
+    <View
+      style={[
+        styles.wrap,
+        {
+          paddingLeft: UI_TAB_ROOT_INSET + leadingInsetExtra,
+          paddingRight: UI_TAB_ROOT_INSET,
+        },
+      ]}
+    >
       <PageTitleRow {...props} />
     </View>
   );
@@ -18,9 +38,8 @@ export function TabRootScreenHeader(props: TabRootScreenHeaderProps) {
 
 const styles = StyleSheet.create({
   wrap: {
-    paddingHorizontal: UI_TAB_ROOT_INSET,
     paddingTop: 16,
-    paddingBottom: 10,
+    paddingBottom: 12,
     backgroundColor: UI_APP_SCREEN_BG,
   },
 });

--- a/lib/ui/WeightTrendChart.tsx
+++ b/lib/ui/WeightTrendChart.tsx
@@ -181,7 +181,7 @@ function ticksForRangeUsingData(
     return ticks;
   }
 
-  if (range === "1Y") {
+  if (range === "1Y" || range === "YTD") {
     const midT = dataStartMs + (dataEndMs - dataStartMs) / 2;
     const triple = [dataStartMs, midT, dataEndMs] as const;
     triple.forEach((tMs, i) => {

--- a/lib/ui/body/BodyDayRing.tsx
+++ b/lib/ui/body/BodyDayRing.tsx
@@ -36,7 +36,7 @@ export function BodyDayRing({ size, hasMeasurement, emphasized = false, testID }
             width: size,
             height: size,
             borderRadius: size / 2,
-            borderWidth: emphasized ? 2.75 : 1.75,
+            borderWidth: emphasized ? 3 : 1.75,
           },
         ]}
       />

--- a/lib/ui/body/BodyMonthGrid.tsx
+++ b/lib/ui/body/BodyMonthGrid.tsx
@@ -7,6 +7,7 @@ import {
   getTodayDayKeyLocal,
   type MonthYear,
 } from "@/lib/ui/calendar/dateUtils";
+import { UI_TEXT_PRIMARY, UI_TEXT_MUTED } from "@/lib/ui/theme/uiTokens";
 import { BodyDayRing } from "./BodyDayRing";
 
 type BodyMonthGridProps = {
@@ -72,17 +73,25 @@ export function BodyMonthGrid({ monthYear, markerForDay, onDayPress }: BodyMonth
 }
 
 const styles = StyleSheet.create({
-  container: { paddingHorizontal: 16, paddingTop: 4 },
+  container: { paddingHorizontal: 16, paddingTop: 10, paddingBottom: 4 },
   headerTitle: {
-    fontSize: 17,
+    fontSize: 20,
     fontWeight: "700",
     color: "#1C1C1E",
     textAlign: "center",
-    marginBottom: 12,
+    letterSpacing: -0.28,
+    marginBottom: 14,
   },
-  dowRow: { flexDirection: "row", justifyContent: "space-between", marginBottom: 8 },
-  dowLabel: { flex: 1, textAlign: "center", fontSize: 12, color: "#8E8E93" },
-  weekRow: { flexDirection: "row", justifyContent: "space-between", marginBottom: 6 },
+  dowRow: { flexDirection: "row", justifyContent: "space-between", marginBottom: 10 },
+  dowLabel: {
+    flex: 1,
+    textAlign: "center",
+    fontSize: 13,
+    fontWeight: "500",
+    color: UI_TEXT_MUTED,
+    letterSpacing: 0.15,
+  },
+  weekRow: { flexDirection: "row", justifyContent: "space-between", marginBottom: 5 },
   dayCellEmpty: { flex: 1, alignItems: "center", justifyContent: "center", minHeight: 44 },
   dayCell: { flex: 1, alignItems: "center", justifyContent: "center", minHeight: 44 },
   dayCellPressed: { opacity: 0.7 },
@@ -99,6 +108,12 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
   },
-  dayNumber: { fontSize: 15, fontWeight: "600", color: "#1C1C1E" },
+  dayNumber: {
+    fontSize: 17,
+    fontWeight: "600",
+    color: UI_TEXT_PRIMARY,
+    fontVariant: ["tabular-nums"],
+    letterSpacing: -0.2,
+  },
 });
 

--- a/lib/ui/body/BodyTrendsCard.tsx
+++ b/lib/ui/body/BodyTrendsCard.tsx
@@ -1,0 +1,331 @@
+import React, { useState } from "react";
+import {
+  ActivityIndicator,
+  LayoutChangeEvent,
+  Platform,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import type { BodyTrendsV1 } from "@/lib/data/body/useBodyOverviewData";
+import { formatBodyWeight } from "@/lib/ui/body/bodyMetricFormatting";
+import { ErrorState, LoadingState } from "@/lib/ui/ScreenStates";
+import { workoutOverviewInCardHeaderStyles } from "@/lib/ui/workouts/workoutOverviewInCardHeaderStyles";
+import { elevatedCardSurfaceStyle } from "@/lib/ui/theme/elevatedCardSurface";
+import { MODULE_OVERVIEW_SEGMENTED_TRACK } from "@/lib/ui/overview/moduleOverviewSegmentedTrackMetrics";
+import { SYSTEM_ACCENT, SYSTEM_ACCENT_FILL_11 } from "@/lib/ui/theme/systemAccent";
+
+const BAND_DOT = MODULE_OVERVIEW_SEGMENTED_TRACK.dotSize;
+/** Full pill bar; matches overview track height for visual consistency. */
+const BAND_TRACK_H = MODULE_OVERVIEW_SEGMENTED_TRACK.barHeight;
+const BAND_RADIUS = BAND_TRACK_H / 2;
+
+const os = typeof Platform !== "undefined" && Platform.OS != null ? Platform.OS : "ios";
+
+const TRACK_SHADOW =
+  os === "ios"
+    ? {
+        shadowColor: "#000000",
+        shadowOffset: { width: 0, height: 1 },
+        shadowOpacity: 0.06,
+        shadowRadius: 3,
+      }
+    : os === "android"
+      ? { elevation: 2 }
+      : {};
+
+const MARKER_SHADOW =
+  os === "ios"
+    ? {
+        shadowColor: "#000000",
+        shadowOffset: { width: 0, height: 1 },
+        shadowOpacity: 0.1,
+        shadowRadius: 2,
+      }
+    : os === "android"
+      ? { elevation: 1 }
+      : {};
+
+function arrowForSigned(delta: number): "↓" | "↑" | "→" {
+  if (delta < 0) return "↓";
+  if (delta > 0) return "↑";
+  return "→";
+}
+
+/** `useWeightSeries` `weeklyDeltaKg`: latest sample vs last sample on/before 7 calendar days before latest day. */
+function formatWeeklyThisWeekLine(deltaKg: number | null, unit: "kg" | "lb"): string | null {
+  if (deltaKg == null) return null;
+  if (Math.abs(deltaKg) < 1e-6) return "No change this week";
+  const arrow = arrowForSigned(deltaKg);
+  const mag = formatBodyWeight(Math.abs(deltaKg), unit);
+  return `${arrow} ${mag} this week`;
+}
+
+/** Maps current weight onto [0,1] along the YTD min–max weight span (display only). */
+function ytdBandMarker01(lowKg: number, highKg: number, currentKg: number): number {
+  if (!Number.isFinite(lowKg) || !Number.isFinite(highKg) || !Number.isFinite(currentKg)) return 0.5;
+  if (highKg <= lowKg) return 0.5;
+  const t = (currentKg - lowKg) / (highKg - lowKg);
+  return Math.min(1, Math.max(0, t));
+}
+
+export type BodyTrendsCardProps = {
+  unit: "kg" | "lb";
+  trends: BodyTrendsV1;
+  onRetryYtd?: () => void;
+};
+
+function YtdBandTrack({
+  lowKg,
+  highKg,
+  currentKg,
+  unit,
+}: {
+  lowKg: number;
+  highKg: number;
+  currentKg: number;
+  unit: "kg" | "lb";
+}) {
+  const [trackW, setTrackW] = useState(0);
+  const onLayout = (e: LayoutChangeEvent) => {
+    const w = e.nativeEvent.layout.width;
+    if (w > 0 && Math.abs(w - trackW) > 0.5) setTrackW(w);
+  };
+  const t = ytdBandMarker01(lowKg, highKg, currentKg);
+  const dotLeftPx =
+    trackW > 0 ? Math.min(trackW - BAND_DOT, Math.max(0, t * trackW - BAND_DOT / 2)) : undefined;
+
+  return (
+    <View
+      style={styles.bandTrackWrap}
+      onLayout={onLayout}
+      accessibilityRole="none"
+      accessibilityLabel={`Year-to-date weight from ${formatBodyWeight(lowKg, unit)} to ${formatBodyWeight(highKg, unit)}, current ${formatBodyWeight(currentKg, unit)}`}
+    >
+      <View style={[styles.bandTrackRim, TRACK_SHADOW]}>
+        <View style={styles.bandTrack}>
+          {dotLeftPx != null ? (
+            <View
+              style={[styles.bandDot, { left: dotLeftPx }, MARKER_SHADOW]}
+              accessibilityElementsHidden
+              importantForAccessibility="no-hide-descendants"
+            />
+          ) : null}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+export function BodyTrendsCard({ unit, trends, onRetryYtd }: BodyTrendsCardProps) {
+  const { latest, ytd } = trends;
+  const title = `${ytd.trendYear} Weight Trend`;
+
+  const weightPrimary =
+    latest.currentKg != null ? formatBodyWeight(latest.currentKg, unit) : "—";
+
+  const weeklyLine =
+    latest.seriesStatus === "ready" ? formatWeeklyThisWeekLine(latest.weeklyDeltaKg, unit) : null;
+
+  const showBand =
+    ytd.trendsStatus === "ready" &&
+    ytd.bandLowKg != null &&
+    ytd.bandHighKg != null &&
+    ytd.bandCurrentKg != null;
+
+  return (
+    <View style={styles.card}>
+      <View style={styles.headerRow}>
+        <Text style={workoutOverviewInCardHeaderStyles.title}>{title}</Text>
+      </View>
+
+      <View style={styles.weightTrendSection}>
+        <Text style={styles.heroLabel}>Latest</Text>
+        <View style={styles.latestRow}>
+          <Text style={styles.heroValue}>{weightPrimary}</Text>
+          {latest.seriesStatus === "partial" ? (
+            <ActivityIndicator accessibilityLabel="Loading weekly change" size="small" color="#AEAEB2" />
+          ) : weeklyLine != null ? (
+            <Text style={styles.weeklyLine}>{weeklyLine}</Text>
+          ) : null}
+        </View>
+
+        <View style={styles.majorSeparator} />
+
+        <View style={styles.ytdSection}>
+          <Text style={styles.sectionLabel}>YTD</Text>
+
+          {ytd.trendsStatus === "partial" ? (
+            <LoadingState message="Loading…" variant="inline" />
+          ) : ytd.trendsStatus === "error" ? (
+            <ErrorState
+              variant="inline"
+              title="Couldn’t load year-to-date"
+              message={ytd.errorMessage ?? "Something went wrong"}
+              {...(typeof ytd.requestId === "string" ? { requestId: ytd.requestId } : {})}
+              {...(onRetryYtd != null ? { onRetry: onRetryYtd } : {})}
+            />
+          ) : showBand ? (
+            <View style={styles.ytdBandBlock}>
+              <View style={styles.bandValuesAbove}>
+                <Text style={styles.bandValueAbove} numberOfLines={1}>
+                  {formatBodyWeight(ytd.bandLowKg!, unit)}
+                </Text>
+                <Text style={[styles.bandValueAbove, styles.bandValueAboveEnd]} numberOfLines={1}>
+                  {formatBodyWeight(ytd.bandHighKg!, unit)}
+                </Text>
+              </View>
+
+              <View style={styles.bandTrackSlot}>
+                <YtdBandTrack
+                  lowKg={ytd.bandLowKg!}
+                  highKg={ytd.bandHighKg!}
+                  currentKg={ytd.bandCurrentKg!}
+                  unit={unit}
+                />
+              </View>
+
+              <View style={styles.bandLabelsBelow}>
+                <Text style={styles.bandLabelBelow}>Low</Text>
+                <Text style={[styles.bandLabelBelow, styles.bandLabelBelowEnd]}>High</Text>
+              </View>
+            </View>
+          ) : (
+            <Text style={styles.ytdEmpty}>No weight samples in this year yet</Text>
+          )}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: "#FFFFFF",
+    borderRadius: 12,
+    padding: 16,
+    gap: 14,
+    ...elevatedCardSurfaceStyle,
+  },
+  headerRow: {
+    paddingBottom: 4,
+  },
+  weightTrendSection: {
+    gap: 8,
+  },
+  heroLabel: {
+    fontSize: 14,
+    fontWeight: "600",
+    color: "#6E6E73",
+    marginTop: 2,
+  },
+  latestRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    alignItems: "baseline",
+    gap: 10,
+    rowGap: 6,
+  },
+  heroValue: {
+    fontSize: 30,
+    fontWeight: "700",
+    color: "#1C1C1E",
+    letterSpacing: -0.45,
+  },
+  /** Same hue as YTD track wash ({@link SYSTEM_ACCENT_FILL_11}); full-opacity system accent for legibility. */
+  weeklyLine: {
+    fontSize: 14,
+    fontWeight: "500",
+    color: SYSTEM_ACCENT,
+    letterSpacing: -0.12,
+    flexShrink: 1,
+  },
+  majorSeparator: {
+    height: StyleSheet.hairlineWidth,
+    backgroundColor: "#E5E5EA",
+    marginTop: 14,
+    marginBottom: 6,
+  },
+  ytdSection: {
+    gap: 10,
+  },
+  sectionLabel: {
+    fontSize: 14,
+    fontWeight: "600",
+    color: "#6E6E73",
+    letterSpacing: -0.1,
+  },
+  ytdBandBlock: {
+    gap: 10,
+    marginTop: 2,
+  },
+  bandValuesAbove: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "flex-end",
+    gap: 12,
+  },
+  bandValueAbove: {
+    flex: 1,
+    minWidth: 0,
+    fontSize: 15,
+    fontWeight: "600",
+    color: "#1C1C1E",
+    fontVariant: ["tabular-nums"],
+  },
+  bandValueAboveEnd: {
+    textAlign: "right",
+  },
+  bandTrackSlot: {
+    paddingVertical: 2,
+  },
+  bandLabelsBelow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "flex-start",
+    gap: 12,
+    marginTop: -2,
+  },
+  bandLabelBelow: {
+    flex: 1,
+    minWidth: 0,
+    fontSize: 12,
+    fontWeight: "600",
+    color: "#8E8E93",
+  },
+  bandLabelBelowEnd: {
+    textAlign: "right",
+  },
+  ytdEmpty: {
+    fontSize: 14,
+    fontWeight: "500",
+    color: "#8E8E93",
+    marginTop: 2,
+  },
+  bandTrackWrap: {
+    width: "100%",
+  },
+  bandTrackRim: {
+    width: "100%",
+    borderRadius: BAND_RADIUS,
+    backgroundColor: SYSTEM_ACCENT_FILL_11,
+    borderWidth: 1,
+    borderColor: "rgba(60, 60, 67, 0.08)",
+  },
+  bandTrack: {
+    height: BAND_TRACK_H,
+    borderRadius: BAND_RADIUS,
+    position: "relative",
+    overflow: "visible",
+  },
+  bandDot: {
+    position: "absolute",
+    width: BAND_DOT,
+    height: BAND_DOT,
+    borderRadius: BAND_DOT / 2,
+    top: (BAND_TRACK_H - BAND_DOT) / 2,
+    backgroundColor: "#FFFFFF",
+    borderWidth: 2,
+    borderColor: "#636366",
+  },
+});

--- a/lib/ui/body/InterpretationQualityBar.tsx
+++ b/lib/ui/body/InterpretationQualityBar.tsx
@@ -29,6 +29,7 @@ export function InterpretationQualityBar({ bar }: InterpretationQualityBarProps)
       markerPosition01={d.displayMarker01}
       showMarker={bar.hasValue}
       markerBackgroundColor={d.markerDotColor}
+      markerStyle="elevated"
       dotSize={MODULE_OVERVIEW_SEGMENTED_TRACK.dotSize}
       barHeight={MODULE_OVERVIEW_SEGMENTED_TRACK.barHeight}
       trackRadius={MODULE_OVERVIEW_SEGMENTED_TRACK.trackRadius}

--- a/lib/ui/body/InterpretationRatingPill.tsx
+++ b/lib/ui/body/InterpretationRatingPill.tsx
@@ -1,25 +1,32 @@
 // Compact zone label beside metric title (Body Composition overview).
 import React from "react";
-import { Text, View } from "react-native";
+import { Text, View, type StyleProp, type ViewStyle } from "react-native";
 
 import type { InterpretationBarModel } from "@/lib/body/bodyOverviewInterpretationBar";
 import { getBodyOverviewBarDisplay } from "@/lib/body/bodyOverviewBarDisplay";
 import { moduleOverviewMetricLayoutStyles } from "@/lib/ui/overview/moduleOverviewMetricLayout";
 
+const RATING_PILL_LABEL_INK = "#111827";
+
 export type InterpretationRatingPillProps = {
   bar: InterpretationBarModel;
+  /** Merged after shared shell styles (e.g. trailing alignment on overview rows). */
+  shellStyle?: StyleProp<ViewStyle>;
 };
 
-export function InterpretationRatingPill({ bar }: InterpretationRatingPillProps) {
+export function InterpretationRatingPill({ bar, shellStyle }: InterpretationRatingPillProps) {
   const d = getBodyOverviewBarDisplay(bar);
-  const colors = { bg: d.pillBg, fg: d.pillFg };
   return (
     <View
-      style={[moduleOverviewMetricLayoutStyles.ratingPillShell, { backgroundColor: colors.bg }]}
+      style={[
+        moduleOverviewMetricLayoutStyles.ratingPillShell,
+        shellStyle,
+        { backgroundColor: d.pillBg },
+      ]}
       accessibilityElementsHidden
       importantForAccessibility="no"
     >
-      <Text style={[moduleOverviewMetricLayoutStyles.ratingPillLabel, { color: colors.fg }]} numberOfLines={1}>
+      <Text style={[moduleOverviewMetricLayoutStyles.ratingPillLabel, { color: RATING_PILL_LABEL_INK }]} numberOfLines={1}>
         {bar.displayLabel}
       </Text>
     </View>

--- a/lib/ui/body/__tests__/InterpretationQualityBar.test.tsx
+++ b/lib/ui/body/__tests__/InterpretationQualityBar.test.tsx
@@ -62,6 +62,7 @@ describe("InterpretationQualityBar", () => {
     expect(track.props.markerPosition01).toBeGreaterThanOrEqual(0.6);
     expect(track.props.markerPosition01).toBeLessThanOrEqual(0.8);
     expect(track.props.markerBackgroundColor).toBe("#5EC08C");
+    expect(track.props.markerStyle).toBe("elevated");
   });
 
   it("does not render a separate rating label under the track", () => {

--- a/lib/ui/body/formatBodyDayLabel.ts
+++ b/lib/ui/body/formatBodyDayLabel.ts
@@ -1,10 +1,6 @@
-const WEEKDAY_SHORT = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+import { formatDayKeyWeekdayShortMonthDay } from "@/lib/ui/calendar/dayKeyDisplayFormat";
+import type { DayKey } from "@/lib/ui/calendar/types";
 
 export function formatBodyDayLabel(dayKey: string): string {
-  const d = new Date(`${dayKey}T12:00:00.000Z`);
-  const wd = WEEKDAY_SHORT[d.getUTCDay()] ?? "";
-  const month = d.getUTCMonth() + 1;
-  const day = d.getUTCDate();
-  return `${wd} ${month}/${day}`;
+  return formatDayKeyWeekdayShortMonthDay(dayKey as DayKey);
 }
-

--- a/lib/ui/body/formatOverviewAsOfLabel.ts
+++ b/lib/ui/body/formatOverviewAsOfLabel.ts
@@ -1,7 +1,0 @@
-/** Compact label for Overview card header, e.g. "As of 3/27" (month/day, no weekday). */
-export function formatOverviewAsOfLabel(dayKey: string): string {
-  const d = new Date(`${dayKey}T12:00:00.000Z`);
-  const month = d.getUTCMonth() + 1;
-  const day = d.getUTCDate();
-  return `As of ${month}/${day}`;
-}

--- a/lib/ui/calendar/MonthGrid.tsx
+++ b/lib/ui/calendar/MonthGrid.tsx
@@ -8,6 +8,7 @@ import {
 import type { DayKey } from "./types";
 import { getMonthGrid, formatMonthYearLabel, getTodayDayKeyLocal, type MonthYear } from "./dateUtils";
 import type { WorkoutMarkerFlags } from "@/lib/data/workouts/workoutMarkerFlags";
+import { UI_TEXT_PRIMARY, UI_TEXT_MUTED } from "@/lib/ui/theme/uiTokens";
 import { WorkoutDayRing } from "./WorkoutDayRing";
 
 export type MonthGridProps = {
@@ -86,30 +87,34 @@ export function MonthGrid({ monthYear, markerForDay, onDayPress }: MonthGridProp
 const styles = StyleSheet.create({
   container: {
     paddingHorizontal: 16,
-    paddingTop: 4,
+    paddingTop: 10,
+    paddingBottom: 4,
   },
   headerTitle: {
-    fontSize: 17,
+    fontSize: 20,
     fontWeight: "700",
     color: "#1C1C1E",
     textAlign: "center",
-    marginBottom: 12,
+    letterSpacing: -0.28,
+    marginBottom: 14,
   },
   dowRow: {
     flexDirection: "row",
     justifyContent: "space-between",
-    marginBottom: 8,
+    marginBottom: 10,
   },
   dowLabel: {
     flex: 1,
     textAlign: "center",
-    fontSize: 12,
-    color: "#8E8E93",
+    fontSize: 13,
+    fontWeight: "500",
+    color: UI_TEXT_MUTED,
+    letterSpacing: 0.15,
   },
   weekRow: {
     flexDirection: "row",
     justifyContent: "space-between",
-    marginBottom: 6,
+    marginBottom: 5,
   },
   dayCellEmpty: {
     flex: 1,
@@ -140,9 +145,11 @@ const styles = StyleSheet.create({
     justifyContent: "center",
   },
   dayNumber: {
-    fontSize: 15,
+    fontSize: 17,
     fontWeight: "600",
-    color: "#1C1C1E",
+    color: UI_TEXT_PRIMARY,
+    fontVariant: ["tabular-nums"],
+    letterSpacing: -0.2,
   },
 });
 

--- a/lib/ui/calendar/WorkoutDayRing.tsx
+++ b/lib/ui/calendar/WorkoutDayRing.tsx
@@ -27,7 +27,7 @@ const RING_MIXED_FILL = SYSTEM_ACCENT_OVERLAY_10;
 
 /** Default ring: slightly finer so selected (emphasized) reads clearly. */
 const STROKE_WIDTH = 1.75;
-const STROKE_WIDTH_EMPHASIZED = 2.75;
+const STROKE_WIDTH_EMPHASIZED = 3;
 
 export type WorkoutDayRingProps = {
   size: number;

--- a/lib/ui/calendar/__tests__/dayKeyDisplayFormat.test.ts
+++ b/lib/ui/calendar/__tests__/dayKeyDisplayFormat.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, jest, beforeEach } from "@jest/globals";
+
+jest.mock("../dateUtils", () => {
+  const actual = jest.requireActual<typeof import("../dateUtils")>("../dateUtils");
+  return {
+    ...actual,
+    getTodayDayKeyLocal: jest.fn(() => "2026-04-06"),
+  };
+});
+
+import { formatDayKeyWeekdayShortMonthDay, formatOverviewAsOfLabel } from "../dayKeyDisplayFormat";
+import * as dateUtils from "../dateUtils";
+
+const getToday = dateUtils.getTodayDayKeyLocal as jest.MockedFunction<typeof dateUtils.getTodayDayKeyLocal>;
+
+describe("formatDayKeyWeekdayShortMonthDay", () => {
+  it("formats Tue 3/31 for 2026-03-31", () => {
+    expect(formatDayKeyWeekdayShortMonthDay("2026-03-31")).toBe("Tue 3/31");
+  });
+});
+
+describe("formatOverviewAsOfLabel", () => {
+  beforeEach(() => {
+    getToday.mockReturnValue("2026-04-06");
+  });
+
+  it('returns "As of Today" when dayKey matches local today', () => {
+    getToday.mockReturnValue("2026-03-31");
+    expect(formatOverviewAsOfLabel("2026-03-31")).toBe("As of Today");
+  });
+
+  it('returns "As of {weekday} {M/D}" when dayKey is not today', () => {
+    expect(formatOverviewAsOfLabel("2026-03-31")).toBe("As of Tue 3/31");
+  });
+});

--- a/lib/ui/calendar/dayKeyDisplayFormat.ts
+++ b/lib/ui/calendar/dayKeyDisplayFormat.ts
@@ -1,0 +1,26 @@
+import { getTodayDayKeyLocal } from "@/lib/ui/calendar/dateUtils";
+import type { DayKey } from "@/lib/ui/calendar/types";
+
+const WEEKDAY_SHORT = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
+
+/**
+ * Weekday short + M/D for a calendar day key (UTC noon anchor), e.g. `Tue 3/31`.
+ * Matches historical overview / recent-row copy ({@link formatBodyDayLabel}).
+ */
+export function formatDayKeyWeekdayShortMonthDay(dayKey: DayKey): string {
+  const d = new Date(`${dayKey}T12:00:00.000Z`);
+  const wd = WEEKDAY_SHORT[d.getUTCDay()] ?? "";
+  const month = d.getUTCMonth() + 1;
+  const day = d.getUTCDate();
+  return `${wd} ${month}/${day}`;
+}
+
+/**
+ * Overview header line: "As of Today" when `dayKey` is the device-local today, else "As of Tue 4/6".
+ */
+export function formatOverviewAsOfLabel(dayKey: string): string {
+  if (dayKey === getTodayDayKeyLocal()) {
+    return "As of Today";
+  }
+  return `As of ${formatDayKeyWeekdayShortMonthDay(dayKey)}`;
+}

--- a/lib/ui/calendar/moduleCalendarHeaderYear.ts
+++ b/lib/ui/calendar/moduleCalendarHeaderYear.ts
@@ -1,0 +1,31 @@
+import type { TextStyle } from "react-native";
+import type { ViewToken } from "react-native";
+
+import type { MonthYear } from "@/lib/ui/calendar/dateUtils";
+import { WORKOUTS_HEADER_TITLE_COLOR } from "@/lib/ui/headers/workoutsStackHeader";
+
+/** Matches Body / Strength calendar nav title — centered year. */
+export const MODULE_CALENDAR_HEADER_YEAR_TEXT_STYLE: TextStyle = {
+  fontSize: 22,
+  fontWeight: "700",
+  color: WORKOUTS_HEADER_TITLE_COLOR,
+  letterSpacing: -0.35,
+};
+
+/**
+ * Picks the calendar year from the month row at the middle of the visible indices
+ * (same heuristic as Body calendar when scrolling across months/years).
+ */
+export function headerYearFromViewableMonthItems<T extends { monthYear: MonthYear }>(
+  viewableItems: ViewToken[],
+  months: readonly T[],
+): number | null {
+  const indices = viewableItems
+    .map((t) => t.index)
+    .filter((i): i is number => typeof i === "number")
+    .sort((a, b) => a - b);
+  if (indices.length === 0) return null;
+  const pick = indices[Math.floor(indices.length / 2)]!;
+  const item = months[pick];
+  return item?.monthYear.year ?? null;
+}

--- a/lib/ui/calendar/useModuleCalendarYearNavigationHeader.tsx
+++ b/lib/ui/calendar/useModuleCalendarYearNavigationHeader.tsx
@@ -1,0 +1,35 @@
+import { useEffect } from "react";
+import { Platform, Text } from "react-native";
+
+import { HeaderBackButton } from "@/lib/ui/HeaderBackButton";
+import {
+  workoutsStackNavigationOptions,
+  WORKOUTS_HEADER_TITLE_COLOR,
+} from "@/lib/ui/headers/workoutsStackHeader";
+import { UI_APP_SCREEN_BG } from "@/lib/ui/theme/uiTokens";
+
+import { MODULE_CALENDAR_HEADER_YEAR_TEXT_STYLE } from "./moduleCalendarHeaderYear";
+
+type MinimalStackNav = {
+  setOptions: (opts: Record<string, unknown>) => void;
+  goBack: () => void;
+};
+
+/**
+ * Stack header: blue-gray bar, circular back, centered bold year (module calendar system).
+ */
+export function useModuleCalendarYearNavigationHeader(
+  navigation: MinimalStackNav,
+  headerYear: number,
+): void {
+  useEffect(() => {
+    navigation.setOptions({
+      ...workoutsStackNavigationOptions("detail"),
+      headerStyle: { backgroundColor: UI_APP_SCREEN_BG },
+      headerTintColor: WORKOUTS_HEADER_TITLE_COLOR,
+      headerLeft: () => <HeaderBackButton onPress={() => navigation.goBack()} />,
+      headerTitle: () => <Text style={MODULE_CALENDAR_HEADER_YEAR_TEXT_STYLE}>{String(headerYear)}</Text>,
+      ...(Platform.OS === "ios" ? { headerTitleAlign: "center" as const } : {}),
+    });
+  }, [navigation, headerYear]);
+}

--- a/lib/ui/dash/DashRecapCard.tsx
+++ b/lib/ui/dash/DashRecapCard.tsx
@@ -1,6 +1,7 @@
 // lib/ui/dash/DashRecapCard.tsx
 import React from "react";
 import { View, Text, StyleSheet, Pressable } from "react-native";
+import { elevatedCardSurfaceStyle } from "@/lib/ui/theme/elevatedCardSurface";
 import type { DashRecapViewModel } from "@/lib/data/dash/dashRecapViewModel";
 import { dashRecapRowAccessibilityLabel } from "@/lib/data/dash/dashRecapA11y";
 import { moduleOverviewMetricLayoutStyles } from "@/lib/ui/overview/moduleOverviewMetricLayout";
@@ -8,9 +9,13 @@ import { MODULE_OVERVIEW_SEGMENT_ZONE_FILLS } from "@/lib/ui/overview/moduleOver
 import { MODULE_OVERVIEW_SEGMENTED_TRACK } from "@/lib/ui/overview/moduleOverviewSegmentedTrackMetrics";
 import { SegmentedZoneTrack } from "@/lib/ui/primitives/SegmentedZoneTrack";
 import { workoutOverviewInCardHeaderStyles } from "@/lib/ui/workouts/workoutOverviewInCardHeaderStyles";
-import { formatOverviewAsOfLabel } from "@/lib/ui/body/formatOverviewAsOfLabel";
+import { formatOverviewAsOfLabel } from "@/lib/ui/calendar/dayKeyDisplayFormat";
 import { ErrorState, LoadingState } from "@/lib/ui/ScreenStates";
-import { UI_CARD_SURFACE, UI_DASH_RECAP_CARD_RADIUS } from "@/lib/ui/theme/uiTokens";
+import {
+  UI_CARD_SURFACE,
+  UI_DASH_RECAP_CARD_RADIUS,
+  UI_TAB_ROOT_CONTENT_GUTTER,
+} from "@/lib/ui/theme/uiTokens";
 
 /** Marker fill: neutral gray — does not encode Strength tier semantics. */
 const DASH_RECAP_PLACEMENT_MARKER_COLOR = "#6E6E73";
@@ -162,8 +167,10 @@ export function DashRecapCard({ model, onViewMore }: DashRecapCardProps) {
 const styles = StyleSheet.create({
   card: {
     backgroundColor: UI_CARD_SURFACE,
+    ...elevatedCardSurfaceStyle,
     borderRadius: UI_DASH_RECAP_CARD_RADIUS,
-    padding: 20,
+    paddingVertical: 20,
+    paddingHorizontal: UI_TAB_ROOT_CONTENT_GUTTER,
     gap: 12,
   },
   headerRow: {

--- a/lib/ui/overview/moduleOverviewMetricLayout.ts
+++ b/lib/ui/overview/moduleOverviewMetricLayout.ts
@@ -41,10 +41,12 @@ export const moduleOverviewMetricLayoutStyles = StyleSheet.create({
   },
   ratingPillShell: {
     flexShrink: 1,
-    paddingHorizontal: 8,
-    paddingVertical: 3,
+    paddingHorizontal: 11,
+    paddingVertical: 4,
     borderRadius: 8,
     maxWidth: "46%",
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: "rgba(60, 60, 67, 0.12)",
   },
   ratingPillLabel: {
     fontSize: 11,

--- a/lib/ui/overview/moduleOverviewSegmentedTrackMetrics.ts
+++ b/lib/ui/overview/moduleOverviewSegmentedTrackMetrics.ts
@@ -4,6 +4,6 @@
  */
 export const MODULE_OVERVIEW_SEGMENTED_TRACK = {
   barHeight: 10,
-  trackRadius: 5,
+  trackRadius: 6,
   dotSize: 10,
 } as const;

--- a/lib/ui/overview/moduleOverviewStrengthTierPillChrome.ts
+++ b/lib/ui/overview/moduleOverviewStrengthTierPillChrome.ts
@@ -3,9 +3,9 @@
  * Order matches {@link MODULE_OVERVIEW_SEGMENT_ZONE_FILLS} and Strength tier indices 0–4.
  */
 export const MODULE_OVERVIEW_STRENGTH_TIER_PILL_CHROME = [
-  { pillBg: "#FDEBEB", pillFg: "#E57373" },
-  { pillBg: "#F5ECD8", pillFg: "#F2D06B" },
-  { pillBg: "#FFF4E8", pillFg: "#E6A15C" },
-  { pillBg: "#E8F6EF", pillFg: "#5EC08C" },
-  { pillBg: "#E9F0FC", pillFg: "#5C8FE6" },
+  { pillBg: "#FDF5F5", pillFg: "#E57373" },
+  { pillBg: "#F8F4EC", pillFg: "#F2D06B" },
+  { pillBg: "#FFFAF4", pillFg: "#E6A15C" },
+  { pillBg: "#F0F8F4", pillFg: "#5EC08C" },
+  { pillBg: "#F2F6FC", pillFg: "#5C8FE6" },
 ] as const;

--- a/lib/ui/primitives/SegmentedZoneTrack.tsx
+++ b/lib/ui/primitives/SegmentedZoneTrack.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { LayoutChangeEvent, StyleSheet, View, type ViewProps } from "react-native";
+import { LayoutChangeEvent, Platform, StyleSheet, View, type ViewProps } from "react-native";
 
 import { clampedDotLeftPx } from "@/lib/ui/body/interpretationBarDotLayout";
 import { MODULE_OVERVIEW_SEGMENTED_TRACK } from "@/lib/ui/overview/moduleOverviewSegmentedTrackMetrics";
@@ -25,6 +25,11 @@ export type SegmentedZoneTrackProps = {
   dotSize?: number;
   barHeight?: number;
   trackRadius?: number;
+  /**
+   * `elevated` — white halo + soft shadow + vertical centering (Strength + Body overview markers).
+   * Default keeps the compact hairline ring for Dash recap.
+   */
+  markerStyle?: "default" | "elevated";
   /** Applied to the outer wrapper (layout + testID are owned by this component). */
   wrapperProps?: Omit<ViewProps, "children" | "onLayout" | "testID" | "style"> & {
     style?: ViewProps["style"];
@@ -44,6 +49,7 @@ export function SegmentedZoneTrack({
   dotSize = DEFAULT_DOT_SIZE,
   barHeight = DEFAULT_BAR_HEIGHT,
   trackRadius = DEFAULT_TRACK_RADIUS,
+  markerStyle = "default",
   wrapperProps,
 }: SegmentedZoneTrackProps) {
   const [trackW, setTrackW] = useState(0);
@@ -58,9 +64,37 @@ export function SegmentedZoneTrack({
   const dotLeft =
     showMarker && trackW > 0 ? clampedDotLeftPx(trackW, marker01, dotSize) : undefined;
 
+  const os = typeof Platform !== "undefined" && Platform.OS != null ? Platform.OS : "ios";
+
+  const markerElevated = markerStyle === "elevated";
+  const dotTop = markerElevated ? (barHeight - dotSize) / 2 : 0;
+
+  const markerDotShadow =
+    markerElevated && os === "ios"
+      ? {
+          shadowColor: "#000000",
+          shadowOffset: { width: 0, height: 1 },
+          shadowOpacity: 0.1,
+          shadowRadius: 2,
+        }
+      : markerElevated && os === "android"
+        ? { elevation: 1 }
+        : {};
+
   const zonesTestID = testID != null ? `${testID}-zones` : undefined;
   const markerTestID = testID != null ? `${testID}-marker` : undefined;
   const { style: wrapperStyle, ...wrapperRest } = wrapperProps ?? {};
+  const rimShadow =
+    os === "ios"
+      ? {
+          shadowColor: "#000000",
+          shadowOffset: { width: 0, height: 1 },
+          shadowOpacity: 0.06,
+          shadowRadius: 3,
+        }
+      : os === "android"
+        ? { elevation: 2 }
+        : {};
 
   return (
     <View
@@ -70,30 +104,44 @@ export function SegmentedZoneTrack({
       onLayout={onTrackLayout}
     >
       <View
-        style={[styles.zonesClip, { borderRadius: trackRadius, height: barHeight }]}
-        {...(zonesTestID != null ? { testID: zonesTestID } : {})}
+        style={[
+          styles.trackRim,
+          {
+            height: barHeight,
+            borderRadius: trackRadius,
+            ...rimShadow,
+          },
+        ]}
         importantForAccessibility="no"
       >
-        <View style={[styles.zonesRow, { height: barHeight }]} importantForAccessibility="no">
-          {zoneColors.map((color, i) => (
-            <View
-              key={i}
-              style={[styles.zone, { backgroundColor: color }]}
-              importantForAccessibility="no"
-            />
-          ))}
+        <View
+          style={[styles.zonesClip, { borderRadius: trackRadius, height: barHeight }]}
+          {...(zonesTestID != null ? { testID: zonesTestID } : {})}
+          importantForAccessibility="no"
+        >
+          <View style={[styles.zonesRow, { height: barHeight }]} importantForAccessibility="no">
+            {zoneColors.map((color, i) => (
+              <View
+                key={i}
+                style={[styles.zone, { backgroundColor: color }]}
+                importantForAccessibility="no"
+              />
+            ))}
+          </View>
         </View>
       </View>
       {dotLeft != null ? (
         <View
           style={[
-            styles.markerDot,
+            markerElevated ? styles.markerDotElevated : styles.markerDot,
             {
               left: dotLeft,
+              top: dotTop,
               width: dotSize,
               height: dotSize,
               borderRadius: dotSize / 2,
               backgroundColor: markerBackgroundColor,
+              ...markerDotShadow,
             },
           ]}
           importantForAccessibility="no"
@@ -110,6 +158,11 @@ const styles = StyleSheet.create({
     position: "relative",
     justifyContent: "center",
   },
+  trackRim: {
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: "rgba(60, 60, 67, 0.11)",
+    backgroundColor: "#FFFFFF",
+  },
   zonesClip: {
     overflow: "hidden",
   },
@@ -125,5 +178,10 @@ const styles = StyleSheet.create({
     top: 0,
     borderWidth: StyleSheet.hairlineWidth,
     borderColor: "rgba(255,255,255,0.85)",
+  },
+  markerDotElevated: {
+    position: "absolute",
+    borderWidth: 2,
+    borderColor: "#FFFFFF",
   },
 });

--- a/lib/ui/profile/ProfileMainScreen.tsx
+++ b/lib/ui/profile/ProfileMainScreen.tsx
@@ -6,7 +6,11 @@ import { useRouter } from "expo-router";
 
 import { ScreenContainer } from "@/lib/ui/ScreenStates";
 import { TabRootScreenHeader } from "@/lib/ui/TabRootScreenHeader";
-import { UI_APP_SCREEN_BG, UI_TAB_ROOT_INSET } from "@/lib/ui/theme/uiTokens";
+import {
+  UI_APP_SCREEN_BG,
+  UI_TAB_ROOT_CONTENT_GUTTER_STYLE,
+  UI_TAB_ROOT_INSET,
+} from "@/lib/ui/theme/uiTokens";
 import type { MassUnit, UserProfileMain } from "@oli/contracts";
 import {
   formatHeightForDisplay,
@@ -88,6 +92,7 @@ export function ProfileMainScreen({
           showsVerticalScrollIndicator={false}
           bounces
         >
+          <View style={[styles.scrollInner, UI_TAB_ROOT_CONTENT_GUTTER_STYLE]}>
         {showLoadError ? <Text style={styles.errorText}>{errorMessage}</Text> : null}
 
         {hydrating ? (
@@ -211,6 +216,7 @@ export function ProfileMainScreen({
           Profile and body inputs help tailor your experience. You can skip any optional field. Oli does not ask for
           Social Security numbers, government IDs, or payment details in Profile.
         </Text>
+          </View>
       </ScrollView>
       </View>
     </ScreenContainer>
@@ -226,8 +232,11 @@ const styles = StyleSheet.create({
   scrollContent: {
     flexGrow: 1,
     paddingHorizontal: UI_TAB_ROOT_INSET,
-    paddingTop: 8,
+    paddingTop: 6,
     paddingBottom: 40,
+  },
+  scrollInner: {
+    flexGrow: 1,
   },
   sectionLabel: {
     marginTop: 18,
@@ -248,7 +257,8 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     paddingVertical: 14,
-    paddingHorizontal: 16,
+    paddingLeft: 0,
+    paddingRight: 12,
     minHeight: 48,
     borderBottomWidth: StyleSheet.hairlineWidth,
     borderBottomColor: ROW_DIVIDER,

--- a/lib/ui/theme/elevatedCardSurface.ts
+++ b/lib/ui/theme/elevatedCardSurface.ts
@@ -1,0 +1,25 @@
+// Shared subtle border + platform shadow for white cards on grouped sheets (e.g. Dash).
+import { Platform, type ViewStyle } from "react-native";
+import { UI_CARD_ELEVATED_BORDER } from "@/lib/ui/theme/uiTokens";
+
+function elevatedShadowStyle(): ViewStyle {
+  const os = typeof Platform !== "undefined" && Platform.OS != null ? Platform.OS : "ios";
+  if (os === "ios") {
+    return {
+      shadowColor: "#000000",
+      shadowOffset: { width: 0, height: 2 },
+      shadowOpacity: 0.05,
+      shadowRadius: 8,
+    };
+  }
+  if (os === "android") {
+    return { elevation: 2 };
+  }
+  return {};
+}
+
+export const elevatedCardSurfaceStyle: ViewStyle = {
+  borderWidth: 1,
+  borderColor: UI_CARD_ELEVATED_BORDER,
+  ...elevatedShadowStyle(),
+};

--- a/lib/ui/theme/uiTokens.ts
+++ b/lib/ui/theme/uiTokens.ts
@@ -35,6 +35,9 @@ export const UI_BORDER_HAIRLINE = "#E5E5EA";
 export const UI_SCREEN_BG = "#F2F2F7";
 export const UI_CARD_SURFACE = "#FFFFFF";
 
+/** 1px edge on elevated white cards over grouped backgrounds — barely visible, iOS-style hairline. */
+export const UI_CARD_ELEVATED_BORDER = "rgba(60, 60, 67, 0.08)";
+
 /** App-wide grouped page root (tab roots, ScreenContainer default). Calm blue-gray. */
 export const UI_APP_SCREEN_BG = "#EEF3F8";
 
@@ -42,9 +45,19 @@ export const UI_APP_SCREEN_BG = "#EEF3F8";
 export const UI_DASH_SCREEN_BG = UI_APP_SCREEN_BG;
 
 /**
- * Horizontal inset for tab root headers and scroll content so title, gear, and cards share one grid.
+ * Horizontal inset for tab root scroll areas and the outer edge of grouped content (card shells).
  */
 export const UI_TAB_ROOT_INSET = 20;
+
+/**
+ * Inner gutter from `UI_TAB_ROOT_INSET` so tab header titles and primary row / card text share one vertical alignment.
+ */
+export const UI_TAB_ROOT_CONTENT_GUTTER = 18;
+
+/** Apply inside tab-root scroll bodies (after horizontal `UI_TAB_ROOT_INSET`) for primary text alignment. */
+export const UI_TAB_ROOT_CONTENT_GUTTER_STYLE = {
+  paddingHorizontal: UI_TAB_ROOT_CONTENT_GUTTER,
+} as const;
 
 /** Default corner radius for white cards on grouped backgrounds (non-Dash). */
 export const UI_GROUPED_CARD_RADIUS = 16;

--- a/lib/ui/workouts/StrengthOverviewCard.tsx
+++ b/lib/ui/workouts/StrengthOverviewCard.tsx
@@ -13,6 +13,7 @@ import { MODULE_OVERVIEW_SEGMENTED_TRACK } from "@/lib/ui/overview/moduleOvervie
 import { SegmentedZoneTrack } from "@/lib/ui/primitives/SegmentedZoneTrack";
 import { workoutOverviewInCardHeaderStyles } from "@/lib/ui/workouts/workoutOverviewInCardHeaderStyles";
 import { LoadingState } from "@/lib/ui/ScreenStates";
+import { elevatedCardSurfaceStyle } from "@/lib/ui/theme/elevatedCardSurface";
 
 type StrengthOverviewCardProps = {
   loading: boolean;
@@ -23,7 +24,7 @@ type StrengthOverviewCardProps = {
 /**
  * Strength-only tier palette (not Body interpretation zones).
  * Tier chroma: Low #E57373, Developing #F2D06B, Solid #E6A15C, Strong #5EC08C, Optimal #5C8FE6.
- * Bar segments: same RGB at ~35% alpha on white. Pill fg + marker: full-opacity tier hex. Pill bg: soft opaque tints.
+ * Bar segments: same RGB at ~35% alpha on white. Pill fg: tier chroma (API/tests). Bar marker: neutral elevated dot. Pill bg: soft opaque tints.
  */
 const STRENGTH_OVERVIEW_TIER_COLORS: Record<
   StrengthOverviewTimeframeRatingTier,
@@ -66,6 +67,12 @@ const RATING_PILL_STYLES: Record<StrengthOverviewTimeframeRatingTier, { bg: stri
     {} as Record<StrengthOverviewTimeframeRatingTier, { bg: string; fg: string }>,
   );
 
+/** Tier tint stays on pill shell; label text reads in neutral ink (Strength overview). */
+const STRENGTH_RATING_PILL_LABEL_INK = "#111827";
+
+/** Consistency bar marker: dark neutral fill + elevated halo (see {@link SegmentedZoneTrack} `markerStyle`). */
+const STRENGTH_CONSISTENCY_MARKER_FILL = "#1F2937";
+
 const TIER_FOR_RATING_LABEL: Record<StrengthOverviewTimeframeRatingLabel, StrengthOverviewTimeframeRatingTier> = {
   Low: "low",
   Developing: "developing",
@@ -95,16 +102,13 @@ function clamp01(x: number): number {
 function StrengthOverviewConsistencyTrack({
   testID,
   markerPosition01,
-  ratingLabel,
 }: {
   testID: string;
   /** 0–1 along full track; must already lie inside the tier segment (see {@link computeStrengthOverviewMarkerPosition01}). */
   markerPosition01: number;
-  ratingLabel: StrengthOverviewTimeframeRatingLabel;
 }) {
   const marker01 = clamp01(markerPosition01);
   const pct = Math.round(marker01 * 100);
-  const markerColor = getStrengthOverviewMarkerColorForRatingLabel(ratingLabel);
 
   return (
     <SegmentedZoneTrack
@@ -112,7 +116,8 @@ function StrengthOverviewConsistencyTrack({
       testID={testID}
       markerPosition01={marker01}
       showMarker
-      markerBackgroundColor={markerColor}
+      markerBackgroundColor={STRENGTH_CONSISTENCY_MARKER_FILL}
+      markerStyle="elevated"
       dotSize={MODULE_OVERVIEW_SEGMENTED_TRACK.dotSize}
       barHeight={MODULE_OVERVIEW_SEGMENTED_TRACK.barHeight}
       trackRadius={MODULE_OVERVIEW_SEGMENTED_TRACK.trackRadius}
@@ -155,19 +160,32 @@ export function StrengthOverviewCard({ loading, model, onViewMore }: StrengthOve
             return (
               <View key={tf.key} style={moduleOverviewMetricLayoutStyles.metricBlock} accessibilityLabel={a11y} accessible>
                 <View style={moduleOverviewMetricLayoutStyles.topRow}>
-                  <View style={moduleOverviewMetricLayoutStyles.titlePillCluster}>
-                    <Text style={moduleOverviewMetricLayoutStyles.primaryLabel} numberOfLines={1}>
+                  <View style={styles.leftSummary}>
+                    <Text style={styles.timeframeLabel} numberOfLines={1}>
                       {tf.label}
                     </Text>
-                    <View style={[moduleOverviewMetricLayoutStyles.ratingPillShell, { backgroundColor: pill.bg }]}>
-                      <Text style={[moduleOverviewMetricLayoutStyles.ratingPillLabel, { color: pill.fg }]} numberOfLines={1}>
-                        {tf.rating.label}
-                      </Text>
-                    </View>
+                    <Text
+                      style={styles.resultSummary}
+                      numberOfLines={1}
+                      ellipsizeMode="tail"
+                    >
+                      {tf.compactStatsSummary}
+                    </Text>
                   </View>
-                  <Text style={moduleOverviewMetricLayoutStyles.trailingValue} numberOfLines={1}>
-                    {tf.compactStatsSummary}
-                  </Text>
+                  <View
+                    style={[
+                      moduleOverviewMetricLayoutStyles.ratingPillShell,
+                      styles.ratingPillTrailing,
+                      { backgroundColor: pill.bg },
+                    ]}
+                  >
+                    <Text
+                      style={[moduleOverviewMetricLayoutStyles.ratingPillLabel, { color: STRENGTH_RATING_PILL_LABEL_INK }]}
+                      numberOfLines={1}
+                    >
+                      {tf.rating.label}
+                    </Text>
+                  </View>
                 </View>
                 <StrengthOverviewConsistencyTrack
                   testID={`strength-overview-consistency-bar-${tf.key}`}
@@ -175,7 +193,6 @@ export function StrengthOverviewCard({ loading, model, onViewMore }: StrengthOve
                     tier: tf.rating.tier,
                     scoringAvg: tf.rating.scoringAvg,
                   })}
-                  ratingLabel={tf.rating.label}
                 />
               </View>
             );
@@ -192,8 +209,40 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     padding: 16,
     gap: 12,
+    ...elevatedCardSurfaceStyle,
   },
   headerRow: {
     alignItems: "flex-start",
+    paddingBottom: 2,
+  },
+  /** Timeframe + numeric result (scan line); pill sits on the right. */
+  leftSummary: {
+    flex: 1,
+    minWidth: 0,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    paddingRight: 8,
+  },
+  timeframeLabel: {
+    fontSize: 15,
+    fontWeight: "600",
+    color: "#6E6E73",
+    letterSpacing: -0.12,
+    flexShrink: 0,
+  },
+  resultSummary: {
+    flex: 1,
+    minWidth: 0,
+    fontSize: 14,
+    fontWeight: "600",
+    color: "#3C3C43",
+    letterSpacing: -0.15,
+  },
+  /** Overrides shared shell when pill is the trailing control (no max-width squeeze with title). */
+  ratingPillTrailing: {
+    flexShrink: 0,
+    maxWidth: "40%",
+    alignSelf: "center",
   },
 });

--- a/lib/ui/workouts/WeeklyInsightsCard.tsx
+++ b/lib/ui/workouts/WeeklyInsightsCard.tsx
@@ -6,6 +6,7 @@ import type {
   WeeklyInsightsCardModel,
 } from "@/lib/data/workouts/weeklyInsightsCardModel";
 import { workoutOverviewInCardHeaderStyles } from "@/lib/ui/workouts/workoutOverviewInCardHeaderStyles";
+import { elevatedCardSurfaceStyle } from "@/lib/ui/theme/elevatedCardSurface";
 
 type WeeklyInsightsCardProps = {
   model: WeeklyInsightsCardModel;
@@ -71,6 +72,7 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     padding: 16,
     gap: 12,
+    ...elevatedCardSurfaceStyle,
   },
   insightList: {
     gap: 12,

--- a/lib/ui/workouts/workoutOverviewInCardHeaderStyles.ts
+++ b/lib/ui/workouts/workoutOverviewInCardHeaderStyles.ts
@@ -14,9 +14,9 @@ export const workoutOverviewInCardHeaderStyles = StyleSheet.create({
   },
   title: {
     fontSize: 21,
-    fontWeight: "800",
+    fontWeight: "900",
     color: "#1C1C1E",
-    letterSpacing: -0.35,
+    letterSpacing: -0.38,
   },
   linkHit: { paddingVertical: 4, paddingLeft: 8 },
   link: { fontSize: 15, fontWeight: "600", color: UI_LINK_SECONDARY, letterSpacing: -0.2 },


### PR DESCRIPTION
…stem across modules

- replace Body 'Recent' with Weight Trend card using year-based summary (YTD + latest)
- align Weight Trend stats with Weight detail page (Change / Avg / High / Low)
- add weekly delta indicator and improve visual hierarchy
- redesign trend card layout with premium range bar (low/high positioning)
- remove redundant elements (change pill, duplicate current value)
- standardize calendar headers across modules (year-based titles)
- fix calendar opening month bug (now opens to current month)
- remove duplicate header layer and improve spacing
- improve calendar typography (weekday + date hierarchy)
- unify calendar styling across Body, Strength, Nutrition, etc.

- introduce shared calendar header utilities and formatting helpers
- add bodyMetricDetailDefaults and BodyTrendsCard components
- update overview + calendar hooks to support consistent trend data
- improve UI tokens and elevated card surface system

all checks passing (typecheck, lint, test, invariants)