### PR TITLE
fix(activity): complete steps pipeline repair + YTD recompute + infra…

### DIFF
--- a/app/(app)/_layout.tsx
+++ b/app/(app)/_layout.tsx
@@ -59,6 +59,10 @@ export default function AppLayout() {
             options={{ title: "", ...workoutsStackNavigationOptions("detail") }}
           />
           <Stack.Screen
+            name="activity/day/[day]"
+            options={{ title: "Activity day", ...workoutsStackNavigationOptions("detail") }}
+          />
+          <Stack.Screen
             name="activity/settings"
             options={{ title: "Activity settings", ...workoutsStackNavigationOptions("detail") }}
           />

--- a/app/(app)/activity/__tests__/activity-overview.test.tsx
+++ b/app/(app)/activity/__tests__/activity-overview.test.tsx
@@ -2,6 +2,68 @@ import React from "react";
 import renderer, { act } from "react-test-renderer";
 
 const mockRouterPush = jest.fn();
+const mockSetSelectedDay = jest.fn();
+
+const defaultOverviewData = {
+  user: { uid: "u1" },
+  initializing: false,
+  selectedDay: "2026-04-06",
+  setSelectedDay: mockSetSelectedDay,
+  weeklyStripDays: [
+    { day: "2026-04-05", meta: { hasSteps: false } },
+    { day: "2026-04-06", meta: { hasSteps: true } },
+    { day: "2026-04-07", meta: { hasSteps: false } },
+    { day: "2026-04-08", meta: { hasSteps: false } },
+    { day: "2026-04-09", meta: { hasSteps: false } },
+    { day: "2026-04-10", meta: { hasSteps: false } },
+    { day: "2026-04-11", meta: { hasSteps: false } },
+  ],
+  stepsRollup: { status: "ready" as const, rollupByDay: {}, refetch: jest.fn() },
+  overview: {
+    loading: false,
+    error: null,
+    model: {
+      timeframes: [
+        {
+          key: "today" as const,
+          label: "Today",
+          compactStatsSummary: "5,000 steps",
+          markerPosition01: 0.4,
+        },
+        {
+          key: "avg7d" as const,
+          label: "7D Avg",
+          compactStatsSummary: "3,000/day",
+          markerPosition01: 0.25,
+        },
+        {
+          key: "avg30d" as const,
+          label: "30D Avg",
+          compactStatsSummary: "2,000/day",
+          markerPosition01: 0.17,
+        },
+        {
+          key: "avg365d" as const,
+          label: "365D Avg",
+          compactStatsSummary: "4,000/day",
+          markerPosition01: 0.33,
+        },
+      ],
+    },
+  },
+  dailyDetails: {
+    loading: false,
+    error: null,
+    model: {
+      title: "Sun 4/6",
+      compactStatsSummary: "1,234 steps",
+      markerPosition01: 0.12,
+    },
+  },
+};
+
+const mockUseActivityOverviewScreenData = jest.fn(() => defaultOverviewData);
+
 let navigationOptions: { headerRight?: () => React.ReactElement; headerLeft?: () => React.ReactElement } = {};
 
 jest.mock("expo-router", () => ({
@@ -32,61 +94,31 @@ jest.mock("@/lib/auth/AuthProvider", () => ({
 }));
 
 jest.mock("@/lib/data/activity/useActivityOverviewScreenData", () => ({
-  useActivityOverviewScreenData: () => ({
-    user: { uid: "u1" },
-    initializing: false,
-    selectedDay: "2026-04-06",
-    setSelectedDay: jest.fn(),
-    weeklyStripDays: [
-      { day: "2026-04-05", meta: { hasSteps: false } },
-      { day: "2026-04-06", meta: { hasSteps: true } },
-      { day: "2026-04-07", meta: { hasSteps: false } },
-      { day: "2026-04-08", meta: { hasSteps: false } },
-      { day: "2026-04-09", meta: { hasSteps: false } },
-      { day: "2026-04-10", meta: { hasSteps: false } },
-      { day: "2026-04-11", meta: { hasSteps: false } },
-    ],
-    stepsRollup: { status: "ready" as const, rollupByDay: {}, refetch: jest.fn() },
-    overview: {
-      loading: false,
-      error: null,
-      model: {
-        timeframes: [
-          {
-            key: "today" as const,
-            label: "Today",
-            compactStatsSummary: "5,000 steps",
-            markerPosition01: 0.4,
-          },
-          {
-            key: "thisWeek" as const,
-            label: "This Week",
-            compactStatsSummary: "3,000/day",
-            markerPosition01: 0.25,
-          },
-          {
-            key: "mtd" as const,
-            label: "MTD",
-            compactStatsSummary: "2,000/day",
-            markerPosition01: 0.17,
-          },
-          {
-            key: "ytd" as const,
-            label: "YTD",
-            compactStatsSummary: "4,000/day",
-            markerPosition01: 0.33,
-          },
-        ],
-      },
-    },
-  }),
+  useActivityOverviewScreenData: () => mockUseActivityOverviewScreenData(),
 }));
 
 import ActivityOverviewScreen from "../index";
 
+function findStripDayPressable(root: renderer.ReactTestRenderer["root"], dayKey: string) {
+  const label = `${dayKey},`;
+  const nodes = root.findAll(
+    (n) =>
+      typeof n.props?.accessibilityLabel === "string" &&
+      n.props.accessibilityRole === "button" &&
+      (n.props.accessibilityLabel as string).startsWith(label),
+  );
+  const hit = nodes[0];
+  if (hit == null) {
+    throw new Error(`No weekly strip cell found for day ${dayKey}`);
+  }
+  return hit;
+}
+
 describe("ActivityOverviewScreen", () => {
   beforeEach(() => {
     mockRouterPush.mockClear();
+    mockSetSelectedDay.mockClear();
+    mockUseActivityOverviewScreenData.mockImplementation(() => defaultOverviewData);
     navigationOptions = {};
   });
 
@@ -115,7 +147,7 @@ describe("ActivityOverviewScreen", () => {
     expect(mockRouterPush).toHaveBeenCalledWith("/(app)/activity/settings");
   });
 
-  it("renders Overview card with average-only multi-day rows", async () => {
+  it("renders Overview and Daily details cards with trailing averages", async () => {
     let tree!: renderer.ReactTestRenderer;
     await act(async () => {
       tree = renderer.create(<ActivityOverviewScreen />);
@@ -123,12 +155,85 @@ describe("ActivityOverviewScreen", () => {
     });
     const str = JSON.stringify(tree.toJSON());
     expect(str).toContain("Overview");
+    expect(str).toContain("Daily details");
     expect(str).toContain("5,000 steps");
     expect(str).toContain("3,000/day");
     expect(str).toContain("2,000/day");
     expect(str).toContain("4,000/day");
+    expect(str).toContain("1,234 steps");
     expect(str).not.toMatch(/\d+ steps · \d/);
     expect(str).toContain("activity-overview-steps-bar-today");
-    expect(str).toContain("activity-overview-steps-bar-ytd");
+    expect(str).toContain("activity-overview-steps-bar-avg365d");
+    expect(str).toContain("activity-daily-details-steps-bar");
+  });
+
+  it("tapping a weekly strip day pushes activity day detail with local YYYY-MM-DD param", async () => {
+    let tree!: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<ActivityOverviewScreen />);
+      await Promise.resolve();
+    });
+    const cell = findStripDayPressable(tree.root, "2026-04-07");
+    await act(async () => {
+      cell.props.onPress();
+    });
+    expect(mockSetSelectedDay).toHaveBeenCalledWith("2026-04-07");
+    expect(mockRouterPush).toHaveBeenCalledWith({
+      pathname: "/(app)/activity/day/[day]",
+      params: { day: "2026-04-07" },
+    });
+  });
+
+  it("strip selection uses the same day key string as the calendar and day route (zero-padded month/day)", async () => {
+    let tree!: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<ActivityOverviewScreen />);
+      await Promise.resolve();
+    });
+    const cell = findStripDayPressable(tree.root, "2026-04-05");
+    expect(cell.props.accessibilityLabel).toMatch(/^2026-04-05,/);
+    await act(async () => {
+      cell.props.onPress();
+    });
+    expect(mockRouterPush).toHaveBeenCalledWith({
+      pathname: "/(app)/activity/day/[day]",
+      params: { day: "2026-04-05" },
+    });
+  });
+
+  it("navigates to day detail for the strip day marked as today and for a non-today strip day", async () => {
+    mockUseActivityOverviewScreenData.mockImplementation(() => ({
+      ...defaultOverviewData,
+      selectedDay: "2026-04-10",
+      weeklyStripDays: [
+        { day: "2026-04-05", meta: { hasSteps: false } },
+        { day: "2026-04-10", meta: { hasSteps: true } },
+      ],
+    }));
+
+    let tree!: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<ActivityOverviewScreen />);
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      findStripDayPressable(tree.root, "2026-04-10").props.onPress();
+    });
+    expect(mockRouterPush).toHaveBeenLastCalledWith({
+      pathname: "/(app)/activity/day/[day]",
+      params: { day: "2026-04-10" },
+    });
+
+    mockRouterPush.mockClear();
+    mockSetSelectedDay.mockClear();
+
+    await act(async () => {
+      findStripDayPressable(tree.root, "2026-04-05").props.onPress();
+    });
+    expect(mockRouterPush).toHaveBeenLastCalledWith({
+      pathname: "/(app)/activity/day/[day]",
+      params: { day: "2026-04-05" },
+    });
   });
 });

--- a/app/(app)/activity/calendar.tsx
+++ b/app/(app)/activity/calendar.tsx
@@ -1,12 +1,138 @@
-import React from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { FlatList, Platform, StyleSheet, View, type ViewToken } from "react-native";
+import { useNavigation, useRouter } from "expo-router";
+import { ScreenContainer } from "@/lib/ui/ScreenStates";
+import { MonthGrid } from "@/lib/ui/calendar/MonthGrid";
+import {
+  clampMonthYear,
+  getTodayDayKeyLocal,
+  type MonthYear,
+} from "@/lib/ui/calendar/dateUtils";
+import { headerYearFromViewableMonthItems } from "@/lib/ui/calendar/moduleCalendarHeaderYear";
+import { useModuleCalendarYearNavigationHeader } from "@/lib/ui/calendar/useModuleCalendarYearNavigationHeader";
+import { computeActivityCalendarFetchDayKeys } from "@/lib/data/activity/activityOverviewRanges";
+import { useActivityStepsRollupForKeys } from "@/lib/data/activity/useActivityStepsRollupMap";
+import { UI_APP_SCREEN_BG } from "@/lib/ui/theme/uiTokens";
 
-import { ModuleCalendarPlaceholderScreen } from "@/lib/ui/ModuleCalendarPlaceholderScreen";
+type MonthModel = { key: string; monthYear: MonthYear };
+const MONTHS_BACK = 12;
+const MONTHS_FORWARD = 12;
+const CALENDAR_MONTH_ITEM_HEIGHT = 372;
+
+function monthYearFromToday(): MonthYear {
+  const d = getTodayDayKeyLocal();
+  const y = Number(d.slice(0, 4));
+  const m = Number(d.slice(5, 7));
+  return clampMonthYear({ year: y, month: m });
+}
+
+function shiftMonth(monthYear: MonthYear, delta: number): MonthYear {
+  return clampMonthYear({ year: monthYear.year, month: monthYear.month + delta });
+}
+
+function buildMonthRange(center: MonthYear): MonthModel[] {
+  const out: MonthModel[] = [];
+  for (let i = -MONTHS_BACK; i <= MONTHS_FORWARD; i += 1) {
+    const m = shiftMonth(center, i);
+    out.push({ key: `${m.year}-${String(m.month).padStart(2, "0")}`, monthYear: m });
+  }
+  return out;
+}
 
 export default function ActivityCalendarScreen() {
+  const router = useRouter();
+  const navigation = useNavigation();
+  const todayMonth = monthYearFromToday();
+  const months = useMemo(() => buildMonthRange(todayMonth), [todayMonth.year, todayMonth.month]);
+  const todayMonthIndex = MONTHS_BACK;
+  const flatListRef = useRef<FlatList<MonthModel>>(null);
+  const [headerYear, setHeaderYear] = useState(todayMonth.year);
+
+  const todayDayKey = getTodayDayKeyLocal();
+  const fetchKeys = useMemo(() => computeActivityCalendarFetchDayKeys(todayDayKey), [todayDayKey]);
+  const rollup = useActivityStepsRollupForKeys(fetchKeys);
+
+  const markedDays = useMemo(() => {
+    if (rollup.status !== "ready") return new Set<string>();
+    const s = new Set<string>();
+    for (const [d, e] of Object.entries(rollup.rollupByDay)) {
+      if (e?.kind === "numeric" && e.steps > 0) s.add(d);
+    }
+    return s;
+  }, [rollup]);
+
+  useModuleCalendarYearNavigationHeader(navigation, headerYear);
+
+  useEffect(() => {
+    if (process.env.JEST_WORKER_ID) return;
+    const id = requestAnimationFrame(() => {
+      flatListRef.current?.scrollToIndex({
+        index: todayMonthIndex,
+        animated: false,
+        viewPosition: 0,
+      });
+    });
+    return () => cancelAnimationFrame(id);
+  }, [todayMonthIndex]);
+
+  const onViewableItemsChanged = useCallback(
+    ({ viewableItems }: { viewableItems: ViewToken[] }) => {
+      const y = headerYearFromViewableMonthItems(viewableItems, months);
+      if (y != null) setHeaderYear(y);
+    },
+    [months],
+  );
+
+  const viewabilityConfig = useRef({
+    itemVisiblePercentThreshold: 20,
+  }).current;
+
+  const screenEdges = ["left", "right", "bottom"] as const;
+
   return (
-    <ModuleCalendarPlaceholderScreen
-      title="Activity calendar"
-      description="A month-by-month activity calendar will appear here when this module is expanded. For now, use the week strip on Activity for day selection."
-    />
+    <ScreenContainer backgroundColor={UI_APP_SCREEN_BG} padded={false} edges={[...screenEdges]}>
+      <FlatList
+        ref={flatListRef}
+        data={months}
+        keyExtractor={(item) => item.key}
+        contentContainerStyle={styles.scroll}
+        initialScrollIndex={todayMonthIndex}
+        initialNumToRender={5}
+        maxToRenderPerBatch={6}
+        windowSize={7}
+        getItemLayout={(_, index) => ({
+          length: CALENDAR_MONTH_ITEM_HEIGHT,
+          offset: CALENDAR_MONTH_ITEM_HEIGHT * index,
+          index,
+        })}
+        viewabilityConfig={viewabilityConfig}
+        onViewableItemsChanged={onViewableItemsChanged}
+        onScrollToIndexFailed={() => {
+          flatListRef.current?.scrollToOffset({
+            offset: todayMonthIndex * CALENDAR_MONTH_ITEM_HEIGHT,
+            animated: false,
+          });
+        }}
+        {...(Platform.OS === "ios" ? { contentInsetAdjustmentBehavior: "never" as const } : {})}
+        renderItem={({ item }) => (
+          <View style={styles.monthItem}>
+            <MonthGrid
+              monthYear={item.monthYear}
+              dayKeyBasis="local"
+              ringSemantics="activity"
+              markerForDay={(day) =>
+                markedDays.has(day) ? { hasStrength: false, hasCardio: true } : null
+              }
+              onDayPress={(day) => router.push({ pathname: "/(app)/activity/day/[day]", params: { day } })}
+            />
+          </View>
+        )}
+      />
+    </ScreenContainer>
   );
 }
+
+const styles = StyleSheet.create({
+  scroll: { paddingBottom: 32 },
+  monthItem: { height: CALENDAR_MONTH_ITEM_HEIGHT },
+});

--- a/app/(app)/activity/day/[day].tsx
+++ b/app/(app)/activity/day/[day].tsx
@@ -19,18 +19,18 @@ export default function ActivityDayScreen() {
     );
   }
 
-  if (initializing || state.status === "idle" || state.status === "loading") {
+  if (!user && !initializing) {
     return (
       <ScreenContainer>
-        <LoadingState message="Loading steps…" />
+        <EmptyState title="Sign in" description="Sign in to view steps for this day." />
       </ScreenContainer>
     );
   }
 
-  if (!user) {
+  if (initializing || state.status === "partial") {
     return (
       <ScreenContainer>
-        <EmptyState title="Sign in" description="Sign in to view steps for this day." />
+        <LoadingState message="Loading steps…" />
       </ScreenContainer>
     );
   }
@@ -47,7 +47,7 @@ export default function ActivityDayScreen() {
     );
   }
 
-  if (state.status === "empty") {
+  if (state.status === "missing") {
     return (
       <ScreenContainer>
         <EmptyState

--- a/app/(app)/activity/day/[day].tsx
+++ b/app/(app)/activity/day/[day].tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import { ScrollView, StyleSheet, Text, View } from "react-native";
+import { useLocalSearchParams } from "expo-router";
+
+import { useActivityDayScreenData } from "@/lib/data/activity/useActivityDayScreenData";
+import { useAuth } from "@/lib/auth/AuthProvider";
+import { EmptyState, ErrorState, LoadingState, ScreenContainer } from "@/lib/ui/ScreenStates";
+
+export default function ActivityDayScreen() {
+  const params = useLocalSearchParams<{ day?: string | string[] }>();
+  const { normalized, state, reload } = useActivityDayScreenData(params.day);
+  const { user, initializing } = useAuth();
+
+  if (!normalized.ok) {
+    return (
+      <ScreenContainer>
+        <ErrorState message="That date isn’t valid. Use a day in YYYY-MM-DD format." />
+      </ScreenContainer>
+    );
+  }
+
+  if (initializing || state.status === "idle" || state.status === "loading") {
+    return (
+      <ScreenContainer>
+        <LoadingState message="Loading steps…" />
+      </ScreenContainer>
+    );
+  }
+
+  if (!user) {
+    return (
+      <ScreenContainer>
+        <EmptyState title="Sign in" description="Sign in to view steps for this day." />
+      </ScreenContainer>
+    );
+  }
+
+  if (state.status === "error") {
+    return (
+      <ScreenContainer>
+        <ErrorState
+          message={state.message}
+          requestId={state.requestId}
+          onRetry={() => void reload()}
+        />
+      </ScreenContainer>
+    );
+  }
+
+  if (state.status === "empty") {
+    return (
+      <ScreenContainer>
+        <EmptyState
+          title="No steps for this day"
+          description="When Apple Health or other sources sync steps for this date, the total will appear here."
+        />
+      </ScreenContainer>
+    );
+  }
+
+  return (
+    <ScreenContainer>
+      <ScrollView contentContainerStyle={styles.scroll}>
+        <View style={styles.card}>
+          <Text style={styles.title}>{normalized.ok ? normalized.day : ""}</Text>
+          <View style={styles.row}>
+            <Text style={styles.label}>Steps</Text>
+            <Text style={styles.value}>{state.steps.toLocaleString()}</Text>
+          </View>
+          <Text style={styles.caption}>Total from your daily rollup (same source as Activity overview).</Text>
+        </View>
+      </ScrollView>
+    </ScreenContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  scroll: { padding: 16, paddingBottom: 32 },
+  card: { backgroundColor: "#FFFFFF", borderRadius: 12, padding: 16, gap: 10 },
+  title: { fontSize: 18, fontWeight: "700", color: "#1C1C1E", marginBottom: 6 },
+  row: { flexDirection: "row", alignItems: "center", justifyContent: "space-between" },
+  label: { fontSize: 14, color: "#6E6E73" },
+  value: { fontSize: 15, fontWeight: "600", color: "#1C1C1E" },
+  caption: { fontSize: 12, color: "#8E8E93", marginTop: 4 },
+});

--- a/app/(app)/activity/index.tsx
+++ b/app/(app)/activity/index.tsx
@@ -3,6 +3,7 @@ import { StyleSheet, View } from "react-native";
 import { useNavigation, useRouter } from "expo-router";
 
 import { useActivityOverviewScreenData } from "@/lib/data/activity/useActivityOverviewScreenData";
+import { ActivityDailyDetailsCard } from "@/lib/ui/activity/ActivityDailyDetailsCard";
 import { ActivityOverviewCard } from "@/lib/ui/activity/ActivityOverviewCard";
 import { ActivityWeeklyStrip } from "@/lib/ui/activity/ActivityWeeklyStrip";
 import { EmptyState, LoadingState } from "@/lib/ui/ScreenStates";
@@ -51,11 +52,16 @@ export default function ActivityOverviewScreen() {
     );
   }
 
+  const onStripDayPress = (day: string) => {
+    data.setSelectedDay(day);
+    router.push({ pathname: "/(app)/activity/day/[day]", params: { day } });
+  };
+
   const headerStrip = (
     <ActivityWeeklyStrip
       days={data.weeklyStripDays}
       selectedDay={data.selectedDay}
-      onDayPress={data.setSelectedDay}
+      onDayPress={onStripDayPress}
     />
   );
 
@@ -74,6 +80,12 @@ export default function ActivityOverviewScreen() {
             error={data.overview.error}
             model={data.overview.model}
           />
+          <View style={styles.cardSpacer} />
+          <ActivityDailyDetailsCard
+            loading={data.dailyDetails.loading}
+            error={data.dailyDetails.error}
+            model={data.dailyDetails.model}
+          />
         </View>
       </ModuleScreenShell>
     </View>
@@ -88,4 +100,5 @@ const styles = StyleSheet.create({
     paddingTop: 16,
     flexGrow: 1,
   },
+  cardSpacer: { height: 16 },
 });

--- a/lib/contracts/__tests__/activityStepsResolution.test.ts
+++ b/lib/contracts/__tests__/activityStepsResolution.test.ts
@@ -1,0 +1,77 @@
+import {
+  pickContributingStepEventsForDailyFacts,
+  resolvedStepsTotalFromContributing,
+} from "../activityStepsResolution";
+
+describe("activityStepsResolution", () => {
+  it("prefers apple_health when present (no double count with manual)", () => {
+    const contributing = pickContributingStepEventsForDailyFacts([
+      { id: "m1", sourceId: "manual", steps: 9000 },
+      { id: "a1", sourceId: "apple_health", steps: 5012 },
+    ]);
+    expect(contributing.map((e) => e.id)).toEqual(["a1"]);
+    expect(resolvedStepsTotalFromContributing(contributing)).toBe(5012);
+  });
+
+  it("multiple apple_health: picks one row (highest steps) to avoid double-counting daily totals", () => {
+    const contributing = pickContributingStepEventsForDailyFacts([
+      { id: "b", sourceId: "apple_health", steps: 1000 },
+      { id: "a", sourceId: "apple_health", steps: 5000 },
+    ]);
+    expect(contributing).toHaveLength(1);
+    expect(contributing[0]!.steps).toBe(5000);
+  });
+
+  it("single non-apple event wins alone", () => {
+    const contributing = pickContributingStepEventsForDailyFacts([
+      { id: "m1", sourceId: "manual", steps: 3333 },
+    ]);
+    expect(resolvedStepsTotalFromContributing(contributing)).toBe(3333);
+  });
+
+  it("multiple non-apple: picks highest steps, tie-break by id", () => {
+    const contributing = pickContributingStepEventsForDailyFacts([
+      { id: "z", sourceId: "manual", steps: 4000 },
+      { id: "a", sourceId: "manual", steps: 4000 },
+    ]);
+    expect(contributing).toHaveLength(1);
+    expect(contributing[0]!.id).toBe("a");
+  });
+
+  it("healthkit is Apple-class: excludes non-apple sources (same as apple_health)", () => {
+    const contributing = pickContributingStepEventsForDailyFacts([
+      { id: "oura", sourceId: "oura", steps: 4794 },
+      { id: "hk", sourceId: "healthkit", steps: 74 },
+    ]);
+    expect(contributing.map((e) => e.id)).toEqual(["hk"]);
+    expect(resolvedStepsTotalFromContributing(contributing)).toBe(74);
+  });
+
+  it("resolvedStepsTotalFromContributing collapses a raw multi-source list (never sums vendors)", () => {
+    const raw = [
+      { id: "oura", sourceId: "oura", steps: 4794 },
+      { id: "ah", sourceId: "apple_health", steps: 74 },
+    ];
+    expect(resolvedStepsTotalFromContributing(raw)).toBe(74);
+  });
+
+  it("regression: apple_health wins over Oura (74 vs 4794; pick + resolved, never sum)", () => {
+    const events = [
+      { id: "oura_steps", sourceId: "oura", steps: 4794 },
+      { id: "appleHealth:v2:steps:2026-03-01", sourceId: "apple_health", steps: 74 },
+    ];
+    const contributing = pickContributingStepEventsForDailyFacts(events);
+    expect(contributing.map((e) => e.id)).toEqual(["appleHealth:v2:steps:2026-03-01"]);
+    expect(resolvedStepsTotalFromContributing(events)).toBe(74);
+  });
+
+  it("regression: HealthKit is Apple-class over Oura (67 vs 4794)", () => {
+    const events = [
+      { id: "oura_steps", sourceId: "oura", steps: 4794 },
+      { id: "hk_daily", sourceId: "healthkit", steps: 67 },
+    ];
+    const contributing = pickContributingStepEventsForDailyFacts(events);
+    expect(contributing.map((e) => e.id)).toEqual(["hk_daily"]);
+    expect(resolvedStepsTotalFromContributing(events)).toBe(67);
+  });
+});

--- a/lib/contracts/activityStepsResolution.ts
+++ b/lib/contracts/activityStepsResolution.ts
@@ -1,0 +1,56 @@
+/**
+ * Deterministic rules for collapsing multiple `kind: "steps"` canonical events for one calendar day
+ * into a single display / daily-facts scalar (avoids double-counting Apple Health + manual, etc.).
+ *
+ * Policy (near-term):
+ * - If any event is an Apple-class read (`apple_health` or `healthkit`, see {@link isAppleHealthBodyReadSourceId}),
+ *   pick **one** Apple-class row (highest `steps`, then lexicographic `id`) and **ignore all non-Apple** sources for that day.
+ * - Else if exactly one valid steps event, it wins.
+ * - Else multiple non–Apple events: pick the single event with the highest `steps`; tie-break by `id` (lexicographic).
+ */
+
+import { isAppleHealthBodyReadSourceId } from "./bodyReadSources";
+
+export type ActivityStepsCanonicalLike = {
+  readonly id: string;
+  readonly sourceId: string;
+  readonly steps: number;
+  readonly distanceKm?: number | null;
+  readonly moveMinutes?: number | null;
+};
+
+function isValidSteps(n: number): boolean {
+  return typeof n === "number" && Number.isFinite(n) && n >= 0;
+}
+
+export function pickContributingStepEventsForDailyFacts(
+  events: readonly ActivityStepsCanonicalLike[],
+): readonly ActivityStepsCanonicalLike[] {
+  const valid = events.filter((e) => isValidSteps(e.steps));
+  if (valid.length === 0) return [];
+  const apple = valid.filter((e) => isAppleHealthBodyReadSourceId(e.sourceId));
+  if (apple.length > 0) {
+    if (apple.length === 1) return apple;
+    const sorted = [...apple].sort((a, b) =>
+      b.steps !== a.steps ? b.steps - a.steps : a.id.localeCompare(b.id),
+    );
+    const top = sorted[0];
+    return top != null ? [top] : [];
+  }
+  if (valid.length === 1) return valid;
+  const sorted = [...valid].sort((a, b) =>
+    b.steps !== a.steps ? b.steps - a.steps : a.id.localeCompare(b.id),
+  );
+  const top = sorted[0];
+  return top != null ? [top] : [];
+}
+
+export function resolvedStepsTotalFromContributing(
+  contributing: readonly ActivityStepsCanonicalLike[],
+): number {
+  // Never sum multiple same-day vendors: collapse here so callers cannot double-count by
+  // passing the full steps list (scalar DailyFacts.activity.steps is always one authority).
+  const collapsed = pickContributingStepEventsForDailyFacts(contributing);
+  if (collapsed.length === 0) return 0;
+  return Math.round(collapsed[0]!.steps);
+}

--- a/lib/contracts/index.ts
+++ b/lib/contracts/index.ts
@@ -2,6 +2,7 @@
 
 export * from "./rawEvent";
 export * from "./dailyFacts";
+export * from "./activityStepsResolution";
 export * from "./derivedLedger";
 export * from "./insights";
 export * from "./intelligenceContext";

--- a/lib/data/activity/__tests__/activityDayRouteParam.test.ts
+++ b/lib/data/activity/__tests__/activityDayRouteParam.test.ts
@@ -1,0 +1,19 @@
+import { normalizeActivityDayRouteParam } from "../activityDayRouteParam";
+
+describe("normalizeActivityDayRouteParam", () => {
+  it("accepts a valid string", () => {
+    expect(normalizeActivityDayRouteParam("2026-04-08")).toEqual({ ok: true, day: "2026-04-08" });
+  });
+
+  it("uses the first element when given string[]", () => {
+    expect(normalizeActivityDayRouteParam(["2026-05-01", "ignored"])).toEqual({ ok: true, day: "2026-05-01" });
+  });
+
+  it("rejects invalid day strings", () => {
+    expect(normalizeActivityDayRouteParam("04-08-2026").ok).toBe(false);
+    expect(normalizeActivityDayRouteParam("2026-4-8").ok).toBe(false);
+    expect(normalizeActivityDayRouteParam("").ok).toBe(false);
+    expect(normalizeActivityDayRouteParam(undefined).ok).toBe(false);
+    expect(normalizeActivityDayRouteParam(["bad"]).ok).toBe(false);
+  });
+});

--- a/lib/data/activity/__tests__/activityOverviewCardModel.test.ts
+++ b/lib/data/activity/__tests__/activityOverviewCardModel.test.ts
@@ -1,10 +1,23 @@
 import type { ActivityStepsRollupMap } from "@/lib/data/activity/activityOverviewRollupTypes";
+import { rollupEntryIsFailure } from "@/lib/data/activity/activityRollupErrorSummary";
 import {
   ACTIVITY_OVERVIEW_STEPS_PLACEMENT_CAP,
+  buildActivityDailyDetailsCardModel,
   buildActivityOverviewCardModel,
   formatActivityAverageRowSummary,
+  formatActivityDailyDetailsTitle,
   formatActivityTodayRowSummary,
 } from "@/lib/data/activity/activityOverviewCardModel";
+
+describe("formatActivityDailyDetailsTitle", () => {
+  it('uses "Today" when selected is local today', () => {
+    expect(formatActivityDailyDetailsTitle("2026-04-10", "2026-04-10")).toBe("Today");
+  });
+
+  it("uses weekday short date for historical selection", () => {
+    expect(formatActivityDailyDetailsTitle("2026-04-05", "2026-04-10")).toMatch(/Sun/);
+  });
+});
 
 describe("formatActivityTodayRowSummary", () => {
   it("shows total steps only when numeric", () => {
@@ -18,7 +31,7 @@ describe("formatActivityTodayRowSummary", () => {
 });
 
 describe("formatActivityAverageRowSummary", () => {
-  it("shows average per day only", () => {
+  it("shows average per day with /day suffix", () => {
     expect(formatActivityAverageRowSummary(6026.8)).toBe("6,027/day");
   });
 });
@@ -32,87 +45,83 @@ function numericMap(pairs: [string, number][]): ActivityStepsRollupMap {
 }
 
 describe("buildActivityOverviewCardModel", () => {
-  const selectedDay = "2026-04-09";
-  const todayDayKey = "2026-04-09";
+  const todayDayKey = "2026-04-08";
 
-  it("orders rows Today, This Week, MTD, YTD", () => {
+  it("treats error rollup days as 0 in trailing averages (caller surfaces rollup errors separately)", () => {
+    const rollup: ActivityStepsRollupMap = {
+      "2026-04-08": { kind: "numeric", steps: 7000 },
+      "2026-04-07": { kind: "error", message: "network", requestId: "x" },
+    };
+    expect(rollupEntryIsFailure(rollup["2026-04-07"])).toBe(true);
+    const { timeframes } = buildActivityOverviewCardModel({ todayDayKey, rollupByDay: rollup });
+    expect(timeframes[0]?.compactStatsSummary).toBe("7,000 steps");
+    // 7d window still divides by 7; failed day contributes 0, not "absent" silently as if loaded
+    expect(timeframes[1]?.compactStatsSummary).toBe("1,000/day");
+  });
+
+  it("orders rows Today, 7D Avg, 30D Avg, 365D Avg", () => {
+    const rollup = numericMap([["2026-04-08", 7000]]);
+    const { timeframes } = buildActivityOverviewCardModel({ todayDayKey, rollupByDay: rollup });
+    expect(timeframes.map((r) => r.key)).toEqual(["today", "avg7d", "avg30d", "avg365d"]);
+    expect(timeframes.map((r) => r.label)).toEqual(["Today", "7D Avg", "30D Avg", "365D Avg"]);
+  });
+
+  it("uses fixed trailing windows: 7/30/365 days inclusive of today", () => {
     const rollup = numericMap([
+      ["2026-04-02", 1000],
+      ["2026-04-03", 1000],
+      ["2026-04-04", 1000],
       ["2026-04-05", 1000],
       ["2026-04-06", 1000],
       ["2026-04-07", 1000],
-      ["2026-04-08", 1000],
-      ["2026-04-09", 1000],
-      ["2026-04-01", 1000],
-      ["2026-04-02", 1000],
-      ["2026-01-01", 1000],
+      ["2026-04-08", 7000],
     ]);
-    const { timeframes } = buildActivityOverviewCardModel({
-      selectedDay,
-      todayDayKey,
-      rollupByDay: rollup,
-    });
-    expect(timeframes.map((r) => r.key)).toEqual(["today", "thisWeek", "mtd", "ytd"]);
-    expect(timeframes.map((r) => r.label)).toEqual(["Today", "This Week", "MTD", "YTD"]);
+    const { timeframes } = buildActivityOverviewCardModel({ todayDayKey, rollupByDay: rollup });
+    expect(timeframes[0]?.compactStatsSummary).toBe("7,000 steps");
+    // sum 7d = 6×1000 + 7000 = 13_000 / 7
+    expect(timeframes[1]?.compactStatsSummary).toBe("1,857/day");
+    // sum 30d = same 13_000 over 7 populated days in window / 30
+    expect(timeframes[2]?.compactStatsSummary).toBe("433/day");
+    expect(timeframes[3]?.compactStatsSummary).toBe("36/day");
   });
 
-  it("Today shows total only; multi-day rows show average only (no totals in copy)", () => {
-    const rollup = numericMap([
-      ["2026-04-05", 4000],
-      ["2026-04-06", 4000],
-      ["2026-04-07", 4000],
-      ["2026-04-08", 4000],
-      ["2026-04-09", 8000],
-    ]);
-    const { timeframes } = buildActivityOverviewCardModel({
-      selectedDay,
-      todayDayKey,
-      rollupByDay: rollup,
-    });
-    expect(timeframes[0]?.compactStatsSummary).toBe("8,000 steps");
-    expect(timeframes[1]?.compactStatsSummary).toBe("4,800/day");
-    expect(timeframes[1]?.compactStatsSummary).not.toContain("steps");
-    expect(timeframes[2]?.compactStatsSummary).toMatch(/\/day$/);
-    expect(timeframes[3]?.compactStatsSummary).toMatch(/\/day$/);
-  });
-
-  it("when Today is absent but week has numeric rollups, Today is honest and averages still compute", () => {
-    const rollup: ActivityStepsRollupMap = {
-      "2026-04-09": { kind: "absent" },
-      "2026-04-05": { kind: "numeric", steps: 6000 },
-      "2026-04-06": { kind: "numeric", steps: 6000 },
-      "2026-04-07": { kind: "numeric", steps: 6000 },
-      "2026-04-08": { kind: "numeric", steps: 6000 },
-    };
-    const { timeframes } = buildActivityOverviewCardModel({
-      selectedDay: "2026-04-09",
-      todayDayKey: "2026-04-09",
-      rollupByDay: rollup,
-    });
-    expect(timeframes[0]?.compactStatsSummary).toBe("No daily rollup for this day");
-    expect(timeframes[0]?.markerPosition01).toBe(0);
-    expect(timeframes[1]?.compactStatsSummary).toBe("4,800/day");
-  });
-
-  it("uses weekday label when selected day is not local today", () => {
-    const { timeframes } = buildActivityOverviewCardModel({
-      selectedDay: "2026-04-07",
-      todayDayKey: "2026-04-09",
-      rollupByDay: numericMap([["2026-04-07", 500]]),
-    });
-    expect(timeframes[0]?.label).toMatch(/Tue/);
-    expect(timeframes[0]?.compactStatsSummary).toBe("500 steps");
+  it("365D average divides by 365 even when only part of the trailing window has data", () => {
+    const pairs: [string, number][] = [];
+    for (let i = 0; i < 10; i += 1) {
+      const d = `2026-04-${String(i + 1).padStart(2, "0")}` as `${string}-${string}-${string}`;
+      pairs.push([d, 3650]);
+    }
+    const rollup = numericMap(pairs);
+    const { timeframes } = buildActivityOverviewCardModel({ todayDayKey: "2026-04-10", rollupByDay: rollup });
+    expect(timeframes[3]?.compactStatsSummary).toBe("100/day");
   });
 
   it("exposes marker positions within 0–1 for bars", () => {
     const { timeframes } = buildActivityOverviewCardModel({
-      selectedDay,
       todayDayKey,
-      rollupByDay: numericMap([[selectedDay, ACTIVITY_OVERVIEW_STEPS_PLACEMENT_CAP]]),
+      rollupByDay: numericMap([[todayDayKey, ACTIVITY_OVERVIEW_STEPS_PLACEMENT_CAP]]),
     });
     for (const tf of timeframes) {
       expect(tf.markerPosition01).toBeGreaterThanOrEqual(0);
       expect(tf.markerPosition01).toBeLessThanOrEqual(1);
     }
     expect(timeframes[0]?.markerPosition01).toBe(1);
+  });
+});
+
+describe("buildActivityDailyDetailsCardModel", () => {
+  it("uses selected day rollup independent of overview today row", () => {
+    const rollup = numericMap([
+      ["2026-04-05", 100],
+      ["2026-04-08", 9999],
+    ]);
+    const m = buildActivityDailyDetailsCardModel({
+      selectedDay: "2026-04-05",
+      todayDayKey: "2026-04-08",
+      rollupByDay: rollup,
+    });
+    expect(m.compactStatsSummary).toBe("100 steps");
+    const overview = buildActivityOverviewCardModel({ todayDayKey: "2026-04-08", rollupByDay: rollup });
+    expect(overview.timeframes[0]?.compactStatsSummary).toBe("9,999 steps");
   });
 });

--- a/lib/data/activity/__tests__/activityOverviewRanges.test.ts
+++ b/lib/data/activity/__tests__/activityOverviewRanges.test.ts
@@ -1,41 +1,48 @@
 import {
-  activityMtdDaysThrough,
-  activityWeekElapsedDaysThrough,
-  activityYtdDaysThrough,
+  ACTIVITY_CALENDAR_MARKER_SPAN_DAYS,
+  ACTIVITY_OVERVIEW_AVG_12M_DAYS,
+  activityTrailingNDaysInclusive,
+  computeActivityCalendarFetchDayKeys,
   computeActivityOverviewFetchDayKeys,
 } from "@/lib/data/activity/activityOverviewRanges";
 
-describe("activityWeekElapsedDaysThrough", () => {
-  it("includes only week days on or before anchor (Sun–Sat week)", () => {
-    const days = activityWeekElapsedDaysThrough("2026-04-09");
-    expect(days[0]).toBe("2026-04-05");
-    expect(days[days.length - 1]).toBe("2026-04-09");
-    expect(days).toHaveLength(5);
-  });
-});
-
-describe("activityMtdDaysThrough", () => {
-  it("enumerates month start through selected day", () => {
-    const days = activityMtdDaysThrough("2026-04-09");
-    expect(days[0]).toBe("2026-04-01");
-    expect(days[days.length - 1]).toBe("2026-04-09");
-  });
-});
-
-describe("activityYtdDaysThrough", () => {
-  it("enumerates Jan 1 through selected day", () => {
-    const days = activityYtdDaysThrough("2026-04-09");
-    expect(days[0]).toBe("2026-01-01");
-    expect(days[days.length - 1]).toBe("2026-04-09");
+describe("activityTrailingNDaysInclusive", () => {
+  it("returns N consecutive days ending on endDay", () => {
+    const days = activityTrailingNDaysInclusive("2026-04-08", 7);
+    expect(days).toHaveLength(7);
+    expect(days[0]).toBe("2026-04-02");
+    expect(days[6]).toBe("2026-04-08");
   });
 });
 
 describe("computeActivityOverviewFetchDayKeys", () => {
-  it("returns sorted unique keys covering all windows", () => {
-    const keys = computeActivityOverviewFetchDayKeys("2026-04-09");
-    expect(keys[0]).toBe("2026-01-01");
-    expect(keys[keys.length - 1]).toBe("2026-04-09");
+  it("includes trailing 365d through today and week around selectedDay", () => {
+    const keys = computeActivityOverviewFetchDayKeys("2026-04-08", "2026-04-08");
+    expect(keys[0]).toBe("2025-04-09");
+    expect(keys[keys.length - 1]).toBe("2026-04-11");
     const set = new Set(keys);
     expect(set.size).toBe(keys.length);
+    expect(keys).toContain("2026-04-08");
+  });
+
+  it("includes an off-window selected day in its week strip", () => {
+    const keys = computeActivityOverviewFetchDayKeys("2026-03-15", "2026-04-08");
+    expect(keys).toContain("2026-03-15");
+    expect(keys[keys.length - 1]).toBe("2026-04-08");
+  });
+});
+
+describe("computeActivityCalendarFetchDayKeys", () => {
+  it("returns a fixed trailing span for markers", () => {
+    const keys = computeActivityCalendarFetchDayKeys("2026-04-08");
+    expect(keys).toHaveLength(ACTIVITY_CALENDAR_MARKER_SPAN_DAYS);
+    expect(keys[0]).toBe("2024-10-16");
+    expect(keys[keys.length - 1]).toBe("2026-04-08");
+  });
+});
+
+describe("overview 12M window length", () => {
+  it("matches Apple-aligned 365-day rolling year", () => {
+    expect(ACTIVITY_OVERVIEW_AVG_12M_DAYS).toBe(365);
   });
 });

--- a/lib/data/activity/__tests__/activityRollupErrorSummary.test.ts
+++ b/lib/data/activity/__tests__/activityRollupErrorSummary.test.ts
@@ -1,0 +1,66 @@
+import {
+  buildActivityRollupAggregateError,
+  buildActivitySelectedDayRollupError,
+  rollupEntryIsFailure,
+} from "@/lib/data/activity/activityRollupErrorSummary";
+import type { ActivityStepsRollupMap } from "@/lib/data/activity/activityOverviewRollupTypes";
+
+describe("buildActivityRollupAggregateError", () => {
+  it("returns null when no per-day errors", () => {
+    const map: ActivityStepsRollupMap = {
+      "2026-04-01": { kind: "numeric", steps: 100 },
+      "2026-04-02": { kind: "absent" },
+    };
+    expect(buildActivityRollupAggregateError(map, jest.fn())).toBeNull();
+  });
+
+  it("surfaces a distinct message when at least one day failed (not treated as absent)", () => {
+    const map: ActivityStepsRollupMap = {
+      "2026-04-01": { kind: "numeric", steps: 100 },
+      "2026-04-02": { kind: "error", message: "timeout", requestId: "rid-1" },
+    };
+    const onRetry = jest.fn();
+    const err = buildActivityRollupAggregateError(map, onRetry);
+    expect(err).not.toBeNull();
+    expect(err!.message).toContain("one day");
+    expect(err!.requestId).toBe("rid-1");
+    err!.onRetry();
+    expect(onRetry).toHaveBeenCalled();
+  });
+
+  it("pluralizes when multiple days failed", () => {
+    const map: ActivityStepsRollupMap = {
+      "2026-04-01": { kind: "error", message: "a", requestId: null },
+      "2026-04-02": { kind: "error", message: "b", requestId: null },
+    };
+    const err = buildActivityRollupAggregateError(map, jest.fn());
+    expect(err?.message).toContain("2 days");
+  });
+});
+
+describe("buildActivitySelectedDayRollupError", () => {
+  it("returns error payload for the selected day when that fetch failed", () => {
+    const map: ActivityStepsRollupMap = {
+      "2026-04-10": { kind: "error", message: "bad gateway", requestId: "r9" },
+    };
+    const err = buildActivitySelectedDayRollupError("2026-04-10", map, jest.fn());
+    expect(err?.message).toBe("bad gateway");
+    expect(err?.requestId).toBe("r9");
+  });
+
+  it("returns null when selected day is numeric", () => {
+    const map: ActivityStepsRollupMap = {
+      "2026-04-10": { kind: "numeric", steps: 50 },
+    };
+    expect(buildActivitySelectedDayRollupError("2026-04-10", map, jest.fn())).toBeNull();
+  });
+});
+
+describe("rollupEntryIsFailure", () => {
+  it("is true only for error kind", () => {
+    expect(rollupEntryIsFailure({ kind: "error", message: "x", requestId: null })).toBe(true);
+    expect(rollupEntryIsFailure({ kind: "absent" })).toBe(false);
+    expect(rollupEntryIsFailure({ kind: "numeric", steps: 0 })).toBe(false);
+    expect(rollupEntryIsFailure(undefined)).toBe(false);
+  });
+});

--- a/lib/data/activity/__tests__/interpretDailyFactsStepsRollupEntry.test.ts
+++ b/lib/data/activity/__tests__/interpretDailyFactsStepsRollupEntry.test.ts
@@ -1,0 +1,49 @@
+import type { ApiResult } from "@/lib/api/http";
+import type { DailyFactsDto } from "@/lib/contracts/dailyFacts";
+import { interpretDailyFactsStepsRollupEntry } from "@/lib/data/activity/dailyFactsStepsRollupEntry";
+
+function okFacts(partial: Partial<DailyFactsDto>): ApiResult<DailyFactsDto> {
+  const json = {
+    schemaVersion: 1 as const,
+    userId: "u",
+    date: "2026-04-01",
+    computedAt: "2026-04-01T12:00:00.000Z",
+    ...partial,
+  } as DailyFactsDto;
+  return { ok: true, status: 200, requestId: "r1", json };
+}
+
+describe("interpretDailyFactsStepsRollupEntry", () => {
+  it("returns numeric when activity.steps is present", () => {
+    const r = okFacts({ activity: { steps: 8123 } });
+    expect(interpretDailyFactsStepsRollupEntry(r)).toEqual({ kind: "numeric", steps: 8123 });
+  });
+
+  it("returns absent on 404", () => {
+    const r: ApiResult<DailyFactsDto> = {
+      ok: false,
+      status: 404,
+      kind: "http",
+      error: "Not found",
+      requestId: "r2",
+      json: null,
+    };
+    expect(interpretDailyFactsStepsRollupEntry(r)).toEqual({ kind: "absent" });
+  });
+
+  it("returns error on HTTP failure (not silent absent)", () => {
+    const r: ApiResult<DailyFactsDto> = {
+      ok: false,
+      status: 503,
+      kind: "http",
+      error: "Upstream unavailable",
+      requestId: "r3",
+      json: null,
+    };
+    expect(interpretDailyFactsStepsRollupEntry(r)).toEqual({
+      kind: "error",
+      message: "Upstream unavailable",
+      requestId: "r3",
+    });
+  });
+});

--- a/lib/data/activity/__tests__/useActivityDayScreenData.test.tsx
+++ b/lib/data/activity/__tests__/useActivityDayScreenData.test.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+import renderer, { act } from "react-test-renderer";
+
+jest.mock("@/lib/api/usersMe", () => ({
+  getDailyFacts: jest.fn(),
+}));
+
+/** Stable identity — `useActivityDaySteps` depends on `getIdToken`; a new fn each render retriggers fetch forever. */
+const mockAuth = {
+  user: { uid: "u1" },
+  initializing: false,
+  getIdToken: jest.fn().mockResolvedValue("token-1"),
+};
+
+jest.mock("@/lib/auth/AuthProvider", () => ({
+  useAuth: () => mockAuth,
+}));
+
+import { getDailyFacts } from "@/lib/api/usersMe";
+import { useActivityDayScreenData } from "@/lib/data/activity/useActivityDayScreenData";
+
+function Harness({ raw, probe }: { raw: unknown; probe: { current: ReturnType<typeof useActivityDayScreenData> | null } }) {
+  const v = useActivityDayScreenData(raw);
+  probe.current = v;
+  return null;
+}
+
+describe("useActivityDayScreenData", () => {
+  beforeEach(() => {
+    (getDailyFacts as jest.Mock).mockClear();
+    (getDailyFacts as jest.Mock).mockImplementation(async (day: string) => ({
+      ok: true as const,
+      status: 200,
+      requestId: "r0",
+      json: {
+        schemaVersion: 1 as const,
+        userId: "u1",
+        date: day,
+        computedAt: "2026-06-15T12:00:00.000Z",
+      },
+    }));
+  });
+
+  it("marks invalid route param without calling getDailyFacts", async () => {
+    const probe: { current: ReturnType<typeof useActivityDayScreenData> | null } = { current: null };
+    await act(async () => {
+      renderer.create(<Harness raw="not-a-day" probe={probe} />);
+    });
+    expect(probe.current?.normalized.ok).toBe(false);
+    expect(getDailyFacts).not.toHaveBeenCalled();
+  });
+
+  it("accepts string[] and uses first element", async () => {
+    const probe: { current: ReturnType<typeof useActivityDayScreenData> | null } = { current: null };
+    await act(async () => {
+      renderer.create(<Harness raw={["2026-06-15", "ignored"]} probe={probe} />);
+    });
+    expect(probe.current?.normalized).toEqual({ ok: true, day: "2026-06-15" });
+  });
+
+  it("fetches daily facts for valid day", async () => {
+    (getDailyFacts as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      requestId: "r1",
+      json: {
+        schemaVersion: 1,
+        userId: "u1",
+        date: "2026-06-20",
+        computedAt: "2026-06-20T12:00:00.000Z",
+        activity: { steps: 4444 },
+      },
+    });
+    const probe: { current: ReturnType<typeof useActivityDayScreenData> | null } = { current: null };
+    await act(async () => {
+      renderer.create(<Harness raw="2026-06-20" probe={probe} />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(getDailyFacts).toHaveBeenCalledWith("2026-06-20", "token-1");
+    expect(probe.current?.state).toEqual({ status: "ready", steps: 4444 });
+  });
+});

--- a/lib/data/activity/activityDayRouteParam.ts
+++ b/lib/data/activity/activityDayRouteParam.ts
@@ -1,0 +1,12 @@
+const DAY_KEY_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Normalize Expo Router search params for `activity/day/[day]` (`string | string[] | undefined`).
+ */
+export function normalizeActivityDayRouteParam(raw: unknown): { ok: true; day: string } | { ok: false } {
+  const first = Array.isArray(raw) ? raw[0] : raw;
+  if (typeof first !== "string" || !DAY_KEY_RE.test(first)) {
+    return { ok: false };
+  }
+  return { ok: true, day: first };
+}

--- a/lib/data/activity/activityOverviewCardModel.ts
+++ b/lib/data/activity/activityOverviewCardModel.ts
@@ -3,9 +3,10 @@ import {
   dashRecapPlacementMarker01,
 } from "@/lib/data/dash/dashRecapDisplayPlacement";
 import {
-  activityMtdDaysThrough,
-  activityWeekElapsedDaysThrough,
-  activityYtdDaysThrough,
+  ACTIVITY_OVERVIEW_AVG_12M_DAYS,
+  ACTIVITY_OVERVIEW_AVG_30D_DAYS,
+  ACTIVITY_OVERVIEW_AVG_7D_DAYS,
+  activityTrailingNDaysInclusive,
 } from "@/lib/data/activity/activityOverviewRanges";
 import type { ActivityStepsRollupMap, DayStepsRollupEntry } from "@/lib/data/activity/activityOverviewRollupTypes";
 import { formatDayKeyWeekdayShortMonthDay } from "@/lib/ui/calendar/dayKeyDisplayFormat";
@@ -14,7 +15,7 @@ import type { DayKey } from "@/lib/ui/calendar/types";
 /** Same neutral display cap as Daily Recap steps bar — not a clinical target. */
 export const ACTIVITY_OVERVIEW_STEPS_PLACEMENT_CAP = DASH_RECAP_DISPLAY_PLACEMENT_CAPS.steps;
 
-export type ActivityOverviewTimeframeKey = "today" | "thisWeek" | "mtd" | "ytd";
+export type ActivityOverviewTimeframeKey = "today" | "avg7d" | "avg30d" | "avg365d";
 
 export type ActivityOverviewRowModel = {
   key: ActivityOverviewTimeframeKey;
@@ -29,11 +30,7 @@ export type ActivityOverviewCardModel = {
   timeframes: ActivityOverviewRowModel[];
 };
 
-function primaryDayRowLabel(selectedDay: DayKey, todayDayKey: DayKey): string {
-  return selectedDay === todayDayKey ? "Today" : formatDayKeyWeekdayShortMonthDay(selectedDay);
-}
-
-/** Steps counted toward multi-day averages: numeric rollups only; absent/error days contribute 0. */
+/** Steps counted toward period sums: numeric rollups only; absent/error days contribute 0. */
 function numericContribution(rollup: Readonly<ActivityStepsRollupMap>, d: DayKey): number {
   const e = rollup[d];
   return e?.kind === "numeric" ? e.steps : 0;
@@ -47,12 +44,19 @@ function sumNumericForDays(days: readonly DayKey[], rollup: Readonly<ActivitySte
   return t;
 }
 
-function averageOverCalendarDays(totalNumericSteps: number, dayCount: number): number {
-  if (dayCount <= 0) return 0;
-  return totalNumericSteps / dayCount;
+/**
+ * Average steps per day over a fixed-length trailing window ending on `todayDayKey`.
+ * Missing/absent days count as 0 steps and still count in the denominator (deterministic).
+ */
+function averageStepsFixedWindow(totalSteps: number, windowDays: number): number {
+  if (windowDays <= 0) return 0;
+  return totalSteps / windowDays;
 }
 
-/** @internal — tests */
+export function formatActivityDailyDetailsTitle(selectedDay: DayKey, todayDayKey: DayKey): string {
+  return selectedDay === todayDayKey ? "Today" : formatDayKeyWeekdayShortMonthDay(selectedDay);
+}
+
 export function formatActivityTodayRowSummary(entry: DayStepsRollupEntry | undefined): string {
   if (entry?.kind === "numeric") {
     return `${Math.round(entry.steps).toLocaleString()} steps`;
@@ -60,34 +64,39 @@ export function formatActivityTodayRowSummary(entry: DayStepsRollupEntry | undef
   return "No daily rollup for this day";
 }
 
-/** @internal — tests */
 export function formatActivityAverageRowSummary(avgStepsPerDay: number): string {
   return `${Math.round(avgStepsPerDay).toLocaleString()}/day`;
 }
 
 /**
- * Builds Activity Overview rows from per-day rollup entries (GET /users/me/daily-facts).
- * Today: total only when `activity.steps` exists; multi-day rows: calendar average (sum of numeric days / calendar span).
+ * Activity Overview summary — **independent of strip selection**.
+ * Source of truth: persisted `activity.steps` per day from GET /users/me/daily-facts (rolled into {@link rollupByDay}).
+ *
+ * Formulas (local calendar days, inclusive of today):
+ * - **Today:** steps for `todayDayKey` only.
+ * - **7D Avg:** (Σ steps over last 7 days including today) / 7.
+ * - **30D Avg:** (Σ steps over last 30 days including today) / 30.
+ * - **365D Avg:** (Σ steps over last 365 days including today) / 365 (trailing window, not calendar year).
  */
 export function buildActivityOverviewCardModel(input: {
-  selectedDay: DayKey;
   todayDayKey: DayKey;
   rollupByDay: Readonly<ActivityStepsRollupMap>;
 }): ActivityOverviewCardModel {
-  const { selectedDay, todayDayKey, rollupByDay } = input;
+  const { todayDayKey, rollupByDay } = input;
 
-  const weekDays = activityWeekElapsedDaysThrough(selectedDay);
-  const mtdDays = activityMtdDaysThrough(selectedDay);
-  const ytdDays = activityYtdDaysThrough(selectedDay);
+  const d7 = activityTrailingNDaysInclusive(todayDayKey, ACTIVITY_OVERVIEW_AVG_7D_DAYS);
+  const d30 = activityTrailingNDaysInclusive(todayDayKey, ACTIVITY_OVERVIEW_AVG_30D_DAYS);
+  const d365 = activityTrailingNDaysInclusive(todayDayKey, ACTIVITY_OVERVIEW_AVG_12M_DAYS);
 
-  const todayEntry = rollupByDay[selectedDay];
-  const weekTotal = sumNumericForDays(weekDays, rollupByDay);
-  const mtdTotal = sumNumericForDays(mtdDays, rollupByDay);
-  const ytdTotal = sumNumericForDays(ytdDays, rollupByDay);
+  const todayEntry = rollupByDay[todayDayKey];
 
-  const weekAvg = averageOverCalendarDays(weekTotal, weekDays.length);
-  const mtdAvg = averageOverCalendarDays(mtdTotal, mtdDays.length);
-  const ytdAvg = averageOverCalendarDays(ytdTotal, ytdDays.length);
+  const sum7 = sumNumericForDays(d7, rollupByDay);
+  const sum30 = sumNumericForDays(d30, rollupByDay);
+  const sum365 = sumNumericForDays(d365, rollupByDay);
+
+  const avg7 = averageStepsFixedWindow(sum7, ACTIVITY_OVERVIEW_AVG_7D_DAYS);
+  const avg30 = averageStepsFixedWindow(sum30, ACTIVITY_OVERVIEW_AVG_30D_DAYS);
+  const avg365 = averageStepsFixedWindow(sum365, ACTIVITY_OVERVIEW_AVG_12M_DAYS);
 
   const cap = ACTIVITY_OVERVIEW_STEPS_PLACEMENT_CAP;
 
@@ -98,29 +107,51 @@ export function buildActivityOverviewCardModel(input: {
   const timeframes: ActivityOverviewRowModel[] = [
     {
       key: "today",
-      label: primaryDayRowLabel(selectedDay, todayDayKey),
+      label: "Today",
       compactStatsSummary: formatActivityTodayRowSummary(todayEntry),
       markerPosition01: todayMarker,
     },
     {
-      key: "thisWeek",
-      label: "This Week",
-      compactStatsSummary: formatActivityAverageRowSummary(weekAvg),
-      markerPosition01: dashRecapPlacementMarker01(weekAvg, cap),
+      key: "avg7d",
+      label: "7D Avg",
+      compactStatsSummary: formatActivityAverageRowSummary(avg7),
+      markerPosition01: dashRecapPlacementMarker01(avg7, cap),
     },
     {
-      key: "mtd",
-      label: "MTD",
-      compactStatsSummary: formatActivityAverageRowSummary(mtdAvg),
-      markerPosition01: dashRecapPlacementMarker01(mtdAvg, cap),
+      key: "avg30d",
+      label: "30D Avg",
+      compactStatsSummary: formatActivityAverageRowSummary(avg30),
+      markerPosition01: dashRecapPlacementMarker01(avg30, cap),
     },
     {
-      key: "ytd",
-      label: "YTD",
-      compactStatsSummary: formatActivityAverageRowSummary(ytdAvg),
-      markerPosition01: dashRecapPlacementMarker01(ytdAvg, cap),
+      key: "avg365d",
+      label: "365D Avg",
+      compactStatsSummary: formatActivityAverageRowSummary(avg365),
+      markerPosition01: dashRecapPlacementMarker01(avg365, cap),
     },
   ];
 
   return { timeframes };
+}
+
+export type ActivityDailyDetailsCardModel = {
+  title: string;
+  compactStatsSummary: string;
+  markerPosition01: number;
+};
+
+export function buildActivityDailyDetailsCardModel(input: {
+  selectedDay: DayKey;
+  todayDayKey: DayKey;
+  rollupByDay: Readonly<ActivityStepsRollupMap>;
+}): ActivityDailyDetailsCardModel {
+  const { selectedDay, todayDayKey, rollupByDay } = input;
+  const entry = rollupByDay[selectedDay];
+  const numericSteps = entry?.kind === "numeric" ? entry.steps : 0;
+  const cap = ACTIVITY_OVERVIEW_STEPS_PLACEMENT_CAP;
+  return {
+    title: formatActivityDailyDetailsTitle(selectedDay, todayDayKey),
+    compactStatsSummary: formatActivityTodayRowSummary(entry),
+    markerPosition01: entry?.kind === "numeric" ? dashRecapPlacementMarker01(numericSteps, cap) : 0,
+  };
 }

--- a/lib/data/activity/activityOverviewRanges.ts
+++ b/lib/data/activity/activityOverviewRanges.ts
@@ -1,44 +1,42 @@
 import type { DayKey } from "@/lib/ui/calendar/types";
-import {
-  enumerateDaysInclusive,
-  getMonthFirstDay,
-  getWeekDaysForAnchor,
-} from "@/lib/ui/calendar/dateUtils";
+import { addCalendarDaysToDayKey, enumerateDaysInclusive, getWeekDaysForAnchor } from "@/lib/ui/calendar/dateUtils";
 
 /**
- * Calendar windows for Activity Overview rows (Today / This Week / MTD / YTD).
- * All bounds are inclusive day keys in device-neutral UTC-noon calendar math (same as Strength).
+ * Inclusive trailing window of local calendar days ending on `endDay`, length `dayCount`.
+ * Uses the same UTC-noon day arithmetic as {@link enumerateDaysInclusive} (repo standard).
  */
-
-export function activityWeekElapsedDaysThrough(selectedDay: DayKey): DayKey[] {
-  return getWeekDaysForAnchor(selectedDay).filter((d) => d <= selectedDay);
+export function activityTrailingNDaysInclusive(endDay: DayKey, dayCount: number): DayKey[] {
+  if (dayCount <= 0) return [];
+  const start = addCalendarDaysToDayKey(endDay, -(dayCount - 1));
+  return enumerateDaysInclusive(start, endDay);
 }
 
-export function activityMtdDaysThrough(selectedDay: DayKey): DayKey[] {
-  const year = Number(selectedDay.slice(0, 4));
-  const month = Number(selectedDay.slice(5, 7));
-  if (!Number.isFinite(year) || !Number.isFinite(month)) return [];
-  const monthStart = getMonthFirstDay({ year, month });
-  if (monthStart > selectedDay) return [];
-  return enumerateDaysInclusive(monthStart, selectedDay);
-}
-
-export function activityYtdDaysThrough(selectedDay: DayKey): DayKey[] {
-  const year = selectedDay.slice(0, 4);
-  if (year.length !== 4) return [];
-  const yearStart = `${year}-01-01` as DayKey;
-  if (yearStart > selectedDay) return [];
-  return enumerateDaysInclusive(yearStart, selectedDay);
-}
+/** Apple-aligned overview row: average over these trailing day counts (inclusive of today). */
+export const ACTIVITY_OVERVIEW_AVG_7D_DAYS = 7;
+export const ACTIVITY_OVERVIEW_AVG_30D_DAYS = 30;
+/** Rolling “12 months” ≈ 365 local days including today (deterministic; matches common Health rolling-year summaries). */
+export const ACTIVITY_OVERVIEW_AVG_12M_DAYS = 365;
 
 /**
- * Unique sorted day keys to fetch via GET /users/me/daily-facts (union of week ∪ MTD ∪ YTD windows).
+ * Days fetched for calendar month markers (~18 months back from today).
+ * Must cover visible months in the Activity calendar FlatList (−12 … +12 from current month).
  */
-export function computeActivityOverviewFetchDayKeys(selectedDay: DayKey): DayKey[] {
+export const ACTIVITY_CALENDAR_MARKER_SPAN_DAYS = 540;
+
+/**
+ * GET /users/me/daily-facts keys for the Activity overview + week strip.
+ * - Trailing {@link ACTIVITY_OVERVIEW_AVG_12M_DAYS} days through **today** (overview windows are all subsets).
+ * - Full Sun–Sat week containing **selectedDay** (strip markers; may include future days).
+ */
+export function computeActivityOverviewFetchDayKeys(selectedDay: DayKey, todayDayKey: DayKey): DayKey[] {
   const u = new Set<DayKey>([
-    ...activityWeekElapsedDaysThrough(selectedDay),
-    ...activityMtdDaysThrough(selectedDay),
-    ...activityYtdDaysThrough(selectedDay),
+    ...getWeekDaysForAnchor(selectedDay),
+    ...activityTrailingNDaysInclusive(todayDayKey, ACTIVITY_OVERVIEW_AVG_12M_DAYS),
   ]);
   return [...u].sort();
+}
+
+/** Keys to mark days with steps on the Activity full-calendar screen. */
+export function computeActivityCalendarFetchDayKeys(todayDayKey: DayKey): DayKey[] {
+  return activityTrailingNDaysInclusive(todayDayKey, ACTIVITY_CALENDAR_MARKER_SPAN_DAYS);
 }

--- a/lib/data/activity/activityOverviewRollupTypes.ts
+++ b/lib/data/activity/activityOverviewRollupTypes.ts
@@ -5,6 +5,7 @@ import type { DayKey } from "@/lib/ui/calendar/types";
  */
 export type DayStepsRollupEntry =
   | { kind: "numeric"; steps: number }
-  | { kind: "absent" };
+  | { kind: "absent" }
+  | { kind: "error"; message: string; requestId: string | null };
 
 export type ActivityStepsRollupMap = Record<DayKey, DayStepsRollupEntry>;

--- a/lib/data/activity/activityRollupErrorSummary.ts
+++ b/lib/data/activity/activityRollupErrorSummary.ts
@@ -1,0 +1,53 @@
+import type { ActivityStepsRollupMap, DayStepsRollupEntry } from "@/lib/data/activity/activityOverviewRollupTypes";
+import type { DayKey } from "@/lib/ui/calendar/types";
+
+export type ActivityRollupInlineError = {
+  message: string;
+  requestId: string | null;
+  onRetry: () => void;
+};
+
+/**
+ * When some daily-facts fetches fail, surface a partial error (remaining days may still be numeric).
+ */
+export function buildActivityRollupAggregateError(
+  rollupByDay: ActivityStepsRollupMap,
+  onRetry: () => void,
+): ActivityRollupInlineError | null {
+  let failed = 0;
+  let requestId: string | null = null;
+  for (const v of Object.values(rollupByDay)) {
+    if (v?.kind === "error") {
+      failed += 1;
+      if (requestId == null && v.requestId != null) requestId = v.requestId;
+    }
+  }
+  if (failed === 0) return null;
+  return {
+    message:
+      failed === 1
+        ? "Couldn’t load steps for one day. Other days may still show below."
+        : `Couldn’t load steps for ${failed} days. Other days may still show below.`,
+    requestId,
+    onRetry,
+  };
+}
+
+export function buildActivitySelectedDayRollupError(
+  selectedDay: DayKey,
+  rollupByDay: ActivityStepsRollupMap,
+  onRetry: () => void,
+): ActivityRollupInlineError | null {
+  const e = rollupByDay[selectedDay];
+  if (e?.kind !== "error") return null;
+  return {
+    message: e.message,
+    requestId: e.requestId,
+    onRetry,
+  };
+}
+
+/** For tests and diagnostics: HTTP/API failures must not be conflated with absent rollups. */
+export function rollupEntryIsFailure(entry: DayStepsRollupEntry | undefined): boolean {
+  return entry?.kind === "error";
+}

--- a/lib/data/activity/dailyFactsStepsRollupEntry.ts
+++ b/lib/data/activity/dailyFactsStepsRollupEntry.ts
@@ -1,0 +1,18 @@
+import type { ApiResult } from "@/lib/api/http";
+import type { DailyFactsDto } from "@/lib/contracts/dailyFacts";
+import type { DayStepsRollupEntry } from "@/lib/data/activity/activityOverviewRollupTypes";
+import { truthOutcomeFromApiResult } from "@/lib/data/truthOutcome";
+
+/** Maps one GET /users/me/daily-facts result to a rollup cell (shared by multi-day hooks). */
+export function interpretDailyFactsStepsRollupEntry(res: ApiResult<DailyFactsDto>): DayStepsRollupEntry {
+  const outcome = truthOutcomeFromApiResult(res);
+  if (outcome.status === "ready") {
+    const s = outcome.data.activity?.steps;
+    if (typeof s === "number" && Number.isFinite(s) && s >= 0) {
+      return { kind: "numeric", steps: Math.round(s) };
+    }
+    return { kind: "absent" };
+  }
+  if (outcome.status === "missing") return { kind: "absent" };
+  return { kind: "error", message: outcome.error, requestId: outcome.requestId };
+}

--- a/lib/data/activity/useActivityDayScreenData.ts
+++ b/lib/data/activity/useActivityDayScreenData.ts
@@ -1,0 +1,17 @@
+import { normalizeActivityDayRouteParam } from "@/lib/data/activity/activityDayRouteParam";
+import { useActivityDaySteps } from "@/lib/data/activity/useActivityDaySteps";
+
+/**
+ * Activity day route: normalize `day` search param (string | string[] | undefined) and load steps
+ * via GET /users/me/daily-facts — same trust boundary as {@link useActivityStepsRollupMap}.
+ */
+export function useActivityDayScreenData(rawDayParam: unknown): {
+  normalized: ReturnType<typeof normalizeActivityDayRouteParam>;
+  state: ReturnType<typeof useActivityDaySteps>["state"];
+  reload: ReturnType<typeof useActivityDaySteps>["reload"];
+} {
+  const normalized = normalizeActivityDayRouteParam(rawDayParam);
+  const dayKey = normalized.ok ? normalized.day : null;
+  const { state, reload } = useActivityDaySteps(dayKey);
+  return { normalized, state, reload };
+}

--- a/lib/data/activity/useActivityDaySteps.ts
+++ b/lib/data/activity/useActivityDaySteps.ts
@@ -6,46 +6,53 @@ import { useAuth } from "@/lib/auth/AuthProvider";
 import type { DailyFactsDto } from "@/lib/contracts/dailyFacts";
 import { truthOutcomeFromApiResult } from "@/lib/data/truthOutcome";
 
+/**
+ * Activity day steps fetch surface — `status` uses Phase 1 canonical readiness only
+ * (`missing` | `partial` | `ready` | `error`, see `@oli/contracts/readiness`).
+ */
 export type ActivityDayStepsState =
-  | { status: "idle" }
-  | { status: "loading" }
-  | {
-      status: "error";
-      message: string;
-      requestId: string | null;
-    }
-  | { status: "empty" }
-  | { status: "ready"; steps: number };
+  | { status: "missing" }
+  | { status: "partial" }
+  | { status: "ready"; steps: number }
+  | { status: "error"; message: string; requestId: string | null };
 
 /**
  * Loads `activity.steps` for one day via GET /users/me/daily-facts (same trust boundary as Activity rollups).
- * Pass `null` when the route day is invalid or absent — no network calls are made.
+ * Pass `null` when the route day is invalid or absent — no network calls are made (`missing`).
  */
 export function useActivityDaySteps(dayKey: string | null): {
   state: ActivityDayStepsState;
   reload: () => void;
 } {
   const { user, initializing, getIdToken } = useAuth();
-  const [state, setState] = useState<ActivityDayStepsState>({ status: "idle" });
+  const [state, setState] = useState<ActivityDayStepsState>({ status: "missing" });
   const seqRef = useRef(0);
+
+  useEffect(() => {
+    if (dayKey == null || dayKey.length === 0) {
+      setState({ status: "missing" });
+      return;
+    }
+    setState({ status: "partial" });
+  }, [dayKey]);
 
   const run = useCallback(async () => {
     const seq = ++seqRef.current;
     if (dayKey == null || dayKey.length === 0) {
-      setState({ status: "idle" });
+      setState({ status: "missing" });
       return;
     }
     const key = dayKey;
     if (initializing) {
-      setState({ status: "idle" });
+      setState({ status: "partial" });
       return;
     }
     if (!user) {
-      setState({ status: "idle" });
+      setState({ status: "missing" });
       return;
     }
 
-    setState({ status: "loading" });
+    setState({ status: "partial" });
     const token = await getIdToken(false);
     if (seq !== seqRef.current) return;
     if (!token) {
@@ -70,7 +77,7 @@ export function useActivityDaySteps(dayKey: string | null): {
       return;
     }
     if (outcome.status === "missing") {
-      setState({ status: "empty" });
+      setState({ status: "missing" });
       return;
     }
 
@@ -79,7 +86,7 @@ export function useActivityDaySteps(dayKey: string | null): {
       setState({ status: "ready", steps: Math.round(s) });
       return;
     }
-    setState({ status: "empty" });
+    setState({ status: "missing" });
   }, [dayKey, getIdToken, initializing, user]);
 
   useEffect(() => {

--- a/lib/data/activity/useActivityDaySteps.ts
+++ b/lib/data/activity/useActivityDaySteps.ts
@@ -1,0 +1,94 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { ApiResult } from "@/lib/api/http";
+import { getDailyFacts } from "@/lib/api/usersMe";
+import { useAuth } from "@/lib/auth/AuthProvider";
+import type { DailyFactsDto } from "@/lib/contracts/dailyFacts";
+import { truthOutcomeFromApiResult } from "@/lib/data/truthOutcome";
+
+export type ActivityDayStepsState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | {
+      status: "error";
+      message: string;
+      requestId: string | null;
+    }
+  | { status: "empty" }
+  | { status: "ready"; steps: number };
+
+/**
+ * Loads `activity.steps` for one day via GET /users/me/daily-facts (same trust boundary as Activity rollups).
+ * Pass `null` when the route day is invalid or absent — no network calls are made.
+ */
+export function useActivityDaySteps(dayKey: string | null): {
+  state: ActivityDayStepsState;
+  reload: () => void;
+} {
+  const { user, initializing, getIdToken } = useAuth();
+  const [state, setState] = useState<ActivityDayStepsState>({ status: "idle" });
+  const seqRef = useRef(0);
+
+  const run = useCallback(async () => {
+    const seq = ++seqRef.current;
+    if (dayKey == null || dayKey.length === 0) {
+      setState({ status: "idle" });
+      return;
+    }
+    const key = dayKey;
+    if (initializing) {
+      setState({ status: "idle" });
+      return;
+    }
+    if (!user) {
+      setState({ status: "idle" });
+      return;
+    }
+
+    setState({ status: "loading" });
+    const token = await getIdToken(false);
+    if (seq !== seqRef.current) return;
+    if (!token) {
+      setState({
+        status: "error",
+        message: "Not signed in",
+        requestId: null,
+      });
+      return;
+    }
+
+    const res: ApiResult<DailyFactsDto> = await getDailyFacts(key, token);
+    if (seq !== seqRef.current) return;
+
+    const outcome = truthOutcomeFromApiResult(res);
+    if (outcome.status === "error") {
+      setState({
+        status: "error",
+        message: outcome.error,
+        requestId: outcome.requestId,
+      });
+      return;
+    }
+    if (outcome.status === "missing") {
+      setState({ status: "empty" });
+      return;
+    }
+
+    const s = outcome.data.activity?.steps;
+    if (typeof s === "number" && Number.isFinite(s) && s >= 0) {
+      setState({ status: "ready", steps: Math.round(s) });
+      return;
+    }
+    setState({ status: "empty" });
+  }, [dayKey, getIdToken, initializing, user]);
+
+  useEffect(() => {
+    void run();
+  }, [run]);
+
+  const reload = useCallback(() => {
+    void run();
+  }, [run]);
+
+  return { state, reload };
+}

--- a/lib/data/activity/useActivityOverviewScreenData.ts
+++ b/lib/data/activity/useActivityOverviewScreenData.ts
@@ -4,7 +4,14 @@ import { useFocusEffect } from "@react-navigation/native";
 
 import { useAuth } from "@/lib/auth/AuthProvider";
 import { scheduleAppleHealthStepsRepair } from "@/lib/data/activity/appleHealthStepsRepairCoordinator";
-import { buildActivityOverviewCardModel } from "@/lib/data/activity/activityOverviewCardModel";
+import {
+  buildActivityDailyDetailsCardModel,
+  buildActivityOverviewCardModel,
+} from "@/lib/data/activity/activityOverviewCardModel";
+import {
+  buildActivityRollupAggregateError,
+  buildActivitySelectedDayRollupError,
+} from "@/lib/data/activity/activityRollupErrorSummary";
 import { useActivityStepsRollupMap } from "@/lib/data/activity/useActivityStepsRollupMap";
 import type { ActivityDayStripMeta } from "@/lib/data/activity/activityDayStripMeta";
 import { getTodayDayKeyLocal, getWeekDaysForAnchor } from "@/lib/ui/calendar/dateUtils";
@@ -15,7 +22,8 @@ export function useActivityOverviewScreenData() {
   const [selectedDay, setSelectedDay] = useState(() => getTodayDayKeyLocal());
   const weekDayKeys = useMemo(() => getWeekDaysForAnchor(selectedDay), [selectedDay]);
 
-  const stepsRollup = useActivityStepsRollupMap(selectedDay);
+  const todayDayKey = getTodayDayKeyLocal();
+  const stepsRollup = useActivityStepsRollupMap(selectedDay, todayDayKey);
 
   useFocusEffect(
     useCallback(() => {
@@ -43,22 +51,55 @@ export function useActivityOverviewScreenData() {
     });
   }, [weekDayKeys, stepsRollup]);
 
+  const rollupAggregateError = useMemo(() => {
+    if (stepsRollup.status !== "ready") return null;
+    return buildActivityRollupAggregateError(stepsRollup.rollupByDay, () =>
+      void stepsRollup.refetch({ cacheBust: `activityRollupRetry:${Date.now()}` }),
+    );
+  }, [stepsRollup]);
+
+  const dailyDetailsSelectedError = useMemo(() => {
+    if (stepsRollup.status !== "ready") return null;
+    return buildActivitySelectedDayRollupError(selectedDay, stepsRollup.rollupByDay, () =>
+      void stepsRollup.refetch({ cacheBust: `activityRollupSelectedRetry:${Date.now()}` }),
+    );
+  }, [selectedDay, stepsRollup]);
+
   const overviewCardModel = useMemo(() => {
     if (stepsRollup.status !== "ready") return null;
     return buildActivityOverviewCardModel({
-      selectedDay,
-      todayDayKey: getTodayDayKeyLocal(),
+      todayDayKey,
       rollupByDay: stepsRollup.rollupByDay,
     });
-  }, [stepsRollup, selectedDay]);
+  }, [stepsRollup, todayDayKey]);
+
+  const dailyDetailsModel = useMemo(() => {
+    if (stepsRollup.status !== "ready") return null;
+    const entry = stepsRollup.rollupByDay[selectedDay];
+    if (entry?.kind === "error") return null;
+    return buildActivityDailyDetailsCardModel({
+      selectedDay,
+      todayDayKey,
+      rollupByDay: stepsRollup.rollupByDay,
+    });
+  }, [stepsRollup, selectedDay, todayDayKey]);
 
   const overview = useMemo(
     () => ({
       loading: stepsRollup.status === "partial",
-      error: null,
+      error: rollupAggregateError,
       model: overviewCardModel,
     }),
-    [stepsRollup, overviewCardModel],
+    [stepsRollup, overviewCardModel, rollupAggregateError],
+  );
+
+  const dailyDetails = useMemo(
+    () => ({
+      loading: stepsRollup.status === "partial",
+      error: dailyDetailsSelectedError ?? rollupAggregateError,
+      model: dailyDetailsModel,
+    }),
+    [stepsRollup, dailyDetailsModel, dailyDetailsSelectedError, rollupAggregateError],
   );
 
   return {
@@ -69,5 +110,6 @@ export function useActivityOverviewScreenData() {
     weeklyStripDays,
     stepsRollup,
     overview,
+    dailyDetails,
   };
 }

--- a/lib/data/activity/useActivityStepsRollupMap.ts
+++ b/lib/data/activity/useActivityStepsRollupMap.ts
@@ -2,45 +2,34 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { getDailyFacts } from "@/lib/api/usersMe";
 import { useAuth } from "@/lib/auth/AuthProvider";
-import type { DailyFactsDto } from "@/lib/contracts/dailyFacts";
-import type { ActivityStepsRollupMap, DayStepsRollupEntry } from "@/lib/data/activity/activityOverviewRollupTypes";
+import type { ActivityStepsRollupMap } from "@/lib/data/activity/activityOverviewRollupTypes";
+import { interpretDailyFactsStepsRollupEntry } from "@/lib/data/activity/dailyFactsStepsRollupEntry";
 import { computeActivityOverviewFetchDayKeys } from "@/lib/data/activity/activityOverviewRanges";
-import type { TruthOutcome } from "@/lib/data/truthOutcome";
-import { truthOutcomeFromApiResult } from "@/lib/data/truthOutcome";
 import type { DayKey } from "@/lib/ui/calendar/types";
 
 type State = { status: "partial" } | { status: "ready"; rollupByDay: ActivityStepsRollupMap };
 
-function rollupFromOutcome(outcome: TruthOutcome<DailyFactsDto>): DayStepsRollupEntry {
-  if (outcome.status === "ready") {
-    const s = outcome.data.activity?.steps;
-    if (typeof s === "number" && Number.isFinite(s) && s >= 0) {
-      return { kind: "numeric", steps: Math.round(s) };
-    }
-    return { kind: "absent" };
-  }
-  if (outcome.status === "missing") return { kind: "absent" };
-  return { kind: "absent" };
-}
-
 /**
- * Fetches GET /users/me/daily-facts for every calendar day in the union of Activity Overview windows.
+ * Fetches GET /users/me/daily-facts for each key in `dayKeys` (parallel).
  * Per-day entries are persisted server rollups only (no client raw-event math).
  */
-export function useActivityStepsRollupMap(selectedDay: DayKey): State & { refetch: (opts?: { cacheBust?: string }) => void } {
+export function useActivityStepsRollupForKeys(dayKeys: readonly DayKey[]): State & {
+  refetch: (opts?: { cacheBust?: string }) => void;
+} {
   const { user, initializing, getIdToken } = useAuth();
-  const selectedRef = useRef(selectedDay);
-  selectedRef.current = selectedDay;
+  const keysRef = useRef(dayKeys);
+  keysRef.current = dayKeys;
   const requestSeq = useRef(0);
   const authRef = useRef({ initializing, userUid: user?.uid, getIdToken });
   authRef.current = { initializing, userUid: user?.uid, getIdToken };
 
   const [state, setState] = useState<State>({ status: "partial" });
 
+  const keySig = useMemo(() => [...dayKeys].sort().join("\0"), [dayKeys]);
+
   const fetchAll = useCallback(async (cacheBust?: string) => {
     const seq = ++requestSeq.current;
-    const day = selectedRef.current;
-    const keys = computeActivityOverviewFetchDayKeys(day);
+    const keys = keysRef.current;
     const { initializing: init, userUid, getIdToken: getToken } = authRef.current;
 
     const safeSet = (next: State) => {
@@ -83,16 +72,14 @@ export function useActivityStepsRollupMap(selectedDay: DayKey): State & { refetc
       const k = keys[i]!;
       const item = settled[i]!;
       if (item.status === "rejected") {
-        rollupByDay[k] = { kind: "absent" };
+        const r = item.reason;
+        const reason =
+          r instanceof Error ? r.message : typeof r === "string" && r.length > 0 ? r : "Request failed";
+        rollupByDay[k] = { kind: "error", message: reason, requestId: null };
         continue;
       }
       const { res } = item.value;
-      const outcome = truthOutcomeFromApiResult(res);
-      if (outcome.status === "error") {
-        rollupByDay[k] = { kind: "absent" };
-        continue;
-      }
-      rollupByDay[k] = rollupFromOutcome(outcome);
+      rollupByDay[k] = interpretDailyFactsStepsRollupEntry(res);
     }
 
     safeSet({ status: "ready", rollupByDay });
@@ -100,7 +87,7 @@ export function useActivityStepsRollupMap(selectedDay: DayKey): State & { refetc
 
   useEffect(() => {
     void fetchAll();
-  }, [fetchAll, selectedDay, user?.uid, initializing]);
+  }, [fetchAll, keySig, user?.uid, initializing]);
 
   const refetch = useCallback(
     (opts?: { cacheBust?: string }) => {
@@ -110,4 +97,18 @@ export function useActivityStepsRollupMap(selectedDay: DayKey): State & { refetc
   );
 
   return useMemo(() => ({ ...state, refetch }), [state, refetch]);
+}
+
+/**
+ * Overview screen: union of trailing 365d through today + week strip around `selectedDay`.
+ */
+export function useActivityStepsRollupMap(
+  selectedDay: DayKey,
+  todayDayKey: DayKey,
+): State & { refetch: (opts?: { cacheBust?: string }) => void } {
+  const keys = useMemo(
+    () => computeActivityOverviewFetchDayKeys(selectedDay, todayDayKey),
+    [selectedDay, todayDayKey],
+  );
+  return useActivityStepsRollupForKeys(keys);
 }

--- a/lib/ui/activity/ActivityDailyDetailsCard.tsx
+++ b/lib/ui/activity/ActivityDailyDetailsCard.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { StyleSheet, Text, View } from "react-native";
 
-import type { ActivityOverviewCardModel } from "@/lib/data/activity/activityOverviewCardModel";
+import type { ActivityDailyDetailsCardModel } from "@/lib/data/activity/activityOverviewCardModel";
 import { moduleOverviewMetricLayoutStyles } from "@/lib/ui/overview/moduleOverviewMetricLayout";
 import { MODULE_OVERVIEW_SEGMENT_ZONE_FILLS } from "@/lib/ui/overview/moduleOverviewSegmentZoneFills";
 import { MODULE_OVERVIEW_SEGMENTED_TRACK } from "@/lib/ui/overview/moduleOverviewSegmentedTrackMetrics";
@@ -10,13 +10,12 @@ import { workoutOverviewInCardHeaderStyles } from "@/lib/ui/workouts/workoutOver
 import { ErrorState, LoadingState } from "@/lib/ui/ScreenStates";
 import { elevatedCardSurfaceStyle } from "@/lib/ui/theme/elevatedCardSurface";
 
-/** Neutral marker fill — same elevated dot treatment as Strength overview (not tier-colored). */
-const ACTIVITY_OVERVIEW_MARKER_FILL = "#1F2937";
+const ACTIVITY_DETAILS_MARKER_FILL = "#1F2937";
 
-type ActivityOverviewCardProps = {
+type ActivityDailyDetailsCardProps = {
   loading: boolean;
   error: { message: string; requestId: string | null; onRetry: () => void } | null;
-  model: ActivityOverviewCardModel | null;
+  model: ActivityDailyDetailsCardModel | null;
 };
 
 function clamp01(x: number): number {
@@ -25,7 +24,7 @@ function clamp01(x: number): number {
   return x;
 }
 
-function ActivityOverviewPlacementTrack({ testID, markerPosition01 }: { testID: string; markerPosition01: number }) {
+function DetailsPlacementTrack({ testID, markerPosition01 }: { testID: string; markerPosition01: number }) {
   const marker01 = clamp01(markerPosition01);
   const pct = Math.round(marker01 * 100);
   return (
@@ -34,7 +33,7 @@ function ActivityOverviewPlacementTrack({ testID, markerPosition01 }: { testID: 
       testID={testID}
       markerPosition01={marker01}
       showMarker
-      markerBackgroundColor={ACTIVITY_OVERVIEW_MARKER_FILL}
+      markerBackgroundColor={ACTIVITY_DETAILS_MARKER_FILL}
       markerStyle="elevated"
       dotSize={MODULE_OVERVIEW_SEGMENTED_TRACK.dotSize}
       barHeight={MODULE_OVERVIEW_SEGMENTED_TRACK.barHeight}
@@ -47,15 +46,12 @@ function ActivityOverviewPlacementTrack({ testID, markerPosition01 }: { testID: 
   );
 }
 
-/**
- * Activity Overview — visual family aligned with StrengthOverviewCard (card shell, row rhythm, segmented bar).
- * No rating pills: steps use neutral placement bands only (dash recap geometry), not Strength consistency tiers.
- */
-export function ActivityOverviewCard({ loading, error, model }: ActivityOverviewCardProps) {
+/** Per-day steps for the week-strip (or calendar) selection — does not drive Overview averages. */
+export function ActivityDailyDetailsCard({ loading, error, model }: ActivityDailyDetailsCardProps) {
   return (
     <View style={styles.card}>
       <View style={[styles.headerRow, workoutOverviewInCardHeaderStyles.row]}>
-        <Text style={workoutOverviewInCardHeaderStyles.title}>Overview</Text>
+        <Text style={workoutOverviewInCardHeaderStyles.title}>Daily details</Text>
       </View>
 
       {loading ? <LoadingState variant="inline" message="Loading steps…" /> : null}
@@ -69,27 +65,19 @@ export function ActivityOverviewCard({ loading, error, model }: ActivityOverview
       ) : null}
       {!loading && model != null ? (
         <View style={moduleOverviewMetricLayoutStyles.metricGroups}>
-          {model.timeframes.map((tf) => {
-            const a11y = `${tf.label}. ${tf.compactStatsSummary}.`;
-            return (
-              <View key={tf.key} style={moduleOverviewMetricLayoutStyles.metricBlock} accessibilityLabel={a11y} accessible>
-                <View style={moduleOverviewMetricLayoutStyles.topRow}>
-                  <View style={styles.leftSummary}>
-                    <Text style={styles.timeframeLabel} numberOfLines={1}>
-                      {tf.label}
-                    </Text>
-                    <Text style={styles.resultSummary} numberOfLines={1} ellipsizeMode="tail">
-                      {tf.compactStatsSummary}
-                    </Text>
-                  </View>
-                </View>
-                <ActivityOverviewPlacementTrack
-                  testID={`activity-overview-steps-bar-${tf.key}`}
-                  markerPosition01={tf.markerPosition01}
-                />
+          <View style={moduleOverviewMetricLayoutStyles.metricBlock} accessible accessibilityLabel={`${model.title}. ${model.compactStatsSummary}.`}>
+            <View style={moduleOverviewMetricLayoutStyles.topRow}>
+              <View style={styles.leftSummary}>
+                <Text style={styles.timeframeLabel} numberOfLines={1}>
+                  {model.title}
+                </Text>
+                <Text style={styles.resultSummary} numberOfLines={1} ellipsizeMode="tail">
+                  {model.compactStatsSummary}
+                </Text>
               </View>
-            );
-          })}
+            </View>
+            <DetailsPlacementTrack testID="activity-daily-details-steps-bar" markerPosition01={model.markerPosition01} />
+          </View>
         </View>
       ) : null}
     </View>

--- a/lib/ui/activity/__tests__/ActivityOverviewCard.test.tsx
+++ b/lib/ui/activity/__tests__/ActivityOverviewCard.test.tsx
@@ -18,7 +18,32 @@ describe("ActivityOverviewCard", () => {
     expect(str).not.toContain("activity-overview-steps-bar-today");
   });
 
-  it("shows error inline when error is set", () => {
+  it("shows error inline together with model when both are set", () => {
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(
+        <ActivityOverviewCard
+          loading={false}
+          error={{ message: "partial failure", requestId: "r9", onRetry: jest.fn() }}
+          model={{
+            timeframes: [
+              {
+                key: "today",
+                label: "Today",
+                compactStatsSummary: "100 steps",
+                markerPosition01: 0.1,
+              },
+            ],
+          }}
+        />,
+      );
+    });
+    const str = JSON.stringify(tree.toJSON());
+    expect(str).toContain("partial failure");
+    expect(str).toContain("activity-overview-steps-bar-today");
+  });
+
+  it("shows error inline when error is set and model is null", () => {
     let tree!: renderer.ReactTestRenderer;
     act(() => {
       tree = renderer.create(
@@ -45,8 +70,6 @@ describe("ActivityOverviewCard", () => {
               {
                 key: "today",
                 label: "Today",
-                totalSteps: 100,
-                averageStepsPerDay: null,
                 compactStatsSummary: "100 steps",
                 markerPosition01: 0.1,
               },

--- a/lib/ui/calendar/MonthGrid.tsx
+++ b/lib/ui/calendar/MonthGrid.tsx
@@ -6,7 +6,13 @@ import {
   View,
 } from "react-native";
 import type { DayKey } from "./types";
-import { getMonthGrid, formatMonthYearLabel, getTodayDayKeyLocal, type MonthYear } from "./dateUtils";
+import {
+  getMonthGrid,
+  getMonthGridLocal,
+  formatMonthYearLabel,
+  getTodayDayKeyLocal,
+  type MonthYear,
+} from "./dateUtils";
 import type { WorkoutMarkerFlags } from "@/lib/data/workouts/workoutMarkerFlags";
 import { UI_TEXT_PRIMARY, UI_TEXT_MUTED } from "@/lib/ui/theme/uiTokens";
 import { WorkoutDayRing } from "./WorkoutDayRing";
@@ -15,12 +21,25 @@ export type MonthGridProps = {
   monthYear: MonthYear;
   markerForDay: (day: DayKey) => WorkoutMarkerFlags | null;
   onDayPress: (day: DayKey) => void;
+  /**
+   * `local` — cell `DayKey`s use the device calendar (matches Apple Health daily steps keys).
+   * `utc` — legacy UTC-noon grid (default for Strength/Cardio calendars).
+   */
+  dayKeyBasis?: "utc" | "local";
+  /** `activity` — a11y copy for step rollup markers; default `workout` for strength/cardio grids. */
+  ringSemantics?: "workout" | "activity";
 };
 
 const DOW_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-export function MonthGrid({ monthYear, markerForDay, onDayPress }: MonthGridProps) {
+export function MonthGrid({
+  monthYear,
+  markerForDay,
+  onDayPress,
+  dayKeyBasis = "utc",
+  ringSemantics = "workout",
+}: MonthGridProps) {
   const todayKey = getTodayDayKeyLocal();
-  const weeks = getMonthGrid(monthYear);
+  const weeks = dayKeyBasis === "local" ? getMonthGridLocal(monthYear) : getMonthGrid(monthYear);
   const paddedWeeks = [...weeks];
   while (paddedWeeks.length < 6) {
     paddedWeeks.push([null, null, null, null, null, null, null]);
@@ -45,15 +64,21 @@ export function MonthGrid({ monthYear, markerForDay, onDayPress }: MonthGridProp
             const marker = markerForDay(dayKey);
             const hasStrength = !!marker?.hasStrength;
             const hasCardio = !!marker?.hasCardio;
-            const hasWorkoutMarker = hasStrength || hasCardio;
+            const hasRingMarker = hasStrength || hasCardio;
+            const a11yDetail =
+              ringSemantics === "activity"
+                ? hasRingMarker
+                  ? "steps in daily rollup"
+                  : "no steps in daily rollup"
+                : hasRingMarker
+                  ? "has workouts"
+                  : "no workouts";
             return (
               <Pressable
                 key={dayKey}
                 onPress={() => onDayPress(dayKey)}
                 accessibilityRole="button"
-                accessibilityLabel={
-                  hasWorkoutMarker ? `${dayKey}, has workouts` : `${dayKey}, no workouts`
-                }
+                accessibilityLabel={`${dayKey}, ${a11yDetail}`}
                 style={({ pressed }) => [
                   styles.dayCell,
                   pressed && styles.dayCellPressed,

--- a/lib/ui/calendar/__tests__/dateUtils.monthGridLocal.test.ts
+++ b/lib/ui/calendar/__tests__/dateUtils.monthGridLocal.test.ts
@@ -1,0 +1,12 @@
+import { getMonthGridLocal } from "@/lib/ui/calendar/dateUtils";
+
+/** Activity calendar uses `MonthGrid` with `dayKeyBasis="local"` so cell keys align with Apple Health day ingestion. */
+describe("getMonthGridLocal", () => {
+  it("includes one DayKey per calendar day in the target month (local calendar)", () => {
+    const grid = getMonthGridLocal({ year: 2026, month: 6 });
+    const keys = grid.flat().filter((k): k is string => k != null);
+    expect(keys.length).toBe(30);
+    expect(new Set(keys).size).toBe(30);
+    expect(keys.every((k) => /^\d{4}-\d{2}-\d{2}$/.test(k))).toBe(true);
+  });
+});

--- a/lib/ui/calendar/dateUtils.ts
+++ b/lib/ui/calendar/dateUtils.ts
@@ -144,6 +144,52 @@ export function getMonthGrid({ year, month }: MonthYear): (DayKey | null)[][] {
   return weeks;
 }
 
+/**
+ * Month grid using the device **local** calendar for each cell’s `DayKey`.
+ * Aligns with Apple Health steps ingest (`getLocalCalendarDayBoundsFromYmd`) and {@link getTodayDayKeyLocal}.
+ */
+export function getMonthGridLocal({ year, month }: MonthYear): (DayKey | null)[][] {
+  const { year: y, month: mo } = clampMonthYear({ year, month });
+  const firstMid = new Date(y, mo - 1, 1, 12, 0, 0, 0);
+  const lastMid = new Date(y, mo, 0, 12, 0, 0, 0);
+
+  const start = new Date(firstMid);
+  const startDow = start.getDay();
+  start.setDate(start.getDate() - startDow);
+  start.setHours(12, 0, 0, 0);
+
+  const end = new Date(lastMid);
+  const endDow = end.getDay();
+  end.setDate(end.getDate() + (6 - endDow));
+  end.setHours(12, 0, 0, 0);
+
+  const targetMonthIndex = firstMid.getMonth();
+  const targetYear = firstMid.getFullYear();
+
+  const weeks: (DayKey | null)[][] = [];
+  const cursor = new Date(start);
+
+  while (cursor <= end) {
+    const week: (DayKey | null)[] = [];
+    for (let i = 0; i < 7; i += 1) {
+      const dayKey = localNoonDateToDayKey(cursor);
+      const inMonth = cursor.getMonth() === targetMonthIndex && cursor.getFullYear() === targetYear;
+      week.push(inMonth ? dayKey : null);
+      cursor.setDate(cursor.getDate() + 1);
+    }
+    weeks.push(week);
+  }
+
+  return weeks;
+}
+
+function localNoonDateToDayKey(d: Date): DayKey {
+  const yy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${yy}-${mm}-${dd}`;
+}
+
 export function formatMonthYearLabel({ year, month }: MonthYear): string {
   const { year: y, month: m } = clampMonthYear({ year, month });
   const d = new Date(Date.UTC(y, m - 1, 1, 12, 0, 0, 0));

--- a/scripts/admin/apply-run-invokers.sh
+++ b/scripts/admin/apply-run-invokers.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Re-apply Cloud Run invoker IAM for Gen2 Firestore triggers and admin HTTP functions.
+# Safe to re-run (gcloud add-iam-policy-binding is idempotent for existing bindings).
+#
+# Usage:
+#   ./scripts/admin/apply-run-invokers.sh [PROJECT_ID] [REGION] [USER_EMAIL]
+#
+# Defaults: oli-staging-fdbba us-central1 dhendel4@gmail.com
+#
+# Recommended after functions deploy:
+#   firebase deploy --only functions --project oli-staging-fdbba && \
+#     ./scripts/admin/apply-run-invokers.sh oli-staging-fdbba us-central1 dhendel4@gmail.com
+
+set -euo pipefail
+
+PROJECT_ID="${1:-oli-staging-fdbba}"
+REGION="${2:-us-central1}"
+USER_EMAIL="${3:-dhendel4@gmail.com}"
+
+SERVICES=(
+  "onraweventupdatedfornormalization"
+  "recomputedailyfactsadminhttp"
+)
+
+log() {
+  printf '%s\n' "[apply-run-invokers] $*"
+}
+
+log "project=${PROJECT_ID} region=${REGION} user=${USER_EMAIL}"
+
+PROJECT_NUMBER="$(gcloud projects describe "${PROJECT_ID}" --format='value(projectNumber)')"
+if [[ -z "${PROJECT_NUMBER}" ]]; then
+  log "ERROR: could not resolve project number for ${PROJECT_ID}"
+  exit 1
+fi
+
+EVENTARC_SA="service-${PROJECT_NUMBER}@gcp-sa-eventarc.iam.gserviceaccount.com"
+PUBSUB_SA="service-${PROJECT_NUMBER}@gcp-sa-pubsub.iam.gserviceaccount.com"
+FUNCTIONS_RUNTIME_SA="oli-functions-runtime@${PROJECT_ID}.iam.gserviceaccount.com"
+
+log "PROJECT_NUMBER=${PROJECT_NUMBER}"
+log "EVENTARC_SA=${EVENTARC_SA}"
+log "PUBSUB_SA=${PUBSUB_SA}"
+log "FUNCTIONS_RUNTIME_SA=${FUNCTIONS_RUNTIME_SA}"
+
+bind_invoker() {
+  local service="$1"
+  local member="$2"
+  log "binding ${member} -> ${service}"
+  gcloud run services add-iam-policy-binding "${service}" \
+    --region="${REGION}" \
+    --project="${PROJECT_ID}" \
+    --member="${member}" \
+    --role="roles/run.invoker" \
+    --quiet
+}
+
+for svc in "${SERVICES[@]}"; do
+  bind_invoker "${svc}" "serviceAccount:${EVENTARC_SA}"
+  bind_invoker "${svc}" "serviceAccount:${PUBSUB_SA}"
+  bind_invoker "${svc}" "serviceAccount:${FUNCTIONS_RUNTIME_SA}"
+done
+
+log "binding user:${USER_EMAIL} -> recomputedailyfactsadminhttp only"
+gcloud run services add-iam-policy-binding "recomputedailyfactsadminhttp" \
+  --region="${REGION}" \
+  --project="${PROJECT_ID}" \
+  --member="user:${USER_EMAIL}" \
+  --role="roles/run.invoker" \
+  --quiet
+
+log "done. IAM policy bindings applied (idempotent)."

--- a/scripts/admin/recompute-steps-ytd.mjs
+++ b/scripts/admin/recompute-steps-ytd.mjs
@@ -1,0 +1,301 @@
+#!/usr/bin/env node
+/**
+ * Sequential dailyFacts recompute for a date range (e.g. YTD) for one user.
+ *
+ * Calls ONLY `recomputeDailyFactsAdminHttp` (POST). That handler overwrites
+ * `users/{userId}/dailyFacts/{date}` from existing canonical events + raw body
+ * loaders — it does NOT mutate `rawEvents` or `events`.
+ *
+ * Usage (repo root):
+ *
+ *   export FIREBASE_TOKEN='<Firebase ID token with admin: true claim>'
+ *   export RECOMPUTE_DAILY_FACTS_URL='https://recomputedailyfactsadminhttp-XXXX-uc.a.run.app'
+ *   node scripts/admin/recompute-steps-ytd.mjs \
+ *     --userId <firebaseUid> \
+ *     --startDate 2026-01-01 \
+ *     --endDate 2026-04-07
+ *
+ * Optional:
+ *   --url <url>     overrides RECOMPUTE_DAILY_FACTS_URL
+ *   GOOGLE_IDENTITY_TOKEN   if set, used instead of `gcloud auth print-identity-token`
+ *
+ * Resume after failure: fix the issue, then rerun with `--startDate` set to the
+ * failed day (or the next day if that day succeeded).
+ *
+ * Auth headers (private Gen2 Cloud Run + Firebase admin):
+ *   - X-Serverless-Authorization: Bearer <Google identity token> (invoker)
+ *   - Authorization: Bearer <Firebase ID token> (requireAdmin)
+ *
+ * Requires: `gcloud` on PATH and authenticated (unless GOOGLE_IDENTITY_TOKEN is set).
+ */
+
+import { execFileSync } from "node:child_process";
+import process from "node:process";
+
+/** @param {string} label */
+function logInfo(label, payload = {}) {
+  const line = { level: "info", ts: new Date().toISOString(), msg: label, ...payload };
+  // eslint-disable-next-line no-console
+  console.log(JSON.stringify(line));
+}
+
+/** @param {string} label */
+function logError(label, payload = {}) {
+  const line = { level: "error", ts: new Date().toISOString(), msg: label, ...payload };
+  // eslint-disable-next-line no-console
+  console.error(JSON.stringify(line));
+}
+
+function printUsage() {
+  // eslint-disable-next-line no-console
+  console.error(`
+Usage:
+  export FIREBASE_TOKEN='...'
+  export RECOMPUTE_DAILY_FACTS_URL='https://...run.app'
+  node scripts/admin/recompute-steps-ytd.mjs \\
+    --userId <uid> \\
+    --startDate YYYY-MM-DD \\
+    --endDate YYYY-MM-DD
+
+Options:
+  --url <url>   Override RECOMPUTE_DAILY_FACTS_URL
+`);
+}
+
+function parseArgs(argv) {
+  const out = {
+    userId: null,
+    startDate: null,
+    endDate: null,
+    url: process.env.RECOMPUTE_DAILY_FACTS_URL?.trim() || null,
+    help: false,
+  };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--help" || a === "-h") out.help = true;
+    else if (a === "--userId") out.userId = argv[++i] ?? null;
+    else if (a === "--startDate") out.startDate = argv[++i] ?? null;
+    else if (a === "--endDate") out.endDate = argv[++i] ?? null;
+    else if (a === "--url") out.url = argv[++i]?.trim() ?? null;
+  }
+  return out;
+}
+
+/** @param {string} name @param {string | null} value */
+function assertYmd(name, value) {
+  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    throw new Error(`${name} must be YYYY-MM-DD (got ${JSON.stringify(value)})`);
+  }
+}
+
+/** @param {string} ymd */
+function parseYmdUtc(ymd) {
+  const [y, m, d] = ymd.split("-").map((x) => parseInt(x, 10));
+  if (!y || !m || !d) throw new Error(`Invalid date: ${ymd}`);
+  return new Date(Date.UTC(y, m - 1, d));
+}
+
+/** @param {Date} d */
+function formatYmdUtc(d) {
+  const y = d.getUTCFullYear();
+  const mo = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const da = String(d.getUTCDate()).padStart(2, "0");
+  return `${y}-${mo}-${da}`;
+}
+
+/**
+ * Inclusive UTC calendar days from startYmd through endYmd.
+ * @param {string} startYmd
+ * @param {string} endYmd
+ * @returns {string[]}
+ */
+function enumerateDatesInclusive(startYmd, endYmd) {
+  const start = parseYmdUtc(startYmd);
+  const end = parseYmdUtc(endYmd);
+  if (start.getTime() > end.getTime()) {
+    throw new Error(`startDate ${startYmd} must be <= endDate ${endYmd}`);
+  }
+  const out = [];
+  for (let t = start.getTime(); t <= end.getTime(); t += 24 * 60 * 60 * 1000) {
+    out.push(formatYmdUtc(new Date(t)));
+  }
+  return out;
+}
+
+function readGoogleIdentityToken() {
+  const fromEnv = process.env.GOOGLE_IDENTITY_TOKEN?.trim();
+  if (fromEnv) {
+    logInfo("identity_token_source", { source: "GOOGLE_IDENTITY_TOKEN" });
+    return fromEnv;
+  }
+  try {
+    const token = execFileSync("gcloud", ["auth", "print-identity-token"], {
+      encoding: "utf-8",
+    }).trim();
+    if (!token) throw new Error("empty token from gcloud");
+    logInfo("identity_token_source", { source: "gcloud_auth_print_identity_token" });
+    return token;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Failed to obtain Google identity token (set GOOGLE_IDENTITY_TOKEN or run gcloud auth login): ${message}`,
+    );
+  }
+}
+
+/**
+ * @param {object} opts
+ * @param {string} opts.url
+ * @param {string} opts.userId
+ * @param {string} opts.date
+ * @param {string} opts.firebaseToken
+ * @param {string} opts.googleIdentityToken
+ */
+async function postRecompute({ url, userId, date, firebaseToken, googleIdentityToken }) {
+  const base = url.replace(/\/$/, "");
+  const target = `${base}/`;
+
+  const body = JSON.stringify({ userId, date });
+
+  const res = await fetch(target, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${firebaseToken}`,
+      "X-Serverless-Authorization": `Bearer ${googleIdentityToken}`,
+    },
+    body,
+  });
+
+  const text = await res.text();
+  let json = null;
+  try {
+    json = text ? JSON.parse(text) : null;
+  } catch {
+    json = { _parseError: true, rawBody: text.slice(0, 2000) };
+  }
+
+  return { status: res.status, ok: res.ok, json, text };
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) {
+    printUsage();
+    process.exit(0);
+  }
+
+  assertYmd("startDate", args.startDate);
+  assertYmd("endDate", args.endDate);
+
+  if (!args.userId?.trim()) {
+    logError("config_error", { error: "Missing --userId" });
+    printUsage();
+    process.exit(1);
+  }
+
+  if (!args.url) {
+    logError("config_error", {
+      error: "Missing RECOMPUTE_DAILY_FACTS_URL or --url",
+    });
+    printUsage();
+    process.exit(1);
+  }
+
+  const firebaseToken = process.env.FIREBASE_TOKEN?.trim();
+  if (!firebaseToken) {
+    logError("config_error", { error: "Missing env FIREBASE_TOKEN" });
+    printUsage();
+    process.exit(1);
+  }
+
+  const dates = enumerateDatesInclusive(args.startDate, args.endDate);
+  logInfo("run_start", {
+    userId: args.userId.trim(),
+    startDate: args.startDate,
+    endDate: args.endDate,
+    dayCount: dates.length,
+    urlHost: (() => {
+      try {
+        return new URL(args.url).host;
+      } catch {
+        return "(invalid-url)";
+      }
+    })(),
+  });
+
+  let googleIdentityToken = readGoogleIdentityToken();
+
+  for (let i = 0; i < dates.length; i++) {
+    const date = dates[i];
+    const dayIndex = i + 1;
+
+    logInfo("day_start", { date, dayIndex, of: dates.length });
+
+    let result;
+    try {
+      result = await postRecompute({
+        url: args.url,
+        userId: args.userId.trim(),
+        date,
+        firebaseToken,
+        googleIdentityToken,
+      });
+    } catch (err) {
+      const stack = err instanceof Error ? err.stack : undefined;
+      const message = err instanceof Error ? err.message : String(err);
+      logError("day_fetch_failed", { date, dayIndex, error: message, stack });
+      process.exit(1);
+    }
+
+    if (result.status === 401 || result.status === 403) {
+      logInfo("auth_retry_refresh_identity_token", { date, status: result.status });
+      try {
+        googleIdentityToken = readGoogleIdentityToken();
+        result = await postRecompute({
+          url: args.url,
+          userId: args.userId.trim(),
+          date,
+          firebaseToken,
+          googleIdentityToken,
+        });
+      } catch (err) {
+        const stack = err instanceof Error ? err.stack : undefined;
+        const message = err instanceof Error ? err.message : String(err);
+        logError("day_fetch_failed_after_token_refresh", { date, dayIndex, error: message, stack });
+        process.exit(1);
+      }
+    }
+
+    if (!result.ok || (result.json && result.json.ok === false)) {
+      logError("day_recompute_failed", {
+        date,
+        dayIndex,
+        httpStatus: result.status,
+        responseBody: result.json ?? result.text.slice(0, 4000),
+      });
+      process.exit(1);
+    }
+
+    logInfo("day_ok", {
+      date,
+      dayIndex,
+      httpStatus: result.status,
+      response: result.json,
+    });
+  }
+
+  logInfo("run_complete", {
+    userId: args.userId.trim(),
+    startDate: args.startDate,
+    endDate: args.endDate,
+    daysProcessed: dates.length,
+  });
+}
+
+main().catch((err) => {
+  const stack = err instanceof Error ? err.stack : undefined;
+  const message = err instanceof Error ? err.message : String(err);
+  logError("fatal", { error: message, stack });
+  process.exit(1);
+});

--- a/services/api/src/lib/activityFactsSynthesizeFromCanonical.ts
+++ b/services/api/src/lib/activityFactsSynthesizeFromCanonical.ts
@@ -1,9 +1,13 @@
 /**
- * When users/me/dailyFacts/{day} is missing, synthesize `activity.steps` from canonical
- * `events` for that day (same sum as {@link aggregateDailyFactsForDay} for steps-only).
- * Read-only; does not write Firestore. Mirrors the body synthesis path on GET /daily-facts.
+ * When users/me/dailyFacts/{day} is missing (or activity is merged), synthesize `activity.steps`
+ * from canonical `events` for that day — same resolution rules as {@link aggregateDailyFactsForDay}.
+ * Read-only; does not write Firestore.
  */
 
+import {
+  pickContributingStepEventsForDailyFacts,
+  resolvedStepsTotalFromContributing,
+} from "@oli/contracts";
 import { userCollection } from "../db";
 
 export type ActivityStepsSynthesized = { steps: number };
@@ -17,18 +21,19 @@ export async function loadActivityStepsFromCanonicalForApi(
 ): Promise<ActivityStepsSynthesized | undefined> {
   const snap = await userCollection(uid, "events").where("day", "==", dayKey).get();
 
-  let sum = 0;
-  let any = false;
+  const likes: { id: string; sourceId: string; steps: number }[] = [];
   for (const d of snap.docs) {
     const data = d.data() as Record<string, unknown>;
     if (data["kind"] !== "steps") continue;
     const s = data["steps"];
-    if (typeof s === "number" && Number.isFinite(s)) {
-      sum += s;
-      any = true;
-    }
+    if (typeof s !== "number" || !Number.isFinite(s) || s < 0) continue;
+    const rawSource = data["sourceId"];
+    const sourceId =
+      typeof rawSource === "string" && rawSource.length > 0 ? rawSource : "unknown_source";
+    likes.push({ id: d.id, sourceId, steps: s });
   }
 
-  if (!any) return undefined;
-  return { steps: sum };
+  const contributing = pickContributingStepEventsForDailyFacts(likes);
+  if (contributing.length === 0) return undefined;
+  return { steps: resolvedStepsTotalFromContributing(contributing) };
 }

--- a/services/api/src/routes/__tests__/events.ingest.steps-idempotent-replay.test.ts
+++ b/services/api/src/routes/__tests__/events.ingest.steps-idempotent-replay.test.ts
@@ -63,7 +63,7 @@ describe("POST /ingest — steps idempotent replay", () => {
     jest.restoreAllMocks();
   });
 
-  it("updates receivedAt on idempotent replay so normalization can re-run", async () => {
+  it("updates payload, observedAt, and receivedAt on steps idempotent replay (cumulative day total)", async () => {
     const app = createIngestApp();
     const server = app.listen(0);
     const addr = server.address();
@@ -87,9 +87,52 @@ describe("POST /ingest — steps idempotent replay", () => {
       expect(json.idempotentReplay).toBe(true);
 
       expect(mockDocRef.update).toHaveBeenCalledTimes(1);
-      const patch = mockDocRef.update.mock.calls[0][0] as { receivedAt?: string };
+      const patch = mockDocRef.update.mock.calls[0][0] as {
+        receivedAt?: string;
+        observedAt?: string;
+        payload?: { steps?: number };
+      };
       expect(typeof patch.receivedAt).toBe("string");
       expect(patch.receivedAt!.length).toBeGreaterThan(10);
+      expect(patch.observedAt).toBe(baseBody.occurredAt);
+      expect(patch.payload?.steps).toBe(5000);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("overwrites stale stored steps on replay when incoming cumulative total is higher", async () => {
+    mockDocRef.get.mockResolvedValue({
+      exists: true,
+      data: () => ({
+        ...baseBody,
+        id: mockDocRef.id,
+        userId: "user_steps_replay",
+        payload: { ...baseBody.payload, steps: 37 },
+      }),
+    });
+
+    const app = createIngestApp();
+    const server = app.listen(0);
+    const addr = server.address();
+    if (!addr || typeof addr === "string") {
+      server.close();
+      throw new Error("Failed to bind");
+    }
+
+    try {
+      const res = await fetch(`http://127.0.0.1:${addr.port}/ingest`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "Idempotency-Key": "idem_steps_replay",
+        },
+        body: JSON.stringify(baseBody),
+      });
+
+      expect(res.status).toBe(202);
+      const patch = mockDocRef.update.mock.calls[0][0] as { payload?: { steps?: number } };
+      expect(patch.payload?.steps).toBe(5000);
     } finally {
       server.close();
     }

--- a/services/api/src/routes/__tests__/usersMe.daily-facts.test.ts
+++ b/services/api/src/routes/__tests__/usersMe.daily-facts.test.ts
@@ -221,4 +221,138 @@ describe("GET /users/me/daily-facts", () => {
       expect.objectContaining({ synthesizedActivityFromRaw: true }),
     );
   });
+
+  test("synthesized steps prefer apple_health when multiple canonical step events exist", async () => {
+    const stepsApple = { kind: "steps", day: "2026-04-21", sourceId: "apple_health", steps: 4000 };
+    const stepsManual = { kind: "steps", day: "2026-04-21", sourceId: "manual", steps: 9999 };
+
+    (userCollection as jest.Mock).mockImplementation((_uid: string, name: string) => {
+      if (name === "dailyFacts") {
+        return {
+          doc: () => ({
+            get: async () => ({ exists: false }),
+          }),
+        };
+      }
+      if (name === "rawEvents") {
+        return rawEventsMockWithDoc({});
+      }
+      if (name === "events") {
+        const eventsQuery = {
+          where: (): typeof eventsQuery => eventsQuery,
+          get: async () => ({
+            docs: [
+              { data: () => stepsManual },
+              { data: () => stepsApple },
+            ],
+          }),
+        };
+        return eventsQuery;
+      }
+      return {};
+    });
+
+    (userDoc as jest.Mock).mockReturnValue({
+      get: async () => ({ data: () => ({}) }),
+    });
+
+    const res = await fetch(`${baseUrl}/users/me/daily-facts?day=2026-04-21`);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { activity?: { steps?: number } };
+    expect(json.activity?.steps).toBe(4000);
+  });
+
+  test("merges activity.steps when dailyFacts has activity object but no numeric steps field", async () => {
+    const storedFacts = {
+      schemaVersion: 1,
+      userId: "user_body_test",
+      date: "2026-04-22",
+      computedAt: "2026-04-22T10:00:00.000Z",
+      activity: { distanceKm: 3.2 },
+    };
+
+    const stepsCanonical = {
+      kind: "steps",
+      day: "2026-04-22",
+      sourceId: "apple_health",
+      steps: 6060,
+    };
+
+    (userCollection as jest.Mock).mockImplementation((_uid: string, name: string) => {
+      if (name === "dailyFacts") {
+        return {
+          doc: () => ({
+            get: async () => ({ exists: true, data: () => storedFacts }),
+          }),
+        };
+      }
+      if (name === "events") {
+        const eventsQuery = {
+          where: (): typeof eventsQuery => eventsQuery,
+          get: async () => ({ docs: [{ id: "e1", data: () => stepsCanonical }] }),
+        };
+        return eventsQuery;
+      }
+      return {};
+    });
+
+    (userDoc as jest.Mock).mockReturnValue({
+      get: async () => ({ data: () => ({}) }),
+    });
+
+    const res = await fetch(`${baseUrl}/users/me/daily-facts?day=2026-04-22`);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      activity?: { steps?: number; distanceKm?: number };
+      meta?: { source?: Record<string, unknown> };
+    };
+    expect(json.activity?.steps).toBe(6060);
+    expect(json.activity?.distanceKm).toBe(3.2);
+    expect(json.meta?.source?.activityStepsFilledOnRead).toBe(true);
+  });
+
+  test("merges activity.steps when dailyFacts exists but omits numeric steps and canonical has steps", async () => {
+    const storedFacts = {
+      schemaVersion: 1,
+      userId: "user_body_test",
+      date: "2026-04-20",
+      computedAt: "2026-04-20T10:00:00.000Z",
+      sleep: { totalMinutes: 420 },
+    };
+
+    const stepsCanonical = {
+      kind: "steps",
+      day: "2026-04-20",
+      sourceId: "apple_health",
+      steps: 7777,
+    };
+
+    (userCollection as jest.Mock).mockImplementation((_uid: string, name: string) => {
+      if (name === "dailyFacts") {
+        return {
+          doc: () => ({
+            get: async () => ({ exists: true, data: () => storedFacts }),
+          }),
+        };
+      }
+      if (name === "events") {
+        const eventsQuery = {
+          where: (): typeof eventsQuery => eventsQuery,
+          get: async () => ({ docs: [{ id: "appleHealth:v2:steps:2026-04-20", data: () => stepsCanonical }] }),
+        };
+        return eventsQuery;
+      }
+      return {};
+    });
+
+    (userDoc as jest.Mock).mockReturnValue({
+      get: async () => ({ data: () => ({}) }),
+    });
+
+    const res = await fetch(`${baseUrl}/users/me/daily-facts?day=2026-04-20`);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { activity?: { steps?: number }; meta?: { source?: Record<string, unknown> } };
+    expect(json.activity?.steps).toBe(7777);
+    expect(json.meta?.source?.activityStepsFilledOnRead).toBe(true);
+  });
 });

--- a/services/api/src/routes/events.ts
+++ b/services/api/src/routes/events.ts
@@ -338,10 +338,19 @@ router.post("/", async (req: AuthedRequest, res: Response) => {
           update: (payload) => docRef.update({ payload }),
         });
         // Steps replays use the same raw doc id; `onDocumentCreated` does not re-fire.
-        // Bump `receivedAt` so `onRawEventUpdatedForNormalization` can re-run the mapper
-        // after deploys that fix normalization (e.g. apple_health steps).
+        // Apple Health sends an updated cumulative total for the same calendar day under the
+        // same idempotency key — we must persist the new payload, not only bump receivedAt,
+        // or Firestore stays on an early partial (e.g. 37) while HealthKit shows thousands.
         if (validated.data.kind === "steps") {
-          await docRef.update({ receivedAt: validated.data.receivedAt });
+          const patch: Record<string, unknown> = {
+            payload: validated.data.payload,
+            observedAt: validated.data.observedAt,
+            receivedAt: validated.data.receivedAt,
+          };
+          if (validated.data.occurredAt !== undefined) {
+            patch.occurredAt = validated.data.occurredAt;
+          }
+          await docRef.update(patch);
         }
         return res.status(202).json({
           ok: true as const,

--- a/services/api/src/routes/usersMe.ts
+++ b/services/api/src/routes/usersMe.ts
@@ -1662,7 +1662,59 @@ router.get(
       return;
     }
 
-    res.status(200).json(parsed.data);
+    let out = parsed.data;
+    const stepsVal = out.activity?.steps;
+    const hasNumericActivitySteps =
+      typeof stepsVal === "number" && Number.isFinite(stepsVal) && stepsVal >= 0;
+
+    if (!hasNumericActivitySteps) {
+      let synthesizedActivity: Awaited<ReturnType<typeof loadActivityStepsFromCanonicalForApi>> | undefined;
+      try {
+        synthesizedActivity = await loadActivityStepsFromCanonicalForApi(uid, day);
+      } catch (err) {
+        logger.info({
+          msg: "daily_facts_merge_activity_from_canonical_failed",
+          level: "warn",
+          rid: getRid(req),
+          day,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+      if (!synthesizedActivity) {
+        try {
+          synthesizedActivity = await loadActivityStepsFromRawForApi(uid, day);
+        } catch (err) {
+          logger.info({
+            msg: "daily_facts_merge_activity_from_raw_failed",
+            level: "warn",
+            rid: getRid(req),
+            day,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+      if (synthesizedActivity) {
+        const priorSource =
+          typeof out.meta?.source === "object" && out.meta.source !== null && !Array.isArray(out.meta.source)
+            ? { ...(out.meta.source as Record<string, unknown>) }
+            : {};
+        const merged = {
+          ...out,
+          activity: { ...(out.activity ?? {}), steps: synthesizedActivity.steps },
+          meta: {
+            computedAt: out.meta?.computedAt ?? out.computedAt,
+            pipelineVersion: out.meta?.pipelineVersion ?? 1,
+            source: { ...priorSource, activityStepsFilledOnRead: true },
+          },
+        };
+        const mergedParsed = dailyFactsDtoSchema.safeParse(merged);
+        if (mergedParsed.success) {
+          out = mergedParsed.data;
+        }
+      }
+    }
+
+    res.status(200).json(out);
   }),
 );
 

--- a/services/api/tsconfig.base.json
+++ b/services/api/tsconfig.base.json
@@ -21,7 +21,9 @@
     "paths": {
       "@/lib": ["lib/index.ts"],
       "@/lib/*": ["lib/*"],
-      "@/*": ["./*"]
+      "@/*": ["./*"],
+      "@oli/contracts": ["../../lib/contracts/index.ts"],
+      "@oli/contracts/*": ["../../lib/contracts/*"]
     }
   }
 }

--- a/services/functions/firestore.indexes.json
+++ b/services/functions/firestore.indexes.json
@@ -22,9 +22,7 @@
       "queryScope": "COLLECTION",
       "fields": [
         { "fieldPath": "kind", "order": "ASCENDING" },
-        { "fieldPath": "sourceId", "order": "ASCENDING" },
-        { "fieldPath": "observedAt", "order": "DESCENDING" },
-        { "fieldPath": "__name__", "order": "DESCENDING" }
+        { "fieldPath": "observedAt", "order": "ASCENDING" }
       ]
     },
     {
@@ -32,8 +30,16 @@
       "queryScope": "COLLECTION",
       "fields": [
         { "fieldPath": "kind", "order": "ASCENDING" },
-        { "fieldPath": "observedAt", "order": "DESCENDING" },
-        { "fieldPath": "__name__", "order": "DESCENDING" }
+        { "fieldPath": "sourceId", "order": "ASCENDING" },
+        { "fieldPath": "observedAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "rawEvents",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "kind", "order": "ASCENDING" },
+        { "fieldPath": "observedAt", "order": "DESCENDING" }
       ]
     },
     {
@@ -41,8 +47,7 @@
       "queryScope": "COLLECTION",
       "fields": [
         { "fieldPath": "sourceId", "order": "ASCENDING" },
-        { "fieldPath": "observedAt", "order": "DESCENDING" },
-        { "fieldPath": "__name__", "order": "DESCENDING" }
+        { "fieldPath": "observedAt", "order": "DESCENDING" }
       ]
     },
     {

--- a/services/functions/src/dailyFacts/__tests__/aggregateDailyFacts.test.ts
+++ b/services/functions/src/dailyFacts/__tests__/aggregateDailyFacts.test.ts
@@ -155,8 +155,8 @@ describe('aggregateDailyFactsForDay', () => {
     expect(sleep.mainSleepMinutes).toBe(480);
 
     const activity = result.activity!;
-    // 8000 + 4000 = 12000
-    expect(activity.steps).toBe(12000);
+    // Two non-apple step events: pick higher (8000), do not sum (avoids duplicate sources)
+    expect(activity.steps).toBe(8000);
     // training load from single workout
     expect(activity.trainingLoad).toBe(50);
 
@@ -167,6 +167,20 @@ describe('aggregateDailyFactsForDay', () => {
     const recovery = result.recovery!;
     // average of 80 and 60 = 70
     expect(recovery.hrvRmssd).toBe(70);
+  });
+
+  it('prefers apple_health steps over other sources for the same day', () => {
+    const events: CanonicalEvent[] = [
+      makeSteps({ id: 'manual_steps', sourceId: 'manual', steps: 12000 }),
+      makeSteps({ id: 'appleHealth:v2:steps:2025-01-01', sourceId: 'apple_health', steps: 5011 }),
+    ];
+    const result = aggregateDailyFactsForDay({
+      userId: 'user_123',
+      date: '2025-01-01',
+      computedAt: '2025-01-02T03:00:00.000Z',
+      events,
+    });
+    expect(result.activity?.steps).toBe(5011);
   });
 
   it('includes activity.steps when steps canonical events sum to zero (HealthKit empty / explicit zero)', () => {
@@ -262,6 +276,20 @@ describe('aggregateDailyFactsForDay', () => {
     });
 
     expect(result.strength).toBeUndefined();
+  });
+
+  it('prefers apple_health steps when another source also reports steps (no double count)', () => {
+    const events: CanonicalEvent[] = [
+      makeSteps({ id: 'manual_1', sourceId: 'manual_entry', steps: 9000 }),
+      makeSteps({ id: 'ah_1', sourceId: 'apple_health', steps: 5012 }),
+    ];
+    const result = aggregateDailyFactsForDay({
+      userId: 'user_123',
+      date: '2025-01-01',
+      computedAt: '2025-01-02T03:00:00.000Z',
+      events,
+    });
+    expect(result.activity?.steps).toBe(5012);
   });
 
   it('returns minimal DailyFacts when no events exist', () => {

--- a/services/functions/src/dailyFacts/aggregateDailyFacts.ts
+++ b/services/functions/src/dailyFacts/aggregateDailyFacts.ts
@@ -20,6 +20,11 @@ import type {
   NutritionCanonicalEvent,
 } from '../types/health';
 
+import {
+  pickContributingStepEventsForDailyFacts,
+  resolvedStepsTotalFromContributing,
+} from '@oli/contracts';
+
 const isNumber = (value: unknown): value is number =>
   typeof value === 'number' && Number.isFinite(value);
 
@@ -99,12 +104,12 @@ const buildActivityFacts = (events: CanonicalEvent[]): DailyActivityFacts | unde
 
   const facts: DailyActivityFacts = {};
 
-  const steps = stepsEvents.reduce((sum, e) => sum + e.steps, 0);
-  if (stepsEvents.length > 0) {
-    facts.steps = steps;
+  const contributing = pickContributingStepEventsForDailyFacts(stepsEvents);
+  if (contributing.length > 0) {
+    facts.steps = resolvedStepsTotalFromContributing(contributing);
   }
 
-  const distanceKm = stepsEvents
+  const distanceKm = contributing
     .map((e) => e.distanceKm)
     .filter(isNumber)
     .reduce((sum, v) => sum + v, 0);
@@ -112,7 +117,7 @@ const buildActivityFacts = (events: CanonicalEvent[]): DailyActivityFacts | unde
     facts.distanceKm = distanceKm;
   }
 
-  const moveMinutes = stepsEvents
+  const moveMinutes = contributing
     .map((e) => e.moveMinutes)
     .filter(isNumber)
     .reduce((sum, v) => sum + v, 0);

--- a/services/functions/src/normalization/__tests__/writeCanonicalEventImmutable.steps-intraday.test.ts
+++ b/services/functions/src/normalization/__tests__/writeCanonicalEventImmutable.steps-intraday.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Same-id Apple Health / manual daily steps must update intraday without immutability conflict.
+ */
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+
+jest.mock("firebase-functions/logger", () => ({
+  error: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  debug: jest.fn(),
+}));
+
+const mockTransactionStore = new Map<string, Record<string, unknown>>();
+
+jest.mock("../../firebaseAdmin", () => ({
+  admin: {
+    firestore: {
+      FieldValue: {
+        serverTimestamp: () => ({}),
+      },
+    },
+  },
+  db: {
+    collection(col: string) {
+      return {
+        doc(id: string) {
+          const base = `${col}/${id}`;
+          return {
+            collection(sub: string) {
+              return {
+                doc(subId: string) {
+                  const path = `${base}/${sub}/${subId}`;
+                  return { path };
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+    runTransaction<T>(
+      fn: (tx: {
+        get: (ref: { path: string }) => Promise<{
+          exists: boolean;
+          data: () => Record<string, unknown> | undefined;
+        }>;
+        create: (ref: { path: string }, data: Record<string, unknown>) => void;
+        set: (ref: { path: string }, data: Record<string, unknown>) => void;
+      }) => Promise<T>,
+    ): Promise<T> {
+      const tx = {
+        async get(ref: { path: string }) {
+          const d = mockTransactionStore.get(ref.path);
+          return { exists: mockTransactionStore.has(ref.path), data: () => d };
+        },
+        create(ref: { path: string }, data: Record<string, unknown>) {
+          if (mockTransactionStore.has(ref.path)) {
+            throw new Error("ALREADY_EXISTS");
+          }
+          mockTransactionStore.set(ref.path, { ...data });
+        },
+        set(ref: { path: string }, data: Record<string, unknown>) {
+          mockTransactionStore.set(ref.path, { ...data });
+        },
+      };
+      return fn(tx);
+    },
+  },
+}));
+
+import type { StepsCanonicalEvent } from "../../types/health";
+import { writeCanonicalEventImmutable } from "../writeCanonicalEventImmutable";
+
+function stepsCanonical(steps: number, updatedAt: string): StepsCanonicalEvent {
+  return {
+    id: "appleHealth:v2:steps:2026-04-08",
+    userId: "u_steps",
+    sourceId: "manual",
+    kind: "steps",
+    start: "2026-04-08T04:00:00.000Z",
+    end: "2026-04-09T03:59:59.999Z",
+    day: "2026-04-08",
+    timezone: "America/New_York",
+    createdAt: "2026-04-08T08:00:00.000Z",
+    updatedAt,
+    schemaVersion: 1,
+    steps,
+    distanceKm: null,
+    moveMinutes: null,
+  };
+}
+
+describe("writeCanonicalEventImmutable — steps intraday", () => {
+  beforeEach(() => {
+    mockTransactionStore.clear();
+  });
+
+  it("returns replaced and overwrites when same id steps total changes", async () => {
+    const path = "users/u_steps/events/appleHealth:v2:steps:2026-04-08";
+    mockTransactionStore.set(path, { ...stepsCanonical(37, "2026-04-08T08:00:00.000Z") } as Record<string, unknown>);
+
+    const res = await writeCanonicalEventImmutable({
+      userId: "u_steps",
+      canonical: { ...stepsCanonical(5834, "2026-04-08T18:00:00.000Z") },
+      sourceRawEventId: "appleHealth:v2:steps:2026-04-08",
+      sourceRawEventPath: "users/u_steps/rawEvents/appleHealth:v2:steps:2026-04-08",
+    });
+
+    expect(res).toEqual({ ok: true, mode: "replaced" });
+    expect((mockTransactionStore.get(path) as { steps?: number }).steps).toBe(5834);
+  });
+
+  it("returns identical_noop when steps canonical is unchanged", async () => {
+    const c = stepsCanonical(100, "2026-04-08T12:00:00.000Z");
+    const path = "users/u_steps/events/appleHealth:v2:steps:2026-04-08";
+    mockTransactionStore.set(path, { ...c } as Record<string, unknown>);
+
+    const res = await writeCanonicalEventImmutable({
+      userId: "u_steps",
+      canonical: { ...c },
+      sourceRawEventId: "appleHealth:v2:steps:2026-04-08",
+      sourceRawEventPath: "x",
+    });
+
+    expect(res).toEqual({ ok: true, mode: "identical_noop" });
+  });
+});

--- a/services/functions/src/normalization/processRawEventForNormalization.ts
+++ b/services/functions/src/normalization/processRawEventForNormalization.ts
@@ -412,6 +412,44 @@ export async function processRawEventForNormalization(params: {
     }
   } else {
     /**
+     * Same-id steps canonical was overwritten (intraday cumulative update). `onDocumentCreated`
+     * does not run for updates — recompute here so dailyFacts track the latest total.
+     */
+    if (writeRes.mode === "replaced" && rawEvent.kind === "steps") {
+      const dayKey = canonical.day as YmdDateString;
+      try {
+        logger.info("steps_canonical_replaced_recompute_start", {
+          msg: "steps_canonical_replaced_recompute_start",
+          userId: rawEvent.userId,
+          rawEventId: rawEvent.id,
+          dayKey,
+          trigger,
+        });
+        await recomputeDerivedTruthForDay({
+          db,
+          userId: rawEvent.userId,
+          dayKey,
+          trigger: { type: "realtime", eventId: `${canonical.id}:steps_canonical_replaced` },
+        });
+        logger.info("steps_canonical_replaced_recompute_done", {
+          msg: "steps_canonical_replaced_recompute_done",
+          userId: rawEvent.userId,
+          dayKey,
+          trigger,
+        });
+      } catch (err) {
+        logger.error("steps_canonical_replaced_recompute_failed", {
+          msg: "steps_canonical_replaced_recompute_failed",
+          userId: rawEvent.userId,
+          rawEventId: rawEvent.id,
+          dayKey,
+          trigger,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    /**
      * `onCanonicalEventCreated` only runs on Firestore **create**. Identical replays use
      * `writeCanonicalEventImmutable` → `identical_noop` (no write), so derived truth is not
      * recomputed unless we invoke it here. Steps replays after pipeline fixes depend on this.

--- a/services/functions/src/normalization/writeCanonicalEventImmutable.ts
+++ b/services/functions/src/normalization/writeCanonicalEventImmutable.ts
@@ -7,7 +7,7 @@ import type { CanonicalEvent } from "../types/health";
 import { canonicalEquals, canonicalHash } from "./canonicalImmutability";
 
 export type WriteCanonicalResult =
-  | { ok: true; mode: "created" | "identical_noop" }
+  | { ok: true; mode: "created" | "identical_noop" | "replaced" }
   | {
       ok: false;
       mode: "conflict";
@@ -52,6 +52,20 @@ export async function writeCanonicalEventImmutable(params: {
 
     if (canonicalEquals(existing, canonical)) {
       return { ok: true, mode: "identical_noop" } as const;
+    }
+
+    /**
+     * Daily step totals are cumulative for the local calendar window and legitimately change
+     * intraday under the same raw/canonical id (same idempotency key). Immutability conflicts
+     * here would strand DailyFacts on the first ingested value.
+     */
+    if (
+      existing.kind === "steps" &&
+      canonical.kind === "steps" &&
+      existing.id === canonical.id
+    ) {
+      tx.set(ref, canonical);
+      return { ok: true, mode: "replaced" } as const;
     }
 
     const existingHash = canonicalHash(existing);


### PR DESCRIPTION
… hardening

- fix step resolution: Apple (apple_health + healthkit) is authoritative, no overlapping aggregation
- fix dailyFacts recompute to use canonical collapse (no summing multiple sources)
- repair entire YTD dataset via recompute pipeline (102 days verified)

- persist Firestore composite index for rawEvents (kind + observedAt)
- reconcile firestore.indexes.json with live indexes (no drift)
- add post-deploy IAM script to restore Cloud Run invoker bindings
- ensure Eventarc, Pub/Sub, and functions runtime have correct permissions

- add regression tests for step resolution (Apple over Oura, HealthKit as Apple)
- update activity overview, calendar, and UI data flows to use corrected dailyFacts
- add activity day detail screen + supporting hooks/data layer

- add safe recompute script (scripts/admin/recompute-steps-ytd.mjs)

System status:
- ingestion ✔
- normalization ✔
- aggregation ✔
- recompute ✔
- data correctness ✔
- infra stability ✔