### PR TITLE
fix(activity): stabilize steps finalization pipeline, global yesterda…

### DIFF
--- a/app/(app)/activity/__tests__/activity-day-screen.test.tsx
+++ b/app/(app)/activity/__tests__/activity-day-screen.test.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import renderer, { act } from "react-test-renderer";
+
+const mockSetOptions = jest.fn();
+const mockGoBack = jest.fn();
+
+jest.mock("expo-router", () => ({
+  useLocalSearchParams: () => ({ day: "2026-04-14" }),
+  usePathname: () => "/activity/day/2026-04-14",
+  useNavigation: () => ({
+    setOptions: mockSetOptions,
+    goBack: mockGoBack,
+  }),
+}));
+
+jest.mock("@/lib/auth/AuthProvider", () => ({
+  useAuth: () => ({
+    user: { uid: "u1" },
+    initializing: false,
+  }),
+}));
+
+jest.mock("@/lib/data/activity/useActivityDayScreenData", () => ({
+  useActivityDayScreenData: () => ({
+    normalized: { ok: true as const, day: "2026-04-14" },
+    state: { status: "ready" as const, steps: 9021 },
+    reload: jest.fn(),
+  }),
+}));
+
+import ActivityDayScreen from "../day/[day]";
+
+describe("ActivityDayScreen", () => {
+  beforeEach(() => {
+    mockSetOptions.mockClear();
+  });
+
+  it("sets native header with centered formatted date and back affordance", async () => {
+    let tree!: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<ActivityDayScreen />);
+    });
+    expect(mockSetOptions).toHaveBeenCalled();
+    const lastCall = mockSetOptions.mock.calls[mockSetOptions.mock.calls.length - 1]![0] as {
+      title?: string;
+      headerTitleAlign?: string;
+      headerLeft?: () => unknown;
+    };
+    expect(lastCall.headerTitleAlign).toBe("center");
+    expect(lastCall.title).toMatch(/Apr/);
+    expect(lastCall.title).toMatch(/14/);
+    expect(lastCall.title).toMatch(/2026/);
+    expect(typeof lastCall.headerLeft).toBe("function");
+
+    const str = JSON.stringify(tree.toJSON());
+    expect(str).toContain("9,021");
+  });
+});

--- a/app/(app)/activity/__tests__/activity-overview.test.tsx
+++ b/app/(app)/activity/__tests__/activity-overview.test.tsx
@@ -10,41 +10,48 @@ const defaultOverviewData = {
   selectedDay: "2026-04-06",
   setSelectedDay: mockSetSelectedDay,
   weeklyStripDays: [
-    { day: "2026-04-05", meta: { hasSteps: false } },
-    { day: "2026-04-06", meta: { hasSteps: true } },
-    { day: "2026-04-07", meta: { hasSteps: false } },
-    { day: "2026-04-08", meta: { hasSteps: false } },
-    { day: "2026-04-09", meta: { hasSteps: false } },
-    { day: "2026-04-10", meta: { hasSteps: false } },
-    { day: "2026-04-11", meta: { hasSteps: false } },
+    { day: "2026-04-05", meta: { hasSteps: false, ringTierIndex: null } },
+    { day: "2026-04-06", meta: { hasSteps: true, ringTierIndex: 0 } },
+    { day: "2026-04-07", meta: { hasSteps: false, ringTierIndex: null } },
+    { day: "2026-04-08", meta: { hasSteps: false, ringTierIndex: null } },
+    { day: "2026-04-09", meta: { hasSteps: false, ringTierIndex: null } },
+    { day: "2026-04-10", meta: { hasSteps: false, ringTierIndex: null } },
+    { day: "2026-04-11", meta: { hasSteps: false, ringTierIndex: null } },
   ],
-  stepsRollup: { status: "ready" as const, rollupByDay: {}, refetch: jest.fn() },
+  stepsRollup: {
+    status: "ready" as const,
+    rollupByDay: {},
+    rollupDisplayByDay: {},
+    rollupFallbackBase: {},
+    isRefreshing: false,
+    refetch: jest.fn(),
+  },
   overview: {
     loading: false,
     error: null,
     model: {
       timeframes: [
         {
-          key: "today" as const,
-          label: "Today",
-          compactStatsSummary: "5,000 steps",
-          markerPosition01: 0.4,
-        },
-        {
-          key: "avg7d" as const,
-          label: "7D Avg",
+          key: "day7" as const,
+          label: "7 Day",
           compactStatsSummary: "3,000/day",
           markerPosition01: 0.25,
         },
         {
-          key: "avg30d" as const,
-          label: "30D Avg",
+          key: "day30" as const,
+          label: "30 Day",
           compactStatsSummary: "2,000/day",
           markerPosition01: 0.17,
         },
         {
-          key: "avg365d" as const,
-          label: "365D Avg",
+          key: "ytd" as const,
+          label: "YTD",
+          compactStatsSummary: "Not enough data",
+          markerPosition01: 0,
+        },
+        {
+          key: "month12" as const,
+          label: "12 Month",
           compactStatsSummary: "4,000/day",
           markerPosition01: 0.33,
         },
@@ -147,23 +154,33 @@ describe("ActivityOverviewScreen", () => {
     expect(mockRouterPush).toHaveBeenCalledWith("/(app)/activity/settings");
   });
 
-  it("renders Overview and Daily details cards with trailing averages", async () => {
+  it("renders Overview and Today’s Steps cards with timeframe rows", async () => {
     let tree!: renderer.ReactTestRenderer;
     await act(async () => {
       tree = renderer.create(<ActivityOverviewScreen />);
       await Promise.resolve();
     });
     const str = JSON.stringify(tree.toJSON());
-    expect(str).toContain("Overview");
-    expect(str).toContain("Daily details");
-    expect(str).toContain("5,000 steps");
-    expect(str).toContain("3,000/day");
-    expect(str).toContain("2,000/day");
-    expect(str).toContain("4,000/day");
-    expect(str).toContain("1,234 steps");
+    expect(str).toContain("Step Ratings");
+    expect(str).toContain("activity-step-ratings-toggle");
+    expect(str.indexOf("Step Ratings")).toBeLessThan(str.indexOf("Today’s Steps"));
+    const overviewBarMarker = "activity-overview-steps-bar-day7";
+    expect(str.indexOf("Today’s Steps")).toBeLessThan(str.indexOf(overviewBarMarker));
+    expect(str).toContain(overviewBarMarker);
+    expect(str).toContain("Today’s Steps");
+    expect(str).toContain("7 Day");
+    expect(str).toContain("30 Day");
+    expect(str).toContain("YTD");
+    expect(str).toContain("12 Month");
+    expect(str).toContain("3,000");
+    expect(str).toContain("2,000");
+    expect(str).toContain("Not enough data");
+    expect(str).toContain("4,000");
+    expect(str).toContain("1,234");
+    expect(str).not.toMatch(/1,234 steps/);
     expect(str).not.toMatch(/\d+ steps · \d/);
-    expect(str).toContain("activity-overview-steps-bar-today");
-    expect(str).toContain("activity-overview-steps-bar-avg365d");
+    expect(str).toContain("activity-overview-steps-bar-day7");
+    expect(str).toContain("activity-overview-steps-bar-month12");
     expect(str).toContain("activity-daily-details-steps-bar");
   });
 
@@ -177,11 +194,8 @@ describe("ActivityOverviewScreen", () => {
     await act(async () => {
       cell.props.onPress();
     });
-    expect(mockSetSelectedDay).toHaveBeenCalledWith("2026-04-07");
-    expect(mockRouterPush).toHaveBeenCalledWith({
-      pathname: "/(app)/activity/day/[day]",
-      params: { day: "2026-04-07" },
-    });
+    expect(mockSetSelectedDay).not.toHaveBeenCalled();
+    expect(mockRouterPush).toHaveBeenCalledWith("/(app)/activity/day/2026-04-07");
   });
 
   it("strip selection uses the same day key string as the calendar and day route (zero-padded month/day)", async () => {
@@ -195,10 +209,87 @@ describe("ActivityOverviewScreen", () => {
     await act(async () => {
       cell.props.onPress();
     });
-    expect(mockRouterPush).toHaveBeenCalledWith({
-      pathname: "/(app)/activity/day/[day]",
-      params: { day: "2026-04-05" },
+    expect(mockRouterPush).toHaveBeenCalledWith("/(app)/activity/day/2026-04-05");
+  });
+
+  it("shows overview rollup warning on Overview only, not on Today’s Steps, when daily model is ready", async () => {
+    const aggregateMessage = "Couldn’t load steps for 38 days. Other days may still show below.";
+    mockUseActivityOverviewScreenData.mockImplementation(() => ({
+      ...defaultOverviewData,
+      overview: {
+        ...defaultOverviewData.overview,
+        error: {
+          message: aggregateMessage,
+          requestId: "rAgg",
+          onRetry: jest.fn(),
+        },
+      },
+      dailyDetails: {
+        loading: false,
+        error: null,
+        model: {
+          title: "Today",
+          compactStatsSummary: "148 steps",
+          markerPosition01: 0.15,
+        },
+      },
+    }));
+
+    let tree!: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<ActivityOverviewScreen />);
+      await Promise.resolve();
     });
+    const str = JSON.stringify(tree.toJSON());
+    expect(str).toContain(aggregateMessage);
+    expect(str).toContain("148");
+    expect(str).not.toMatch(/148 steps/);
+    const first = str.indexOf(aggregateMessage);
+    const second = str.indexOf(aggregateMessage, first + 1);
+    expect(second).toBe(-1);
+  });
+
+  it("shows Today’s Steps own error when daily fetch failed, separate from overview warning", async () => {
+    const aggregateMessage = "Couldn’t load steps for 2 days. Other days may still show below.";
+    const todayMessage = "Selected day request failed";
+    mockUseActivityOverviewScreenData.mockImplementation(() => ({
+      ...defaultOverviewData,
+      overview: {
+        ...defaultOverviewData.overview,
+        error: {
+          message: aggregateMessage,
+          requestId: "rAgg",
+          onRetry: jest.fn(),
+        },
+      },
+      dailyDetails: {
+        loading: false,
+        error: { message: todayMessage, requestId: "rDay", onRetry: jest.fn() },
+        model: null,
+      },
+    }));
+
+    let tree!: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<ActivityOverviewScreen />);
+      await Promise.resolve();
+    });
+    const str = JSON.stringify(tree.toJSON());
+    expect(str).toContain(aggregateMessage);
+    expect(str).toContain(todayMessage);
+    expect(str).not.toContain("148 steps");
+  });
+
+  it("shows no rollup warning when overview has no error", async () => {
+    let tree!: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<ActivityOverviewScreen />);
+      await Promise.resolve();
+    });
+    const str = JSON.stringify(tree.toJSON());
+    expect(str).not.toContain("Couldn’t load steps for");
+    expect(str).toContain("1,234");
+    expect(str).not.toMatch(/1,234 steps/);
   });
 
   it("navigates to day detail for the strip day marked as today and for a non-today strip day", async () => {
@@ -206,8 +297,8 @@ describe("ActivityOverviewScreen", () => {
       ...defaultOverviewData,
       selectedDay: "2026-04-10",
       weeklyStripDays: [
-        { day: "2026-04-05", meta: { hasSteps: false } },
-        { day: "2026-04-10", meta: { hasSteps: true } },
+        { day: "2026-04-05", meta: { hasSteps: false, ringTierIndex: null } },
+        { day: "2026-04-10", meta: { hasSteps: true, ringTierIndex: 3 } },
       ],
     }));
 
@@ -220,10 +311,7 @@ describe("ActivityOverviewScreen", () => {
     await act(async () => {
       findStripDayPressable(tree.root, "2026-04-10").props.onPress();
     });
-    expect(mockRouterPush).toHaveBeenLastCalledWith({
-      pathname: "/(app)/activity/day/[day]",
-      params: { day: "2026-04-10" },
-    });
+    expect(mockRouterPush).toHaveBeenLastCalledWith("/(app)/activity/day/2026-04-10");
 
     mockRouterPush.mockClear();
     mockSetSelectedDay.mockClear();
@@ -231,9 +319,7 @@ describe("ActivityOverviewScreen", () => {
     await act(async () => {
       findStripDayPressable(tree.root, "2026-04-05").props.onPress();
     });
-    expect(mockRouterPush).toHaveBeenLastCalledWith({
-      pathname: "/(app)/activity/day/[day]",
-      params: { day: "2026-04-05" },
-    });
+    expect(mockSetSelectedDay).not.toHaveBeenCalled();
+    expect(mockRouterPush).toHaveBeenLastCalledWith("/(app)/activity/day/2026-04-05");
   });
 });

--- a/app/(app)/activity/calendar.tsx
+++ b/app/(app)/activity/calendar.tsx
@@ -12,6 +12,8 @@ import { headerYearFromViewableMonthItems } from "@/lib/ui/calendar/moduleCalend
 import { useModuleCalendarYearNavigationHeader } from "@/lib/ui/calendar/useModuleCalendarYearNavigationHeader";
 import { computeActivityCalendarFetchDayKeys } from "@/lib/data/activity/activityOverviewRanges";
 import { useActivityStepsRollupForKeys } from "@/lib/data/activity/useActivityStepsRollupMap";
+import { buildActivityCalendarDayModelFromRollup } from "@/lib/ui/activity/activityCalendarDayRingPresentation";
+import type { DayKey } from "@/lib/ui/calendar/types";
 import { UI_APP_SCREEN_BG } from "@/lib/ui/theme/uiTokens";
 
 type MonthModel = { key: string; monthYear: MonthYear };
@@ -52,14 +54,18 @@ export default function ActivityCalendarScreen() {
   const fetchKeys = useMemo(() => computeActivityCalendarFetchDayKeys(todayDayKey), [todayDayKey]);
   const rollup = useActivityStepsRollupForKeys(fetchKeys);
 
-  const markedDays = useMemo(() => {
-    if (rollup.status !== "ready") return new Set<string>();
-    const s = new Set<string>();
-    for (const [d, e] of Object.entries(rollup.rollupByDay)) {
-      if (e?.kind === "numeric" && e.steps > 0) s.add(d);
-    }
-    return s;
-  }, [rollup]);
+  const activityCalendarDayForDay = useCallback(
+    (day: DayKey) => {
+      const rollupEntry = rollup.rollupDisplayByDay[day];
+      return buildActivityCalendarDayModelFromRollup({
+        dayKey: day,
+        todayKey: todayDayKey,
+        rollupReady: rollupEntry !== undefined,
+        rollupEntry,
+      });
+    },
+    [rollup, todayDayKey],
+  );
 
   useModuleCalendarYearNavigationHeader(navigation, headerYear);
 
@@ -120,10 +126,9 @@ export default function ActivityCalendarScreen() {
               monthYear={item.monthYear}
               dayKeyBasis="local"
               ringSemantics="activity"
-              markerForDay={(day) =>
-                markedDays.has(day) ? { hasStrength: false, hasCardio: true } : null
-              }
-              onDayPress={(day) => router.push({ pathname: "/(app)/activity/day/[day]", params: { day } })}
+              markerForDay={() => null}
+              activityCalendarDayForDay={activityCalendarDayForDay}
+              onDayPress={(day) => router.push(`/(app)/activity/day/${day}`)}
             />
           </View>
         )}

--- a/app/(app)/activity/day/[day].tsx
+++ b/app/(app)/activity/day/[day].tsx
@@ -1,15 +1,40 @@
-import React from "react";
+import React, { useLayoutEffect } from "react";
 import { ScrollView, StyleSheet, Text, View } from "react-native";
-import { useLocalSearchParams } from "expo-router";
+import { useLocalSearchParams, useNavigation, usePathname } from "expo-router";
 
+import { activityDayKeyFromActivityDayPathname } from "@/lib/data/activity/activityDayRouteParam";
 import { useActivityDayScreenData } from "@/lib/data/activity/useActivityDayScreenData";
 import { useAuth } from "@/lib/auth/AuthProvider";
+import { formatDayKeyStackNavTitle } from "@/lib/ui/calendar/dayKeyDisplayFormat";
+import { HeaderBackButton } from "@/lib/ui/HeaderBackButton";
+import { workoutsStackNavigationOptions } from "@/lib/ui/headers/workoutsStackHeader";
 import { EmptyState, ErrorState, LoadingState, ScreenContainer } from "@/lib/ui/ScreenStates";
 
 export default function ActivityDayScreen() {
+  const navigation = useNavigation();
+  const pathname = usePathname();
   const params = useLocalSearchParams<{ day?: string | string[] }>();
-  const { normalized, state, reload } = useActivityDayScreenData(params.day);
+  const rawDayParam = activityDayKeyFromActivityDayPathname(pathname) ?? params.day;
+  const { normalized, state, reload } = useActivityDayScreenData(rawDayParam);
   const { user, initializing } = useAuth();
+
+  useLayoutEffect(() => {
+    if (!normalized.ok) {
+      navigation.setOptions({
+        ...workoutsStackNavigationOptions("detail"),
+        title: "Activity",
+        headerTitleAlign: "center",
+        headerLeft: () => <HeaderBackButton onPress={() => navigation.goBack()} />,
+      });
+      return;
+    }
+    navigation.setOptions({
+      ...workoutsStackNavigationOptions("detail"),
+      title: formatDayKeyStackNavTitle(normalized.day),
+      headerTitleAlign: "center",
+      headerLeft: () => <HeaderBackButton onPress={() => navigation.goBack()} />,
+    });
+  }, [navigation, normalized]);
 
   if (!normalized.ok) {
     return (
@@ -62,7 +87,6 @@ export default function ActivityDayScreen() {
     <ScreenContainer>
       <ScrollView contentContainerStyle={styles.scroll}>
         <View style={styles.card}>
-          <Text style={styles.title}>{normalized.ok ? normalized.day : ""}</Text>
           <View style={styles.row}>
             <Text style={styles.label}>Steps</Text>
             <Text style={styles.value}>{state.steps.toLocaleString()}</Text>
@@ -77,7 +101,6 @@ export default function ActivityDayScreen() {
 const styles = StyleSheet.create({
   scroll: { padding: 16, paddingBottom: 32 },
   card: { backgroundColor: "#FFFFFF", borderRadius: 12, padding: 16, gap: 10 },
-  title: { fontSize: 18, fontWeight: "700", color: "#1C1C1E", marginBottom: 6 },
   row: { flexDirection: "row", alignItems: "center", justifyContent: "space-between" },
   label: { fontSize: 14, color: "#6E6E73" },
   value: { fontSize: 15, fontWeight: "600", color: "#1C1C1E" },

--- a/app/(app)/activity/index.tsx
+++ b/app/(app)/activity/index.tsx
@@ -5,6 +5,7 @@ import { useNavigation, useRouter } from "expo-router";
 import { useActivityOverviewScreenData } from "@/lib/data/activity/useActivityOverviewScreenData";
 import { ActivityDailyDetailsCard } from "@/lib/ui/activity/ActivityDailyDetailsCard";
 import { ActivityOverviewCard } from "@/lib/ui/activity/ActivityOverviewCard";
+import { ActivityStepRatingsCard } from "@/lib/ui/activity/ActivityStepRatingsCard";
 import { ActivityWeeklyStrip } from "@/lib/ui/activity/ActivityWeeklyStrip";
 import { EmptyState, LoadingState } from "@/lib/ui/ScreenStates";
 import { HeaderBackButton } from "@/lib/ui/HeaderBackButton";
@@ -53,8 +54,9 @@ export default function ActivityOverviewScreen() {
   }
 
   const onStripDayPress = (day: string) => {
-    data.setSelectedDay(day);
-    router.push({ pathname: "/(app)/activity/day/[day]", params: { day } });
+    // Day detail is route-driven only; do not mutate strip/overview anchor state here.
+    // Push a concrete path so the dynamic segment always matches the tapped day (avoids param merge edge cases).
+    router.push(`/(app)/activity/day/${day}`);
   };
 
   const headerStrip = (
@@ -75,16 +77,18 @@ export default function ActivityOverviewScreen() {
         headerContent={headerStrip}
       >
         <View style={styles.pageBody}>
-          <ActivityOverviewCard
-            loading={data.overview.loading}
-            error={data.overview.error}
-            model={data.overview.model}
-          />
+          <ActivityStepRatingsCard />
           <View style={styles.cardSpacer} />
           <ActivityDailyDetailsCard
             loading={data.dailyDetails.loading}
             error={data.dailyDetails.error}
             model={data.dailyDetails.model}
+          />
+          <View style={styles.cardSpacer} />
+          <ActivityOverviewCard
+            loading={data.overview.loading}
+            error={data.overview.error}
+            model={data.overview.model}
           />
         </View>
       </ModuleScreenShell>

--- a/app/(app)/workouts/__tests__/anchored-sync.test.ts
+++ b/app/(app)/workouts/__tests__/anchored-sync.test.ts
@@ -46,6 +46,76 @@ describe("anchored sync determinism", () => {
     mockGetWorkoutsAnchor.mockResolvedValue(null);
   });
 
+  it("still ingests workouts and advances anchor when pullTodaySnapshot fails", async () => {
+    const mockPullAnchored = jest.fn().mockResolvedValue({
+      ok: true,
+      data: { workouts: [oneWorkout], anchor: "next-anchor" },
+    });
+    const mockPullToday = jest.fn().mockResolvedValue({
+      ok: false,
+      error: "HealthKit snapshot failed",
+    });
+    const mockIngest = jest.fn().mockResolvedValue({ ok: true });
+
+    const deps = baseDeps({
+      pullAnchoredWorkouts: mockPullAnchored,
+      pullTodaySnapshot: mockPullToday,
+      ingestRawEvent: mockIngest,
+    });
+
+    const result = await runAnchoredWorkoutsSync(
+      { uid: "u1", token: "tok", limit: ANCHOR_LIMIT },
+      deps,
+    );
+
+    expect(result).toEqual({ ok: true, mayHaveMoreWorkouts: false });
+    expect(mockSetWorkoutsAnchor).toHaveBeenCalledWith("u1", "next-anchor");
+    expect(mockIngest).toHaveBeenCalledTimes(1);
+    const workoutCall = (mockIngest as jest.Mock).mock.calls.find((c) => c[0]?.kind === "workout");
+    expect(workoutCall).toBeDefined();
+  });
+
+  it("still ingests workouts and advances anchor when steps ingest fails", async () => {
+    const mockPullAnchored = jest.fn().mockResolvedValue({
+      ok: true,
+      data: { workouts: [oneWorkout], anchor: "next-anchor" },
+    });
+    const mockPullToday = jest.fn().mockResolvedValue({
+      ok: true,
+      data: {
+        day: "2026-03-01",
+        steps: 8000,
+        exerciseMinutes: null,
+        activeEnergyKcal: null,
+        restingHeartRateBpm: null,
+        workouts: [],
+      },
+    });
+    const mockIngest = jest.fn(async (body: { kind?: string }) => {
+      if (body?.kind === "steps") {
+        return { ok: false, error: "steps ingest rejected", requestId: "req-steps" };
+      }
+      return { ok: true };
+    });
+
+    const deps = baseDeps({
+      pullAnchoredWorkouts: mockPullAnchored,
+      pullTodaySnapshot: mockPullToday,
+      ingestRawEvent: mockIngest,
+    });
+
+    const result = await runAnchoredWorkoutsSync(
+      { uid: "u1", token: "tok", limit: ANCHOR_LIMIT },
+      deps,
+    );
+
+    expect(result).toEqual({ ok: true, mayHaveMoreWorkouts: false });
+    expect(mockSetWorkoutsAnchor).toHaveBeenCalledWith("u1", "next-anchor");
+    expect(mockIngest).toHaveBeenCalledTimes(2);
+    expect((mockIngest as jest.Mock).mock.calls.some((c) => c[0]?.kind === "steps")).toBe(true);
+    expect((mockIngest as jest.Mock).mock.calls.some((c) => c[0]?.kind === "workout")).toBe(true);
+  });
+
   it("does not call setWorkoutsAnchor when workout ingest fails", async () => {
     const mockPullAnchored = jest.fn().mockResolvedValue({
       ok: true,

--- a/app/(app)/workouts/day/[day].tsx
+++ b/app/(app)/workouts/day/[day].tsx
@@ -21,6 +21,7 @@ import {
   resolveWorkoutDisplay,
   resolveWorkoutDisplayDurationMinutes,
 } from "@/lib/data/workouts/workoutDisplay";
+import { formatDayKeyStackNavTitle } from "@/lib/ui/calendar/dayKeyDisplayFormat";
 import { useWorkoutOverrides } from "@/lib/data/workouts/workoutOverrides";
 import { reconcileWorkoutSessionsForDay } from "@/lib/data/workouts/workoutSessionReconciliation";
 import {
@@ -63,14 +64,6 @@ const useLocalSearchParamsSafe: typeof useLocalSearchParams =
   typeof useLocalSearchParams === "function"
     ? useLocalSearchParams
     : ((() => ({})) as typeof useLocalSearchParams);
-
-function formatHeaderDate(dayKey: string): string {
-  const d = new Date(`${dayKey}T12:00:00.000Z`);
-  if (Number.isNaN(d.getTime())) return dayKey;
-  const weekday = d.toLocaleDateString(undefined, { weekday: "short" }).replace(",", "");
-  const rest = d.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" });
-  return `${weekday} ${rest}`;
-}
 
 function aggregateHeartRateZoneMinutes(session: ReconciledWorkoutSession): HeartRateZoneMinutes5 | null {
   const sums = [0, 0, 0, 0, 0];
@@ -285,7 +278,7 @@ export function WorkoutDayScreen({ domain }: { domain: WorkoutProductDomain }) {
     if (!isDayKey) return;
     navigation.setOptions({
       ...workoutsStackNavigationOptions("detail"),
-      title: formatHeaderDate(day),
+      title: formatDayKeyStackNavTitle(day),
       headerLeft: () => <HeaderBackButton onPress={() => navigation.goBack()} />,
       headerRight: () => (
         <Text

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -4,8 +4,14 @@ import { Stack, useRouter, useSegments } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 
 import { AuthProvider, useAuth } from "../lib/auth/AuthProvider";
+import { useAppleHealthForcedYesterdayFinalize } from "../lib/data/activity/useAppleHealthForcedYesterdayFinalize";
 import { PreferencesProvider } from "../lib/preferences/PreferencesProvider";
 import { UserProfileMainProvider } from "../lib/data/profile/useUserProfileMain";
+
+function AppleHealthForcedYesterdayFinalizeRunner() {
+  useAppleHealthForcedYesterdayFinalize();
+  return null;
+}
 
 function RouteGuard() {
   const { user, initializing } = useAuth();
@@ -41,6 +47,7 @@ export default function RootLayout() {
       <PreferencesProvider>
         <UserProfileMainProvider>
           <StatusBar style="auto" />
+          <AppleHealthForcedYesterdayFinalizeRunner />
           <RouteGuard />
           <Stack screenOptions={{ headerShown: false }}>
             {/* Auth flow */}

--- a/lib/contracts/__tests__/activityStepsResolution.test.ts
+++ b/lib/contracts/__tests__/activityStepsResolution.test.ts
@@ -13,13 +13,24 @@ describe("activityStepsResolution", () => {
     expect(resolvedStepsTotalFromContributing(contributing)).toBe(5012);
   });
 
-  it("multiple apple_health: picks one row (highest steps) to avoid double-counting daily totals", () => {
+  it("multiple apple_health same instant: deterministic id tie-break (not higher steps)", () => {
     const contributing = pickContributingStepEventsForDailyFacts([
-      { id: "b", sourceId: "apple_health", steps: 1000 },
-      { id: "a", sourceId: "apple_health", steps: 5000 },
+      { id: "b", sourceId: "apple_health", steps: 5000, updatedAt: "2026-04-01T12:00:00.000Z" },
+      { id: "a", sourceId: "apple_health", steps: 1000, updatedAt: "2026-04-01T12:00:00.000Z" },
     ]);
     expect(contributing).toHaveLength(1);
-    expect(contributing[0]!.steps).toBe(5000);
+    expect(contributing[0]!.id).toBe("a");
+    expect(contributing[0]!.steps).toBe(1000);
+  });
+
+  it("multiple apple_health: latest updatedAt wins even when steps decrease", () => {
+    const contributing = pickContributingStepEventsForDailyFacts([
+      { id: "early", sourceId: "apple_health", steps: 15577, updatedAt: "2026-04-01T08:00:00.000Z" },
+      { id: "late", sourceId: "apple_health", steps: 148, updatedAt: "2026-04-01T18:00:00.000Z" },
+    ]);
+    expect(contributing).toHaveLength(1);
+    expect(contributing[0]!.steps).toBe(148);
+    expect(contributing[0]!.id).toBe("late");
   });
 
   it("single non-apple event wins alone", () => {
@@ -29,10 +40,10 @@ describe("activityStepsResolution", () => {
     expect(resolvedStepsTotalFromContributing(contributing)).toBe(3333);
   });
 
-  it("multiple non-apple: picks highest steps, tie-break by id", () => {
+  it("multiple non-apple same authoritative instant: lexicographic id wins (not higher steps)", () => {
     const contributing = pickContributingStepEventsForDailyFacts([
-      { id: "z", sourceId: "manual", steps: 4000 },
-      { id: "a", sourceId: "manual", steps: 4000 },
+      { id: "z", sourceId: "manual", steps: 4000, updatedAt: "2026-04-01T12:00:00.000Z" },
+      { id: "a", sourceId: "manual", steps: 4000, updatedAt: "2026-04-01T12:00:00.000Z" },
     ]);
     expect(contributing).toHaveLength(1);
     expect(contributing[0]!.id).toBe("a");
@@ -73,5 +84,71 @@ describe("activityStepsResolution", () => {
     const contributing = pickContributingStepEventsForDailyFacts(events);
     expect(contributing.map((e) => e.id)).toEqual(["hk_daily"]);
     expect(resolvedStepsTotalFromContributing(events)).toBe(67);
+  });
+
+  it("same sourceSampleId: later authoritative row wins (downward correction)", () => {
+    const contributing = pickContributingStepEventsForDailyFacts([
+      {
+        id: "idem_a",
+        sourceId: "apple_health",
+        sourceSampleId: "HK-sample-1",
+        steps: 15577,
+        updatedAt: "2026-04-01T08:00:00.000Z",
+      },
+      {
+        id: "idem_b",
+        sourceId: "apple_health",
+        sourceSampleId: "HK-sample-1",
+        steps: 148,
+        updatedAt: "2026-04-01T18:00:00.000Z",
+      },
+    ]);
+    expect(contributing).toHaveLength(1);
+    expect(contributing[0]!.steps).toBe(148);
+    expect(contributing[0]!.id).toBe("idem_b");
+  });
+
+  it("same sourceSampleId: earlier correct value kept when later row is older timestamp", () => {
+    const contributing = pickContributingStepEventsForDailyFacts([
+      {
+        id: "good",
+        sourceId: "apple_health",
+        sourceSampleId: "HK-sample-2",
+        steps: 5000,
+        updatedAt: "2026-04-01T20:00:00.000Z",
+      },
+      {
+        id: "stale_dup",
+        sourceId: "apple_health",
+        sourceSampleId: "HK-sample-2",
+        steps: 999999,
+        updatedAt: "2026-04-01T08:00:00.000Z",
+      },
+    ]);
+    expect(contributing).toHaveLength(1);
+    expect(contributing[0]!.steps).toBe(5000);
+    expect(contributing[0]!.id).toBe("good");
+  });
+
+  it("two distinct sourceSampleIds: scalar picks one representative by latest instant then id", () => {
+    const contributing = pickContributingStepEventsForDailyFacts([
+      {
+        id: "raw_z",
+        sourceId: "apple_health",
+        sourceSampleId: "sample-z",
+        steps: 200,
+        updatedAt: "2026-04-01T12:00:00.000Z",
+      },
+      {
+        id: "raw_a",
+        sourceId: "apple_health",
+        sourceSampleId: "sample-a",
+        steps: 100,
+        updatedAt: "2026-04-01T12:00:00.000Z",
+      },
+    ]);
+    expect(contributing).toHaveLength(1);
+    expect(contributing[0]!.sourceSampleId).toBe("sample-a");
+    expect(contributing[0]!.steps).toBe(100);
   });
 });

--- a/lib/contracts/__tests__/localCalendarDayKey.test.ts
+++ b/lib/contracts/__tests__/localCalendarDayKey.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "@jest/globals";
+import { localCalendarDayKeyFromIsoInTimeZone } from "../localCalendarDayKey";
+
+describe("localCalendarDayKeyFromIsoInTimeZone", () => {
+  it("maps instant to local calendar day in IANA zone (no UTC calendar leakage)", () => {
+    // 2026-04-08 01:30 UTC = still 2026-04-07 evening in New York
+    expect(localCalendarDayKeyFromIsoInTimeZone("2026-04-08T01:30:00.000Z", "America/New_York")).toBe(
+      "2026-04-07",
+    );
+  });
+
+  it("uses en-CA YYYY-MM-DD for midnight boundary in Los Angeles", () => {
+    // Just after midnight local — same calendar day as start-of-day bucket tests
+    expect(localCalendarDayKeyFromIsoInTimeZone("2026-06-15T07:00:00.000Z", "America/Los_Angeles")).toBe(
+      "2026-06-15",
+    );
+  });
+
+  it("returns null for invalid ISO", () => {
+    expect(localCalendarDayKeyFromIsoInTimeZone("not-a-date", "America/New_York")).toBeNull();
+  });
+
+  it("returns null for invalid timezone", () => {
+    expect(localCalendarDayKeyFromIsoInTimeZone("2026-01-01T12:00:00.000Z", "Not/A_Zone")).toBeNull();
+  });
+});

--- a/lib/contracts/__tests__/rawEvent.stepsSampleIdentity.test.ts
+++ b/lib/contracts/__tests__/rawEvent.stepsSampleIdentity.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "@jest/globals";
+import { rawEventDocSchema } from "../rawEvent";
+
+describe("rawEventDocSchema — steps sample identity (additive)", () => {
+  it("accepts optional sourceSampleId, sampleId, and sourceUUID on steps payload", () => {
+    const doc = {
+      schemaVersion: 1,
+      id: "test-steps-1",
+      userId: "u1",
+      sourceId: "apple_health",
+      provider: "apple_health",
+      sourceType: "mobile_app",
+      kind: "steps",
+      receivedAt: "2026-04-01T12:00:00.000Z",
+      observedAt: "2026-04-01T12:00:00.000Z",
+      payload: {
+        start: "2026-04-01T04:00:00.000Z",
+        end: "2026-04-02T03:59:59.999Z",
+        timezone: "America/New_York",
+        steps: 5000,
+        sampleId: "hk-uuid-42",
+        sourceSampleId: "preferred-id",
+      },
+    };
+
+    const parsed = rawEventDocSchema.safeParse(doc);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    const p = parsed.data.payload as { sampleId?: string; sourceSampleId?: string };
+    expect(p.sourceSampleId).toBe("preferred-id");
+    expect(p.sampleId).toBe("hk-uuid-42");
+  });
+});

--- a/lib/contracts/activityStepsResolution.ts
+++ b/lib/contracts/activityStepsResolution.ts
@@ -2,11 +2,14 @@
  * Deterministic rules for collapsing multiple `kind: "steps"` canonical events for one calendar day
  * into a single display / daily-facts scalar (avoids double-counting Apple Health + manual, etc.).
  *
- * Policy (near-term):
- * - If any event is an Apple-class read (`apple_health` or `healthkit`, see {@link isAppleHealthBodyReadSourceId}),
- *   pick **one** Apple-class row (highest `steps`, then lexicographic `id`) and **ignore all non-Apple** sources for that day.
+ * Policy:
+ * - Apple-class (`apple_health` / `healthkit`): first collapse rows that share the same
+ *   {@link appleStepsStableIdentity} (payload `sourceSampleId` / aliases, else canonical `id`).
+ *   Within each identity, keep the latest authoritative instant (`updatedAt` then `createdAt`);
+ *   ties break by lexicographic `id` (never by step magnitude).
+ *   Then pick a single daily scalar row from the per-identity representatives (same ordering).
  * - Else if exactly one valid steps event, it wins.
- * - Else multiple non–Apple events: pick the single event with the highest `steps`; tie-break by `id` (lexicographic).
+ * - Else multiple non–Apple events: latest by timestamp ordering; ties break by lexicographic `id` only.
  */
 
 import { isAppleHealthBodyReadSourceId } from "./bodyReadSources";
@@ -15,12 +18,74 @@ export type ActivityStepsCanonicalLike = {
   readonly id: string;
   readonly sourceId: string;
   readonly steps: number;
+  /** Stable logical sample id from raw payload when present; else identity falls back to `id`. */
+  readonly sourceSampleId?: string | null;
   readonly distanceKm?: number | null;
   readonly moveMinutes?: number | null;
+  /** Lexicographic ISO timestamps from canonical events (raw `receivedAt` at write time). */
+  readonly updatedAt?: string;
+  readonly createdAt?: string;
 };
 
 function isValidSteps(n: number): boolean {
   return typeof n === "number" && Number.isFinite(n) && n >= 0;
+}
+
+function authoritativeInstant(e: ActivityStepsCanonicalLike): string {
+  return (e.updatedAt ?? e.createdAt ?? "") as string;
+}
+
+/** Newer ISO first; empty timestamps sort last. */
+function compareByAuthoritativeTimeDesc(a: ActivityStepsCanonicalLike, b: ActivityStepsCanonicalLike): number {
+  const ta = authoritativeInstant(a);
+  const tb = authoritativeInstant(b);
+  if (ta !== tb) return tb.localeCompare(ta);
+  return 0;
+}
+
+/** One physical sample / ingest row: explicit Apple id, else one canonical Firestore row. */
+export function appleStepsStableIdentity(e: ActivityStepsCanonicalLike): string {
+  const s = e.sourceSampleId;
+  if (typeof s === "string" && s.trim().length > 0) return s.trim();
+  return e.id;
+}
+
+function pickAuthoritativeWithinIdentity(
+  prev: ActivityStepsCanonicalLike,
+  incoming: ActivityStepsCanonicalLike,
+): ActivityStepsCanonicalLike {
+  const cmp = compareByAuthoritativeTimeDesc(incoming, prev);
+  if (cmp < 0) return incoming;
+  if (cmp > 0) return prev;
+  return incoming.id.localeCompare(prev.id) < 0 ? incoming : prev;
+}
+
+function dedupeAppleStepsByStableIdentity(
+  apple: readonly ActivityStepsCanonicalLike[],
+): ActivityStepsCanonicalLike[] {
+  const byKey = new Map<string, ActivityStepsCanonicalLike>();
+  for (const e of apple) {
+    const key = appleStepsStableIdentity(e);
+    const prev = byKey.get(key);
+    if (!prev) {
+      byKey.set(key, e);
+      continue;
+    }
+    byKey.set(key, pickAuthoritativeWithinIdentity(prev, e));
+  }
+  return [...byKey.values()];
+}
+
+function pickSingleContributing(valid: readonly ActivityStepsCanonicalLike[]): readonly ActivityStepsCanonicalLike[] {
+  if (valid.length === 0) return [];
+  if (valid.length === 1) return valid;
+  const sorted = [...valid].sort((a, b) => {
+    const t = compareByAuthoritativeTimeDesc(a, b);
+    if (t !== 0) return t;
+    return a.id.localeCompare(b.id);
+  });
+  const top = sorted[0];
+  return top != null ? [top] : [];
 }
 
 export function pickContributingStepEventsForDailyFacts(
@@ -30,19 +95,10 @@ export function pickContributingStepEventsForDailyFacts(
   if (valid.length === 0) return [];
   const apple = valid.filter((e) => isAppleHealthBodyReadSourceId(e.sourceId));
   if (apple.length > 0) {
-    if (apple.length === 1) return apple;
-    const sorted = [...apple].sort((a, b) =>
-      b.steps !== a.steps ? b.steps - a.steps : a.id.localeCompare(b.id),
-    );
-    const top = sorted[0];
-    return top != null ? [top] : [];
+    const perIdentity = dedupeAppleStepsByStableIdentity(apple);
+    return pickSingleContributing(perIdentity);
   }
-  if (valid.length === 1) return valid;
-  const sorted = [...valid].sort((a, b) =>
-    b.steps !== a.steps ? b.steps - a.steps : a.id.localeCompare(b.id),
-  );
-  const top = sorted[0];
-  return top != null ? [top] : [];
+  return pickSingleContributing(valid);
 }
 
 export function resolvedStepsTotalFromContributing(

--- a/lib/contracts/index.ts
+++ b/lib/contracts/index.ts
@@ -7,6 +7,7 @@ export * from "./derivedLedger";
 export * from "./insights";
 export * from "./intelligenceContext";
 export * from "./day";
+export * from "./localCalendarDayKey";
 export * from "./dayTruth";
 export * from "./failure";
 export * from "./weight";

--- a/lib/contracts/localCalendarDayKey.ts
+++ b/lib/contracts/localCalendarDayKey.ts
@@ -1,0 +1,19 @@
+/**
+ * Local calendar day key (YYYY-MM-DD) for instant `iso` in IANA `ianaTimeZone`.
+ *
+ * Used for:
+ * - Apple Health `steps` (and other window payloads): canonical `day` = f(payload.start, payload.timezone)
+ * - POST /ingest acknowledgement `day` for those same payloads
+ *
+ * Algorithm matches historical ingest + normalization: `Intl.DateTimeFormat("en-CA", { timeZone })`.
+ * Returns `null` if `iso` is not parseable or `ianaTimeZone` is invalid (fail closed; no silent UTC fallback).
+ */
+export function localCalendarDayKeyFromIsoInTimeZone(iso: string, ianaTimeZone: string): string | null {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  try {
+    return new Intl.DateTimeFormat("en-CA", { timeZone: ianaTimeZone }).format(d);
+  } catch {
+    return null;
+  }
+}

--- a/lib/contracts/rawEvent.ts
+++ b/lib/contracts/rawEvent.ts
@@ -127,6 +127,11 @@ const manualStepsPayloadSchema = manualWindowBaseSchema
     steps: z.number().finite().nonnegative(),
     distanceKm: z.number().finite().nonnegative().nullable().optional(),
     moveMinutes: z.number().finite().nonnegative().nullable().optional(),
+    /** Preferred stable HealthKit / Apple sample identity (additive). */
+    sourceSampleId: z.string().min(1).max(512).optional(),
+    /** Alias accepted from some clients; normalized to canonical `sourceSampleId` in the mapper. */
+    sampleId: z.string().min(1).max(512).optional(),
+    sourceUUID: z.string().min(1).max(512).optional(),
   })
   .strip();
 

--- a/lib/data/activity/__tests__/activityDayRouteParam.test.ts
+++ b/lib/data/activity/__tests__/activityDayRouteParam.test.ts
@@ -1,4 +1,20 @@
-import { normalizeActivityDayRouteParam } from "../activityDayRouteParam";
+import { activityDayKeyFromActivityDayPathname, normalizeActivityDayRouteParam } from "../activityDayRouteParam";
+
+describe("activityDayKeyFromActivityDayPathname", () => {
+  it("parses the trailing day segment from the normalized activity day path", () => {
+    expect(activityDayKeyFromActivityDayPathname("/activity/day/2026-04-14")).toBe("2026-04-14");
+  });
+
+  it("accepts a trailing slash", () => {
+    expect(activityDayKeyFromActivityDayPathname("/activity/day/2026-04-14/")).toBe("2026-04-14");
+  });
+
+  it("returns null when the path does not match", () => {
+    expect(activityDayKeyFromActivityDayPathname("/activity/day/not-a-day")).toBeNull();
+    expect(activityDayKeyFromActivityDayPathname("/workouts/day/2026-04-14")).toBeNull();
+    expect(activityDayKeyFromActivityDayPathname(undefined)).toBeNull();
+  });
+});
 
 describe("normalizeActivityDayRouteParam", () => {
   it("accepts a valid string", () => {

--- a/lib/data/activity/__tests__/activityOverviewCardModel.test.ts
+++ b/lib/data/activity/__tests__/activityOverviewCardModel.test.ts
@@ -4,10 +4,20 @@ import {
   ACTIVITY_OVERVIEW_STEPS_PLACEMENT_CAP,
   buildActivityDailyDetailsCardModel,
   buildActivityOverviewCardModel,
+  buildActivityTodayStepsLiveCardModel,
   formatActivityAverageRowSummary,
   formatActivityDailyDetailsTitle,
   formatActivityTodayRowSummary,
 } from "@/lib/data/activity/activityOverviewCardModel";
+import { ACTIVITY_OVERVIEW_NOT_ENOUGH_DATA } from "@/lib/data/activity/activityOverviewSufficiency";
+import {
+  ACTIVITY_OVERVIEW_TRAILING_12_MONTH_DAY_COUNT,
+  ACTIVITY_OVERVIEW_TRAILING_7_DAY_COUNT,
+  activityTrailingNDaysInclusive,
+  activityYtdInclusiveThroughEndDay,
+} from "@/lib/data/activity/activityOverviewRanges";
+import { addCalendarDaysToDayKey } from "@/lib/ui/calendar/dateUtils";
+import type { DayKey } from "@/lib/ui/calendar/types";
 
 describe("formatActivityDailyDetailsTitle", () => {
   it('uses "Today" when selected is local today', () => {
@@ -44,125 +54,201 @@ function numericMap(pairs: [string, number][]): ActivityStepsRollupMap {
   return out;
 }
 
+function fillTrailingNumeric(end: string, dayCount: number, steps: number): ActivityStepsRollupMap {
+  const days = activityTrailingNDaysInclusive(end, dayCount);
+  return numericMap(days.map((d) => [d, steps]));
+}
+
+function overviewAnchorFromToday(today: DayKey): DayKey {
+  return addCalendarDaysToDayKey(today, -1);
+}
+
+function buildOverview(rollup: ActivityStepsRollupMap, today: DayKey) {
+  return buildActivityOverviewCardModel({
+    overviewAnchorEndDay: overviewAnchorFromToday(today),
+    rollupByDay: rollup,
+  });
+}
+
 describe("buildActivityOverviewCardModel", () => {
-  const overviewAnchorDay = "2026-04-08";
+  const today: DayKey = "2026-04-08";
+  const anchor = overviewAnchorFromToday(today);
 
-  it("excludes error rollup days from trailing averages (only numeric daily-facts days count)", () => {
-    const rollup: ActivityStepsRollupMap = {
-      "2026-04-08": { kind: "numeric", steps: 7000 },
-      "2026-04-07": { kind: "error", message: "network", requestId: "x" },
-    };
-    expect(rollupEntryIsFailure(rollup["2026-04-07"])).toBe(true);
-    const { timeframes } = buildActivityOverviewCardModel({ overviewAnchorDay, rollupByDay: rollup });
-    expect(timeframes[0]?.compactStatsSummary).toBe("7,000 steps");
-    // 7d window: only 2026-04-08 is numeric; others absent → avg = 7000 / 1
-    expect(timeframes[1]?.compactStatsSummary).toBe("7,000/day");
+  it("orders rows 7 Day, 30 Day, YTD, 12 Month", () => {
+    const rollup = fillTrailingNumeric(anchor, ACTIVITY_OVERVIEW_TRAILING_12_MONTH_DAY_COUNT, 1000);
+    const { timeframes } = buildOverview(rollup, today);
+    expect(timeframes.map((r) => r.key)).toEqual(["day7", "day30", "ytd", "month12"]);
+    expect(timeframes.map((r) => r.label)).toEqual(["7 Day", "30 Day", "YTD", "12 Month"]);
   });
 
-  it("orders rows Today, 7D Avg, 30D Avg, 365D Avg", () => {
-    const rollup = numericMap([["2026-04-08", 7000]]);
-    const { timeframes } = buildActivityOverviewCardModel({ overviewAnchorDay, rollupByDay: rollup });
-    expect(timeframes.map((r) => r.key)).toEqual(["today", "avg7d", "avg30d", "avg365d"]);
-    expect(timeframes.map((r) => r.label)).toEqual(["Today", "7D Avg", "30D Avg", "365D Avg"]);
+  it("anchors overview to yesterday of today, not a future strip day", () => {
+    const todayKey: DayKey = "2026-04-14";
+    const anchorKey = overviewAnchorFromToday(todayKey);
+    const rollup = fillTrailingNumeric(anchorKey, ACTIVITY_OVERVIEW_TRAILING_12_MONTH_DAY_COUNT, 2000);
+    const { timeframes } = buildActivityOverviewCardModel({
+      overviewAnchorEndDay: anchorKey,
+      rollupByDay: rollup,
+    });
+    const d7 = activityTrailingNDaysInclusive(anchorKey, ACTIVITY_OVERVIEW_TRAILING_7_DAY_COUNT);
+    const sum7 = d7.length * 2000;
+    expect(timeframes[0]?.compactStatsSummary).toBe(`${Math.round(sum7 / 7).toLocaleString()}/day`);
   });
 
-  it("uses fixed trailing windows: 7/30/365 days inclusive of overview anchor day", () => {
-    const rollup = numericMap([
+  it("7 Day: full numeric window => mean; missing any day => Not enough data", () => {
+    const full = numericMap([
+      ["2026-04-01", 1000],
       ["2026-04-02", 1000],
       ["2026-04-03", 1000],
       ["2026-04-04", 1000],
       ["2026-04-05", 1000],
       ["2026-04-06", 1000],
-      ["2026-04-07", 1000],
-      ["2026-04-08", 7000],
+      ["2026-04-07", 7000],
     ]);
-    const { timeframes } = buildActivityOverviewCardModel({ overviewAnchorDay, rollupByDay: rollup });
-    expect(timeframes[0]?.compactStatsSummary).toBe("7,000 steps");
-    // sum 7d = 6×1000 + 7000 = 13_000; all 7 days numeric → / 7
-    expect(timeframes[1]?.compactStatsSummary).toBe("1,857/day");
-    // 30d window contains the same 7 numeric days; rest absent → 13_000 / 7
-    expect(timeframes[2]?.compactStatsSummary).toBe("1,857/day");
-    // 365d window: same seven numeric days in range, remainder absent → 13_000 / 7
-    expect(timeframes[3]?.compactStatsSummary).toBe("1,857/day");
+    const { timeframes: ok } = buildOverview(full, today);
+    expect(ok[0]?.compactStatsSummary).toBe("1,857/day");
+
+    const partial: ActivityStepsRollupMap = {
+      ...full,
+      "2026-04-05": { kind: "absent" },
+    };
+    const { timeframes: bad } = buildOverview(partial, today);
+    expect(bad[0]?.compactStatsSummary).toBe(ACTIVITY_OVERVIEW_NOT_ENOUGH_DATA);
   });
 
-  it("365D average uses only numeric days in window (not fixed 365 denominator)", () => {
-    const pairs: [string, number][] = [];
-    for (let i = 0; i < 10; i += 1) {
-      const d = `2026-04-${String(i + 1).padStart(2, "0")}` as `${string}-${string}-${string}`;
-      pairs.push([d, 3650]);
+  it("30 Day: requires all 30 numeric days", () => {
+    const rollup = fillTrailingNumeric(anchor, 30, 3000);
+    const { timeframes } = buildOverview(rollup, today);
+    expect(timeframes[1]?.compactStatsSummary).toBe("3,000/day");
+
+    const gap = { ...rollup, "2026-03-20": { kind: "error", message: "x", requestId: null } as const };
+    const { timeframes: err } = buildOverview(gap, today);
+    expect(err[1]?.compactStatsSummary).toBe(ACTIVITY_OVERVIEW_NOT_ENOUGH_DATA);
+  });
+
+  it("YTD and 12 Month: any error day in window => Not enough data (no silent zero-fill)", () => {
+    const ytdDays = activityYtdInclusiveThroughEndDay(anchor);
+    const rollupYtd = numericMap(ytdDays.map((d) => [d, 1000]));
+    const failYtd = ytdDays[Math.floor(ytdDays.length / 2)]!;
+    rollupYtd[failYtd] = { kind: "error", message: "503", requestId: "r1" };
+    const ytdRow = buildOverview(rollupYtd, today);
+    expect(ytdRow.timeframes[2]?.compactStatsSummary).toBe(ACTIVITY_OVERVIEW_NOT_ENOUGH_DATA);
+    expect(ytdRow.timeframes[2]?.markerPosition01).toBe(0);
+
+    const d365 = activityTrailingNDaysInclusive(anchor, ACTIVITY_OVERVIEW_TRAILING_12_MONTH_DAY_COUNT);
+    const rollup365 = numericMap(d365.map((d) => [d, 500]));
+    const fail365 = d365[100]!;
+    rollup365[fail365] = { kind: "error", message: "503", requestId: null };
+    const m12 = buildOverview(rollup365, today);
+    expect(m12.timeframes[3]?.compactStatsSummary).toBe(ACTIVITY_OVERVIEW_NOT_ENOUGH_DATA);
+    expect(m12.timeframes[3]?.markerPosition01).toBe(0);
+  });
+
+  it("YTD: fixed denominator Jan 1..anchor; missing days count as 0 in numerator", () => {
+    const ytdDays = activityYtdInclusiveThroughEndDay(anchor);
+    const rollup = numericMap(ytdDays.map((d) => [d, 1000]));
+    const { timeframes } = buildOverview(rollup, today);
+    expect(timeframes[2]?.compactStatsSummary).toBe("1,000/day");
+
+    const sparse: ActivityStepsRollupMap = { "2026-04-07": { kind: "numeric", steps: 7000 } };
+    const { timeframes: partial } = buildOverview(sparse, today);
+    const denom = ytdDays.length;
+    expect(partial[2]?.compactStatsSummary).toBe(`${Math.round(7000 / denom).toLocaleString()}/day`);
+  });
+
+  it("12 Month: rolling average uses fixed 365 denominator; 10 days at 10k and 355 missing => ~274/day", () => {
+    const d365 = activityTrailingNDaysInclusive(anchor, ACTIVITY_OVERVIEW_TRAILING_12_MONTH_DAY_COUNT);
+    const rollup: ActivityStepsRollupMap = {};
+    for (const d of d365.slice(-10)) {
+      rollup[d] = { kind: "numeric", steps: 10_000 };
     }
-    const rollup = numericMap(pairs);
-    const { timeframes } = buildActivityOverviewCardModel({ overviewAnchorDay: "2026-04-10", rollupByDay: rollup });
-    // 10 days × 3650 = 36_500 / 10
-    expect(timeframes[3]?.compactStatsSummary).toBe("3,650/day");
+    const { timeframes } = buildOverview(rollup, today);
+    const expected = (10 * 10_000) / 365;
+    expect(Math.round(expected)).toBe(274);
+    expect(timeframes[3]?.compactStatsSummary).toBe(`${Math.round(expected).toLocaleString()}/day`);
   });
 
-  it("returns 0/day when the trailing window has no numeric rollups", () => {
+  it("12 Month: absent map entries count as 0 (not NED)", () => {
+    const rollup = fillTrailingNumeric(anchor, ACTIVITY_OVERVIEW_TRAILING_12_MONTH_DAY_COUNT, 500);
+    const { timeframes } = buildOverview(rollup, today);
+    expect(timeframes[3]?.compactStatsSummary).toBe("500/day");
+
+    const oneMissing = { ...rollup };
+    delete (oneMissing as Record<string, unknown>)["2025-04-09"];
+    const { timeframes: withGap } = buildOverview(oneMissing, today);
+    const expectedAvg = (364 * 500) / 365;
+    expect(withGap[3]?.compactStatsSummary).toBe(`${Math.round(expectedAvg).toLocaleString()}/day`);
+  });
+
+  it("excludes error rollup from sufficiency (not treated as numeric)", () => {
     const rollup: ActivityStepsRollupMap = {
-      "2026-04-07": { kind: "absent" },
-      "2026-04-08": { kind: "error", message: "x", requestId: null },
+      "2026-04-08": { kind: "numeric", steps: 7000 },
+      "2026-04-07": { kind: "error", message: "network", requestId: "x" },
     };
-    const { timeframes } = buildActivityOverviewCardModel({ overviewAnchorDay: "2026-04-08", rollupByDay: rollup });
-    expect(timeframes[1]?.compactStatsSummary).toBe("0/day");
-    expect(timeframes[2]?.compactStatsSummary).toBe("0/day");
-    expect(timeframes[3]?.compactStatsSummary).toBe("0/day");
+    expect(rollupEntryIsFailure(rollup["2026-04-07"])).toBe(true);
+    const { timeframes } = buildOverview(rollup, today);
+    expect(timeframes[0]?.compactStatsSummary).toBe(ACTIVITY_OVERVIEW_NOT_ENOUGH_DATA);
   });
 
-  it("trailing averages ignore absent days: only valid numeric rollups in the denominator", () => {
+  it("sparse rollup: 7 and 30 day NED; YTD and 12 Month still show zero-filled averages", () => {
     const rollup: ActivityStepsRollupMap = {
-      "2026-04-08": { kind: "numeric", steps: 3000 },
-      "2026-04-06": { kind: "numeric", steps: 1000 },
-      "2026-04-04": { kind: "numeric", steps: 0 },
+      "2026-04-07": { kind: "numeric", steps: ACTIVITY_OVERVIEW_STEPS_PLACEMENT_CAP },
     };
-    const { timeframes } = buildActivityOverviewCardModel({ overviewAnchorDay: "2026-04-08", rollupByDay: rollup });
-    // 7d window Apr 2–8: numeric Apr 4 (0), Apr 6 (1000), Apr 8 (3000); Apr 2,3,5,7 absent → 4000/3
-    expect(timeframes[1]?.compactStatsSummary).toBe("1,333/day");
+    const { timeframes } = buildOverview(rollup, today);
+    expect(timeframes[0]?.compactStatsSummary).toBe(ACTIVITY_OVERVIEW_NOT_ENOUGH_DATA);
+    expect(timeframes[1]?.compactStatsSummary).toBe(ACTIVITY_OVERVIEW_NOT_ENOUGH_DATA);
+    expect(timeframes[0]?.markerPosition01).toBe(0);
+    expect(timeframes[1]?.markerPosition01).toBe(0);
+    const ytdDays = activityYtdInclusiveThroughEndDay(anchor);
+    const ytdAvg = ACTIVITY_OVERVIEW_STEPS_PLACEMENT_CAP / ytdDays.length;
+    expect(timeframes[2]?.compactStatsSummary).toBe(`${Math.round(ytdAvg).toLocaleString()}/day`);
+    const d365Avg = ACTIVITY_OVERVIEW_STEPS_PLACEMENT_CAP / ACTIVITY_OVERVIEW_TRAILING_12_MONTH_DAY_COUNT;
+    expect(timeframes[3]?.compactStatsSummary).toBe(`${Math.round(d365Avg).toLocaleString()}/day`);
+    expect(timeframes[2]?.markerPosition01).toBeGreaterThan(0);
+    expect(timeframes[3]?.markerPosition01).toBeGreaterThan(0);
   });
 
-  it("treats days missing from the rollup map like 404/absent (undefined cell, not 0 in denominator)", () => {
-    // Only today is present; other 6 days in the 7D window were never fetched into the map
-    const rollup = numericMap([["2026-04-08", 7000]]);
-    const { timeframes } = buildActivityOverviewCardModel({ overviewAnchorDay: "2026-04-08", rollupByDay: rollup });
-    expect(timeframes[1]?.compactStatsSummary).toBe("7,000/day");
-  });
-
-  it("mixes explicit absent entries (404-shaped) with numeric days in a partial 7D window", () => {
-    const rollup: ActivityStepsRollupMap = {
-      "2026-04-06": { kind: "absent" },
-      "2026-04-07": { kind: "absent" },
-      "2026-04-08": { kind: "numeric", steps: 9000 },
-    };
-    const { timeframes } = buildActivityOverviewCardModel({ overviewAnchorDay: "2026-04-08", rollupByDay: rollup });
-    expect(timeframes[1]?.compactStatsSummary).toBe("9,000/day");
-  });
-
-  it("exposes marker positions within 0–1 for bars", () => {
-    const { timeframes } = buildActivityOverviewCardModel({
-      overviewAnchorDay,
-      rollupByDay: numericMap([[overviewAnchorDay, ACTIVITY_OVERVIEW_STEPS_PLACEMENT_CAP]]),
-    });
+  it("when fully covered, marker positions stay within 0–1", () => {
+    const rollup = fillTrailingNumeric(anchor, ACTIVITY_OVERVIEW_TRAILING_12_MONTH_DAY_COUNT, 1000);
+    const { timeframes } = buildOverview(rollup, today);
     for (const tf of timeframes) {
       expect(tf.markerPosition01).toBeGreaterThanOrEqual(0);
       expect(tf.markerPosition01).toBeLessThanOrEqual(1);
     }
-    expect(timeframes[0]?.markerPosition01).toBe(1);
+  });
+
+  it("7 Day uses completed window through yesterday: absent/partial today does not break sufficiency", () => {
+    const rollup = fillTrailingNumeric(anchor, ACTIVITY_OVERVIEW_TRAILING_7_DAY_COUNT, 4000);
+    rollup["2026-04-08"] = { kind: "absent" };
+    const { timeframes } = buildOverview(rollup, today);
+    expect(timeframes[0]?.compactStatsSummary).toBe("4,000/day");
+  });
+});
+
+describe("buildActivityTodayStepsLiveCardModel", () => {
+  it("formats Today title and steps from HealthKit total", () => {
+    const m = buildActivityTodayStepsLiveCardModel({ todayDayKey: "2026-04-14", steps: 5313 });
+    expect(m.title).toBe("Today");
+    expect(m.compactStatsSummary).toBe("5,313 steps");
+    expect(m.markerPosition01).toBeGreaterThan(0);
   });
 });
 
 describe("buildActivityDailyDetailsCardModel", () => {
-  it("uses selected day rollup independent of overview anchor row", () => {
+  it("uses detail day rollup independent of overview rows", () => {
     const rollup = numericMap([
       ["2026-04-05", 100],
       ["2026-04-08", 9999],
     ]);
     const m = buildActivityDailyDetailsCardModel({
-      selectedDay: "2026-04-05",
+      detailDayKey: "2026-04-05",
       todayDayKey: "2026-04-08",
       rollupByDay: rollup,
     });
     expect(m.compactStatsSummary).toBe("100 steps");
-    const overview = buildActivityOverviewCardModel({ overviewAnchorDay: "2026-04-08", rollupByDay: rollup });
-    expect(overview.timeframes[0]?.compactStatsSummary).toBe("9,999 steps");
+    const overview = buildOverview(rollup, "2026-04-08");
+    expect(overview.timeframes[0]?.compactStatsSummary).toBe(ACTIVITY_OVERVIEW_NOT_ENOUGH_DATA);
+    expect(overview.timeframes[1]?.compactStatsSummary).toBe(ACTIVITY_OVERVIEW_NOT_ENOUGH_DATA);
+    expect(overview.timeframes[2]?.compactStatsSummary).not.toBe(ACTIVITY_OVERVIEW_NOT_ENOUGH_DATA);
+    expect(overview.timeframes[3]?.compactStatsSummary).not.toBe(ACTIVITY_OVERVIEW_NOT_ENOUGH_DATA);
   });
 });

--- a/lib/data/activity/__tests__/activityOverviewRanges.test.ts
+++ b/lib/data/activity/__tests__/activityOverviewRanges.test.ts
@@ -1,63 +1,105 @@
 import type { DayKey } from "@/lib/ui/calendar/types";
 import {
   ACTIVITY_CALENDAR_MARKER_SPAN_DAYS,
-  ACTIVITY_OVERVIEW_AVG_12M_DAYS,
-  ACTIVITY_OVERVIEW_AVG_30D_DAYS,
-  ACTIVITY_OVERVIEW_AVG_7D_DAYS,
+  ACTIVITY_OVERVIEW_TRAILING_12_MONTH_DAY_COUNT,
+  ACTIVITY_OVERVIEW_TRAILING_30_DAY_COUNT,
+  ACTIVITY_OVERVIEW_TRAILING_7_DAY_COUNT,
   activityTrailingNDaysInclusive,
+  activityYtdInclusiveThroughEndDay,
   computeActivityCalendarFetchDayKeys,
   computeActivityOverviewFetchDayKeys,
+  getActivityOverviewAnchorEndDay,
 } from "@/lib/data/activity/activityOverviewRanges";
+import { addCalendarDaysToDayKey, getWeekDaysForAnchor } from "@/lib/ui/calendar/dateUtils";
 
 describe("activityTrailingNDaysInclusive", () => {
-  it("returns N consecutive days ending on endDay", () => {
-    const days = activityTrailingNDaysInclusive("2026-04-08", 7);
+  it("returns N consecutive days ending on endDay (7-day inclusive)", () => {
+    const days = activityTrailingNDaysInclusive("2026-04-08", ACTIVITY_OVERVIEW_TRAILING_7_DAY_COUNT);
     expect(days).toHaveLength(7);
     expect(days[0]).toBe("2026-04-02");
     expect(days[6]).toBe("2026-04-08");
   });
+
+  it("returns 30 consecutive days inclusive of end day", () => {
+    const days = activityTrailingNDaysInclusive("2026-04-08", ACTIVITY_OVERVIEW_TRAILING_30_DAY_COUNT);
+    expect(days).toHaveLength(30);
+    expect(days[0]).toBe("2026-03-10");
+    expect(days[29]).toBe("2026-04-08");
+  });
+
+  it("returns 365 consecutive days inclusive of end day (12 Month)", () => {
+    const days = activityTrailingNDaysInclusive("2026-04-08", ACTIVITY_OVERVIEW_TRAILING_12_MONTH_DAY_COUNT);
+    expect(days).toHaveLength(365);
+    expect(days[0]).toBe("2025-04-09");
+    expect(days[364]).toBe("2026-04-08");
+    expect(days.every((k) => k <= "2026-04-08")).toBe(true);
+  });
 });
 
-/** Spec: distinct GET keys equal union(Today row, 7D, 30D, 365D) — nested windows collapse to the 365 trail. */
-function expectedDedupedOverviewFetchUnionSize(anchor: DayKey): number {
-  return new Set<DayKey>([
-    anchor,
-    ...activityTrailingNDaysInclusive(anchor, ACTIVITY_OVERVIEW_AVG_7D_DAYS),
-    ...activityTrailingNDaysInclusive(anchor, ACTIVITY_OVERVIEW_AVG_30D_DAYS),
-    ...activityTrailingNDaysInclusive(anchor, ACTIVITY_OVERVIEW_AVG_12M_DAYS),
-  ]).size;
-}
+describe("activityYtdInclusiveThroughEndDay", () => {
+  it("runs Jan 1 through end day inclusive in the same calendar year", () => {
+    const days = activityYtdInclusiveThroughEndDay("2026-04-08" as DayKey);
+    expect(days[0]).toBe("2026-01-01");
+    expect(days[days.length - 1]).toBe("2026-04-08");
+    expect(days).toHaveLength(98);
+  });
+
+  it("includes only Jan 1 when end is Jan 1", () => {
+    expect(activityYtdInclusiveThroughEndDay("2027-01-01" as DayKey)).toEqual(["2027-01-01"]);
+  });
+});
 
 describe("computeActivityOverviewFetchDayKeys", () => {
-  it("returns exactly the 365-day inclusive trail ending on the anchor (no device-today bleed, no week future days)", () => {
-    const anchor = "2026-04-08" as DayKey;
-    const keys = computeActivityOverviewFetchDayKeys(anchor);
-    const trail = activityTrailingNDaysInclusive(anchor, ACTIVITY_OVERVIEW_AVG_12M_DAYS);
-    expect(keys).toEqual([...trail].sort());
-    expect(keys).toHaveLength(ACTIVITY_OVERVIEW_AVG_12M_DAYS);
-    expect(keys[0]).toBe("2025-04-09");
-    expect(keys[keys.length - 1]).toBe("2026-04-08");
-    expect(expectedDedupedOverviewFetchUnionSize(anchor)).toBe(keys.length);
+  it("returns sorted union of trailing-365 + YTD through yesterday, today, and strip week around selected", () => {
+    const selectedStrip = "2026-04-08" as DayKey;
+    const today = "2026-04-14" as DayKey;
+    const keys = computeActivityOverviewFetchDayKeys(selectedStrip, today);
+    const overviewEnd = getActivityOverviewAnchorEndDay(today);
+    expect(overviewEnd).toBe("2026-04-13");
+    const trail = activityTrailingNDaysInclusive(overviewEnd, ACTIVITY_OVERVIEW_TRAILING_12_MONTH_DAY_COUNT);
+    const ytd = activityYtdInclusiveThroughEndDay(overviewEnd);
+    const strip = getWeekDaysForAnchor(selectedStrip);
+    const expected = [...new Set([...trail, ...ytd, today, ...strip])].sort();
+    expect(keys).toEqual(expected);
+    expect(keys).toContain(today);
+    expect(keys).toContain("2026-04-13");
+    expect(keys[keys.length - 1]).toBe("2026-04-14");
   });
 
-  it("for anchor 2026-04-12: bounded to trailing windows ending that day, no keys after anchor, earliest is 365D start only", () => {
-    const anchor = "2026-04-12" as DayKey;
-    const keys = computeActivityOverviewFetchDayKeys(anchor);
-    const trail365 = activityTrailingNDaysInclusive(anchor, ACTIVITY_OVERVIEW_AVG_12M_DAYS);
-
-    expect(keys).toEqual([...trail365].sort());
-    expect(keys).toHaveLength(365);
-    expect(keys[keys.length - 1]).toBe("2026-04-12");
-    expect(keys.every((k) => k <= anchor)).toBe(true);
-    expect(keys[0]).toBe(trail365[0]);
-    expect(keys[0]).toBe("2025-04-13");
-    expect(expectedDedupedOverviewFetchUnionSize(anchor)).toBe(365);
+  it("uses yesterday for overview trail/YTD even when strip selected day is in the future", () => {
+    const selected = "2026-04-20" as DayKey;
+    const today = "2026-04-14" as DayKey;
+    const keys = computeActivityOverviewFetchDayKeys(selected, today);
+    const overviewEnd = getActivityOverviewAnchorEndDay(today);
+    expect(overviewEnd).toBe("2026-04-13");
+    const trail = activityTrailingNDaysInclusive(overviewEnd, ACTIVITY_OVERVIEW_TRAILING_12_MONTH_DAY_COUNT);
+    const ytd = activityYtdInclusiveThroughEndDay(overviewEnd);
+    const strip = getWeekDaysForAnchor(selected);
+    const expected = [...new Set([...trail, ...ytd, today, ...strip, selected])].sort();
+    expect(keys).toEqual(expected);
+    expect(keys.filter((k) => k > today).sort()).toEqual(
+      [...new Set([...strip.filter((k) => k > today), selected])].sort(),
+    );
   });
 
-  it("does not extend fetch range when calendar today is after the selected anchor", () => {
-    const keysHistorical = computeActivityOverviewFetchDayKeys("2026-03-15");
-    expect(keysHistorical[keysHistorical.length - 1]).toBe("2026-03-15");
-    expect(keysHistorical.every((k) => k <= "2026-03-15")).toBe(true);
+  it("for leap-year overview anchor, union includes full YTD through yesterday", () => {
+    const selectedStrip = "2024-06-01" as DayKey;
+    const today = "2025-01-01" as DayKey;
+    const keys = computeActivityOverviewFetchDayKeys(selectedStrip, today);
+    const overviewEnd = getActivityOverviewAnchorEndDay(today);
+    expect(overviewEnd).toBe("2024-12-31");
+    const ytd = activityYtdInclusiveThroughEndDay(overviewEnd);
+    expect(ytd).toHaveLength(366);
+    expect(keys).toContain("2024-01-01");
+    expect(keys).toContain("2024-12-31");
+    expect(new Set(keys).size).toBeGreaterThanOrEqual(365);
+  });
+});
+
+describe("getActivityOverviewAnchorEndDay", () => {
+  it("is local calendar yesterday", () => {
+    expect(getActivityOverviewAnchorEndDay("2026-04-14")).toBe("2026-04-13");
+    expect(getActivityOverviewAnchorEndDay("2026-01-01")).toBe(addCalendarDaysToDayKey("2026-01-01", -1));
   });
 });
 
@@ -70,8 +112,8 @@ describe("computeActivityCalendarFetchDayKeys", () => {
   });
 });
 
-describe("overview 12M window length", () => {
-  it("matches Apple-aligned 365-day rolling year", () => {
-    expect(ACTIVITY_OVERVIEW_AVG_12M_DAYS).toBe(365);
+describe("overview 12M window length constant", () => {
+  it("is 365 trailing local days", () => {
+    expect(ACTIVITY_OVERVIEW_TRAILING_12_MONTH_DAY_COUNT).toBe(365);
   });
 });

--- a/lib/data/activity/__tests__/activityOverviewSufficiency.test.ts
+++ b/lib/data/activity/__tests__/activityOverviewSufficiency.test.ts
@@ -1,0 +1,87 @@
+import type { ActivityStepsRollupMap } from "@/lib/data/activity/activityOverviewRollupTypes";
+import {
+  ACTIVITY_OVERVIEW_NOT_ENOUGH_DATA,
+  meanNumericStepsForWindow,
+  meanStepsPerDayZeroFilled,
+  stepsWindowHasAnyErrorDay,
+  stepsWindowHasFullNumericCoverage,
+} from "@/lib/data/activity/activityOverviewSufficiency";
+
+describe("stepsWindowHasFullNumericCoverage", () => {
+  it("returns false when any day is absent from the map", () => {
+    const rollup: ActivityStepsRollupMap = {
+      "2026-04-07": { kind: "numeric", steps: 1 },
+    };
+    expect(stepsWindowHasFullNumericCoverage(["2026-04-07", "2026-04-08"], rollup)).toBe(false);
+  });
+
+  it("returns false for explicit absent or error", () => {
+    const rollup: ActivityStepsRollupMap = {
+      "2026-04-07": { kind: "numeric", steps: 0 },
+      "2026-04-08": { kind: "absent" },
+    };
+    expect(stepsWindowHasFullNumericCoverage(["2026-04-07", "2026-04-08"], rollup)).toBe(false);
+  });
+
+  it("returns true when all days are numeric including explicit zero", () => {
+    const rollup: ActivityStepsRollupMap = {
+      "2026-04-07": { kind: "numeric", steps: 0 },
+      "2026-04-08": { kind: "numeric", steps: 100 },
+    };
+    expect(stepsWindowHasFullNumericCoverage(["2026-04-07", "2026-04-08"], rollup)).toBe(true);
+  });
+
+  it("returns false for empty day list", () => {
+    expect(stepsWindowHasFullNumericCoverage([], {})).toBe(false);
+  });
+});
+
+describe("meanNumericStepsForWindow", () => {
+  it("averages after caller verified coverage", () => {
+    const rollup: ActivityStepsRollupMap = {
+      "2026-04-07": { kind: "numeric", steps: 10 },
+      "2026-04-08": { kind: "numeric", steps: 20 },
+    };
+    const days = ["2026-04-07", "2026-04-08"] as const;
+    expect(stepsWindowHasFullNumericCoverage(days, rollup)).toBe(true);
+    expect(meanNumericStepsForWindow(days, rollup)).toBe(15);
+  });
+});
+
+describe("ACTIVITY_OVERVIEW_NOT_ENOUGH_DATA", () => {
+  it("matches product copy", () => {
+    expect(ACTIVITY_OVERVIEW_NOT_ENOUGH_DATA).toBe("Not enough data");
+  });
+});
+
+describe("stepsWindowHasAnyErrorDay", () => {
+  it("is true when any listed day has kind error", () => {
+    const rollup: ActivityStepsRollupMap = {
+      "2026-04-07": { kind: "numeric", steps: 1 },
+      "2026-04-08": { kind: "error", message: "503", requestId: "r1" },
+    };
+    expect(stepsWindowHasAnyErrorDay(["2026-04-07", "2026-04-08"], rollup)).toBe(true);
+  });
+
+  it("is false when days are numeric, absent, or missing from map", () => {
+    const rollup: ActivityStepsRollupMap = {
+      "2026-04-07": { kind: "numeric", steps: 1 },
+    };
+    expect(stepsWindowHasAnyErrorDay(["2026-04-07", "2026-04-08"], rollup)).toBe(false);
+  });
+});
+
+describe("meanStepsPerDayZeroFilled", () => {
+  it("uses full window length; non-numeric days count as 0", () => {
+    const rollup: ActivityStepsRollupMap = {
+      "2026-04-07": { kind: "numeric", steps: 10_000 },
+      "2026-04-08": { kind: "error", message: "x", requestId: null },
+    };
+    const days = ["2026-04-07", "2026-04-08"] as const;
+    expect(meanStepsPerDayZeroFilled(days, rollup)).toBe(5000);
+  });
+
+  it("returns 0 for empty day list", () => {
+    expect(meanStepsPerDayZeroFilled([], {})).toBe(0);
+  });
+});

--- a/lib/data/activity/__tests__/appleHealthForcedLocalYesterdaySteps.test.ts
+++ b/lib/data/activity/__tests__/appleHealthForcedLocalYesterdaySteps.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import type { ApiResult } from "@/lib/api/http";
+import * as ingestApi from "@/lib/api/ingest";
+import * as usersMeApi from "@/lib/api/usersMe";
+import type { DailyFactsDto } from "@/lib/contracts/dailyFacts";
+import { runForcedLocalYesterdayAppleHealthStepsIngest } from "@/lib/data/activity/appleHealthForcedLocalYesterdaySteps";
+import * as healthKit from "@/lib/integrations/appleHealth/healthKit";
+import * as appleStorage from "@/lib/integrations/appleHealth/storage";
+
+jest.mock("@/lib/ui/calendar/dateUtils", () => ({
+  getTodayDayKeyLocal: () => "2026-04-16",
+}));
+
+const pullStepCountForLocalCalendarDay = jest.spyOn(healthKit, "pullStepCountForLocalCalendarDay");
+const requestPermissions = jest.spyOn(healthKit, "requestPermissions");
+const ingestRawEvent = jest.spyOn(ingestApi, "ingestRawEvent");
+const getDailyFacts = jest.spyOn(usersMeApi, "getDailyFacts");
+
+function dailyFactsOk(steps: number | undefined, day = "2026-04-15"): ApiResult<DailyFactsDto> {
+  const base = {
+    schemaVersion: 1 as const,
+    userId: "test-user",
+    date: day,
+    computedAt: "2026-04-15T12:00:00.000Z",
+  };
+  return {
+    ok: true,
+    status: 200,
+    requestId: null,
+    json:
+      steps === undefined
+        ? { ...base, activity: {} }
+        : { ...base, activity: { steps } },
+  };
+}
+
+describe("runForcedLocalYesterdayAppleHealthStepsIngest", () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+    jest.clearAllMocks();
+    jest.spyOn(appleStorage, "getAppleHealthConnected").mockResolvedValue(true);
+    requestPermissions.mockResolvedValue({ ok: true } as never);
+    pullStepCountForLocalCalendarDay.mockResolvedValue({ ok: true, steps: 8421 });
+    ingestRawEvent.mockResolvedValue({
+      ok: true,
+      status: 202,
+      data: { ok: true, rawEventId: "x", day: "2026-04-15" },
+      requestId: null,
+    });
+    getDailyFacts.mockResolvedValue(dailyFactsOk(8421));
+  });
+
+  it("does not POST when GET dailyFacts steps already match HealthKit", async () => {
+    await runForcedLocalYesterdayAppleHealthStepsIngest(async () => "token");
+
+    expect(pullStepCountForLocalCalendarDay).toHaveBeenCalledWith("2026-04-15");
+    expect(getDailyFacts).toHaveBeenCalledWith("2026-04-15", "token", expect.any(Object));
+    expect(ingestRawEvent).not.toHaveBeenCalled();
+  });
+
+  it("POSTs ingest when stored steps disagree with HealthKit", async () => {
+    getDailyFacts.mockResolvedValueOnce(dailyFactsOk(138)).mockResolvedValue(dailyFactsOk(8421));
+
+    await runForcedLocalYesterdayAppleHealthStepsIngest(async () => "token");
+
+    expect(ingestRawEvent).toHaveBeenCalledTimes(1);
+    const idem = ingestRawEvent.mock.calls[0]![2]?.idempotencyKey;
+    expect(idem).toBe("appleHealth:v2:steps:2026-04-15");
+  });
+
+  it("POSTs ingest when dailyFacts has no steps (stored null)", async () => {
+    getDailyFacts.mockResolvedValueOnce(dailyFactsOk(undefined)).mockResolvedValue(dailyFactsOk(8421));
+
+    await runForcedLocalYesterdayAppleHealthStepsIngest(async () => "token");
+
+    expect(ingestRawEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("polls dailyFacts after ingest until steps match HK", async () => {
+    getDailyFacts
+      .mockResolvedValueOnce(dailyFactsOk(100))
+      .mockResolvedValueOnce(dailyFactsOk(100))
+      .mockResolvedValueOnce(dailyFactsOk(100))
+      .mockResolvedValueOnce(dailyFactsOk(8421));
+
+    await runForcedLocalYesterdayAppleHealthStepsIngest(async () => "token");
+
+    expect(ingestRawEvent).toHaveBeenCalledTimes(1);
+    expect(getDailyFacts.mock.calls.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it("does not pull/ingest today (only yesterday)", async () => {
+    await runForcedLocalYesterdayAppleHealthStepsIngest(async () => "token");
+
+    expect(pullStepCountForLocalCalendarDay).toHaveBeenCalledWith("2026-04-15");
+    expect(pullStepCountForLocalCalendarDay).not.toHaveBeenCalledWith("2026-04-16");
+  });
+});

--- a/lib/data/activity/__tests__/useActivityDayScreenData.test.tsx
+++ b/lib/data/activity/__tests__/useActivityDayScreenData.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import renderer, { act } from "react-test-renderer";
+import { NavigationContainer } from "@react-navigation/native";
 
 jest.mock("@/lib/api/usersMe", () => ({
   getDailyFacts: jest.fn(),
@@ -25,6 +26,10 @@ function Harness({ raw, probe }: { raw: unknown; probe: { current: ReturnType<ty
   return null;
 }
 
+function renderWithNavigation(ui: React.ReactElement) {
+  return renderer.create(<NavigationContainer>{ui}</NavigationContainer>);
+}
+
 describe("useActivityDayScreenData", () => {
   beforeEach(() => {
     (getDailyFacts as jest.Mock).mockClear();
@@ -44,7 +49,7 @@ describe("useActivityDayScreenData", () => {
   it("marks invalid route param without calling getDailyFacts", async () => {
     const probe: { current: ReturnType<typeof useActivityDayScreenData> | null } = { current: null };
     await act(async () => {
-      renderer.create(<Harness raw="not-a-day" probe={probe} />);
+      renderWithNavigation(<Harness raw="not-a-day" probe={probe} />);
     });
     expect(probe.current?.normalized.ok).toBe(false);
     expect(getDailyFacts).not.toHaveBeenCalled();
@@ -53,12 +58,13 @@ describe("useActivityDayScreenData", () => {
   it("accepts string[] and uses first element", async () => {
     const probe: { current: ReturnType<typeof useActivityDayScreenData> | null } = { current: null };
     await act(async () => {
-      renderer.create(<Harness raw={["2026-06-15", "ignored"]} probe={probe} />);
+      renderWithNavigation(<Harness raw={["2026-06-15", "ignored"]} probe={probe} />);
     });
     expect(probe.current?.normalized).toEqual({ ok: true, day: "2026-06-15" });
   });
 
   it("fetches daily facts for valid day", async () => {
+    const probe: { current: ReturnType<typeof useActivityDayScreenData> | null } = { current: null };
     (getDailyFacts as jest.Mock).mockResolvedValue({
       ok: true,
       status: 200,
@@ -71,14 +77,28 @@ describe("useActivityDayScreenData", () => {
         activity: { steps: 4444 },
       },
     });
-    const probe: { current: ReturnType<typeof useActivityDayScreenData> | null } = { current: null };
     await act(async () => {
-      renderer.create(<Harness raw="2026-06-20" probe={probe} />);
+      renderWithNavigation(<Harness raw="2026-06-20" probe={probe} />);
     });
     await act(async () => {
       await Promise.resolve();
+      await Promise.resolve();
     });
-    expect(getDailyFacts).toHaveBeenCalledWith("2026-06-20", "token-1");
+    await act(async () => {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 850);
+      });
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getDailyFacts).toHaveBeenCalledWith(
+      "2026-06-20",
+      "token-1",
+      expect.objectContaining({ cacheBust: expect.stringMatching(/^activityDay:/) }),
+    );
     expect(probe.current?.state).toEqual({ status: "ready", steps: 4444 });
   });
 });

--- a/lib/data/activity/__tests__/useActivityOverviewScreenData.test.tsx
+++ b/lib/data/activity/__tests__/useActivityOverviewScreenData.test.tsx
@@ -1,0 +1,228 @@
+import React from "react";
+import renderer, { act } from "react-test-renderer";
+
+jest.mock("@react-navigation/native", () => ({
+  useFocusEffect: jest.fn(),
+}));
+
+jest.mock("@/lib/data/activity/appleHealthStepsRepairCoordinator", () => ({
+  scheduleAppleHealthStepsRepair: jest.fn(),
+}));
+
+jest.mock("@/lib/ui/calendar/dateUtils", () => {
+  const actual = jest.requireActual<typeof import("@/lib/ui/calendar/dateUtils")>("@/lib/ui/calendar/dateUtils");
+  return {
+    ...actual,
+    getTodayDayKeyLocal: () => "2026-04-14",
+  };
+});
+
+const mockUseActivityStepsRollupMap = jest.fn();
+
+jest.mock("@/lib/data/activity/useActivityStepsRollupMap", () => ({
+  useActivityStepsRollupMap: () => mockUseActivityStepsRollupMap(),
+}));
+
+const mockUseActivityHealthKitTodayStepsCard = jest.fn(() => ({
+  hkToday: { status: "skipped" as const },
+  refreshHealthKitToday: jest.fn(),
+}));
+
+jest.mock("@/lib/data/activity/useActivityHealthKitTodayStepsCard", () => ({
+  useActivityHealthKitTodayStepsCard: () => mockUseActivityHealthKitTodayStepsCard(),
+}));
+
+jest.mock("@/lib/auth/AuthProvider", () => ({
+  useAuth: () => ({
+    user: { uid: "u1" },
+    initializing: false,
+    getIdToken: jest.fn(),
+  }),
+}));
+
+import type { ActivityStepsRollupMap } from "@/lib/data/activity/activityOverviewRollupTypes";
+import {
+  ACTIVITY_OVERVIEW_TRAILING_7_DAY_COUNT,
+  activityTrailingNDaysInclusive,
+} from "@/lib/data/activity/activityOverviewRanges";
+import { useActivityOverviewScreenData } from "@/lib/data/activity/useActivityOverviewScreenData";
+
+function mockStepsRollup(
+  rollupByDay: ActivityStepsRollupMap,
+  opts?: { status?: "ready" | "partial"; refetch?: jest.Mock },
+) {
+  const refetch = opts?.refetch ?? jest.fn();
+  return {
+    status: opts?.status ?? ("ready" as const),
+    rollupByDay,
+    rollupDisplayByDay: rollupByDay,
+    rollupFallbackBase: {} as ActivityStepsRollupMap,
+    isRefreshing: false,
+    refetch,
+  };
+}
+
+function Harness({ probe }: { probe: { current: ReturnType<typeof useActivityOverviewScreenData> | null } }) {
+  const v = useActivityOverviewScreenData();
+  probe.current = v;
+  return null;
+}
+
+describe("useActivityOverviewScreenData", () => {
+  beforeEach(() => {
+    mockUseActivityStepsRollupMap.mockReset();
+    mockUseActivityHealthKitTodayStepsCard.mockReturnValue({
+      hkToday: { status: "skipped" },
+      refreshHealthKitToday: jest.fn(),
+    });
+  });
+
+  it("keeps overview aggregate rollup error off Today’s Steps when selected day is numeric", async () => {
+    const refetch = jest.fn();
+    const rollupByDay: Record<string, { kind: string; steps?: number; message?: string; requestId?: string | null }> =
+      {
+        "2026-04-14": { kind: "numeric", steps: 148 },
+        "2026-04-01": { kind: "error", message: "fail", requestId: "r1" },
+        "2026-04-02": { kind: "error", message: "fail", requestId: "r2" },
+        "2026-04-03": { kind: "error", message: "fail", requestId: null },
+      };
+    mockUseActivityStepsRollupMap.mockReturnValue(mockStepsRollup(rollupByDay, { refetch }));
+
+    const probe: { current: ReturnType<typeof useActivityOverviewScreenData> | null } = { current: null };
+    await act(async () => {
+      renderer.create(<Harness probe={probe} />);
+    });
+
+    expect(probe.current?.overview.error?.message).toMatch(/Couldn’t load steps for 3 days/);
+    expect(probe.current?.dailyDetails.error).toBeNull();
+    expect(probe.current?.dailyDetails.model?.compactStatsSummary).toBe("148 steps");
+    expect(probe.current?.weeklyStripDays.find((d) => d.day === "2026-04-14")?.meta).toEqual(
+      expect.objectContaining({ hasSteps: true, ringTierIndex: 0 }),
+    );
+  });
+
+  it("surfaces selected-day rollup error on daily details only, independent of overview aggregate", async () => {
+    const refetch = jest.fn();
+    const rollupByDay = {
+      "2026-04-14": { kind: "error" as const, message: "Today fetch failed", requestId: "rx" as string | null },
+      "2026-04-13": { kind: "numeric" as const, steps: 10 },
+    };
+    mockUseActivityStepsRollupMap.mockReturnValue(mockStepsRollup(rollupByDay, { refetch }));
+
+    const probe: { current: ReturnType<typeof useActivityOverviewScreenData> | null } = { current: null };
+    await act(async () => {
+      renderer.create(<Harness probe={probe} />);
+    });
+
+    expect(probe.current?.overview.error?.message).toMatch(/Couldn’t load steps for one day/);
+    expect(probe.current?.dailyDetails.error?.message).toBe("Today fetch failed");
+    expect(probe.current?.dailyDetails.model).toBeNull();
+  });
+
+  it("prefers live HealthKit steps for Today’s Steps when the hook reports ready", async () => {
+    mockUseActivityHealthKitTodayStepsCard.mockReturnValue({
+      hkToday: { status: "ready", steps: 5313 },
+      refreshHealthKitToday: jest.fn(),
+    });
+    const refetch = jest.fn();
+    mockUseActivityStepsRollupMap.mockReturnValue(
+      mockStepsRollup({ "2026-04-14": { kind: "numeric" as const, steps: 148 } }, { refetch }),
+    );
+
+    const probe: { current: ReturnType<typeof useActivityOverviewScreenData> | null } = { current: null };
+    await act(async () => {
+      renderer.create(<Harness probe={probe} />);
+    });
+
+    expect(probe.current?.dailyDetails.model?.compactStatsSummary).toBe("5,313 steps");
+    expect(probe.current?.dailyDetails.error).toBeNull();
+  });
+
+  it("Today’s Steps stays on live today when strip selection changes; overview uses yesterday anchor", async () => {
+    const refetch = jest.fn();
+    const rollupByDay = {
+      "2026-04-14": { kind: "numeric" as const, steps: 5313 },
+      "2026-04-05": { kind: "numeric" as const, steps: 148 },
+    };
+    mockUseActivityStepsRollupMap.mockReturnValue(mockStepsRollup(rollupByDay, { refetch }));
+
+    const probe: { current: ReturnType<typeof useActivityOverviewScreenData> | null } = { current: null };
+    await act(async () => {
+      renderer.create(<Harness probe={probe} />);
+    });
+
+    expect(probe.current?.dailyDetails.model?.compactStatsSummary).toBe("5,313 steps");
+    expect(probe.current?.overview.model?.timeframes[0]?.label).toBe("7 Day");
+
+    await act(async () => {
+      probe.current?.setSelectedDay("2026-04-05");
+    });
+
+    expect(probe.current?.selectedDay).toBe("2026-04-05");
+    expect(probe.current?.dailyDetails.model?.compactStatsSummary).toBe("5,313 steps");
+    expect(probe.current?.weeklyStripDays.map((d) => d.day)).toContain("2026-04-05");
+    expect(probe.current?.overview.model).not.toBeNull();
+  });
+
+  it("overview 7 Day stays on yesterday-completed window when strip day moves to the future", async () => {
+    mockUseActivityHealthKitTodayStepsCard.mockReturnValue({
+      hkToday: { status: "skipped" },
+      refreshHealthKitToday: jest.fn(),
+    });
+    const refetch = jest.fn();
+    const anchor = "2026-04-13";
+    const d7 = activityTrailingNDaysInclusive(anchor, ACTIVITY_OVERVIEW_TRAILING_7_DAY_COUNT);
+    const rollupByDay: Record<string, { kind: "numeric"; steps: number }> = {};
+    for (const d of d7) {
+      rollupByDay[d] = { kind: "numeric", steps: 8000 };
+    }
+    rollupByDay["2026-04-14"] = { kind: "numeric", steps: 12 };
+    mockUseActivityStepsRollupMap.mockReturnValue(mockStepsRollup(rollupByDay, { refetch }));
+
+    const probe: { current: ReturnType<typeof useActivityOverviewScreenData> | null } = { current: null };
+    await act(async () => {
+      renderer.create(<Harness probe={probe} />);
+    });
+
+    expect(probe.current?.overview.model?.timeframes[0]?.compactStatsSummary).toBe("8,000/day");
+
+    await act(async () => {
+      probe.current?.setSelectedDay("2026-04-20");
+    });
+
+    expect(probe.current?.overview.model?.timeframes[0]?.compactStatsSummary).toBe("8,000/day");
+    expect(probe.current?.dailyDetails.model?.compactStatsSummary).toBe("12 steps");
+  });
+
+  it("uses neutral weekly strip ring tier when numeric rollup is zero steps", async () => {
+    const refetch = jest.fn();
+    mockUseActivityStepsRollupMap.mockReturnValue(
+      mockStepsRollup({ "2026-04-14": { kind: "numeric" as const, steps: 0 } }, { refetch }),
+    );
+
+    const probe: { current: ReturnType<typeof useActivityOverviewScreenData> | null } = { current: null };
+    await act(async () => {
+      renderer.create(<Harness probe={probe} />);
+    });
+
+    expect(probe.current?.weeklyStripDays.find((d) => d.day === "2026-04-14")?.meta).toEqual(
+      expect.objectContaining({ hasSteps: false, ringTierIndex: null }),
+    );
+  });
+
+  it("has no overview or daily rollup errors when map has no failures", async () => {
+    const refetch = jest.fn();
+    mockUseActivityStepsRollupMap.mockReturnValue(
+      mockStepsRollup({ "2026-04-14": { kind: "numeric" as const, steps: 200 } }, { refetch }),
+    );
+
+    const probe: { current: ReturnType<typeof useActivityOverviewScreenData> | null } = { current: null };
+    await act(async () => {
+      renderer.create(<Harness probe={probe} />);
+    });
+
+    expect(probe.current?.overview.error).toBeNull();
+    expect(probe.current?.dailyDetails.error).toBeNull();
+    expect(probe.current?.dailyDetails.model?.compactStatsSummary).toBe("200 steps");
+  });
+});

--- a/lib/data/activity/activityDayRouteParam.ts
+++ b/lib/data/activity/activityDayRouteParam.ts
@@ -1,6 +1,19 @@
 const DAY_KEY_RE = /^\d{4}-\d{2}-\d{2}$/;
 
 /**
+ * Parse `YYYY-MM-DD` from Expo Router's normalized pathname for this screen
+ * (e.g. `/activity/day/2026-04-14`). Prefer this over raw search params when they can lag or shallow-merge
+ * behind the visible stack location.
+ */
+export function activityDayKeyFromActivityDayPathname(pathname: string | undefined): string | null {
+  if (typeof pathname !== "string" || pathname.length === 0) return null;
+  const trimmed = pathname.replace(/\/+$/, "");
+  const m = trimmed.match(/\/activity\/day\/(\d{4}-\d{2}-\d{2})$/);
+  const day = m?.[1];
+  return day != null && DAY_KEY_RE.test(day) ? day : null;
+}
+
+/**
  * Normalize Expo Router search params for `activity/day/[day]` (`string | string[] | undefined`).
  */
 export function normalizeActivityDayRouteParam(raw: unknown): { ok: true; day: string } | { ok: false } {

--- a/lib/data/activity/activityDayStripMeta.ts
+++ b/lib/data/activity/activityDayStripMeta.ts
@@ -1,1 +1,9 @@
-export type ActivityDayStripMeta = { hasSteps: boolean };
+export type ActivityDayStripMeta = {
+  /** True when rollup shows steps > 0 for that day (legacy strip semantics). */
+  hasSteps: boolean;
+  /**
+   * Tier index 0–5 from {@link getStepRatingTierIndex} when rollup is numeric, steps > 0, and day is not in the future;
+   * `null` → neutral ring (no rollup, absent, error, future day, zero steps, or rollup not ready).
+   */
+  ringTierIndex: number | null;
+};

--- a/lib/data/activity/activityOverviewCardModel.ts
+++ b/lib/data/activity/activityOverviewCardModel.ts
@@ -3,11 +3,19 @@ import {
   dashRecapPlacementMarker01,
 } from "@/lib/data/dash/dashRecapDisplayPlacement";
 import {
-  ACTIVITY_OVERVIEW_AVG_12M_DAYS,
-  ACTIVITY_OVERVIEW_AVG_30D_DAYS,
-  ACTIVITY_OVERVIEW_AVG_7D_DAYS,
+  ACTIVITY_OVERVIEW_TRAILING_12_MONTH_DAY_COUNT,
+  ACTIVITY_OVERVIEW_TRAILING_30_DAY_COUNT,
+  ACTIVITY_OVERVIEW_TRAILING_7_DAY_COUNT,
   activityTrailingNDaysInclusive,
+  activityYtdInclusiveThroughEndDay,
 } from "@/lib/data/activity/activityOverviewRanges";
+import {
+  ACTIVITY_OVERVIEW_NOT_ENOUGH_DATA,
+  meanNumericStepsForWindow,
+  meanStepsPerDayZeroFilled,
+  stepsWindowHasAnyErrorDay,
+  stepsWindowHasFullNumericCoverage,
+} from "@/lib/data/activity/activityOverviewSufficiency";
 import type { ActivityStepsRollupMap, DayStepsRollupEntry } from "@/lib/data/activity/activityOverviewRollupTypes";
 import { formatDayKeyWeekdayShortMonthDay } from "@/lib/ui/calendar/dayKeyDisplayFormat";
 import type { DayKey } from "@/lib/ui/calendar/types";
@@ -15,12 +23,12 @@ import type { DayKey } from "@/lib/ui/calendar/types";
 /** Same neutral display cap as Daily Recap steps bar — not a clinical target. */
 export const ACTIVITY_OVERVIEW_STEPS_PLACEMENT_CAP = DASH_RECAP_DISPLAY_PLACEMENT_CAPS.steps;
 
-export type ActivityOverviewTimeframeKey = "today" | "avg7d" | "avg30d" | "avg365d";
+export type ActivityOverviewTimeframeKey = "day7" | "day30" | "ytd" | "month12";
 
 export type ActivityOverviewRowModel = {
   key: ActivityOverviewTimeframeKey;
   label: string;
-  /** Single line for the row (totals vs averages formatted here, not in the screen). */
+  /** Single line for the row (averages when sufficient, otherwise exact insufficient copy). */
   compactStatsSummary: string;
   /** Neutral placement along shared 5-zone track. */
   markerPosition01: number;
@@ -30,22 +38,60 @@ export type ActivityOverviewCardModel = {
   timeframes: ActivityOverviewRowModel[];
 };
 
-/**
- * Mean steps over a trailing calendar window, using **only** days with numeric daily-facts steps.
- * Absent, error, and missing keys are excluded (not treated as 0 in the denominator).
- * If no numeric days in the window → 0.
- */
-function averageStepsNumericDaysOnly(days: readonly DayKey[], rollup: Readonly<ActivityStepsRollupMap>): number {
-  let sum = 0;
-  let count = 0;
-  for (const d of days) {
-    const e = rollup[d];
-    if (e?.kind !== "numeric") continue;
-    sum += e.steps;
-    count += 1;
+function rowFromFullCoverageWindow(input: {
+  key: ActivityOverviewTimeframeKey;
+  label: string;
+  days: readonly DayKey[];
+  rollupByDay: Readonly<ActivityStepsRollupMap>;
+}): ActivityOverviewRowModel {
+  const { key, label, days, rollupByDay } = input;
+  const cap = ACTIVITY_OVERVIEW_STEPS_PLACEMENT_CAP;
+  const sufficient = stepsWindowHasFullNumericCoverage(days, rollupByDay);
+  if (!sufficient) {
+    return {
+      key,
+      label,
+      compactStatsSummary: ACTIVITY_OVERVIEW_NOT_ENOUGH_DATA,
+      markerPosition01: 0,
+    };
   }
-  if (count === 0) return 0;
-  return sum / count;
+  const avg = meanNumericStepsForWindow(days, rollupByDay);
+  return {
+    key,
+    label,
+    compactStatsSummary: formatActivityAverageRowSummary(avg),
+    markerPosition01: dashRecapPlacementMarker01(avg, cap),
+  };
+}
+
+/**
+ * YTD / 12 Month: fixed window length; missing/absent days contribute 0.
+ * If any day has a failed request (`kind: "error"`, e.g. 503), do not show a numeric average — that would
+ * silently treat failures as zero and overstate certainty.
+ */
+function rowFromZeroFilledFixedDenominator(input: {
+  key: ActivityOverviewTimeframeKey;
+  label: string;
+  days: readonly DayKey[];
+  rollupByDay: Readonly<ActivityStepsRollupMap>;
+}): ActivityOverviewRowModel {
+  const { key, label, days, rollupByDay } = input;
+  const cap = ACTIVITY_OVERVIEW_STEPS_PLACEMENT_CAP;
+  if (stepsWindowHasAnyErrorDay(days, rollupByDay)) {
+    return {
+      key,
+      label,
+      compactStatsSummary: ACTIVITY_OVERVIEW_NOT_ENOUGH_DATA,
+      markerPosition01: 0,
+    };
+  }
+  const avg = meanStepsPerDayZeroFilled(days, rollupByDay);
+  return {
+    key,
+    label,
+    compactStatsSummary: formatActivityAverageRowSummary(avg),
+    markerPosition01: dashRecapPlacementMarker01(avg, cap),
+  };
 }
 
 export function formatActivityDailyDetailsTitle(selectedDay: DayKey, todayDayKey: DayKey): string {
@@ -64,61 +110,30 @@ export function formatActivityAverageRowSummary(avgStepsPerDay: number): string 
 }
 
 /**
- * Activity Overview summary — trailing windows **end on `overviewAnchorDay`** (Activity strip selection).
- * Source of truth: `activity.steps` per day from GET /users/me/daily-facts (rolled into {@link rollupByDay} as `kind: "numeric"` only when a finite non-negative steps value exists).
+ * Activity overview rows use a **completed-day anchor** (`overviewAnchorEndDay`, typically local yesterday).
+ * Strip selection and partial “today” do not move these windows.
  *
- * Formulas (local calendar days, inclusive of anchor day):
- * - **Today row:** steps for `overviewAnchorDay` only (UI label unchanged).
- * - **7D / 30D / 365D Avg:** mean of steps on days **with numeric rollups inside that trailing window ending on the anchor** only.
- *   Missing/error/absent days do not count toward the average. No numeric days → **0**.
+ * - **7 Day / 30 Day:** mean steps/day only when every day in the window has a numeric rollup; else
+ *   {@link ACTIVITY_OVERVIEW_NOT_ENOUGH_DATA}.
+ * - **YTD / 12 Month:** true calendar mean `sum(steps or 0) / windowDayCount` when no day in the window
+ *   has a failed daily-facts fetch; otherwise {@link ACTIVITY_OVERVIEW_NOT_ENOUGH_DATA}.
  */
 export function buildActivityOverviewCardModel(input: {
-  overviewAnchorDay: DayKey;
+  overviewAnchorEndDay: DayKey;
   rollupByDay: Readonly<ActivityStepsRollupMap>;
 }): ActivityOverviewCardModel {
-  const { overviewAnchorDay, rollupByDay } = input;
+  const { overviewAnchorEndDay: end, rollupByDay } = input;
 
-  const d7 = activityTrailingNDaysInclusive(overviewAnchorDay, ACTIVITY_OVERVIEW_AVG_7D_DAYS);
-  const d30 = activityTrailingNDaysInclusive(overviewAnchorDay, ACTIVITY_OVERVIEW_AVG_30D_DAYS);
-  const d365 = activityTrailingNDaysInclusive(overviewAnchorDay, ACTIVITY_OVERVIEW_AVG_12M_DAYS);
-
-  const todayEntry = rollupByDay[overviewAnchorDay];
-
-  const avg7 = averageStepsNumericDaysOnly(d7, rollupByDay);
-  const avg30 = averageStepsNumericDaysOnly(d30, rollupByDay);
-  const avg365 = averageStepsNumericDaysOnly(d365, rollupByDay);
-
-  const cap = ACTIVITY_OVERVIEW_STEPS_PLACEMENT_CAP;
-
-  const todayNumericSteps = todayEntry?.kind === "numeric" ? todayEntry.steps : 0;
-  const todayMarker =
-    todayEntry?.kind === "numeric" ? dashRecapPlacementMarker01(todayNumericSteps, cap) : 0;
+  const d7 = activityTrailingNDaysInclusive(end, ACTIVITY_OVERVIEW_TRAILING_7_DAY_COUNT);
+  const d30 = activityTrailingNDaysInclusive(end, ACTIVITY_OVERVIEW_TRAILING_30_DAY_COUNT);
+  const d365 = activityTrailingNDaysInclusive(end, ACTIVITY_OVERVIEW_TRAILING_12_MONTH_DAY_COUNT);
+  const ytdDays = activityYtdInclusiveThroughEndDay(end);
 
   const timeframes: ActivityOverviewRowModel[] = [
-    {
-      key: "today",
-      label: "Today",
-      compactStatsSummary: formatActivityTodayRowSummary(todayEntry),
-      markerPosition01: todayMarker,
-    },
-    {
-      key: "avg7d",
-      label: "7D Avg",
-      compactStatsSummary: formatActivityAverageRowSummary(avg7),
-      markerPosition01: dashRecapPlacementMarker01(avg7, cap),
-    },
-    {
-      key: "avg30d",
-      label: "30D Avg",
-      compactStatsSummary: formatActivityAverageRowSummary(avg30),
-      markerPosition01: dashRecapPlacementMarker01(avg30, cap),
-    },
-    {
-      key: "avg365d",
-      label: "365D Avg",
-      compactStatsSummary: formatActivityAverageRowSummary(avg365),
-      markerPosition01: dashRecapPlacementMarker01(avg365, cap),
-    },
+    rowFromFullCoverageWindow({ key: "day7", label: "7 Day", days: d7, rollupByDay }),
+    rowFromFullCoverageWindow({ key: "day30", label: "30 Day", days: d30, rollupByDay }),
+    rowFromZeroFilledFixedDenominator({ key: "ytd", label: "YTD", days: ytdDays, rollupByDay }),
+    rowFromZeroFilledFixedDenominator({ key: "month12", label: "12 Month", days: d365, rollupByDay }),
   ];
 
   return { timeframes };
@@ -130,17 +145,29 @@ export type ActivityDailyDetailsCardModel = {
   markerPosition01: number;
 };
 
+/** Today’s Steps row from a live HealthKit total (not daily-facts). */
+export function buildActivityTodayStepsLiveCardModel(input: { todayDayKey: DayKey; steps: number }): ActivityDailyDetailsCardModel {
+  const cap = ACTIVITY_OVERVIEW_STEPS_PLACEMENT_CAP;
+  const steps = Math.max(0, input.steps);
+  return {
+    title: formatActivityDailyDetailsTitle(input.todayDayKey, input.todayDayKey),
+    compactStatsSummary: `${Math.round(steps).toLocaleString()} steps`,
+    markerPosition01: dashRecapPlacementMarker01(steps, cap),
+  };
+}
+
 export function buildActivityDailyDetailsCardModel(input: {
-  selectedDay: DayKey;
+  /** Calendar day whose rollup backs the row (Activity overview passes device today for Today’s Steps). */
+  detailDayKey: DayKey;
   todayDayKey: DayKey;
   rollupByDay: Readonly<ActivityStepsRollupMap>;
 }): ActivityDailyDetailsCardModel {
-  const { selectedDay, todayDayKey, rollupByDay } = input;
-  const entry = rollupByDay[selectedDay];
+  const { detailDayKey, todayDayKey, rollupByDay } = input;
+  const entry = rollupByDay[detailDayKey];
   const numericSteps = entry?.kind === "numeric" ? entry.steps : 0;
   const cap = ACTIVITY_OVERVIEW_STEPS_PLACEMENT_CAP;
   return {
-    title: formatActivityDailyDetailsTitle(selectedDay, todayDayKey),
+    title: formatActivityDailyDetailsTitle(detailDayKey, todayDayKey),
     compactStatsSummary: formatActivityTodayRowSummary(entry),
     markerPosition01: entry?.kind === "numeric" ? dashRecapPlacementMarker01(numericSteps, cap) : 0,
   };

--- a/lib/data/activity/activityOverviewRanges.ts
+++ b/lib/data/activity/activityOverviewRanges.ts
@@ -1,5 +1,9 @@
 import type { DayKey } from "@/lib/ui/calendar/types";
-import { addCalendarDaysToDayKey, enumerateDaysInclusive } from "@/lib/ui/calendar/dateUtils";
+import {
+  addCalendarDaysToDayKey,
+  enumerateDaysInclusive,
+  getWeekDaysForAnchor,
+} from "@/lib/ui/calendar/dateUtils";
 
 /**
  * Inclusive trailing window of local calendar days ending on `endDay`, length `dayCount`.
@@ -11,30 +15,58 @@ export function activityTrailingNDaysInclusive(endDay: DayKey, dayCount: number)
   return enumerateDaysInclusive(start, endDay);
 }
 
-/** Apple-aligned overview row: average over these trailing day counts (inclusive of today). */
-export const ACTIVITY_OVERVIEW_AVG_7D_DAYS = 7;
-export const ACTIVITY_OVERVIEW_AVG_30D_DAYS = 30;
-/** Rolling “12 months” ≈ 365 local days including today (deterministic; matches common Health rolling-year summaries). */
-export const ACTIVITY_OVERVIEW_AVG_12M_DAYS = 365;
+/** Trailing 7-day overview row (inclusive of effective anchor day). */
+export const ACTIVITY_OVERVIEW_TRAILING_7_DAY_COUNT = 7;
+/** Trailing 30-day overview row (inclusive of effective anchor day). */
+export const ACTIVITY_OVERVIEW_TRAILING_30_DAY_COUNT = 30;
+/** “12 Month” = 365 trailing local days inclusive of effective anchor day. */
+export const ACTIVITY_OVERVIEW_TRAILING_12_MONTH_DAY_COUNT = 365;
 
 /**
- * Days fetched for calendar month markers (~18 months back from today).
- * Must cover visible months in the Activity calendar FlatList (−12 … +12 from current month).
+ * Local-calendar year-to-date through `endDay`: Jan 1 of `endDay`'s year → `endDay`, inclusive.
  */
-export const ACTIVITY_CALENDAR_MARKER_SPAN_DAYS = 540;
+export function activityYtdInclusiveThroughEndDay(endDay: DayKey): DayKey[] {
+  const year = endDay.slice(0, 4);
+  const jan1 = `${year}-01-01` as DayKey;
+  return enumerateDaysInclusive(jan1, endDay);
+}
+
+/**
+ * Completed-day anchor for Activity **Overview** windows (7 / 30 / YTD / 12 Month).
+ * Always local yesterday so trailing windows never depend on partial or missing “today” rollups.
+ */
+export function getActivityOverviewAnchorEndDay(todayDayKey: DayKey): DayKey {
+  return addCalendarDaysToDayKey(todayDayKey, -1);
+}
 
 /**
  * GET /users/me/daily-facts keys for the Activity overview screen.
  *
- * Exactly the deduped union of trailing windows **ending on `overviewAnchorDay`** (strip-selected day):
- * Today row + 7D + 30D + 365D ⊆ one {@link ACTIVITY_OVERVIEW_AVG_12M_DAYS}-day inclusive trail.
- * No dates after `overviewAnchorDay`, and no extra history outside that trail (no full week union).
+ * Union of:
+ * - trailing {@link ACTIVITY_OVERVIEW_TRAILING_12_MONTH_DAY_COUNT} days and YTD keys through
+ *   {@link getActivityOverviewAnchorEndDay} (yesterday — stable completed history for Overview),
+ * - **always** `todayDayKey` for the live Today’s Steps card,
+ * - the 7 strip days around `overviewStripSelectedDay` so the weekly strip can render regardless of anchor,
+ * - `overviewStripSelectedDay` when it is after `todayDayKey` (future strip selection still fetchable).
  */
-export function computeActivityOverviewFetchDayKeys(overviewAnchorDay: DayKey): DayKey[] {
-  return activityTrailingNDaysInclusive(overviewAnchorDay, ACTIVITY_OVERVIEW_AVG_12M_DAYS).sort();
+export function computeActivityOverviewFetchDayKeys(
+  overviewStripSelectedDay: DayKey,
+  todayDayKey: DayKey,
+): DayKey[] {
+  const overviewEnd = getActivityOverviewAnchorEndDay(todayDayKey);
+  const trail = activityTrailingNDaysInclusive(overviewEnd, ACTIVITY_OVERVIEW_TRAILING_12_MONTH_DAY_COUNT);
+  const ytd = activityYtdInclusiveThroughEndDay(overviewEnd);
+  const stripWeek = getWeekDaysForAnchor(overviewStripSelectedDay);
+  const set = new Set<DayKey>([...trail, ...ytd, todayDayKey, ...stripWeek]);
+  if (overviewStripSelectedDay > todayDayKey) {
+    set.add(overviewStripSelectedDay);
+  }
+  return [...set].sort();
 }
 
 /** Keys to mark days with steps on the Activity full-calendar screen. */
+export const ACTIVITY_CALENDAR_MARKER_SPAN_DAYS = 540;
+
 export function computeActivityCalendarFetchDayKeys(todayDayKey: DayKey): DayKey[] {
   return activityTrailingNDaysInclusive(todayDayKey, ACTIVITY_CALENDAR_MARKER_SPAN_DAYS);
 }

--- a/lib/data/activity/activityOverviewSufficiency.ts
+++ b/lib/data/activity/activityOverviewSufficiency.ts
@@ -1,0 +1,79 @@
+import type { ActivityStepsRollupMap } from "@/lib/data/activity/activityOverviewRollupTypes";
+import type { DayKey } from "@/lib/ui/calendar/types";
+
+/** Exact product copy when a timeframe lacks full per-day numeric coverage. */
+export const ACTIVITY_OVERVIEW_NOT_ENOUGH_DATA = "Not enough data";
+
+/**
+ * True when every day in `days` has `kind: "numeric"` in `rollup` (explicit 0 steps counts).
+ * Missing keys, absent, and error do not satisfy.
+ */
+export function stepsWindowHasFullNumericCoverage(
+  days: readonly DayKey[],
+  rollup: Readonly<ActivityStepsRollupMap>,
+): boolean {
+  if (days.length === 0) return false;
+  for (const d of days) {
+    if (rollup[d]?.kind !== "numeric") return false;
+  }
+  return true;
+}
+
+/** True if any day in the window has a failed daily-facts request (e.g. HTTP 503 → `kind: "error"`). */
+export function stepsWindowHasAnyErrorDay(
+  days: readonly DayKey[],
+  rollup: Readonly<ActivityStepsRollupMap>,
+): boolean {
+  for (const d of days) {
+    if (rollup[d]?.kind === "error") return true;
+  }
+  return false;
+}
+
+/** Mean steps per day; caller must ensure {@link stepsWindowHasFullNumericCoverage} first. */
+export function meanNumericStepsForWindow(
+  days: readonly DayKey[],
+  rollup: Readonly<ActivityStepsRollupMap>,
+): number {
+  let sum = 0;
+  for (const d of days) {
+    const e = rollup[d]!;
+    if (e.kind !== "numeric") {
+      throw new Error(`meanNumericStepsForWindow: non-numeric day ${d}`);
+    }
+    sum += e.steps;
+  }
+  return sum / days.length;
+}
+
+/** Steps for one day: numeric value, else 0 (missing, absent, error). */
+export function stepsForDayOrZero(
+  day: DayKey,
+  rollup: Readonly<ActivityStepsRollupMap>,
+): number {
+  const e = rollup[day];
+  return e?.kind === "numeric" ? e.steps : 0;
+}
+
+export function sumStepsZeroFilledInWindow(
+  days: readonly DayKey[],
+  rollup: Readonly<ActivityStepsRollupMap>,
+): number {
+  let sum = 0;
+  for (const d of days) {
+    sum += stepsForDayOrZero(d, rollup);
+  }
+  return sum;
+}
+
+/**
+ * True rolling average over the full calendar window: sum(steps or 0) / days.length.
+ * Denominator is always `days.length` (e.g. 365 for 12 Month, YTD day count for YTD).
+ */
+export function meanStepsPerDayZeroFilled(
+  days: readonly DayKey[],
+  rollup: Readonly<ActivityStepsRollupMap>,
+): number {
+  if (days.length === 0) return 0;
+  return sumStepsZeroFilledInWindow(days, rollup) / days.length;
+}

--- a/lib/data/activity/appleHealthForcedLocalYesterdaySteps.ts
+++ b/lib/data/activity/appleHealthForcedLocalYesterdaySteps.ts
@@ -1,0 +1,121 @@
+/**
+ * Activity guarantee: re-pull HealthKit + POST /ingest for the **previous local calendar day**
+ * when server rolls (dailyFacts) disagree with HealthKit. Skips ingest only when stored steps
+ * already match HK. After ingest, polls dailyFacts until it matches HK or timeout (async pipeline).
+ */
+
+import { Platform } from "react-native";
+
+import { ingestRawEvent } from "@/lib/api/ingest";
+import { getDailyFacts } from "@/lib/api/usersMe";
+import type { DailyFactsDto } from "@/lib/contracts/dailyFacts";
+import { truthOutcomeFromApiResult } from "@/lib/data/truthOutcome";
+import { buildAppleHealthStepsIngestBody } from "@/lib/integrations/appleHealth/appleHealthStepsIngestBody";
+import {
+  addLocalCalendarDaysToDayKey,
+  getLocalCalendarDayBoundsFromYmd,
+  pullStepCountForLocalCalendarDay,
+  requestPermissions,
+} from "@/lib/integrations/appleHealth/healthKit";
+import { stepsIdempotencyKey } from "@/lib/integrations/appleHealth/idempotency";
+import { getAppleHealthConnected, setLastIngestedStepsForDay } from "@/lib/integrations/appleHealth/storage";
+import { getTodayDayKeyLocal } from "@/lib/ui/calendar/dateUtils";
+
+const VERIFY_POLL_INTERVAL_MS = 500;
+const VERIFY_POLL_MAX_MS = 45_000;
+
+function roundSteps(n: number): number {
+  return Math.round(n);
+}
+
+function stepsFromDailyFactsDto(d: DailyFactsDto): number | null {
+  const s = d.activity?.steps;
+  if (typeof s === "number" && Number.isFinite(s) && s >= 0) return roundSteps(s);
+  return null;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fetchStoredStepsForDay(dayYmd: string, token: string): Promise<number | null> {
+  const res = await getDailyFacts(dayYmd, token, { cacheBust: `compare:${Date.now()}` });
+  const outcome = truthOutcomeFromApiResult(res);
+  if (outcome.status !== "ready") return null;
+  return stepsFromDailyFactsDto(outcome.data);
+}
+
+async function waitUntilDailyFactsMatchesHk(params: {
+  yesterdayYmd: string;
+  token: string;
+  hkStepsRounded: number;
+}): Promise<void> {
+  const deadline = Date.now() + VERIFY_POLL_MAX_MS;
+  while (Date.now() < deadline) {
+    const stored = await fetchStoredStepsForDay(params.yesterdayYmd, params.token);
+    if (stored !== null && stored === params.hkStepsRounded) return;
+    await sleep(VERIFY_POLL_INTERVAL_MS);
+  }
+}
+
+function getDeviceTimezoneIana(): string {
+  try {
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    return typeof tz === "string" && tz.length ? tz : "UTC";
+  } catch {
+    return "UTC";
+  }
+}
+
+/**
+ * Pulls Apple Health cumulative steps for local yesterday; compares to GET /users/me/daily-facts.
+ * POSTs ingest only on mismatch or missing stored steps; then polls dailyFacts until it matches HK
+ * (bounded) so HTTP 202 is not treated as sufficient for correctness.
+ */
+export async function runForcedLocalYesterdayAppleHealthStepsIngest(
+  getIdToken: (forceRefresh?: boolean) => Promise<string | null>,
+): Promise<void> {
+  if (Platform.OS !== "ios") return;
+
+  const connected = await getAppleHealthConnected().catch(() => false);
+  if (!connected) return;
+
+  const token = await getIdToken(false);
+  if (!token) return;
+
+  const todayKey = getTodayDayKeyLocal();
+  const yesterdayYmd = addLocalCalendarDaysToDayKey(todayKey, -1);
+
+  const perm = await requestPermissions();
+  if (!perm.ok) return;
+
+  const pulled = await pullStepCountForLocalCalendarDay(yesterdayYmd);
+  if (!pulled.ok) return;
+
+  const hkStepsRounded = roundSteps(pulled.steps);
+  const storedSteps = await fetchStoredStepsForDay(yesterdayYmd, token);
+  if (storedSteps !== null && storedSteps === hkStepsRounded) {
+    await setLastIngestedStepsForDay(yesterdayYmd, hkStepsRounded);
+    return;
+  }
+
+  const timezone = getDeviceTimezoneIana();
+  const { start, end } = getLocalCalendarDayBoundsFromYmd(yesterdayYmd);
+  const body = buildAppleHealthStepsIngestBody({
+    start,
+    end,
+    day: yesterdayYmd,
+    timezone,
+    steps: pulled.steps,
+  });
+
+  const res = await ingestRawEvent(body, token, {
+    idempotencyKey: stepsIdempotencyKey(yesterdayYmd),
+    timeoutMs: 15000,
+  });
+
+  if (!res.ok) return;
+
+  await setLastIngestedStepsForDay(yesterdayYmd, hkStepsRounded);
+  await waitUntilDailyFactsMatchesHk({ yesterdayYmd, token, hkStepsRounded });
+}

--- a/lib/data/activity/appleHealthStepsRepairCoordinator.ts
+++ b/lib/data/activity/appleHealthStepsRepairCoordinator.ts
@@ -17,7 +17,8 @@ import {
 } from "@/lib/integrations/appleHealth";
 import { getTodayDayKeyLocal } from "@/lib/ui/calendar/dateUtils";
 import { nowIso } from "@/lib/sync/throttle";
-import { computeLocalYtdLookbackDays } from "@/lib/integrations/appleHealth/runAppleHealthStepsBackfill";
+import { APPLE_HEALTH_STEPS_BACKFILL_TRAILING_LOCAL_DAYS } from "@/lib/integrations/appleHealth/runAppleHealthStepsBackfill";
+import { runForcedLocalYesterdayAppleHealthStepsIngest } from "@/lib/data/activity/appleHealthForcedLocalYesterdaySteps";
 import { detectAppleHealthStepsRawGapsForRecentDays } from "@/lib/data/activity/detectAppleHealthStepsRawGaps";
 import { runAppleHealthStepsBackfillSerialized } from "@/lib/data/activity/appleHealthStepsBackfillMutex";
 import { stepsRepairCooldownAllowsRun } from "@/lib/data/activity/stepsRepairCooldown";
@@ -43,8 +44,8 @@ export type ScheduleAppleHealthStepsRepairOpts = {
   bypassCooldown?: boolean;
   getIdToken: (forceRefresh?: boolean) => Promise<string | null>;
   /**
-   * Default: YTD local (`computeLocalYtdLookbackDays(today)`).
-   * Ignored when `trigger === "recovery"` and gaps exist — then uses at least YTD so the window always covers gaps.
+   * Default: trailing {@link APPLE_HEALTH_STEPS_BACKFILL_TRAILING_LOCAL_DAYS} local days.
+   * When `trigger === "recovery"` and gaps exist, the repair still uses at least this default so the window covers recent gaps.
    */
   lookbackDays?: number;
   /** When true, discard in-progress backfill state and restart from window start. */
@@ -61,11 +62,18 @@ async function isOutsideAutoCooldown(bypass: boolean): Promise<boolean> {
 }
 
 /**
- * Runs YTD (or custom lookback) steps backfill with HealthKit + ingest. Serialized so sync + gap + connection do not overlap.
+ * Runs trailing-local-days steps backfill with HealthKit + ingest. Serialized so sync + gap + connection do not overlap.
+ *
+ * Always runs {@link runForcedLocalYesterdayAppleHealthStepsIngest} first (bypasses gap detection, raw presence,
+ * repair cooldown, and client monotonic ingest guard) so the previous local calendar day can finalize via the
+ * normal raw → canonical → dailyFacts pipeline.
  */
 export async function executeAppleHealthStepsRepair(opts: ScheduleAppleHealthStepsRepairOpts): Promise<void> {
   if (Platform.OS !== "ios") return;
-  await runAppleHealthStepsBackfillSerialized(() => runRepairInner(opts));
+  await runAppleHealthStepsBackfillSerialized(async () => {
+    await runForcedLocalYesterdayAppleHealthStepsIngest(opts.getIdToken);
+    await runRepairInner(opts);
+  });
 }
 
 async function runRepairInner(opts: ScheduleAppleHealthStepsRepairOpts): Promise<void> {
@@ -77,8 +85,9 @@ async function runRepairInner(opts: ScheduleAppleHealthStepsRepairOpts): Promise
   const token = await opts.getIdToken(false);
   if (!token) return;
 
+  const today = getTodayDayKeyLocal();
+
   if (opts.trigger === "recovery") {
-    const today = getTodayDayKeyLocal();
     const { gaps, probeReliable } = await detectAppleHealthStepsRawGapsForRecentDays(token, today, RECENT_GAP_DAYS);
     // When the gap probe fails (e.g. raw-events 400), do not skip repair — empty gaps would be a false negative.
     if (probeReliable && gaps.length === 0) return;
@@ -87,12 +96,11 @@ async function runRepairInner(opts: ScheduleAppleHealthStepsRepairOpts): Promise
   const perm = await requestPermissions();
   if (!perm.ok) return;
 
-  const today = getTodayDayKeyLocal();
-  const ytd = computeLocalYtdLookbackDays(today);
+  const defaultLookback = APPLE_HEALTH_STEPS_BACKFILL_TRAILING_LOCAL_DAYS;
   const lookbackDays =
     opts.trigger === "recovery"
-      ? Math.max(ytd, opts.lookbackDays ?? ytd)
-      : Math.max(1, opts.lookbackDays ?? ytd);
+      ? Math.max(defaultLookback, opts.lookbackDays ?? defaultLookback)
+      : Math.max(1, opts.lookbackDays ?? defaultLookback);
 
   const forceRestart =
     opts.forceRestart !== undefined

--- a/lib/data/activity/useActivityDayScreenData.ts
+++ b/lib/data/activity/useActivityDayScreenData.ts
@@ -2,8 +2,9 @@ import { normalizeActivityDayRouteParam } from "@/lib/data/activity/activityDayR
 import { useActivityDaySteps } from "@/lib/data/activity/useActivityDaySteps";
 
 /**
- * Activity day route: normalize `day` search param (string | string[] | undefined) and load steps
- * via GET /users/me/daily-facts — same trust boundary as {@link useActivityStepsRollupMap}.
+ * Activity day route: normalize `day` from the screen (pathname-derived when provided by the screen,
+ * else `string | string[] | undefined`) and load steps via GET /users/me/daily-facts — same trust boundary as
+ * {@link useActivityStepsRollupMap}.
  */
 export function useActivityDayScreenData(rawDayParam: unknown): {
   normalized: ReturnType<typeof normalizeActivityDayRouteParam>;

--- a/lib/data/activity/useActivityDaySteps.ts
+++ b/lib/data/activity/useActivityDaySteps.ts
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useFocusEffect } from "@react-navigation/native";
 
 import type { ApiResult } from "@/lib/api/http";
 import { getDailyFacts } from "@/lib/api/usersMe";
@@ -27,8 +28,10 @@ export function useActivityDaySteps(dayKey: string | null): {
   const { user, initializing, getIdToken } = useAuth();
   const [state, setState] = useState<ActivityDayStepsState>({ status: "missing" });
   const seqRef = useRef(0);
+  const latestDayKeyRef = useRef<string | null>(dayKey);
+  latestDayKeyRef.current = dayKey;
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (dayKey == null || dayKey.length === 0) {
       setState({ status: "missing" });
       return;
@@ -54,7 +57,7 @@ export function useActivityDaySteps(dayKey: string | null): {
 
     setState({ status: "partial" });
     const token = await getIdToken(false);
-    if (seq !== seqRef.current) return;
+    if (seq !== seqRef.current || key !== latestDayKeyRef.current) return;
     if (!token) {
       setState({
         status: "error",
@@ -64,10 +67,13 @@ export function useActivityDaySteps(dayKey: string | null): {
       return;
     }
 
-    const res: ApiResult<DailyFactsDto> = await getDailyFacts(key, token);
-    if (seq !== seqRef.current) return;
+    const res: ApiResult<DailyFactsDto> = await getDailyFacts(key, token, {
+      cacheBust: `activityDay:${Date.now()}`,
+    });
+    if (seq !== seqRef.current || key !== latestDayKeyRef.current) return;
 
     const outcome = truthOutcomeFromApiResult(res);
+    if (seq !== seqRef.current || key !== latestDayKeyRef.current) return;
     if (outcome.status === "error") {
       setState({
         status: "error",
@@ -83,15 +89,34 @@ export function useActivityDaySteps(dayKey: string | null): {
 
     const s = outcome.data.activity?.steps;
     if (typeof s === "number" && Number.isFinite(s) && s >= 0) {
+      if (seq !== seqRef.current || key !== latestDayKeyRef.current) return;
       setState({ status: "ready", steps: Math.round(s) });
       return;
     }
+    if (seq !== seqRef.current || key !== latestDayKeyRef.current) return;
     setState({ status: "missing" });
   }, [dayKey, getIdToken, initializing, user]);
 
   useEffect(() => {
     void run();
   }, [run]);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (dayKey == null || dayKey.length === 0) return;
+      if (initializing || !user) return;
+      void run();
+    }, [dayKey, initializing, user, run]),
+  );
+
+  useEffect(() => {
+    if (dayKey == null || dayKey.length === 0) return;
+    if (initializing || !user) return;
+    const t = setTimeout(() => {
+      void run();
+    }, 800);
+    return () => clearTimeout(t);
+  }, [dayKey, initializing, user, run]);
 
   const reload = useCallback(() => {
     void run();

--- a/lib/data/activity/useActivityHealthKitTodayStepsCard.ts
+++ b/lib/data/activity/useActivityHealthKitTodayStepsCard.ts
@@ -1,0 +1,61 @@
+import { useCallback, useState } from "react";
+import { Platform } from "react-native";
+import { useFocusEffect } from "@react-navigation/native";
+
+import { pullStepCountForLocalCalendarDay } from "@/lib/integrations/appleHealth";
+import type { DayKey } from "@/lib/ui/calendar/types";
+
+export type ActivityHealthKitTodayStepsCardState =
+  | { status: "partial" }
+  | { status: "ready"; steps: number }
+  | { status: "failed"; error: string }
+  | { status: "skipped" };
+
+/**
+ * Live HealthKit step total for one local calendar day (device TZ). Used for Activity “Today’s Steps”
+ * so the card is not limited to persisted daily-facts lag. Non‑iOS or unsigned-in callers get `skipped`.
+ */
+export function useActivityHealthKitTodayStepsCard(opts: { todayDayKey: DayKey; enabled: boolean }): {
+  hkToday: ActivityHealthKitTodayStepsCardState;
+  refreshHealthKitToday: () => void;
+} {
+  const { todayDayKey, enabled } = opts;
+
+  const [hkToday, setHkToday] = useState<ActivityHealthKitTodayStepsCardState>(() =>
+    !enabled || Platform.OS !== "ios" ? { status: "skipped" } : { status: "partial" },
+  );
+
+  const applyPullResult = useCallback((r: Awaited<ReturnType<typeof pullStepCountForLocalCalendarDay>>) => {
+    if (r.ok) {
+      setHkToday({ status: "ready", steps: Math.max(0, r.steps) });
+    } else {
+      setHkToday({ status: "failed", error: r.error });
+    }
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (!enabled || Platform.OS !== "ios") {
+        setHkToday({ status: "skipped" });
+        return undefined;
+      }
+      let cancelled = false;
+      setHkToday({ status: "partial" });
+      void pullStepCountForLocalCalendarDay(todayDayKey).then((r) => {
+        if (cancelled) return;
+        applyPullResult(r);
+      });
+      return () => {
+        cancelled = true;
+      };
+    }, [applyPullResult, enabled, todayDayKey]),
+  );
+
+  const refreshHealthKitToday = useCallback(() => {
+    if (!enabled || Platform.OS !== "ios") return;
+    setHkToday({ status: "partial" });
+    void pullStepCountForLocalCalendarDay(todayDayKey).then(applyPullResult);
+  }, [applyPullResult, enabled, todayDayKey]);
+
+  return { hkToday, refreshHealthKitToday };
+}

--- a/lib/data/activity/useActivityOverviewScreenData.ts
+++ b/lib/data/activity/useActivityOverviewScreenData.ts
@@ -4,18 +4,22 @@ import { useFocusEffect } from "@react-navigation/native";
 
 import { useAuth } from "@/lib/auth/AuthProvider";
 import { scheduleAppleHealthStepsRepair } from "@/lib/data/activity/appleHealthStepsRepairCoordinator";
+import { useActivityHealthKitTodayStepsCard } from "@/lib/data/activity/useActivityHealthKitTodayStepsCard";
 import {
   buildActivityDailyDetailsCardModel,
   buildActivityOverviewCardModel,
+  buildActivityTodayStepsLiveCardModel,
 } from "@/lib/data/activity/activityOverviewCardModel";
 import {
   buildActivityRollupAggregateError,
   buildActivitySelectedDayRollupError,
 } from "@/lib/data/activity/activityRollupErrorSummary";
+import { getActivityOverviewAnchorEndDay } from "@/lib/data/activity/activityOverviewRanges";
 import { useActivityStepsRollupMap } from "@/lib/data/activity/useActivityStepsRollupMap";
 import type { ActivityDayStripMeta } from "@/lib/data/activity/activityDayStripMeta";
 import { getTodayDayKeyLocal, getWeekDaysForAnchor } from "@/lib/ui/calendar/dateUtils";
 import type { CalendarDay } from "@/lib/ui/calendar/types";
+import { getStepRatingTierIndex } from "@/lib/utils/activityStepRating";
 
 export function useActivityOverviewScreenData() {
   const { user, initializing, getIdToken } = useAuth();
@@ -23,83 +27,166 @@ export function useActivityOverviewScreenData() {
   const weekDayKeys = useMemo(() => getWeekDaysForAnchor(selectedDay), [selectedDay]);
 
   const todayDayKey = getTodayDayKeyLocal();
+  const overviewAnchorEndDay = useMemo(() => getActivityOverviewAnchorEndDay(todayDayKey), [todayDayKey]);
   const stepsRollup = useActivityStepsRollupMap(selectedDay);
+  const displayRollup = stepsRollup.rollupDisplayByDay;
+
+  const { hkToday, refreshHealthKitToday } = useActivityHealthKitTodayStepsCard({
+    todayDayKey,
+    enabled: Boolean(user) && !initializing,
+  });
+
+  const scheduleActivityStepsRepair = useCallback(() => {
+    if (Platform.OS !== "ios" || !user || initializing) return;
+    scheduleAppleHealthStepsRepair({
+      trigger: "recovery",
+      getIdToken,
+    });
+  }, [getIdToken, initializing, user]);
 
   useFocusEffect(
     useCallback(() => {
       void stepsRollup.refetch({ cacheBust: `activityRollup:${Date.now()}` });
-      if (Platform.OS === "ios" && user) {
-        scheduleAppleHealthStepsRepair({
-          trigger: "recovery",
-          getIdToken,
-        });
-      }
-    }, [stepsRollup.refetch, user, getIdToken]),
+      scheduleActivityStepsRepair();
+    }, [scheduleActivityStepsRepair, stepsRollup.refetch]),
   );
 
   const weeklyStripDays: CalendarDay<ActivityDayStripMeta>[] = useMemo(() => {
     const todayKey = getTodayDayKeyLocal();
-    const map = stepsRollup.status === "ready" ? stepsRollup.rollupByDay : {};
+    const map = displayRollup;
     return weekDayKeys.map((day) => {
       const e = map[day];
+      const ringTierIndex =
+        day <= todayKey && e?.kind === "numeric" && e.steps > 0
+          ? getStepRatingTierIndex(Math.round(e.steps))
+          : null;
       return {
         day,
         meta: {
           hasSteps: day <= todayKey && e?.kind === "numeric" && e.steps > 0,
+          ringTierIndex,
         },
       };
     });
-  }, [weekDayKeys, stepsRollup]);
+  }, [weekDayKeys, displayRollup]);
 
   const rollupAggregateError = useMemo(() => {
-    if (stepsRollup.status !== "ready") return null;
-    return buildActivityRollupAggregateError(stepsRollup.rollupByDay, () =>
+    return buildActivityRollupAggregateError(displayRollup, () =>
       void stepsRollup.refetch({ cacheBust: `activityRollupRetry:${Date.now()}` }),
     );
-  }, [stepsRollup]);
+  }, [displayRollup, stepsRollup]);
 
-  const dailyDetailsSelectedError = useMemo(() => {
-    if (stepsRollup.status !== "ready") return null;
-    return buildActivitySelectedDayRollupError(selectedDay, stepsRollup.rollupByDay, () =>
-      void stepsRollup.refetch({ cacheBust: `activityRollupSelectedRetry:${Date.now()}` }),
+  const rollupTodayEntryError = useMemo(() => {
+    return buildActivitySelectedDayRollupError(todayDayKey, displayRollup, () =>
+      void stepsRollup.refetch({ cacheBust: `activityRollupTodayRetry:${Date.now()}` }),
     );
-  }, [selectedDay, stepsRollup]);
+  }, [todayDayKey, displayRollup, stepsRollup]);
 
   const overviewCardModel = useMemo(() => {
-    if (stepsRollup.status !== "ready") return null;
     return buildActivityOverviewCardModel({
-      overviewAnchorDay: selectedDay,
-      rollupByDay: stepsRollup.rollupByDay,
+      overviewAnchorEndDay,
+      rollupByDay: displayRollup,
     });
-  }, [stepsRollup, selectedDay]);
+  }, [displayRollup, overviewAnchorEndDay]);
+
+  const todayRollupEntry = displayRollup[todayDayKey];
+  const hasRollupForTodayCard =
+    todayRollupEntry != null && todayRollupEntry.kind !== "error";
 
   const dailyDetailsModel = useMemo(() => {
-    if (stepsRollup.status !== "ready") return null;
-    const entry = stepsRollup.rollupByDay[selectedDay];
-    if (entry?.kind === "error") return null;
-    return buildActivityDailyDetailsCardModel({
-      selectedDay,
-      todayDayKey,
-      rollupByDay: stepsRollup.rollupByDay,
-    });
-  }, [stepsRollup, selectedDay, todayDayKey]);
+    const entry = displayRollup[todayDayKey];
+
+    if (user && hkToday.status === "ready") {
+      return buildActivityTodayStepsLiveCardModel({ todayDayKey, steps: hkToday.steps });
+    }
+
+    if (user && hkToday.status === "partial") {
+      if (entry?.kind === "error") return null;
+      if (entry?.kind === "numeric" || entry?.kind === "absent") {
+        return buildActivityDailyDetailsCardModel({
+          detailDayKey: todayDayKey,
+          todayDayKey,
+          rollupByDay: displayRollup,
+        });
+      }
+      return null;
+    }
+
+    if (user && hkToday.status === "failed") {
+      if (entry?.kind === "error") return null;
+      if (entry?.kind === "numeric" || entry?.kind === "absent") {
+        return buildActivityDailyDetailsCardModel({
+          detailDayKey: todayDayKey,
+          todayDayKey,
+          rollupByDay: displayRollup,
+        });
+      }
+      return null;
+    }
+
+    if (user && hkToday.status === "skipped") {
+      if (entry?.kind === "error") return null;
+      if (entry?.kind === "numeric" || entry?.kind === "absent") {
+        return buildActivityDailyDetailsCardModel({
+          detailDayKey: todayDayKey,
+          todayDayKey,
+          rollupByDay: displayRollup,
+        });
+      }
+      return null;
+    }
+
+    return null;
+  }, [hkToday, displayRollup, todayDayKey, user]);
+
+  const dailyDetailsTodayError = useMemo(() => {
+    if (user && hkToday.status === "ready") {
+      return null;
+    }
+    if (user && hkToday.status === "failed" && hasRollupForTodayCard) {
+      const e = displayRollup[todayDayKey];
+      if (e?.kind === "numeric" || e?.kind === "absent") return null;
+      if (e?.kind === "error") return rollupTodayEntryError;
+      return {
+        message: hkToday.error,
+        requestId: null as string | null,
+        onRetry: () => {
+          refreshHealthKitToday();
+          void stepsRollup.refetch({ cacheBust: `activityRollupTodayHkRetry:${Date.now()}` });
+        },
+      };
+    }
+    return rollupTodayEntryError;
+  }, [hkToday, refreshHealthKitToday, hasRollupForTodayCard, rollupTodayEntryError, displayRollup, todayDayKey, user]);
+
+  const dailyDetailsLoading = useMemo(() => {
+    if (!user) return false;
+    if (hkToday.status === "partial") {
+      return !hasRollupForTodayCard;
+    }
+    if (hkToday.status === "failed") {
+      return displayRollup[todayDayKey] === undefined;
+    }
+    if (hkToday.status === "ready") return false;
+    return stepsRollup.status === "partial";
+  }, [hkToday.status, hasRollupForTodayCard, displayRollup, stepsRollup.status, user]);
 
   const overview = useMemo(
     () => ({
-      loading: stepsRollup.status === "partial",
+      loading: false,
       error: rollupAggregateError,
       model: overviewCardModel,
     }),
-    [stepsRollup, overviewCardModel, rollupAggregateError],
+    [overviewCardModel, rollupAggregateError],
   );
 
   const dailyDetails = useMemo(
     () => ({
-      loading: stepsRollup.status === "partial",
-      error: dailyDetailsSelectedError ?? rollupAggregateError,
+      loading: dailyDetailsLoading,
+      error: dailyDetailsTodayError,
       model: dailyDetailsModel,
     }),
-    [stepsRollup, dailyDetailsModel, dailyDetailsSelectedError, rollupAggregateError],
+    [dailyDetailsLoading, dailyDetailsModel, dailyDetailsTodayError],
   );
 
   return {

--- a/lib/data/activity/useActivityStepsRollupMap.ts
+++ b/lib/data/activity/useActivityStepsRollupMap.ts
@@ -2,20 +2,35 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { getDailyFacts } from "@/lib/api/usersMe";
 import { useAuth } from "@/lib/auth/AuthProvider";
-import type { ActivityStepsRollupMap } from "@/lib/data/activity/activityOverviewRollupTypes";
+import type { ActivityStepsRollupMap, DayStepsRollupEntry } from "@/lib/data/activity/activityOverviewRollupTypes";
 import { interpretDailyFactsStepsRollupEntry } from "@/lib/data/activity/dailyFactsStepsRollupEntry";
 import { computeActivityOverviewFetchDayKeys } from "@/lib/data/activity/activityOverviewRanges";
+import { getTodayDayKeyLocal } from "@/lib/ui/calendar/dateUtils";
 import type { DayKey } from "@/lib/ui/calendar/types";
 
-type State = { status: "partial" } | { status: "ready"; rollupByDay: ActivityStepsRollupMap };
+type RollupInternalState = {
+  /** Per-wave accumulator (keys filled as each daily-facts response settles). */
+  rollupByDay: ActivityStepsRollupMap;
+  /** Snapshot at wave start; merged under {@link rollupDisplayByDay} until the wave finishes. */
+  rollupFallbackBase: ActivityStepsRollupMap;
+  isRefreshing: boolean;
+};
+
+export type ActivityStepsRollupHookState = RollupInternalState & {
+  /** `partial` only when no displayable rollup entries yet. */
+  status: "partial" | "ready";
+  /** Stale-while-revalidate view: `rollupFallbackBase` ∪ latest per-key overlays. */
+  rollupDisplayByDay: ActivityStepsRollupMap;
+  refetch: (opts?: { cacheBust?: string }) => void;
+};
+
+const emptyRollup = (): ActivityStepsRollupMap => ({});
 
 /**
- * Fetches GET /users/me/daily-facts for each key in `dayKeys` (parallel).
+ * Fetches GET /users/me/daily-facts for each key in `dayKeys` (parallel requests, merged incrementally).
  * Per-day entries are persisted server rollups only (no client raw-event math).
  */
-export function useActivityStepsRollupForKeys(dayKeys: readonly DayKey[]): State & {
-  refetch: (opts?: { cacheBust?: string }) => void;
-} {
+export function useActivityStepsRollupForKeys(dayKeys: readonly DayKey[]): ActivityStepsRollupHookState {
   const { user, initializing, getIdToken } = useAuth();
   const keysRef = useRef(dayKeys);
   keysRef.current = dayKeys;
@@ -23,66 +38,123 @@ export function useActivityStepsRollupForKeys(dayKeys: readonly DayKey[]): State
   const authRef = useRef({ initializing, userUid: user?.uid, getIdToken });
   authRef.current = { initializing, userUid: user?.uid, getIdToken };
 
-  const [state, setState] = useState<State>({ status: "partial" });
+  const [state, setState] = useState<RollupInternalState>({
+    rollupByDay: emptyRollup(),
+    rollupFallbackBase: emptyRollup(),
+    isRefreshing: false,
+  });
 
   const keySig = useMemo(() => [...dayKeys].sort().join("\0"), [dayKeys]);
+
+  const rollupDisplayByDay = useMemo(
+    () => ({ ...state.rollupFallbackBase, ...state.rollupByDay }),
+    [state.rollupFallbackBase, state.rollupByDay],
+  );
+
+  const status = useMemo<"partial" | "ready">(() => {
+    return Object.keys(rollupDisplayByDay).length > 0 ? "ready" : "partial";
+  }, [rollupDisplayByDay]);
 
   const fetchAll = useCallback(async (cacheBust?: string) => {
     const seq = ++requestSeq.current;
     const keys = keysRef.current;
     const { initializing: init, userUid, getIdToken: getToken } = authRef.current;
 
-    const safeSet = (next: State) => {
-      if (seq === requestSeq.current) setState(next);
-    };
-
     if (init) {
-      safeSet({ status: "partial" });
+      if (seq === requestSeq.current) {
+        setState({
+          rollupByDay: emptyRollup(),
+          rollupFallbackBase: emptyRollup(),
+          isRefreshing: false,
+        });
+      }
       return;
     }
     if (!userUid) {
-      safeSet({ status: "ready", rollupByDay: {} });
+      if (seq === requestSeq.current) {
+        setState({
+          rollupByDay: emptyRollup(),
+          rollupFallbackBase: emptyRollup(),
+          isRefreshing: false,
+        });
+      }
       return;
     }
 
     if (keys.length === 0) {
-      safeSet({ status: "ready", rollupByDay: {} });
+      if (seq === requestSeq.current) {
+        setState({
+          rollupByDay: emptyRollup(),
+          rollupFallbackBase: emptyRollup(),
+          isRefreshing: false,
+        });
+      }
       return;
     }
 
-    safeSet({ status: "partial" });
+    setState((prev) => {
+      if (seq !== requestSeq.current) return prev;
+      return {
+        rollupFallbackBase: { ...prev.rollupByDay },
+        rollupByDay: emptyRollup(),
+        isRefreshing: true,
+      };
+    });
 
     const token = await getToken(false);
-    if (!token || seq !== requestSeq.current) return;
+    if (seq !== requestSeq.current) return;
+    if (!token) {
+      setState((prev) => {
+        if (seq !== requestSeq.current) return prev;
+        return {
+          rollupByDay: { ...prev.rollupFallbackBase, ...prev.rollupByDay },
+          rollupFallbackBase: emptyRollup(),
+          isRefreshing: false,
+        };
+      });
+      return;
+    }
 
     const bust = cacheBust ? `${cacheBust}` : undefined;
 
-    const settled = await Promise.allSettled(
+    const waveResults: ActivityStepsRollupMap = {};
+    await Promise.all(
       keys.map(async (k) => {
-        const res = await getDailyFacts(k, token, bust ? { cacheBust: `${bust}:${k}` } : undefined);
-        return { k, res } as const;
+        let entry: DayStepsRollupEntry;
+        try {
+          const res = await getDailyFacts(k, token, bust ? { cacheBust: `${bust}:${k}` } : undefined);
+          entry = interpretDailyFactsStepsRollupEntry(res);
+        } catch (r: unknown) {
+          const reason =
+            r instanceof Error ? r.message : typeof r === "string" && r.length > 0 ? r : "Request failed";
+          entry = { kind: "error", message: reason, requestId: null };
+        }
+        waveResults[k] = entry;
+        setState((prev) => {
+          if (seq !== requestSeq.current) return prev;
+          return {
+            ...prev,
+            rollupByDay: { ...prev.rollupByDay, [k]: entry },
+            isRefreshing: true,
+          };
+        });
       }),
     );
 
     if (seq !== requestSeq.current) return;
 
-    const rollupByDay: ActivityStepsRollupMap = {};
-
-    for (let i = 0; i < settled.length; i += 1) {
-      const k = keys[i]!;
-      const item = settled[i]!;
-      if (item.status === "rejected") {
-        const r = item.reason;
-        const reason =
-          r instanceof Error ? r.message : typeof r === "string" && r.length > 0 ? r : "Request failed";
-        rollupByDay[k] = { kind: "error", message: reason, requestId: null };
-        continue;
-      }
-      const { res } = item.value;
-      rollupByDay[k] = interpretDailyFactsStepsRollupEntry(res);
+    const finalRollup: ActivityStepsRollupMap = {};
+    for (const k of keys) {
+      finalRollup[k] = waveResults[k]!;
     }
-
-    safeSet({ status: "ready", rollupByDay });
+    setState((prev) => {
+      if (seq !== requestSeq.current) return prev;
+      return {
+        rollupByDay: finalRollup,
+        rollupFallbackBase: emptyRollup(),
+        isRefreshing: false,
+      };
+    });
   }, []);
 
   useEffect(() => {
@@ -96,15 +168,26 @@ export function useActivityStepsRollupForKeys(dayKeys: readonly DayKey[]): State
     [fetchAll],
   );
 
-  return useMemo(() => ({ ...state, refetch }), [state, refetch]);
+  return useMemo(
+    () => ({
+      ...state,
+      status,
+      rollupDisplayByDay,
+      refetch,
+    }),
+    [state, status, rollupDisplayByDay, refetch],
+  );
 }
 
 /**
- * Overview screen: trailing `ACTIVITY_OVERVIEW_AVG_12M_DAYS` (365) inclusive calendar days ending on `selectedDay`.
+ * Overview screen: union of overview windows (no future keys except strip-selected future day), always including
+ * device today so Today’s Steps can load current-day rollups while the strip anchor is historical.
  */
-export function useActivityStepsRollupMap(selectedDay: DayKey): State & {
-  refetch: (opts?: { cacheBust?: string }) => void;
-} {
-  const keys = useMemo(() => computeActivityOverviewFetchDayKeys(selectedDay), [selectedDay]);
+export function useActivityStepsRollupMap(selectedDay: DayKey): ActivityStepsRollupHookState {
+  const todayDayKey = getTodayDayKeyLocal();
+  const keys = useMemo(
+    () => computeActivityOverviewFetchDayKeys(selectedDay, todayDayKey),
+    [selectedDay, todayDayKey],
+  );
   return useActivityStepsRollupForKeys(keys);
 }

--- a/lib/data/activity/useAppleHealthForcedYesterdayFinalize.ts
+++ b/lib/data/activity/useAppleHealthForcedYesterdayFinalize.ts
@@ -1,0 +1,33 @@
+import { useCallback, useEffect } from "react";
+import { AppState, InteractionManager, Platform } from "react-native";
+
+import { useAuth } from "@/lib/auth/AuthProvider";
+import { runForcedLocalYesterdayAppleHealthStepsIngest } from "@/lib/data/activity/appleHealthForcedLocalYesterdaySteps";
+
+/**
+ * Runs previous-local-day Apple Health steps finalization whenever auth is ready:
+ * app launch (mount), and whenever the app returns to foreground.
+ * Does not depend on Activity (or any module screen) mounting.
+ */
+export function useAppleHealthForcedYesterdayFinalize(): void {
+  const { user, initializing, getIdToken } = useAuth();
+
+  const run = useCallback(() => {
+    if (Platform.OS !== "ios" || !user || initializing) return;
+    InteractionManager.runAfterInteractions(() => {
+      void runForcedLocalYesterdayAppleHealthStepsIngest(getIdToken);
+    });
+  }, [getIdToken, initializing, user]);
+
+  useEffect(() => {
+    run();
+  }, [run]);
+
+  useEffect(() => {
+    if (Platform.OS !== "ios" || !user || initializing) return;
+    const sub = AppState.addEventListener("change", (state) => {
+      if (state === "active") run();
+    });
+    return () => sub.remove();
+  }, [run, user, initializing]);
+}

--- a/lib/integrations/appleHealth/__tests__/appleHealthStepsIngestGuard.test.ts
+++ b/lib/integrations/appleHealth/__tests__/appleHealthStepsIngestGuard.test.ts
@@ -1,0 +1,50 @@
+import { shouldIngestAppleHealthStepsForDay } from "../appleHealthStepsIngestGuard";
+
+describe("shouldIngestAppleHealthStepsForDay", () => {
+  it("allows first ingest when there is no prior value", () => {
+    expect(
+      shouldIngestAppleHealthStepsForDay({
+        healthSteps: 133,
+        lastIngestedSteps: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("allows higher cumulative than last successful ingest", () => {
+    expect(
+      shouldIngestAppleHealthStepsForDay({
+        healthSteps: 2732,
+        lastIngestedSteps: 133,
+      }),
+    ).toBe(true);
+  });
+
+  it("blocks strict regression when last ingest is known and new count is positive", () => {
+    expect(
+      shouldIngestAppleHealthStepsForDay({
+        healthSteps: 133,
+        lastIngestedSteps: 2732,
+      }),
+    ).toBe(false);
+  });
+
+  it("always ingests hkEmpty (steps 0) so pipeline can record missing aggregate", () => {
+    expect(
+      shouldIngestAppleHealthStepsForDay({
+        healthSteps: 0,
+        hkEmpty: true,
+        lastIngestedSteps: 9000,
+      }),
+    ).toBe(true);
+  });
+
+  it("allows explicit zero when not hkEmpty (true rest day)", () => {
+    expect(
+      shouldIngestAppleHealthStepsForDay({
+        healthSteps: 0,
+        hkEmpty: false,
+        lastIngestedSteps: 5000,
+      }),
+    ).toBe(true);
+  });
+});

--- a/lib/integrations/appleHealth/__tests__/healthKit.stepsQueryOptions.test.ts
+++ b/lib/integrations/appleHealth/__tests__/healthKit.stepsQueryOptions.test.ts
@@ -1,0 +1,13 @@
+import { buildHealthKitGetStepCountOptions, getLocalCalendarDayBoundsFromYmd } from "../healthKit";
+
+describe("buildHealthKitGetStepCountOptions", () => {
+  it("passes local start-of-day ISO as `date` (native getStepCount ignores startDate/endDate)", () => {
+    const day = "2026-04-12";
+    const opts = buildHealthKitGetStepCountOptions(day);
+    const { start } = getLocalCalendarDayBoundsFromYmd(day);
+    expect(opts.date).toBe(start);
+    expect(opts.includeManuallyAdded).toBe(true);
+    expect(opts).not.toHaveProperty("startDate");
+    expect(opts).not.toHaveProperty("endDate");
+  });
+});

--- a/lib/integrations/appleHealth/__tests__/runAppleHealthStepsBackfill.test.ts
+++ b/lib/integrations/appleHealth/__tests__/runAppleHealthStepsBackfill.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, jest, beforeEach } from "@jest/globals";
 import {
   assertStepsBackfillSingleDayInvariant,
-  computeLocalYtdLookbackDays,
+  APPLE_HEALTH_STEPS_BACKFILL_TRAILING_LOCAL_DAYS,
   runAppleHealthStepsBackfill,
 } from "../runAppleHealthStepsBackfill";
+import { addLocalCalendarDaysToDayKey } from "../healthKit";
 import type { AppleHealthStepsBackfillState } from "../storage";
 
 function makeStore(initial: AppleHealthStepsBackfillState | null = null) {
@@ -94,6 +95,40 @@ describe("runAppleHealthStepsBackfill", () => {
     expect(body.payload?.steps).toBe(0);
   });
 
+  it("default lookback is trailing 365 local days ending on getTodayDayKeyLocal, with no dates after today", async () => {
+    const store = makeStore();
+    const ingestRawEvent = jest.fn(async () => ({ ok: true as const }));
+    const pullStepCountForLocalCalendarDay = jest.fn(async () => ({
+      ok: true as const,
+      steps: 0,
+      hkEmpty: true as const,
+    }));
+    const today = "2026-04-14";
+    const result = await runAppleHealthStepsBackfill(
+      { token: "tok" },
+      {
+        nowIso: () => "2026-04-14T15:00:00.000Z",
+        getTodayDayKeyLocal: () => today,
+        getDeviceTimezone: () => "America/Los_Angeles",
+        pullStepCountForLocalCalendarDay,
+        ingestRawEvent,
+        stepsIdempotencyKey: (d) => `appleHealth:v2:steps:${d}`,
+        getBackfillState: store.get,
+        setBackfillState: store.set,
+      },
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.lookbackDays).toBe(APPLE_HEALTH_STEPS_BACKFILL_TRAILING_LOCAL_DAYS);
+    expect(result.windowEndDay).toBe(today);
+    expect(result.daysTotal).toBe(365);
+    const expectedStart = addLocalCalendarDaysToDayKey(today, -(365 - 1));
+    expect(result.windowStartDay).toBe(expectedStart);
+    const pulledDays = pullStepCountForLocalCalendarDay.mock.calls.map((c) => c[0]);
+    expect(pulledDays.every((d) => d <= today)).toBe(true);
+    expect(new Set(pulledDays).size).toBe(365);
+  });
+
   it("assertStepsBackfillSingleDayInvariant rejects payload.day mismatch", () => {
     expect(() =>
       assertStepsBackfillSingleDayInvariant({
@@ -112,11 +147,5 @@ describe("runAppleHealthStepsBackfill", () => {
         payloadDay: "2026-04-07",
       }),
     ).toThrow(/idempotencyKey/);
-  });
-
-  it("computeLocalYtdLookbackDays counts Jan 1 through today inclusive", () => {
-    expect(computeLocalYtdLookbackDays("2026-01-01")).toBe(1);
-    expect(computeLocalYtdLookbackDays("2026-01-03")).toBe(3);
-    expect(computeLocalYtdLookbackDays("2026-04-08")).toBe(98);
   });
 });

--- a/lib/integrations/appleHealth/appleHealthStepsIngestGuard.ts
+++ b/lib/integrations/appleHealth/appleHealthStepsIngestGuard.ts
@@ -1,0 +1,17 @@
+/**
+ * Client-side guard before POST /ingest for Apple daily steps.
+ * Uses last successful ingest per local day (AsyncStorage) as a stand-in for “existing canonical”
+ * when HealthKit returns a lower total (e.g. transient partial read). Always allows hkEmpty → 0.
+ */
+
+export function shouldIngestAppleHealthStepsForDay(params: {
+  healthSteps: number;
+  hkEmpty?: boolean;
+  lastIngestedSteps: number | null;
+}): boolean {
+  const { healthSteps, hkEmpty, lastIngestedSteps } = params;
+  if (hkEmpty) return true;
+  if (lastIngestedSteps == null) return true;
+  if (healthSteps === 0) return true;
+  return healthSteps >= lastIngestedSteps;
+}

--- a/lib/integrations/appleHealth/healthKit.ts
+++ b/lib/integrations/appleHealth/healthKit.ts
@@ -88,6 +88,10 @@ type AnchoredQueryResults = { anchor: string; data: HKWorkoutQueriedSampleType[]
 type HealthKitInstance = {
   initHealthKit: (p: unknown, cb: (err: string, r: unknown) => void) => void;
   isAvailable: (cb: (err: unknown, ok: boolean) => void) => void;
+  /**
+   * Native `fitness_getStepCountOnDay` reads **`date`** only (ISO string). `startDate`/`endDate` are ignored.
+   * Pass local start-of-calendar-day ISO from {@link getLocalCalendarDayBoundsFromYmd} `.start`.
+   */
   getStepCount: (o: HealthInputOptions, cb: (err: string, r: HealthValue) => void) => void;
   getAppleExerciseTime: (o: HealthInputOptions, cb: (err: string, r: HealthValue[]) => void) => void;
   getActiveEnergyBurned: (o: HealthInputOptions, cb: (err: string, r: HealthValue[]) => void) => void;
@@ -573,6 +577,16 @@ export function getLocalCalendarDayBoundsFromYmd(dayYmd: string): { start: strin
   return { start: start.toISOString(), end: end.toISOString(), day: dayYmd };
 }
 
+/**
+ * Arguments for `AppleHealthKit.getStepCount` (react-native-health iOS).
+ * The bridge sums step-count samples for the **local calendar day** containing `date`
+ * via `HKStatisticsOptionCumulativeSum` (full-day total, not a delta).
+ */
+export function buildHealthKitGetStepCountOptions(dayYmd: string): { date: string; includeManuallyAdded: boolean } {
+  const { start } = getLocalCalendarDayBoundsFromYmd(dayYmd);
+  return { date: start, includeManuallyAdded: true };
+}
+
 /** Shift a local calendar day key by `deltaDays` (device local calendar). */
 export function addLocalCalendarDaysToDayKey(dayYmd: string, deltaDays: number): string {
   if (!LOCAL_DAY_KEY_RE.test(dayYmd)) {
@@ -615,8 +629,7 @@ export async function pullStepCountForLocalCalendarDay(
     return { ok: false, error: "HealthKit is not available (e.g. not iOS or native module not linked)." };
   }
   try {
-    const { start, end } = getLocalCalendarDayBoundsFromYmd(dayYmd);
-    const r = await queryStepCount(HK, start, end);
+    const r = await queryStepCountForLocalDay(HK, dayYmd);
     if (r.kind === "error") {
       return { ok: false, error: `HealthKit getStepCount: ${r.message}` };
     }
@@ -638,10 +651,15 @@ type StepCountQueryResult =
 /**
  * Low-level HKStatistics-style callback: distinguishes **error** vs **no aggregate** vs **numeric total**.
  * Previously we treated errors like missing data (`null`), so steps backfill skipped POST /ingest entirely.
+ *
+ * IMPORTANT: react-native-health `getStepCount` → `fitness_getStepCountOnDay` uses option key **`date`** only.
+ * Passing only `startDate`/`endDate` leaves `date` unset, so native code defaults to **now**, and every
+ * backfill day incorrectly queried **today’s** steps while still POSTing historical `payload.day` values.
  */
-function queryStepCount(HK: HealthKitInstance, startDate: string, endDate: string): Promise<StepCountQueryResult> {
+function queryStepCountForLocalDay(HK: HealthKitInstance, dayYmd: string): Promise<StepCountQueryResult> {
+  const opts = buildHealthKitGetStepCountOptions(dayYmd);
   return new Promise((resolve) => {
-    HK.getStepCount({ startDate, endDate }, (err: string, result: HealthValue) => {
+    HK.getStepCount(opts, (err: string, result: HealthValue) => {
       if (err != null && String(err).trim() !== "") {
         resolve({ kind: "error", message: String(err) });
         return;
@@ -655,12 +673,12 @@ function queryStepCount(HK: HealthKitInstance, startDate: string, endDate: strin
   });
 }
 
-async function pStepCount(HK: HealthKitInstance, startDate: string, endDate: string): Promise<number | null> {
-  const r = await queryStepCount(HK, startDate, endDate);
+async function pStepCount(HK: HealthKitInstance, dayYmd: string): Promise<number | null> {
+  const r = await queryStepCountForLocalDay(HK, dayYmd);
   if (r.kind === "error") {
     if (__DEV__ && !process.env.JEST_WORKER_ID) {
       // eslint-disable-next-line no-console
-      console.warn("[AH] getStepCount error", { startDate, endDate, message: r.message });
+      console.warn("[AH] getStepCount error", { dayYmd, message: r.message });
     }
     return null;
   }
@@ -906,7 +924,7 @@ export async function pullTodaySnapshot(): Promise<{ ok: true; data: TodaySnapsh
   const { startDate, endDate, day } = getTodayBounds();
 
   return Promise.all([
-    pStepCount(HK, startDate, endDate),
+    pStepCount(HK, day),
     pAppleExerciseTime(HK, startDate, endDate),
     pActiveEnergyBurned(HK, startDate, endDate),
     pRestingHeartRateSamples(HK, startDate, endDate),

--- a/lib/integrations/appleHealth/index.ts
+++ b/lib/integrations/appleHealth/index.ts
@@ -15,6 +15,7 @@ export {
   getLocalCalendarDayBoundsFromYmd,
   addLocalCalendarDaysToDayKey,
   pullStepCountForLocalCalendarDay,
+  buildHealthKitGetStepCountOptions,
 } from "./healthKit";
 export type { BodyCompositionReadAuthStatusResult } from "./healthKit";
 export {
@@ -46,7 +47,7 @@ export {
 } from "./runAppleHealthBodyBackfill";
 export {
   runAppleHealthStepsBackfill,
-  computeLocalYtdLookbackDays,
+  APPLE_HEALTH_STEPS_BACKFILL_TRAILING_LOCAL_DAYS,
   type RunAppleHealthStepsBackfillDeps,
   type RunAppleHealthStepsBackfillResult,
 } from "./runAppleHealthStepsBackfill";

--- a/lib/integrations/appleHealth/runAnchoredWorkoutsSync.ts
+++ b/lib/integrations/appleHealth/runAnchoredWorkoutsSync.ts
@@ -3,7 +3,9 @@
  * Only calls setWorkoutsAnchor after full success; fail-closed on truncation or ingest failure.
  */
 
+import { shouldIngestAppleHealthStepsForDay } from "./appleHealthStepsIngestGuard";
 import { buildAppleHealthStepsIngestBody } from "./appleHealthStepsIngestBody";
+import { getLastIngestedStepsForDay, setLastIngestedStepsForDay } from "./storage";
 import type { TodaySnapshot, TodayWorkout } from "./types";
 
 export type RunAnchoredWorkoutsSyncDeps = {
@@ -51,28 +53,53 @@ export async function runAnchoredWorkoutsSync(
     return { ok: false, error: anchored.error, requestId: null };
   }
 
-  const pull = await deps.pullTodaySnapshot();
-  if (!pull.ok) {
-    return { ok: false, error: pull.error, requestId: null };
-  }
-  const data = pull.data;
   const timezone = deps.getDeviceTimezone();
   const { start, end, day } = deps.getTodayBounds();
 
+  const pull = await deps.pullTodaySnapshot();
+  const data = pull.ok
+    ? pull.data
+    : {
+        day,
+        steps: null,
+        exerciseMinutes: null,
+        activeEnergyKcal: null,
+        restingHeartRateBpm: null,
+        workouts: [],
+      };
+
+  if (!pull.ok && __DEV__ && !process.env.JEST_WORKER_ID) {
+    // eslint-disable-next-line no-console
+    console.warn("[AH] pullTodaySnapshot failed; continuing workout ingest", pull.error);
+  }
+
   if (data.steps != null && data.steps >= 0) {
-    const body = buildAppleHealthStepsIngestBody({
-      start,
-      end,
-      day,
-      timezone,
-      steps: data.steps,
+    const lastIngested = await getLastIngestedStepsForDay(day);
+    const sendSteps = shouldIngestAppleHealthStepsForDay({
+      healthSteps: data.steps,
+      hkEmpty: false,
+      lastIngestedSteps: lastIngested,
     });
-    const res = await deps.ingestRawEvent(body, token, {
-      idempotencyKey: deps.stepsIdempotencyKey(day),
-      timeoutMs: 15000,
-    });
-    if (!res.ok) {
-      return { ok: false, error: res.error, requestId: res.requestId };
+    if (sendSteps) {
+      const body = buildAppleHealthStepsIngestBody({
+        start,
+        end,
+        day,
+        timezone,
+        steps: data.steps,
+      });
+      const res = await deps.ingestRawEvent(body, token, {
+        idempotencyKey: deps.stepsIdempotencyKey(day),
+        timeoutMs: 15000,
+      });
+      if (!res.ok) {
+        if (__DEV__ && !process.env.JEST_WORKER_ID) {
+          // eslint-disable-next-line no-console
+          console.warn("[AH] steps ingest failed; continuing workout ingest", res.error, res.requestId);
+        }
+      } else {
+        await setLastIngestedStepsForDay(day, data.steps);
+      }
     }
   }
 

--- a/lib/integrations/appleHealth/runAppleHealthStepsBackfill.ts
+++ b/lib/integrations/appleHealth/runAppleHealthStepsBackfill.ts
@@ -1,30 +1,14 @@
+import { shouldIngestAppleHealthStepsForDay } from "./appleHealthStepsIngestGuard";
 import { buildAppleHealthStepsIngestBody } from "./appleHealthStepsIngestBody";
+import { getLastIngestedStepsForDay, setLastIngestedStepsForDay } from "./storage";
 import { addLocalCalendarDaysToDayKey, getLocalCalendarDayBoundsFromYmd } from "./healthKit";
 import type {
   AppleHealthStepsBackfillState,
   AppleHealthStepsRepairTriggerSource,
 } from "./storage";
 
-const DAY_KEY_RE = /^\d{4}-\d{2}-\d{2}$/;
-
-/**
- * Inclusive count of local calendar days from Jan 1 of `todayYmd`'s year through `todayYmd`
- * (used as the default steps backfill window = year-to-date).
- */
-export function computeLocalYtdLookbackDays(todayYmd: string): number {
-  if (!DAY_KEY_RE.test(todayYmd)) {
-    throw new Error(`computeLocalYtdLookbackDays: invalid day "${todayYmd}"`);
-  }
-  const year = todayYmd.slice(0, 4);
-  const jan1 = `${year}-01-01`;
-  let count = 0;
-  let d = jan1;
-  while (d <= todayYmd) {
-    count += 1;
-    d = addLocalCalendarDaysToDayKey(d, 1);
-  }
-  return Math.max(1, count);
-}
+/** Default steps backfill: trailing local calendar days ending on the device “today” day key (inclusive). */
+export const APPLE_HEALTH_STEPS_BACKFILL_TRAILING_LOCAL_DAYS = 365;
 
 export type RunAppleHealthStepsBackfillDeps = {
   nowIso: () => string;
@@ -109,10 +93,7 @@ export async function runAppleHealthStepsBackfill(
   deps: RunAppleHealthStepsBackfillDeps,
 ): Promise<RunAppleHealthStepsBackfillResult> {
   const now = deps.nowIso();
-  const lookbackDays = Math.max(
-    1,
-    opts.lookbackDays ?? computeLocalYtdLookbackDays(deps.getTodayDayKeyLocal()),
-  );
+  const lookbackDays = Math.max(1, opts.lookbackDays ?? APPLE_HEALTH_STEPS_BACKFILL_TRAILING_LOCAL_DAYS);
   const windowEndDay = deps.getTodayDayKeyLocal();
   const windowStartDay = addLocalCalendarDaysToDayKey(windowEndDay, -(lookbackDays - 1));
   const days = enumerateLocalDayWindow(windowEndDay, lookbackDays);
@@ -201,51 +182,61 @@ export async function runAppleHealthStepsBackfill(
       daysSkippedNoData += 1;
     }
 
-    const { start, end } = getLocalCalendarDayBoundsFromYmd(day);
-    const body = buildAppleHealthStepsIngestBody({
-      start,
-      end,
-      day,
-      timezone,
-      steps: pulled.steps,
+    const lastIngested = await getLastIngestedStepsForDay(day);
+    const sendSteps = shouldIngestAppleHealthStepsForDay({
+      healthSteps: pulled.steps,
+      hkEmpty: pulled.hkEmpty === true,
+      lastIngestedSteps: lastIngested,
     });
-    const idempotencyKey = deps.stepsIdempotencyKey(day);
-    assertStepsBackfillSingleDayInvariant({
-      day,
-      idempotencyKey,
-      payloadDay: body.payload.day,
-    });
-    const res = await deps.ingestRawEvent(body, opts.token, {
-      idempotencyKey,
-      timeoutMs: 15000,
-    });
-    if (!res.ok) {
-      await deps.setBackfillState({
-        status: "failed",
-        backfillStartDate: startedAt,
-        windowStartDay,
-        windowEndDay,
-        lookbackDays,
-        lastProcessedDay: day,
-        lastRunAt: deps.nowIso(),
-        error: res.error,
-        lastTriggerSource: triggerSource,
-        summary: {
-          startedAt,
-          completedAt: null,
-          daysTotal: days.length,
-          daysProcessed,
-          daysIngested,
-          daysSkippedNoData,
-          daysFailed: 1,
-          lastSuccessfulDay,
-          lastProcessedDay: day,
-        },
+
+    if (sendSteps) {
+      const { start, end } = getLocalCalendarDayBoundsFromYmd(day);
+      const body = buildAppleHealthStepsIngestBody({
+        start,
+        end,
+        day,
+        timezone,
+        steps: pulled.steps,
       });
-      return { ok: false, error: res.error, requestId: res.requestId };
+      const idempotencyKey = deps.stepsIdempotencyKey(day);
+      assertStepsBackfillSingleDayInvariant({
+        day,
+        idempotencyKey,
+        payloadDay: body.payload.day,
+      });
+      const res = await deps.ingestRawEvent(body, opts.token, {
+        idempotencyKey,
+        timeoutMs: 15000,
+      });
+      if (!res.ok) {
+        await deps.setBackfillState({
+          status: "failed",
+          backfillStartDate: startedAt,
+          windowStartDay,
+          windowEndDay,
+          lookbackDays,
+          lastProcessedDay: day,
+          lastRunAt: deps.nowIso(),
+          error: res.error,
+          lastTriggerSource: triggerSource,
+          summary: {
+            startedAt,
+            completedAt: null,
+            daysTotal: days.length,
+            daysProcessed,
+            daysIngested,
+            daysSkippedNoData,
+            daysFailed: 1,
+            lastSuccessfulDay,
+            lastProcessedDay: day,
+          },
+        });
+        return { ok: false, error: res.error, requestId: res.requestId };
+      }
+      await setLastIngestedStepsForDay(day, pulled.steps);
+      daysIngested += 1;
+      lastSuccessfulDay = day;
     }
-    daysIngested += 1;
-    lastSuccessfulDay = day;
 
     await deps.setBackfillState({
       status: "in_progress",

--- a/lib/integrations/appleHealth/storage.ts
+++ b/lib/integrations/appleHealth/storage.ts
@@ -17,6 +17,12 @@ export const APPLE_HEALTH_NOT_AVAILABLE = "appleHealth:notAvailable";
 export const APPLE_HEALTH_DEEP_BACKFILL_VERSION = "appleHealth:deepBackfillVersion";
 /** Last completed workout range-bootstrap build id (see workoutBootstrapPolicy). */
 export const APPLE_HEALTH_WORKOUT_RANGE_BOOTSTRAP_BUILD = "appleHealth:workoutRangeBootstrapBuild";
+/** JSON map of local day key → last successfully POSTed steps (client guard vs transient HealthKit regression). */
+export const APPLE_HEALTH_LAST_INGESTED_STEPS_BY_DAY = "appleHealth:lastIngestedStepsByDayJson";
+/** Last local calendar `yesterday` YMD for which forced Activity open-ingest succeeded (throttle anchor). */
+export const APPLE_HEALTH_FORCED_YESTERDAY_LAST_YMD = "appleHealth:forcedYesterday:lastYesterdayYmd";
+/** ISO time of last successful forced yesterday ingest (anti-spam within same `yesterday` target). */
+export const APPLE_HEALTH_FORCED_YESTERDAY_LAST_AT = "appleHealth:forcedYesterday:lastAtIso";
 
 export async function getLastSyncAt(): Promise<string | null> {
   return AsyncStorage.getItem(APPLE_HEALTH_LAST_SYNC_AT);
@@ -166,4 +172,51 @@ export async function setAppleHealthWorkoutRangeBootstrapBuild(buildId: string):
 
 export async function clearAppleHealthWorkoutRangeBootstrapBuild(): Promise<void> {
   await AsyncStorage.removeItem(APPLE_HEALTH_WORKOUT_RANGE_BOOTSTRAP_BUILD);
+}
+
+async function readLastIngestedStepsMap(): Promise<Record<string, number>> {
+  const raw = await AsyncStorage.getItem(APPLE_HEALTH_LAST_INGESTED_STEPS_BY_DAY);
+  if (!raw) return {};
+  try {
+    const p = JSON.parse(raw) as unknown;
+    if (typeof p !== "object" || p === null || Array.isArray(p)) return {};
+    return p as Record<string, number>;
+  } catch {
+    return {};
+  }
+}
+
+/** Highest steps value we successfully ingested for this local calendar day (per-device). */
+export async function getLastIngestedStepsForDay(dayYmd: string): Promise<number | null> {
+  const m = await readLastIngestedStepsMap();
+  const v = m[dayYmd];
+  return typeof v === "number" && Number.isFinite(v) && v >= 0 ? v : null;
+}
+
+export async function setLastIngestedStepsForDay(dayYmd: string, steps: number): Promise<void> {
+  const m = await readLastIngestedStepsMap();
+  m[dayYmd] = steps;
+  const keys = Object.keys(m).sort();
+  if (keys.length > 500) {
+    for (const k of keys.slice(0, keys.length - 500)) {
+      delete m[k];
+    }
+  }
+  await AsyncStorage.setItem(APPLE_HEALTH_LAST_INGESTED_STEPS_BY_DAY, JSON.stringify(m));
+}
+
+export async function getAppleHealthForcedYesterdayRefreshLastYmd(): Promise<string | null> {
+  return AsyncStorage.getItem(APPLE_HEALTH_FORCED_YESTERDAY_LAST_YMD);
+}
+
+export async function setAppleHealthForcedYesterdayRefreshLastYmd(ymd: string): Promise<void> {
+  await AsyncStorage.setItem(APPLE_HEALTH_FORCED_YESTERDAY_LAST_YMD, ymd);
+}
+
+export async function getAppleHealthForcedYesterdayRefreshLastAtIso(): Promise<string | null> {
+  return AsyncStorage.getItem(APPLE_HEALTH_FORCED_YESTERDAY_LAST_AT);
+}
+
+export async function setAppleHealthForcedYesterdayRefreshLastAtIso(iso: string): Promise<void> {
+  await AsyncStorage.setItem(APPLE_HEALTH_FORCED_YESTERDAY_LAST_AT, iso);
 }

--- a/lib/ui/activity/ActivityDailyDetailsCard.tsx
+++ b/lib/ui/activity/ActivityDailyDetailsCard.tsx
@@ -2,15 +2,15 @@ import React from "react";
 import { StyleSheet, Text, View } from "react-native";
 
 import type { ActivityDailyDetailsCardModel } from "@/lib/data/activity/activityOverviewCardModel";
+import { ActivityRatingPill } from "@/lib/ui/activity/ActivityRatingPill";
+import {
+  ActivityTierProgressTrack,
+  activityTierProgressAccessibilityPercent,
+} from "@/lib/ui/activity/ActivityTierProgressTrack";
 import { moduleOverviewMetricLayoutStyles } from "@/lib/ui/overview/moduleOverviewMetricLayout";
-import { MODULE_OVERVIEW_SEGMENT_ZONE_FILLS } from "@/lib/ui/overview/moduleOverviewSegmentZoneFills";
-import { MODULE_OVERVIEW_SEGMENTED_TRACK } from "@/lib/ui/overview/moduleOverviewSegmentedTrackMetrics";
-import { SegmentedZoneTrack } from "@/lib/ui/primitives/SegmentedZoneTrack";
-import { workoutOverviewInCardHeaderStyles } from "@/lib/ui/workouts/workoutOverviewInCardHeaderStyles";
 import { ErrorState, LoadingState } from "@/lib/ui/ScreenStates";
 import { elevatedCardSurfaceStyle } from "@/lib/ui/theme/elevatedCardSurface";
-
-const ACTIVITY_DETAILS_MARKER_FILL = "#1F2937";
+import { getStepRating, getStepRatingTierIndex, stepsFromLocaleDigitString } from "@/lib/utils/activityStepRating";
 
 type ActivityDailyDetailsCardProps = {
   loading: boolean;
@@ -18,26 +18,18 @@ type ActivityDailyDetailsCardProps = {
   model: ActivityDailyDetailsCardModel | null;
 };
 
-function clamp01(x: number): number {
-  if (!Number.isFinite(x) || x <= 0) return 0;
-  if (x >= 1) return 1;
-  return x;
+/** Parses `compactStatsSummary` for display only (e.g. `7,524 steps` → `7,524`). Hook output unchanged. */
+function primaryStepsFigureFromCompactSummary(compactStatsSummary: string): string | null {
+  const m = compactStatsSummary.trim().match(/^([\d,]+)\s+steps$/i);
+  return m?.[1] ?? null;
 }
 
-function DetailsPlacementTrack({ testID, markerPosition01 }: { testID: string; markerPosition01: number }) {
-  const marker01 = clamp01(markerPosition01);
-  const pct = Math.round(marker01 * 100);
+function DetailsTierProgressTrack({ testID, tierIndex }: { testID: string; tierIndex: number | null }) {
+  const pct = activityTierProgressAccessibilityPercent(tierIndex);
   return (
-    <SegmentedZoneTrack
-      zoneColors={MODULE_OVERVIEW_SEGMENT_ZONE_FILLS}
+    <ActivityTierProgressTrack
       testID={testID}
-      markerPosition01={marker01}
-      showMarker
-      markerBackgroundColor={ACTIVITY_DETAILS_MARKER_FILL}
-      markerStyle="elevated"
-      dotSize={MODULE_OVERVIEW_SEGMENTED_TRACK.dotSize}
-      barHeight={MODULE_OVERVIEW_SEGMENTED_TRACK.barHeight}
-      trackRadius={MODULE_OVERVIEW_SEGMENTED_TRACK.trackRadius}
+      tierIndex={tierIndex}
       wrapperProps={{
         accessibilityRole: "progressbar",
         accessibilityValue: { now: pct, min: 0, max: 100 },
@@ -46,12 +38,49 @@ function DetailsPlacementTrack({ testID, markerPosition01 }: { testID: string; m
   );
 }
 
-/** Per-day steps for the week-strip (or calendar) selection — does not drive Overview averages. */
 export function ActivityDailyDetailsCard({ loading, error, model }: ActivityDailyDetailsCardProps) {
+  const digits = model != null ? primaryStepsFigureFromCompactSummary(model.compactStatsSummary) : null;
+  const rating = digits != null ? getStepRating(stepsFromLocaleDigitString(digits)) : null;
+  const titleRowA11y =
+    loading || model == null
+      ? "Today’s Steps"
+      : digits != null
+        ? rating != null
+          ? `Today’s steps, ${rating.label}, ${digits}`
+          : `Today’s steps, ${digits}`
+        : `Today’s steps, ${model.compactStatsSummary}`;
+
   return (
     <View style={styles.card}>
-      <View style={[styles.headerRow, workoutOverviewInCardHeaderStyles.row]}>
-        <Text style={workoutOverviewInCardHeaderStyles.title}>Daily details</Text>
+      <View
+        style={[moduleOverviewMetricLayoutStyles.topRow, styles.titleNumberRow]}
+        accessible
+        accessibilityRole="header"
+        accessibilityLabel={titleRowA11y}
+      >
+        <View style={styles.labelPillCluster}>
+          <Text style={styles.cardTitle} numberOfLines={1}>
+            Today’s Steps
+          </Text>
+          {!loading && model != null && rating != null ? (
+            <ActivityRatingPill
+              label={rating.label}
+              color={rating.color}
+              backgroundColor={rating.backgroundColor}
+              emphasis="subtle"
+              testID="activity-daily-details-rating"
+            />
+          ) : null}
+        </View>
+        {!loading && model != null && digits != null ? (
+          <Text style={styles.stepCountFigure} numberOfLines={1}>
+            {digits}
+          </Text>
+        ) : !loading && model != null && digits == null ? (
+          <Text style={styles.stepCountPlaceholder} numberOfLines={1}>
+            —
+          </Text>
+        ) : null}
       </View>
 
       {loading ? <LoadingState variant="inline" message="Loading steps…" /> : null}
@@ -64,20 +93,11 @@ export function ActivityDailyDetailsCard({ loading, error, model }: ActivityDail
         />
       ) : null}
       {!loading && model != null ? (
-        <View style={moduleOverviewMetricLayoutStyles.metricGroups}>
-          <View style={moduleOverviewMetricLayoutStyles.metricBlock} accessible accessibilityLabel={`${model.title}. ${model.compactStatsSummary}.`}>
-            <View style={moduleOverviewMetricLayoutStyles.topRow}>
-              <View style={styles.leftSummary}>
-                <Text style={styles.timeframeLabel} numberOfLines={1}>
-                  {model.title}
-                </Text>
-                <Text style={styles.resultSummary} numberOfLines={1} ellipsizeMode="tail">
-                  {model.compactStatsSummary}
-                </Text>
-              </View>
-            </View>
-            <DetailsPlacementTrack testID="activity-daily-details-steps-bar" markerPosition01={model.markerPosition01} />
-          </View>
+        <View style={moduleOverviewMetricLayoutStyles.metricBlock}>
+          <DetailsTierProgressTrack
+            testID="activity-daily-details-steps-bar"
+            tierIndex={digits != null ? getStepRatingTierIndex(stepsFromLocaleDigitString(digits)) : null}
+          />
         </View>
       ) : null}
     </View>
@@ -92,31 +112,35 @@ const styles = StyleSheet.create({
     gap: 12,
     ...elevatedCardSurfaceStyle,
   },
-  headerRow: {
-    alignItems: "flex-start",
-    paddingBottom: 2,
+  titleNumberRow: {
+    paddingBottom: 0,
   },
-  leftSummary: {
+  labelPillCluster: {
     flex: 1,
     minWidth: 0,
     flexDirection: "row",
     alignItems: "center",
-    gap: 10,
-    paddingRight: 8,
+    gap: 8,
   },
-  timeframeLabel: {
-    fontSize: 15,
+  cardTitle: {
+    flexShrink: 1,
+    minWidth: 0,
+    fontSize: 21,
     fontWeight: "600",
-    color: "#6E6E73",
-    letterSpacing: -0.12,
+    color: "#1C1C1E",
+    letterSpacing: -0.38,
+  },
+  stepCountFigure: {
+    fontSize: 23,
+    fontWeight: "700",
+    color: "#1C1C1E",
+    letterSpacing: -0.42,
     flexShrink: 0,
   },
-  resultSummary: {
-    flex: 1,
-    minWidth: 0,
-    fontSize: 14,
+  stepCountPlaceholder: {
+    fontSize: 21,
     fontWeight: "600",
-    color: "#3C3C43",
-    letterSpacing: -0.15,
+    color: "#8E8E93",
+    flexShrink: 0,
   },
 });

--- a/lib/ui/activity/ActivityDayRing.tsx
+++ b/lib/ui/activity/ActivityDayRing.tsx
@@ -1,21 +1,72 @@
 import React from "react";
 import { StyleSheet, View } from "react-native";
 
-import { ACTIVITY_STRIP_ACCENT, ACTIVITY_STRIP_ACCENT_LIGHT } from "@/lib/ui/activity/activityOverviewTheme";
+import type { ActivityDayRingPresentation } from "@/lib/ui/activity/activityCalendarDayRingPresentation";
+import { ACTIVITY_STEP_TIER_BAR_FILL } from "@/lib/ui/overview/activityStepTierBarFills";
+import { ACTIVITY_STEP_RATING_TIERS } from "@/lib/utils/activityStepRating";
+import { STEP_TIER_TRACK_INNER_BACKGROUND } from "@/lib/utils/activityStepTierVisual";
 
 const STROKE_WIDTH = 1.75;
-const STROKE_WIDTH_EMPHASIZED = 2.75;
+const STROKE_WIDTH_EMPHASIZED = 2.85;
+const NEUTRAL_FALLBACK_STROKE = "rgba(60, 60, 67, 0.14)";
+
+function tierInnerFill(tierIndex: number): string {
+  return ACTIVITY_STEP_RATING_TIERS[tierIndex]!.backgroundColor;
+}
 
 export type ActivityDayRingProps = {
   size: number;
-  hasSteps: boolean;
+  presentation: ActivityDayRingPresentation;
   emphasized?: boolean;
   outerTestID?: string;
 };
 
-/** Ring when persisted daily rollup reports steps for that day (Activity overview map). */
-export function ActivityDayRing({ size, hasSteps, emphasized = false, outerTestID }: ActivityDayRingProps) {
-  if (!hasSteps) return null;
+/** Ring stroke/fill: tier days use Activity bar tokens; past no-data uses neutral track chrome; today has no ring. */
+export function ActivityDayRing({ size, presentation, emphasized = false, outerTestID }: ActivityDayRingProps) {
+  if (presentation.kind === "hidden" || presentation.kind === "currentDayNoRing") return null;
+
+  if (presentation.kind === "tier") {
+    const { tierIndex } = presentation;
+    if (tierIndex < 0 || tierIndex >= ACTIVITY_STEP_TIER_BAR_FILL.length) return null;
+    const strokeColor = ACTIVITY_STEP_TIER_BAR_FILL[tierIndex]!;
+    const diskFill = tierInnerFill(tierIndex);
+    const strokeWidth = emphasized ? STROKE_WIDTH_EMPHASIZED : STROKE_WIDTH;
+    return (
+      <View style={[styles.host, { width: size, height: size, borderRadius: size / 2 }]}>
+        <View
+          pointerEvents="none"
+          style={[
+            styles.fillDisk,
+            {
+              width: size,
+              height: size,
+              borderRadius: size / 2,
+              backgroundColor: diskFill,
+              opacity: emphasized ? 1 : 0.96,
+            },
+          ]}
+        />
+        <View
+          testID={outerTestID}
+          pointerEvents="none"
+          style={[
+            styles.ringLayer,
+            {
+              width: size,
+              height: size,
+              borderRadius: size / 2,
+              borderWidth: strokeWidth,
+              borderColor: strokeColor,
+              opacity: emphasized ? 1 : 0.95,
+            },
+          ]}
+        />
+      </View>
+    );
+  }
+
+  const strokeColor = NEUTRAL_FALLBACK_STROKE;
+  const diskFill = STEP_TIER_TRACK_INNER_BACKGROUND;
   const strokeWidth = emphasized ? STROKE_WIDTH_EMPHASIZED : STROKE_WIDTH;
   return (
     <View style={[styles.host, { width: size, height: size, borderRadius: size / 2 }]}>
@@ -27,7 +78,8 @@ export function ActivityDayRing({ size, hasSteps, emphasized = false, outerTestI
             width: size,
             height: size,
             borderRadius: size / 2,
-            backgroundColor: ACTIVITY_STRIP_ACCENT_LIGHT,
+            backgroundColor: diskFill,
+            opacity: emphasized ? 1 : 0.94,
           },
         ]}
       />
@@ -41,7 +93,8 @@ export function ActivityDayRing({ size, hasSteps, emphasized = false, outerTestI
             height: size,
             borderRadius: size / 2,
             borderWidth: strokeWidth,
-            borderColor: ACTIVITY_STRIP_ACCENT,
+            borderColor: strokeColor,
+            opacity: emphasized ? 1 : 0.92,
           },
         ]}
       />

--- a/lib/ui/activity/ActivityOverviewCard.tsx
+++ b/lib/ui/activity/ActivityOverviewCard.tsx
@@ -2,16 +2,15 @@ import React from "react";
 import { StyleSheet, Text, View } from "react-native";
 
 import type { ActivityOverviewCardModel } from "@/lib/data/activity/activityOverviewCardModel";
+import {
+  ActivityTierProgressTrack,
+  activityTierProgressAccessibilityPercent,
+} from "@/lib/ui/activity/ActivityTierProgressTrack";
 import { moduleOverviewMetricLayoutStyles } from "@/lib/ui/overview/moduleOverviewMetricLayout";
-import { MODULE_OVERVIEW_SEGMENT_ZONE_FILLS } from "@/lib/ui/overview/moduleOverviewSegmentZoneFills";
-import { MODULE_OVERVIEW_SEGMENTED_TRACK } from "@/lib/ui/overview/moduleOverviewSegmentedTrackMetrics";
-import { SegmentedZoneTrack } from "@/lib/ui/primitives/SegmentedZoneTrack";
-import { workoutOverviewInCardHeaderStyles } from "@/lib/ui/workouts/workoutOverviewInCardHeaderStyles";
+import { ActivityRatingPill } from "@/lib/ui/activity/ActivityRatingPill";
 import { ErrorState, LoadingState } from "@/lib/ui/ScreenStates";
 import { elevatedCardSurfaceStyle } from "@/lib/ui/theme/elevatedCardSurface";
-
-/** Neutral marker fill — same elevated dot treatment as Strength overview (not tier-colored). */
-const ACTIVITY_OVERVIEW_MARKER_FILL = "#1F2937";
+import { getStepRating, getStepRatingTierIndex, stepsFromLocaleDigitString } from "@/lib/utils/activityStepRating";
 
 type ActivityOverviewCardProps = {
   loading: boolean;
@@ -19,26 +18,22 @@ type ActivityOverviewCardProps = {
   model: ActivityOverviewCardModel | null;
 };
 
-function clamp01(x: number): number {
-  if (!Number.isFinite(x) || x <= 0) return 0;
-  if (x >= 1) return 1;
-  return x;
+/**
+ * View-only: model still ships `…/day`; strip suffix for large figure (matches Today’s Steps digit treatment).
+ */
+function overviewRowFigureDisplay(compactStatsSummary: string): { numeric: true; digits: string } | { numeric: false; text: string } {
+  const s = compactStatsSummary.trim();
+  const m = s.match(/^([\d,]+)\/day$/);
+  if (m) return { numeric: true, digits: m[1]! };
+  return { numeric: false, text: s };
 }
 
-function ActivityOverviewPlacementTrack({ testID, markerPosition01 }: { testID: string; markerPosition01: number }) {
-  const marker01 = clamp01(markerPosition01);
-  const pct = Math.round(marker01 * 100);
+function ActivityOverviewTierProgressTrack({ testID, tierIndex }: { testID: string; tierIndex: number | null }) {
+  const pct = activityTierProgressAccessibilityPercent(tierIndex);
   return (
-    <SegmentedZoneTrack
-      zoneColors={MODULE_OVERVIEW_SEGMENT_ZONE_FILLS}
+    <ActivityTierProgressTrack
       testID={testID}
-      markerPosition01={marker01}
-      showMarker
-      markerBackgroundColor={ACTIVITY_OVERVIEW_MARKER_FILL}
-      markerStyle="elevated"
-      dotSize={MODULE_OVERVIEW_SEGMENTED_TRACK.dotSize}
-      barHeight={MODULE_OVERVIEW_SEGMENTED_TRACK.barHeight}
-      trackRadius={MODULE_OVERVIEW_SEGMENTED_TRACK.trackRadius}
+      tierIndex={tierIndex}
       wrapperProps={{
         accessibilityRole: "progressbar",
         accessibilityValue: { now: pct, min: 0, max: 100 },
@@ -48,16 +43,11 @@ function ActivityOverviewPlacementTrack({ testID, markerPosition01 }: { testID: 
 }
 
 /**
- * Activity Overview — visual family aligned with StrengthOverviewCard (card shell, row rhythm, segmented bar).
- * No rating pills: steps use neutral placement bands only (dash recap geometry), not Strength consistency tiers.
+ * Activity overview rows — fixed-tier step bars and rating pills (no section title; spacing via card gap).
  */
 export function ActivityOverviewCard({ loading, error, model }: ActivityOverviewCardProps) {
   return (
     <View style={styles.card}>
-      <View style={[styles.headerRow, workoutOverviewInCardHeaderStyles.row]}>
-        <Text style={workoutOverviewInCardHeaderStyles.title}>Overview</Text>
-      </View>
-
       {loading ? <LoadingState variant="inline" message="Loading steps…" /> : null}
       {!loading && error != null ? (
         <ErrorState
@@ -70,23 +60,42 @@ export function ActivityOverviewCard({ loading, error, model }: ActivityOverview
       {!loading && model != null ? (
         <View style={moduleOverviewMetricLayoutStyles.metricGroups}>
           {model.timeframes.map((tf) => {
-            const a11y = `${tf.label}. ${tf.compactStatsSummary}.`;
+            const figure = overviewRowFigureDisplay(tf.compactStatsSummary);
+            const rowSteps = figure.numeric ? stepsFromLocaleDigitString(figure.digits) : null;
+            const rating = rowSteps != null ? getStepRating(rowSteps) : null;
+            const tierIndex = rowSteps != null ? getStepRatingTierIndex(rowSteps) : null;
+            const a11y =
+              rating != null
+                ? `${tf.label}. ${rating.label}. ${tf.compactStatsSummary}.`
+                : `${tf.label}. ${tf.compactStatsSummary}.`;
             return (
-              <View key={tf.key} style={moduleOverviewMetricLayoutStyles.metricBlock} accessibilityLabel={a11y} accessible>
+              <View key={tf.key} style={moduleOverviewMetricLayoutStyles.metricBlock} accessible accessibilityLabel={a11y}>
                 <View style={moduleOverviewMetricLayoutStyles.topRow}>
-                  <View style={styles.leftSummary}>
-                    <Text style={styles.timeframeLabel} numberOfLines={1}>
+                  <View style={styles.labelPillCluster}>
+                    <Text style={styles.rowLabel} numberOfLines={1}>
                       {tf.label}
                     </Text>
-                    <Text style={styles.resultSummary} numberOfLines={1} ellipsizeMode="tail">
-                      {tf.compactStatsSummary}
-                    </Text>
+                    {rating != null ? (
+                      <ActivityRatingPill
+                        label={rating.label}
+                        color={rating.color}
+                        backgroundColor={rating.backgroundColor}
+                        emphasis="subtle"
+                        testID={`activity-overview-rating-${tf.key}`}
+                      />
+                    ) : null}
                   </View>
+                  {figure.numeric ? (
+                    <Text style={styles.rowFigure} numberOfLines={1}>
+                      {figure.digits}
+                    </Text>
+                  ) : (
+                    <Text style={styles.rowNonNumeric} numberOfLines={1} ellipsizeMode="tail">
+                      {figure.text}
+                    </Text>
+                  )}
                 </View>
-                <ActivityOverviewPlacementTrack
-                  testID={`activity-overview-steps-bar-${tf.key}`}
-                  markerPosition01={tf.markerPosition01}
-                />
+                <ActivityOverviewTierProgressTrack testID={`activity-overview-steps-bar-${tf.key}`} tierIndex={tierIndex} />
               </View>
             );
           })}
@@ -96,6 +105,7 @@ export function ActivityOverviewCard({ loading, error, model }: ActivityOverview
   );
 }
 
+/** Matches Today’s Steps card title / step figure sizing (see ActivityDailyDetailsCard). */
 const styles = StyleSheet.create({
   card: {
     backgroundColor: "#FFFFFF",
@@ -104,31 +114,35 @@ const styles = StyleSheet.create({
     gap: 12,
     ...elevatedCardSurfaceStyle,
   },
-  headerRow: {
-    alignItems: "flex-start",
-    paddingBottom: 2,
-  },
-  leftSummary: {
+  labelPillCluster: {
     flex: 1,
     minWidth: 0,
     flexDirection: "row",
     alignItems: "center",
-    gap: 10,
-    paddingRight: 8,
+    gap: 8,
   },
-  timeframeLabel: {
-    fontSize: 15,
+  rowLabel: {
+    flexShrink: 1,
+    minWidth: 0,
+    fontSize: 21,
     fontWeight: "600",
-    color: "#6E6E73",
-    letterSpacing: -0.12,
+    color: "#1C1C1E",
+    letterSpacing: -0.38,
+  },
+  rowFigure: {
+    fontSize: 23,
+    fontWeight: "700",
+    color: "#1C1C1E",
+    letterSpacing: -0.42,
     flexShrink: 0,
   },
-  resultSummary: {
-    flex: 1,
-    minWidth: 0,
-    fontSize: 14,
+  rowNonNumeric: {
+    flexShrink: 1,
+    maxWidth: "52%",
+    fontSize: 15,
     fontWeight: "600",
-    color: "#3C3C43",
-    letterSpacing: -0.15,
+    color: "#8E8E93",
+    letterSpacing: -0.12,
+    textAlign: "right",
   },
 });

--- a/lib/ui/activity/ActivityRatingPill.tsx
+++ b/lib/ui/activity/ActivityRatingPill.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import { Platform, StyleSheet, Text, View } from "react-native";
+
+export type ActivityRatingPillProps = {
+  label: string;
+  /** Text color (darker / tier hue). */
+  color: string;
+  /** Soft background fill. */
+  backgroundColor: string;
+  /** Smaller, quieter chrome for Activity tier labels (bars carry color). */
+  emphasis?: "default" | "subtle";
+  testID?: string;
+};
+
+/**
+ * Capsule for the active step tier (Today’s Steps + Overview rows).
+ * Layout is static (no scale/opacity animation) so labels never clip in flex rows.
+ */
+export function ActivityRatingPill({
+  label,
+  color,
+  backgroundColor,
+  emphasis = "default",
+  testID,
+}: ActivityRatingPillProps) {
+  const subtle = emphasis === "subtle";
+  const os = typeof Platform !== "undefined" && Platform.OS != null ? Platform.OS : "ios";
+  const subtleLift =
+    subtle && os === "ios"
+      ? {
+          shadowColor: "#000000",
+          shadowOffset: { width: 0, height: 1 },
+          shadowOpacity: 0.06,
+          shadowRadius: 2,
+        }
+      : subtle && os === "android"
+        ? { elevation: 1 }
+        : {};
+
+  return (
+    <View
+      style={[
+        styles.shell,
+        subtle ? styles.shellSubtle : null,
+        subtleLift,
+        {
+          backgroundColor,
+          borderColor: subtle ? withAlphaFromHex(color, 0.28) : withAlphaFromHex(color, 0.22),
+          borderWidth: subtle ? 1 : StyleSheet.hairlineWidth,
+        },
+      ]}
+    >
+      <Text style={[subtle ? styles.textSubtle : styles.text, { color }]} numberOfLines={1} testID={testID}>
+        {label}
+      </Text>
+    </View>
+  );
+}
+
+function withAlphaFromHex(hex: string, alpha: number): string {
+  const h = hex.replace("#", "").trim();
+  if (h.length !== 6) return `rgba(60, 60, 67, ${alpha * 0.35})`;
+  const r = Number.parseInt(h.slice(0, 2), 16);
+  const g = Number.parseInt(h.slice(2, 4), 16);
+  const b = Number.parseInt(h.slice(4, 6), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+const styles = StyleSheet.create({
+  shell: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    minHeight: 30,
+    justifyContent: "center",
+    borderRadius: 9999,
+    flexShrink: 0,
+    alignSelf: "flex-start",
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  shellSubtle: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    minHeight: 30,
+  },
+  text: {
+    fontSize: 12,
+    fontWeight: "600",
+    letterSpacing: 0.2,
+  },
+  textSubtle: {
+    fontSize: 13,
+    fontWeight: "700",
+    letterSpacing: -0.05,
+  },
+});

--- a/lib/ui/activity/ActivityStepRatingsCard.tsx
+++ b/lib/ui/activity/ActivityStepRatingsCard.tsx
@@ -1,0 +1,179 @@
+import { Ionicons } from "@expo/vector-icons";
+import React, { useCallback, useState } from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+
+import { elevatedCardSurfaceStyle } from "@/lib/ui/theme/elevatedCardSurface";
+import { ACTIVITY_STEP_TIER_KEYS, STEP_TIER_COLORS } from "@/lib/utils/activityStepTierVisual";
+
+const CHEVRON_SIZE = 22;
+const CHEVRON_COLOR = "#8E8E93";
+const TIER_DOT_SIZE = 7;
+
+/** Display-only legend lines (thresholds unchanged in {@link activityStepRating}). */
+const STEP_RATINGS_TIER_LEGEND_ROWS: readonly { label: string; range: string; meaning: string }[] = [
+  { label: "Low", range: "under 5,000", meaning: "Sedentary" },
+  { label: "Below Avg", range: "5,000\u20137,499", meaning: "Lightly active" },
+  { label: "Average", range: "7,500\u20139,999", meaning: "Moderately active" },
+  { label: "Good", range: "10,000\u201312,499", meaning: "Active" },
+  { label: "Great", range: "12,500\u201314,999", meaning: "Very active" },
+  { label: "Elite", range: "15,000+", meaning: "Highly active" },
+] as const;
+
+const STEP_RATINGS_EXPLAINER_BODY =
+  "Your daily step count reflects your overall activity level. Consistently higher steps support cardiovascular fitness, energy, and long-term health.";
+
+function rangeForA11y(range: string): string {
+  return range.replace(/\u2013/g, " to ");
+}
+
+/**
+ * Collapsible static tier legend — text rows + tier-color dots (no progress bar).
+ */
+export function ActivityStepRatingsCard() {
+  const [expanded, setExpanded] = useState(false);
+  const toggle = useCallback(() => {
+    setExpanded((v) => !v);
+  }, []);
+
+  return (
+    <View style={styles.card}>
+      <View style={styles.headerRow}>
+        <Text style={styles.title} numberOfLines={1}>
+          Step Ratings
+        </Text>
+        <Pressable
+          testID="activity-step-ratings-toggle"
+          onPress={toggle}
+          accessibilityRole="button"
+          accessibilityLabel={expanded ? "Collapse step ratings" : "Expand step ratings"}
+          accessibilityState={{ expanded }}
+          hitSlop={12}
+          style={({ pressed }) => [styles.toggleHit, pressed && styles.togglePressed]}
+        >
+          <Ionicons
+            name={expanded ? "chevron-up" : "chevron-down"}
+            size={CHEVRON_SIZE}
+            color={CHEVRON_COLOR}
+          />
+        </Pressable>
+      </View>
+
+      {expanded ? (
+        <View style={styles.expandedBlock}>
+          <Text style={styles.body}>{STEP_RATINGS_EXPLAINER_BODY}</Text>
+
+          <View style={styles.tierList} accessibilityRole="list" testID="activity-step-ratings-tier-list">
+            {STEP_RATINGS_TIER_LEGEND_ROWS.map((row, i) => {
+              const tierKey = ACTIVITY_STEP_TIER_KEYS[i]!;
+              return (
+                <View
+                  key={row.label}
+                  style={styles.tierRow}
+                  testID={`activity-step-ratings-tier-${i}`}
+                  accessible
+                  accessibilityRole="text"
+                  accessibilityLabel={`${row.label}, ${rangeForA11y(row.range)}, ${row.meaning}`}
+                >
+                  <View
+                    style={[styles.tierDot, { backgroundColor: STEP_TIER_COLORS[tierKey] }]}
+                    testID={`activity-step-ratings-tier-dot-${i}`}
+                    accessibilityElementsHidden
+                    importantForAccessibility="no"
+                  />
+                  <Text style={styles.tierLine} numberOfLines={2}>
+                    <Text style={styles.tierLabel}>{row.label}</Text>
+                    <Text style={styles.tierMeta}>
+                      {" \u2014 "}
+                      {row.range}
+                      {" \u2014 "}
+                      {row.meaning}
+                    </Text>
+                  </Text>
+                </View>
+              );
+            })}
+          </View>
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: "#FFFFFF",
+    borderRadius: 12,
+    padding: 16,
+    gap: 0,
+    ...elevatedCardSurfaceStyle,
+  },
+  title: {
+    flex: 1,
+    minWidth: 0,
+    fontSize: 21,
+    fontWeight: "600",
+    color: "#1C1C1E",
+    letterSpacing: -0.38,
+  },
+  headerRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 12,
+  },
+  toggleHit: {
+    minWidth: 44,
+    minHeight: 44,
+    marginRight: -8,
+    marginVertical: -6,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  togglePressed: {
+    opacity: 0.55,
+  },
+  expandedBlock: {
+    gap: 18,
+    marginTop: 14,
+  },
+  body: {
+    fontSize: 16,
+    fontWeight: "400",
+    color: "#48484A",
+    letterSpacing: -0.22,
+    lineHeight: 24,
+  },
+  tierList: {
+    gap: 16,
+    marginTop: 4,
+  },
+  tierRow: {
+    minWidth: 0,
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: 10,
+  },
+  tierDot: {
+    width: TIER_DOT_SIZE,
+    height: TIER_DOT_SIZE,
+    borderRadius: TIER_DOT_SIZE / 2,
+    marginTop: 6,
+    flexShrink: 0,
+  },
+  tierLine: {
+    flex: 1,
+    fontSize: 15,
+    letterSpacing: -0.12,
+    lineHeight: 23,
+  },
+  tierLabel: {
+    fontSize: 15,
+    fontWeight: "600",
+    color: "#1C1C1E",
+  },
+  tierMeta: {
+    fontSize: 15,
+    fontWeight: "400",
+    color: "#48484A",
+  },
+});

--- a/lib/ui/activity/ActivityTierProgressTrack.tsx
+++ b/lib/ui/activity/ActivityTierProgressTrack.tsx
@@ -1,0 +1,225 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { Animated, Easing, Platform, StyleSheet, View, type ViewProps } from "react-native";
+
+import { useActivityReduceMotion } from "@/lib/ui/activity/useActivityReduceMotion";
+import {
+  STEP_TIER_TRACK_INNER_BACKGROUND,
+  STEP_TIER_TRACK_RIM_BORDER,
+  activityStepTierBarVisual,
+} from "@/lib/utils/activityStepTierVisual";
+import { MODULE_OVERVIEW_SEGMENTED_TRACK } from "@/lib/ui/overview/moduleOverviewSegmentedTrackMetrics";
+
+const DEFAULT_BAR_HEIGHT = MODULE_OVERVIEW_SEGMENTED_TRACK.barHeight;
+const DEFAULT_TRACK_RADIUS = MODULE_OVERVIEW_SEGMENTED_TRACK.trackRadius;
+
+const EASE_OUT = Easing.out(Easing.cubic);
+const DURATION_WIDTH_MS = 260;
+const DURATION_COLOR_MS = 280;
+
+export type ActivityTierProgressTrackProps = {
+  testID?: string;
+  /** Tier 0–5 from {@link getStepRatingTierIndex}; `null` → empty bar (non-numeric / insufficient row). */
+  tierIndex: number | null;
+  barHeight?: number;
+  trackRadius?: number;
+  wrapperProps?: Omit<ViewProps, "children" | "onLayout" | "testID" | "style"> & {
+    style?: ViewProps["style"];
+  };
+};
+
+/**
+ * Single-color tier fill at fixed width ({@link STEP_TIER_FILL}); neutral track; no marker.
+ * Width and fill color animate subtly on tier changes (respects reduce motion).
+ */
+export function ActivityTierProgressTrack({
+  testID,
+  tierIndex,
+  barHeight = DEFAULT_BAR_HEIGHT,
+  trackRadius = DEFAULT_TRACK_RADIUS,
+  wrapperProps,
+}: ActivityTierProgressTrackProps) {
+  const reduceMotion = useActivityReduceMotion();
+  const visual = activityStepTierBarVisual(tierIndex);
+  const targetFill01 = visual?.fill01 ?? 0;
+  const targetColor = visual?.fillColor ?? "rgba(0,0,0,0)";
+
+  const fill01Anim = useRef(new Animated.Value(targetFill01)).current;
+  const colorBlend = useRef(new Animated.Value(1)).current;
+  const [colorPair, setColorPair] = useState<[string, string]>(() => [targetColor, targetColor]);
+  const mounted = useRef(false);
+  const animGeneration = useRef(0);
+  const endColorRef = useRef(targetColor);
+
+  useEffect(() => {
+    const duration = reduceMotion ? 0 : DURATION_WIDTH_MS;
+    const colorDuration = reduceMotion ? 0 : DURATION_COLOR_MS;
+    const gen = ++animGeneration.current;
+
+    if (!mounted.current) {
+      mounted.current = true;
+      fill01Anim.setValue(targetFill01);
+      colorBlend.setValue(1);
+      setColorPair([targetColor, targetColor]);
+      endColorRef.current = targetColor;
+      return undefined;
+    }
+
+    if (tierIndex == null) {
+      fill01Anim.setValue(0);
+      colorBlend.setValue(1);
+      return undefined;
+    }
+
+    const fromColor = endColorRef.current;
+    const sameHue = fromColor === targetColor;
+
+    setColorPair([fromColor, targetColor]);
+    if (sameHue || reduceMotion) {
+      colorBlend.setValue(1);
+    } else {
+      colorBlend.setValue(0);
+    }
+
+    const widthAnim = Animated.timing(fill01Anim, {
+      toValue: targetFill01,
+      duration,
+      easing: EASE_OUT,
+      useNativeDriver: false,
+    });
+
+    const colorAnim =
+      sameHue || reduceMotion
+        ? null
+        : Animated.timing(colorBlend, {
+            toValue: 1,
+            duration: colorDuration,
+            easing: EASE_OUT,
+            useNativeDriver: false,
+          });
+
+    const anim = colorAnim != null ? Animated.parallel([widthAnim, colorAnim]) : widthAnim;
+
+    anim.start(({ finished }) => {
+      if (finished && gen === animGeneration.current) {
+        endColorRef.current = targetColor;
+      }
+    });
+
+    return () => {
+      anim.stop();
+    };
+  }, [tierIndex, targetFill01, targetColor, reduceMotion, fill01Anim, colorBlend]);
+
+  const fillWidthStyle = useMemo(
+    () => ({
+      width: fill01Anim.interpolate({
+        inputRange: [0, 1],
+        outputRange: ["0%", "100%"],
+      }),
+    }),
+    [fill01Anim],
+  );
+
+  const fillColorStyle = useMemo(
+    () => ({
+      backgroundColor: colorBlend.interpolate({
+        inputRange: [0, 1],
+        outputRange: colorPair,
+      }),
+    }),
+    [colorBlend, colorPair],
+  );
+
+  const os = typeof Platform !== "undefined" && Platform.OS != null ? Platform.OS : "ios";
+  const rimShadow =
+    os === "ios"
+      ? {
+          shadowColor: "#000000",
+          shadowOffset: { width: 0, height: 1 },
+          shadowOpacity: 0.05,
+          shadowRadius: 2,
+        }
+      : os === "android"
+        ? { elevation: 1 }
+        : {};
+
+  const { style: wrapperStyle, ...wrapperRest } = wrapperProps ?? {};
+
+  return (
+    <View
+      {...wrapperRest}
+      {...(testID != null ? { testID } : {})}
+      style={[styles.trackWrap, { height: barHeight }, wrapperStyle]}
+    >
+      <View
+        style={[
+          styles.trackRim,
+          {
+            height: barHeight,
+            borderRadius: trackRadius,
+            borderColor: STEP_TIER_TRACK_RIM_BORDER,
+            ...rimShadow,
+          },
+        ]}
+        importantForAccessibility="no"
+      >
+        <View
+          style={[
+            styles.trackInner,
+            {
+              borderRadius: trackRadius,
+              height: barHeight,
+              backgroundColor: STEP_TIER_TRACK_INNER_BACKGROUND,
+            },
+          ]}
+          importantForAccessibility="no"
+        >
+          {visual != null ? (
+            <Animated.View
+              style={[
+                styles.fill,
+                fillWidthStyle,
+                fillColorStyle,
+                {
+                  height: barHeight,
+                  borderTopLeftRadius: trackRadius,
+                  borderBottomLeftRadius: trackRadius,
+                  borderTopRightRadius: trackRadius,
+                  borderBottomRightRadius: trackRadius,
+                },
+              ]}
+              importantForAccessibility="no"
+            />
+          ) : null}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+/** Re-export for callers that set `accessibilityValue` on the wrapper (progressbar). */
+export function activityTierProgressAccessibilityPercent(tierIndex: number | null): number {
+  const v = activityStepTierBarVisual(tierIndex);
+  return v != null ? Math.round(v.fill01 * 100) : 0;
+}
+
+const styles = StyleSheet.create({
+  trackWrap: {
+    width: "100%",
+    position: "relative",
+    justifyContent: "center",
+  },
+  trackRim: {
+    borderWidth: StyleSheet.hairlineWidth,
+    backgroundColor: "#FFFFFF",
+  },
+  trackInner: {
+    position: "relative",
+    overflow: "hidden",
+  },
+  fill: {
+    position: "absolute",
+    left: 0,
+    top: 0,
+  },
+});

--- a/lib/ui/activity/ActivityWeeklyStrip.tsx
+++ b/lib/ui/activity/ActivityWeeklyStrip.tsx
@@ -2,9 +2,11 @@ import React from "react";
 import { View } from "react-native";
 
 import type { ActivityDayStripMeta } from "@/lib/data/activity/activityDayStripMeta";
+import { buildActivityCalendarDayModelFromStripMeta } from "@/lib/ui/activity/activityCalendarDayRingPresentation";
 import { CalendarDayCell } from "@/lib/ui/calendar/CalendarDayCell";
 import { calendarStripDayOfMonth, calendarStripDayOfWeekLabel } from "@/lib/ui/calendar/calendarWeeklyStripDayUtils";
 import { calendarWeeklyStripStyles } from "@/lib/ui/calendar/calendarWeeklyStripStyles";
+import { getTodayDayKeyLocal } from "@/lib/ui/calendar/dateUtils";
 import type { CalendarDay } from "@/lib/ui/calendar/types";
 import { ActivityDayRing } from "@/lib/ui/activity/ActivityDayRing";
 
@@ -15,26 +17,33 @@ export type ActivityWeeklyStripProps = {
 };
 
 export function ActivityWeeklyStrip({ days, selectedDay, onDayPress }: ActivityWeeklyStripProps) {
+  const todayKey = getTodayDayKeyLocal();
   return (
     <View style={calendarWeeklyStripStyles.container}>
       <View style={calendarWeeklyStripStyles.row}>
         {days.map((d) => {
-          const hasSteps = d.meta?.hasSteps === true;
+          const meta = d.meta;
           const isSelected = selectedDay === d.day;
+          const isToday = d.day === todayKey;
+          const ringModel = buildActivityCalendarDayModelFromStripMeta({
+            dayKey: d.day,
+            todayKey: todayKey,
+            meta,
+          });
           return (
             <CalendarDayCell
               key={d.day}
               dayOfWeekLabel={calendarStripDayOfWeekLabel(d.day)}
               dayOfMonthLabel={calendarStripDayOfMonth(d.day)}
               isSelected={isSelected}
+              isToday={isToday}
               onPress={() => onDayPress(d.day)}
-              accessibilityLabel={
-                hasSteps ? `${d.day}, steps in daily rollup` : `${d.day}, no steps in daily rollup`
-              }
+              accessibilityLabel={`${d.day}, ${ringModel.accessibilityDetail}`}
+              emphasizeSelectedTypography
               ring={
                 <ActivityDayRing
                   size={40}
-                  hasSteps={hasSteps}
+                  presentation={ringModel.presentation}
                   emphasized={isSelected}
                   outerTestID={`activity-weekly-outer-ring-${d.day}`}
                 />

--- a/lib/ui/activity/__tests__/ActivityDailyDetailsCard.test.tsx
+++ b/lib/ui/activity/__tests__/ActivityDailyDetailsCard.test.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import renderer, { act } from "react-test-renderer";
+
+import { ActivityDailyDetailsCard } from "@/lib/ui/activity/ActivityDailyDetailsCard";
+
+jest.mock("@expo/vector-icons", () => ({
+  Ionicons: () => null,
+}));
+
+describe("ActivityDailyDetailsCard", () => {
+  it("shows numeric row without aggregate rollup warning when error is null", () => {
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(
+        <ActivityDailyDetailsCard
+          loading={false}
+          error={null}
+          model={{
+            title: "Today",
+            compactStatsSummary: "148 steps",
+            markerPosition01: 0.2,
+          }}
+        />,
+      );
+    });
+    const str = JSON.stringify(tree.toJSON());
+    expect(str).toContain("148");
+    expect(str).toContain("Low");
+    expect(str).not.toMatch(/148 steps/);
+    expect(str).not.toContain("Couldn’t load steps for");
+    expect(str).toContain("activity-daily-details-steps-bar");
+  });
+
+  it("shows selected-day inline error when that day failed and model is absent", () => {
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(
+        <ActivityDailyDetailsCard
+          loading={false}
+          error={{ message: "Today fetch failed", requestId: "r1", onRetry: jest.fn() }}
+          model={null}
+        />,
+      );
+    });
+    const str = JSON.stringify(tree.toJSON());
+    expect(str).toContain("Today fetch failed");
+    expect(str).not.toContain("148 steps");
+  });
+
+  it("does not duplicate overview-style partial failure copy when props omit aggregate error", () => {
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(
+        <ActivityDailyDetailsCard
+          loading={false}
+          error={null}
+          model={{ title: "Today", compactStatsSummary: "1,234 steps", markerPosition01: 0.1 }}
+        />,
+      );
+    });
+    expect(JSON.stringify(tree.toJSON())).not.toContain("Other days may still show");
+  });
+});

--- a/lib/ui/activity/__tests__/ActivityOverviewCard.test.tsx
+++ b/lib/ui/activity/__tests__/ActivityOverviewCard.test.tsx
@@ -15,7 +15,7 @@ describe("ActivityOverviewCard", () => {
     });
     const str = JSON.stringify(tree.toJSON());
     expect(str).toContain("Loading steps");
-    expect(str).not.toContain("activity-overview-steps-bar-today");
+    expect(str).not.toContain("activity-overview-steps-bar-day7");
   });
 
   it("shows error inline together with model when both are set", () => {
@@ -28,9 +28,9 @@ describe("ActivityOverviewCard", () => {
           model={{
             timeframes: [
               {
-                key: "today",
-                label: "Today",
-                compactStatsSummary: "100 steps",
+                key: "day7",
+                label: "7 Day",
+                compactStatsSummary: "100/day",
                 markerPosition01: 0.1,
               },
             ],
@@ -40,7 +40,8 @@ describe("ActivityOverviewCard", () => {
     });
     const str = JSON.stringify(tree.toJSON());
     expect(str).toContain("partial failure");
-    expect(str).toContain("activity-overview-steps-bar-today");
+    expect(str).toContain("100");
+    expect(str).toContain("activity-overview-steps-bar-day7");
   });
 
   it("shows error inline when error is set and model is null", () => {
@@ -68,9 +69,9 @@ describe("ActivityOverviewCard", () => {
           model={{
             timeframes: [
               {
-                key: "today",
-                label: "Today",
-                compactStatsSummary: "100 steps",
+                key: "day7",
+                label: "7 Day",
+                compactStatsSummary: "100/day",
                 markerPosition01: 0.1,
               },
             ],
@@ -78,15 +79,35 @@ describe("ActivityOverviewCard", () => {
         />,
       );
     });
+    const str = JSON.stringify(tree.toJSON());
+    expect(str).toContain("100");
+    expect(str).toContain("activity-overview-steps-bar-day7");
+    expect(str).toContain("Low");
+    expect(str).not.toContain("Optimal");
+    expect(str).not.toContain("Overview");
+  });
+
+  it("renders Not enough data copy when model supplies it", () => {
+    let tree!: renderer.ReactTestRenderer;
     act(() => {
-      tree.root
-        .findAllByProps({ testID: "activity-overview-steps-bar-today" })
-        .find((n) => typeof n.props.onLayout === "function")
-        ?.props.onLayout({ nativeEvent: { layout: { width: 320 } } });
+      tree = renderer.create(
+        <ActivityOverviewCard
+          loading={false}
+          error={null}
+          model={{
+            timeframes: [
+              {
+                key: "ytd",
+                label: "YTD",
+                compactStatsSummary: "Not enough data",
+                markerPosition01: 0,
+              },
+            ],
+          }}
+        />,
+      );
     });
     const str = JSON.stringify(tree.toJSON());
-    expect(str).toContain("activity-overview-steps-bar-today");
-    expect(str).not.toContain("Low");
-    expect(str).not.toContain("Optimal");
+    expect(str).toContain("Not enough data");
   });
 });

--- a/lib/ui/activity/__tests__/ActivityStepRatingsCard.test.tsx
+++ b/lib/ui/activity/__tests__/ActivityStepRatingsCard.test.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import renderer, { act } from "react-test-renderer";
+
+import { ActivityStepRatingsCard } from "@/lib/ui/activity/ActivityStepRatingsCard";
+
+jest.mock("@expo/vector-icons", () => ({
+  Ionicons: () => null,
+}));
+
+describe("ActivityStepRatingsCard", () => {
+  it("starts collapsed: header only, no tier list or progress bar", () => {
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<ActivityStepRatingsCard />);
+    });
+    const str = JSON.stringify(tree.toJSON());
+    expect(str).toContain("Step Ratings");
+    expect(str).toContain("activity-step-ratings-toggle");
+    expect(str).not.toContain("Your daily step count reflects your overall activity level");
+    expect(str).not.toContain("activity-step-ratings-tier-list");
+    expect(str).not.toContain("activity-step-ratings-track");
+  });
+
+  it("expands to explainer, tier rows, and color dots (no progress bar)", () => {
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<ActivityStepRatingsCard />);
+    });
+    const toggle = tree.root.findByProps({ testID: "activity-step-ratings-toggle" });
+    act(() => {
+      toggle.props.onPress();
+    });
+    const str = JSON.stringify(tree.toJSON());
+    expect(str).toContain("Your daily step count reflects your overall activity level");
+    expect(str).toContain("activity-step-ratings-tier-list");
+    expect(str).toContain("activity-step-ratings-tier-0");
+    expect(str).toContain("activity-step-ratings-tier-dot-0");
+    expect(str).toContain("under 5,000");
+    expect(str).not.toContain("activity-step-ratings-track");
+  });
+});

--- a/lib/ui/activity/__tests__/activityCalendarDayRingPresentation.test.ts
+++ b/lib/ui/activity/__tests__/activityCalendarDayRingPresentation.test.ts
@@ -1,0 +1,139 @@
+import {
+  buildActivityCalendarDayModelFromRollup,
+  buildActivityCalendarDayModelFromStripMeta,
+  resolveActivityCalendarDayRingPresentation,
+} from "@/lib/ui/activity/activityCalendarDayRingPresentation";
+
+describe("resolveActivityCalendarDayRingPresentation", () => {
+  const today = "2026-04-15";
+
+  it("uses rollup tier for past completed days only", () => {
+    expect(
+      resolveActivityCalendarDayRingPresentation({
+        dayKey: "2026-04-10",
+        todayKey: today,
+        rollupReady: true,
+        tierSource: "rollup",
+        rollupEntry: { kind: "numeric", steps: 10_000 },
+      }),
+    ).toEqual({ kind: "tier", tierIndex: 3 });
+  });
+
+  it("uses current-day no-ring for today even with high rollup steps", () => {
+    expect(
+      resolveActivityCalendarDayRingPresentation({
+        dayKey: today,
+        todayKey: today,
+        rollupReady: true,
+        tierSource: "rollup",
+        rollupEntry: { kind: "numeric", steps: 20_000 },
+      }),
+    ).toEqual({ kind: "currentDayNoRing" });
+  });
+
+  it("hides rings for future days", () => {
+    expect(
+      resolveActivityCalendarDayRingPresentation({
+        dayKey: "2026-04-20",
+        todayKey: today,
+        rollupReady: true,
+        tierSource: "rollup",
+        rollupEntry: { kind: "numeric", steps: 12_000 },
+      }),
+    ).toEqual({ kind: "hidden" });
+  });
+
+  it("neutral fallback for past day without valid numeric steps", () => {
+    expect(
+      resolveActivityCalendarDayRingPresentation({
+        dayKey: "2026-04-10",
+        todayKey: today,
+        rollupReady: true,
+        tierSource: "rollup",
+        rollupEntry: { kind: "numeric", steps: 0 },
+      }),
+    ).toEqual({ kind: "neutralFallback" });
+  });
+
+  it("strip tier ignores rollupReady (meta-driven only)", () => {
+    expect(
+      resolveActivityCalendarDayRingPresentation({
+        dayKey: "2026-04-14",
+        todayKey: today,
+        rollupReady: false,
+        tierSource: "strip",
+        completedPastTierIndex: 2,
+      }),
+    ).toEqual({ kind: "tier", tierIndex: 2 });
+  });
+});
+
+describe("buildActivityCalendarDayModelFromRollup", () => {
+  const today = "2026-04-15";
+
+  it("labels today without tier name", () => {
+    const m = buildActivityCalendarDayModelFromRollup({
+      dayKey: today,
+      todayKey: today,
+      rollupReady: true,
+      rollupEntry: { kind: "numeric", steps: 9000 },
+    });
+    expect(m.presentation).toEqual({ kind: "currentDayNoRing" });
+    expect(m.accessibilityDetail).toBe("today, steps in daily rollup");
+  });
+
+  it("labels today with no positive rollup steps as current day", () => {
+    const m = buildActivityCalendarDayModelFromRollup({
+      dayKey: today,
+      todayKey: today,
+      rollupReady: true,
+      rollupEntry: { kind: "numeric", steps: 0 },
+    });
+    expect(m.presentation).toEqual({ kind: "currentDayNoRing" });
+    expect(m.accessibilityDetail).toBe("today, current day");
+  });
+
+  it("labels past tier days with rating name", () => {
+    const m = buildActivityCalendarDayModelFromRollup({
+      dayKey: "2026-04-14",
+      todayKey: today,
+      rollupReady: true,
+      rollupEntry: { kind: "numeric", steps: 9000 },
+    });
+    expect(m.presentation).toEqual({ kind: "tier", tierIndex: 2 });
+    expect(m.accessibilityDetail).toBe("Average, steps in daily rollup");
+  });
+});
+
+describe("buildActivityCalendarDayModelFromStripMeta", () => {
+  const today = "2026-04-15";
+
+  it("ignores strip tier index on today", () => {
+    const m = buildActivityCalendarDayModelFromStripMeta({
+      dayKey: today,
+      todayKey: today,
+      meta: { hasSteps: true, ringTierIndex: 0 },
+    });
+    expect(m.presentation).toEqual({ kind: "currentDayNoRing" });
+    expect(m.accessibilityDetail).toBe("today, steps in daily rollup");
+  });
+
+  it("strip today without steps uses current-day copy", () => {
+    const m = buildActivityCalendarDayModelFromStripMeta({
+      dayKey: today,
+      todayKey: today,
+      meta: { hasSteps: false, ringTierIndex: null },
+    });
+    expect(m.presentation).toEqual({ kind: "currentDayNoRing" });
+    expect(m.accessibilityDetail).toBe("today, current day");
+  });
+
+  it("uses strip tier index for completed past days", () => {
+    const m = buildActivityCalendarDayModelFromStripMeta({
+      dayKey: "2026-04-14",
+      todayKey: today,
+      meta: { hasSteps: true, ringTierIndex: 4 },
+    });
+    expect(m.presentation).toEqual({ kind: "tier", tierIndex: 4 });
+  });
+});

--- a/lib/ui/activity/activityCalendarDayRingPresentation.ts
+++ b/lib/ui/activity/activityCalendarDayRingPresentation.ts
@@ -1,0 +1,133 @@
+import { ACTIVITY_STEP_RATING_TIERS, getStepRatingTierIndex } from "@/lib/utils/activityStepRating";
+
+/** Rollup slice used only to derive tier-colored rings (same thresholds as everywhere else). */
+export type ActivityRollupEntryLike = { kind: string; steps?: number } | undefined;
+
+/**
+ * Single source of truth for Activity weekly strip + full-calendar month rings.
+ * Today is never tier-colored (rollup ≠ live Today card); past completed days use tier fill.
+ */
+export type ActivityDayRingPresentation =
+  | { kind: "hidden" }
+  | { kind: "tier"; tierIndex: number }
+  /** Today: no ring — circle chrome matches Strength weekly strip (header-chrome gray fill). */
+  | { kind: "currentDayNoRing" }
+  | { kind: "neutralFallback" };
+
+export type ActivityCalendarDayRingModel = {
+  presentation: ActivityDayRingPresentation;
+  /** Shown after `YYYY-MM-DD, ` in the day cell accessibilityLabel. */
+  accessibilityDetail: string;
+};
+
+const TIER_COUNT = ACTIVITY_STEP_RATING_TIERS.length;
+
+function rollupEntryForTodayStrip(
+  meta: { hasSteps?: boolean; ringTierIndex: number | null } | undefined,
+): ActivityRollupEntryLike {
+  if (meta?.hasSteps === true) return { kind: "numeric", steps: 1 };
+  return undefined;
+}
+
+function accessibilityDetailForPresentation(
+  presentation: ActivityDayRingPresentation,
+  rollupEntryForToday: ActivityRollupEntryLike,
+): string {
+  switch (presentation.kind) {
+    case "hidden":
+      return "future day";
+    case "currentDayNoRing": {
+      const has =
+        rollupEntryForToday != null &&
+        rollupEntryForToday.kind === "numeric" &&
+        (rollupEntryForToday.steps ?? 0) > 0;
+      return has ? "today, steps in daily rollup" : "today, current day";
+    }
+    case "neutralFallback":
+      return "no steps in daily rollup";
+    case "tier": {
+      const label = ACTIVITY_STEP_RATING_TIERS[presentation.tierIndex]!.label;
+      return `${label}, steps in daily rollup`;
+    }
+  }
+}
+
+export function resolveActivityCalendarDayRingPresentation(
+  params:
+    | {
+        dayKey: string;
+        todayKey: string;
+        rollupReady: boolean;
+        tierSource: "rollup";
+        rollupEntry: ActivityRollupEntryLike;
+      }
+    | {
+        dayKey: string;
+        todayKey: string;
+        rollupReady: boolean;
+        tierSource: "strip";
+        completedPastTierIndex: number | null;
+      },
+): ActivityDayRingPresentation {
+  const { dayKey, todayKey } = params;
+  const rollupReady = params.tierSource === "rollup" ? params.rollupReady : true;
+  if (dayKey > todayKey) return { kind: "hidden" };
+  if (dayKey === todayKey) return { kind: "currentDayNoRing" };
+
+  if (params.tierSource === "rollup") {
+    if (!rollupReady) return { kind: "neutralFallback" };
+    const e = params.rollupEntry;
+    const steps = e?.kind === "numeric" ? e.steps : undefined;
+    if (steps == null || !(steps > 0)) return { kind: "neutralFallback" };
+    return { kind: "tier", tierIndex: getStepRatingTierIndex(Math.round(steps)) };
+  }
+
+  const t = params.completedPastTierIndex;
+  if (t != null && t >= 0 && t < TIER_COUNT) return { kind: "tier", tierIndex: t };
+  return { kind: "neutralFallback" };
+}
+
+/** Modal / rollup-backed cells: tier from `rollupEntry` when past + valid numeric steps. */
+export function buildActivityCalendarDayModelFromRollup(params: {
+  dayKey: string;
+  todayKey: string;
+  rollupReady: boolean;
+  rollupEntry: ActivityRollupEntryLike;
+}): ActivityCalendarDayRingModel {
+  const presentation = resolveActivityCalendarDayRingPresentation({
+    dayKey: params.dayKey,
+    todayKey: params.todayKey,
+    rollupReady: params.rollupReady,
+    tierSource: "rollup",
+    rollupEntry: params.rollupEntry,
+  });
+  return {
+    presentation,
+    accessibilityDetail: accessibilityDetailForPresentation(
+      presentation,
+      params.dayKey === params.todayKey ? params.rollupEntry : undefined,
+    ),
+  };
+}
+
+/** Weekly strip: past-day tier from strip meta; today never tier-colored. */
+export function buildActivityCalendarDayModelFromStripMeta(params: {
+  dayKey: string;
+  todayKey: string;
+  meta: { hasSteps?: boolean; ringTierIndex: number | null } | undefined;
+}): ActivityCalendarDayRingModel {
+  const presentation = resolveActivityCalendarDayRingPresentation({
+    dayKey: params.dayKey,
+    todayKey: params.todayKey,
+    rollupReady: true,
+    tierSource: "strip",
+    completedPastTierIndex: params.dayKey < params.todayKey ? params.meta?.ringTierIndex ?? null : null,
+  });
+  return {
+    presentation,
+    accessibilityDetail: accessibilityDetailForPresentation(
+      presentation,
+      params.dayKey === params.todayKey ? rollupEntryForTodayStrip(params.meta) : undefined,
+    ),
+  };
+}

--- a/lib/ui/activity/useActivityReduceMotion.ts
+++ b/lib/ui/activity/useActivityReduceMotion.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from "react";
+import { AccessibilityInfo } from "react-native";
+
+function isJestRuntime(): boolean {
+  return typeof process !== "undefined" && process.env != null && Boolean(process.env.JEST_WORKER_ID);
+}
+
+/**
+ * Mirrors system reduce-motion for subtle Activity tier transitions (width/color/pill).
+ * In Jest, stays `false` and skips async Accessibility work so tests stay deterministic.
+ */
+export function useActivityReduceMotion(): boolean {
+  const [reduceMotion, setReduceMotion] = useState(false);
+
+  useEffect(() => {
+    if (isJestRuntime()) {
+      return undefined;
+    }
+
+    let cancelled = false;
+    void AccessibilityInfo.isReduceMotionEnabled().then((v) => {
+      if (cancelled) return;
+      setReduceMotion(Boolean(v));
+    });
+    const sub = AccessibilityInfo.addEventListener("reduceMotionChanged", (enabled) => {
+      if (cancelled) return;
+      setReduceMotion(Boolean(enabled));
+    });
+    return () => {
+      cancelled = true;
+      sub.remove();
+    };
+  }, []);
+
+  return reduceMotion;
+}

--- a/lib/ui/calendar/CalendarDayCell.tsx
+++ b/lib/ui/calendar/CalendarDayCell.tsx
@@ -7,10 +7,14 @@ export type CalendarDayCellProps = {
   dayOfWeekLabel: string;
   dayOfMonthLabel: string;
   isSelected: boolean;
+  /** Device-local “today” — same light gray circle as Strength strip ({@link calendarWeeklyStripStyles.dayCircleSelected}). */
+  isToday?: boolean;
   onPress: () => void;
   accessibilityLabel: string;
   /** Ring layer (workout / body / nutrition); `null` when the day has no ring. */
   ring: React.ReactNode;
+  /** Slightly stronger weekday + date weight when selected (Activity strip). */
+  emphasizeSelectedTypography?: boolean;
 };
 
 /**
@@ -20,10 +24,14 @@ export function CalendarDayCell({
   dayOfWeekLabel,
   dayOfMonthLabel,
   isSelected,
+  isToday = false,
   onPress,
   accessibilityLabel,
   ring,
+  emphasizeSelectedTypography = false,
 }: CalendarDayCellProps) {
+  const selectedType = emphasizeSelectedTypography && isSelected;
+  const todayOrSelectedCircle = isSelected || isToday;
   return (
     <Pressable
       onPress={onPress}
@@ -36,17 +44,31 @@ export function CalendarDayCell({
         pressed && calendarWeeklyStripStyles.dayCellPressed,
       ]}
     >
-      <Text style={calendarWeeklyStripStyles.dayOfWeek}>{dayOfWeekLabel}</Text>
+      <Text
+        style={[
+          calendarWeeklyStripStyles.dayOfWeek,
+          selectedType && calendarWeeklyStripStyles.dayOfWeekWhenSelected,
+        ]}
+      >
+        {dayOfWeekLabel}
+      </Text>
       <View
         style={[
           calendarWeeklyStripStyles.dayCircle,
-          isSelected && calendarWeeklyStripStyles.dayCircleSelected,
+          todayOrSelectedCircle && calendarWeeklyStripStyles.dayCircleSelected,
         ]}
       >
         <View style={calendarWeeklyStripStyles.dayRingBackdrop} pointerEvents="none">
           {ring}
         </View>
-        <Text style={calendarWeeklyStripStyles.dayNumber}>{dayOfMonthLabel}</Text>
+        <Text
+          style={[
+            calendarWeeklyStripStyles.dayNumber,
+            selectedType && calendarWeeklyStripStyles.dayNumberWhenSelected,
+          ]}
+        >
+          {dayOfMonthLabel}
+        </Text>
       </View>
     </Pressable>
   );

--- a/lib/ui/calendar/MonthGrid.tsx
+++ b/lib/ui/calendar/MonthGrid.tsx
@@ -14,6 +14,9 @@ import {
   type MonthYear,
 } from "./dateUtils";
 import type { WorkoutMarkerFlags } from "@/lib/data/workouts/workoutMarkerFlags";
+import type { ActivityCalendarDayRingModel } from "@/lib/ui/activity/activityCalendarDayRingPresentation";
+import { ActivityDayRing } from "@/lib/ui/activity/ActivityDayRing";
+import { WEEKLY_STRIP_SELECTED_DAY_CIRCLE_FILL } from "@/lib/ui/calendar/weeklyCalendarStripTheme";
 import { UI_TEXT_PRIMARY, UI_TEXT_MUTED } from "@/lib/ui/theme/uiTokens";
 import { WorkoutDayRing } from "./WorkoutDayRing";
 
@@ -28,6 +31,11 @@ export type MonthGridProps = {
   dayKeyBasis?: "utc" | "local";
   /** `activity` — a11y copy for step rollup markers; default `workout` for strength/cardio grids. */
   ringSemantics?: "workout" | "activity";
+  /**
+   * When set, Activity tier / neutral rings replace {@link WorkoutDayRing} (Activity calendar only).
+   * `markerForDay` is ignored for the ring layer (pass a stub if unused).
+   */
+  activityCalendarDayForDay?: (day: DayKey) => ActivityCalendarDayRingModel;
 };
 
 const DOW_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
@@ -37,6 +45,7 @@ export function MonthGrid({
   onDayPress,
   dayKeyBasis = "utc",
   ringSemantics = "workout",
+  activityCalendarDayForDay,
 }: MonthGridProps) {
   const todayKey = getTodayDayKeyLocal();
   const weeks = dayKeyBasis === "local" ? getMonthGridLocal(monthYear) : getMonthGrid(monthYear);
@@ -65,8 +74,10 @@ export function MonthGrid({
             const hasStrength = !!marker?.hasStrength;
             const hasCardio = !!marker?.hasCardio;
             const hasRingMarker = hasStrength || hasCardio;
-            const a11yDetail =
-              ringSemantics === "activity"
+            const activityDayModel = activityCalendarDayForDay?.(dayKey);
+            const a11yDetail = activityDayModel
+              ? activityDayModel.accessibilityDetail
+              : ringSemantics === "activity"
                 ? hasRingMarker
                   ? "steps in daily rollup"
                   : "no steps in daily rollup"
@@ -85,16 +96,32 @@ export function MonthGrid({
                 ]}
                 hitSlop={8}
               >
-                <View style={styles.dayCircle}>
+                <View
+                  style={[
+                    styles.dayCircle,
+                    activityDayModel != null &&
+                      dayKey === todayKey &&
+                      styles.dayCircleActivityToday,
+                  ]}
+                >
                   <View style={styles.dayRingBackdrop} pointerEvents="none">
-                    <WorkoutDayRing
-                      size={32}
-                      hasStrength={hasStrength}
-                      hasCardio={hasCardio}
-                      emphasized={dayKey === todayKey}
-                      outerTestID={`month-outer-ring-${dayKey}`}
-                      innerTestID={`month-cardio-inner-ring-${dayKey}`}
-                    />
+                    {activityDayModel != null ? (
+                      <ActivityDayRing
+                        size={32}
+                        presentation={activityDayModel.presentation}
+                        emphasized={false}
+                        outerTestID={`month-outer-ring-${dayKey}`}
+                      />
+                    ) : (
+                      <WorkoutDayRing
+                        size={32}
+                        hasStrength={hasStrength}
+                        hasCardio={hasCardio}
+                        emphasized={dayKey === todayKey}
+                        outerTestID={`month-outer-ring-${dayKey}`}
+                        innerTestID={`month-cardio-inner-ring-${dayKey}`}
+                      />
+                    )}
                   </View>
                   <Text style={styles.dayNumber}>
                     {Number(dayKey.slice(8, 10))}
@@ -163,6 +190,10 @@ const styles = StyleSheet.create({
     position: "relative",
     alignItems: "center",
     justifyContent: "center",
+  },
+  /** Same fill as Strength weekly strip `dayCircleSelected` / header chrome. */
+  dayCircleActivityToday: {
+    backgroundColor: WEEKLY_STRIP_SELECTED_DAY_CIRCLE_FILL,
   },
   dayRingBackdrop: {
     ...StyleSheet.absoluteFillObject,

--- a/lib/ui/calendar/__tests__/dayKeyDisplayFormat.test.ts
+++ b/lib/ui/calendar/__tests__/dayKeyDisplayFormat.test.ts
@@ -8,10 +8,24 @@ jest.mock("../dateUtils", () => {
   };
 });
 
-import { formatDayKeyWeekdayShortMonthDay, formatOverviewAsOfLabel } from "../dayKeyDisplayFormat";
+import {
+  formatDayKeyStackNavTitle,
+  formatDayKeyWeekdayShortMonthDay,
+  formatOverviewAsOfLabel,
+} from "../dayKeyDisplayFormat";
 import * as dateUtils from "../dateUtils";
 
 const getToday = dateUtils.getTodayDayKeyLocal as jest.MockedFunction<typeof dateUtils.getTodayDayKeyLocal>;
+
+describe("formatDayKeyStackNavTitle", () => {
+  it("includes weekday, month name, day, and year (stack header style)", () => {
+    const s = formatDayKeyStackNavTitle("2026-04-14");
+    expect(s).toMatch(/Tue/);
+    expect(s).toMatch(/Apr/);
+    expect(s).toMatch(/14/);
+    expect(s).toMatch(/2026/);
+  });
+});
 
 describe("formatDayKeyWeekdayShortMonthDay", () => {
   it("formats Tue 3/31 for 2026-03-31", () => {

--- a/lib/ui/calendar/calendarWeeklyStripStyles.ts
+++ b/lib/ui/calendar/calendarWeeklyStripStyles.ts
@@ -32,6 +32,10 @@ export const calendarWeeklyStripStyles = StyleSheet.create({
     color: UI_TEXT_TERTIARY_LABEL,
     marginBottom: 2,
   },
+  dayOfWeekWhenSelected: {
+    fontWeight: "700",
+    letterSpacing: -0.12,
+  },
   dayCircle: {
     width: 40,
     height: 40,
@@ -52,5 +56,10 @@ export const calendarWeeklyStripStyles = StyleSheet.create({
     fontSize: 18,
     fontWeight: "600",
     color: UI_TEXT_PRIMARY,
+  },
+  dayNumberWhenSelected: {
+    fontWeight: "700",
+    fontSize: 19,
+    letterSpacing: -0.35,
   },
 });

--- a/lib/ui/calendar/dayKeyDisplayFormat.ts
+++ b/lib/ui/calendar/dayKeyDisplayFormat.ts
@@ -7,6 +7,18 @@ const WEEKDAY_SHORT = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const
  * Weekday short + M/D for a calendar day key (UTC noon anchor), e.g. `Tue 3/31`.
  * Matches historical overview / recent-row copy ({@link formatBodyDayLabel}).
  */
+/**
+ * Stack header title for a calendar day — matches workout day detail (`formatHeaderDate` style):
+ * e.g. `Tue Apr 14, 2026` (locale weekday + short month + day + year).
+ */
+export function formatDayKeyStackNavTitle(dayKey: DayKey): string {
+  const d = new Date(`${dayKey}T12:00:00.000Z`);
+  if (Number.isNaN(d.getTime())) return dayKey;
+  const weekday = d.toLocaleDateString(undefined, { weekday: "short" }).replace(",", "");
+  const rest = d.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" });
+  return `${weekday} ${rest}`;
+}
+
 export function formatDayKeyWeekdayShortMonthDay(dayKey: DayKey): string {
   const d = new Date(`${dayKey}T12:00:00.000Z`);
   const wd = WEEKDAY_SHORT[d.getUTCDay()] ?? "";

--- a/lib/ui/overview/activityStepTierBarFills.ts
+++ b/lib/ui/overview/activityStepTierBarFills.ts
@@ -1,0 +1,29 @@
+import { MODULE_OVERVIEW_SEGMENT_ZONE_FILLS } from "@/lib/ui/overview/moduleOverviewSegmentZoneFills";
+
+const z = MODULE_OVERVIEW_SEGMENT_ZONE_FILLS;
+
+/**
+ * Maps Activity tier index 0–5 → Body / Strength **segment fill** index for tiers that still
+ * align with Body chrome (Low–Average + Elite). Good and Great use distinct Activity greens below.
+ */
+export const ACTIVITY_STEP_TIER_BODY_SEGMENT_INDEX = [0, 2, 1, 3, 3, 4] as const;
+
+/** Good tier — #7FBF9F at ~35% on white (same alpha scale as {@link MODULE_OVERVIEW_SEGMENT_ZONE_FILLS}). */
+const ACTIVITY_GOOD_TIER_ZONE_FILL = "rgba(127, 191, 159, 0.35)";
+
+/** Great tier — #4ED26F at ~35% on white (matches Good’s alpha scale). */
+const ACTIVITY_GREAT_TIER_ZONE_FILL = "rgba(78, 210, 111, 0.35)";
+
+/**
+ * Single-fill color per Activity tier — Body segment tokens where shared; distinct greens for Good vs Great;
+ * Elite uses Body optimal (blue) unchanged.
+ * Order: Low → Below Avg → Average → Good → Great → Elite.
+ */
+export const ACTIVITY_STEP_TIER_BAR_FILL = [
+  z[ACTIVITY_STEP_TIER_BODY_SEGMENT_INDEX[0]],
+  z[ACTIVITY_STEP_TIER_BODY_SEGMENT_INDEX[1]],
+  z[ACTIVITY_STEP_TIER_BODY_SEGMENT_INDEX[2]],
+  ACTIVITY_GOOD_TIER_ZONE_FILL,
+  ACTIVITY_GREAT_TIER_ZONE_FILL,
+  z[ACTIVITY_STEP_TIER_BODY_SEGMENT_INDEX[5]],
+] as const;

--- a/lib/utils/__tests__/activityStepRating.test.ts
+++ b/lib/utils/__tests__/activityStepRating.test.ts
@@ -1,0 +1,58 @@
+import {
+  ACTIVITY_STEP_RATING_TIERS,
+  getStepRating,
+  getStepRatingTierIndex,
+  stepRatingTierMarkerPosition01,
+  stepsFromLocaleDigitString,
+} from "@/lib/utils/activityStepRating";
+
+describe("getStepRating", () => {
+  it.each([
+    [0, "Low"],
+    [4999, "Low"],
+    [5000, "Below Avg"],
+    [7499, "Below Avg"],
+    [7500, "Average"],
+    [9999, "Average"],
+    [10000, "Good"],
+    [12499, "Good"],
+    [12500, "Great"],
+    [14999, "Great"],
+    [15000, "Elite"],
+    [20000, "Elite"],
+  ])("steps %i → %s", (steps, label) => {
+    expect(getStepRating(steps).label).toBe(label);
+  });
+
+  it("floors non-integers and clamps negatives to Low", () => {
+    expect(getStepRating(7999.9).label).toBe("Average");
+    expect(getStepRating(-100).label).toBe("Low");
+  });
+
+  it("returns color and backgroundColor from Body segment pill chrome", () => {
+    const r = getStepRating(8000);
+    expect(r.color).toMatch(/^#/);
+    expect(r.backgroundColor).toMatch(/^#/);
+  });
+
+  it("stepsFromLocaleDigitString strips grouping commas", () => {
+    expect(stepsFromLocaleDigitString("7,919")).toBe(7919);
+    expect(getStepRating(stepsFromLocaleDigitString("7,919")).label).toBe("Average");
+  });
+});
+
+describe("getStepRatingTierIndex / stepRatingTierMarkerPosition01", () => {
+  it("maps steps to tier index 0–5", () => {
+    expect(getStepRatingTierIndex(1000)).toBe(0);
+    expect(getStepRatingTierIndex(6000)).toBe(1);
+    expect(getStepRatingTierIndex(8000)).toBe(2);
+    expect(getStepRatingTierIndex(11000)).toBe(3);
+    expect(getStepRatingTierIndex(13000)).toBe(4);
+    expect(getStepRatingTierIndex(16000)).toBe(5);
+  });
+
+  it("places marker at band centers", () => {
+    expect(stepRatingTierMarkerPosition01(1000)).toBeCloseTo(0.5 / ACTIVITY_STEP_RATING_TIERS.length, 5);
+    expect(stepRatingTierMarkerPosition01(16000)).toBeCloseTo(5.5 / ACTIVITY_STEP_RATING_TIERS.length, 5);
+  });
+});

--- a/lib/utils/__tests__/activityStepTierVisual.test.ts
+++ b/lib/utils/__tests__/activityStepTierVisual.test.ts
@@ -1,0 +1,39 @@
+import { MODULE_OVERVIEW_SEGMENT_ZONE_FILLS } from "@/lib/ui/overview/moduleOverviewSegmentZoneFills";
+import { ACTIVITY_STEP_TIER_BODY_SEGMENT_INDEX } from "@/lib/ui/overview/activityStepTierBarFills";
+import {
+  STEP_TIER_COLORS,
+  STEP_TIER_FILL,
+  activityStepTierBarVisual,
+  getStepTier,
+} from "@/lib/utils/activityStepTierVisual";
+
+describe("activityStepTierVisual", () => {
+  it("getStepTier mirrors tier index thresholds", () => {
+    expect(getStepTier(4000)).toBe("low");
+    expect(getStepTier(6000)).toBe("belowAvg");
+    expect(getStepTier(8000)).toBe("average");
+    expect(getStepTier(11000)).toBe("good");
+    expect(getStepTier(13000)).toBe("great");
+    expect(getStepTier(16000)).toBe("elite");
+  });
+
+  it("uses fixed fill lengths per tier (Good < Elite)", () => {
+    expect(STEP_TIER_FILL.good).toBe(0.66);
+    expect(STEP_TIER_FILL.elite).toBe(1);
+    expect(activityStepTierBarVisual(3)?.fill01).toBe(0.66);
+    expect(activityStepTierBarVisual(5)?.fill01).toBe(1);
+  });
+
+  it("returns null visual for unknown tier index", () => {
+    expect(activityStepTierBarVisual(null)).toBeNull();
+  });
+
+  it("uses Body segment zone fills except distinct Activity greens for Good and Great", () => {
+    expect(STEP_TIER_COLORS.low).toBe(MODULE_OVERVIEW_SEGMENT_ZONE_FILLS[ACTIVITY_STEP_TIER_BODY_SEGMENT_INDEX[0]!]);
+    expect(STEP_TIER_COLORS.belowAvg).toBe(MODULE_OVERVIEW_SEGMENT_ZONE_FILLS[ACTIVITY_STEP_TIER_BODY_SEGMENT_INDEX[1]!]);
+    expect(STEP_TIER_COLORS.average).toBe(MODULE_OVERVIEW_SEGMENT_ZONE_FILLS[ACTIVITY_STEP_TIER_BODY_SEGMENT_INDEX[2]!]);
+    expect(STEP_TIER_COLORS.good).toBe("rgba(127, 191, 159, 0.35)");
+    expect(STEP_TIER_COLORS.great).toBe("rgba(78, 210, 111, 0.35)");
+    expect(STEP_TIER_COLORS.elite).toBe(MODULE_OVERVIEW_SEGMENT_ZONE_FILLS[ACTIVITY_STEP_TIER_BODY_SEGMENT_INDEX[5]!]);
+  });
+});

--- a/lib/utils/activityStepRating.ts
+++ b/lib/utils/activityStepRating.ts
@@ -1,0 +1,102 @@
+/**
+ * Step-count rating tiers for Activity overview / Today’s Steps pills (UI-only benchmarks).
+ */
+
+import { ACTIVITY_STEP_TIER_BODY_SEGMENT_INDEX } from "@/lib/ui/overview/activityStepTierBarFills";
+import { MODULE_OVERVIEW_STRENGTH_TIER_PILL_CHROME } from "@/lib/ui/overview/moduleOverviewStrengthTierPillChrome";
+
+/** Parses a formatted digit string (e.g. `7,919`) for rating thresholds. */
+export function stepsFromLocaleDigitString(digits: string): number {
+  const n = Number.parseInt(digits.replace(/,/g, ""), 10);
+  return Number.isFinite(n) ? n : 0;
+}
+
+export type ActivityStepRatingTierDefinition = {
+  label: string;
+  /** Human-readable step/day band for explainer UI. */
+  rangeDisplay: string;
+  meaning: string;
+  /** Pill text color (darker). */
+  color: string;
+  /** Soft pill fill. */
+  backgroundColor: string;
+};
+
+const ACTIVITY_STEP_RATING_TIER_META = [
+  { label: "Low", rangeDisplay: "< 5,000", meaning: "Sedentary" },
+  { label: "Below Avg", rangeDisplay: "5,000–7,499", meaning: "Lightly active" },
+  { label: "Average", rangeDisplay: "7,500–9,999", meaning: "Moderately active" },
+  { label: "Good", rangeDisplay: "10,000–12,499", meaning: "Active" },
+  { label: "Great", rangeDisplay: "12,500–14,999", meaning: "Very active" },
+  { label: "Elite", rangeDisplay: "15,000+", meaning: "Highly active" },
+] as const;
+
+/**
+ * Canonical tier order (Low → Elite). Thresholds match {@link getStepRating} / {@link getStepRatingTierIndex}.
+ * Pill chrome follows Body / Strength segments except **Good** and **Great**, which use distinct Activity greens.
+ */
+export const ACTIVITY_STEP_RATING_TIERS: readonly ActivityStepRatingTierDefinition[] =
+  ACTIVITY_STEP_RATING_TIER_META.map((m, i) => {
+    if (i === 3) {
+      return {
+        ...m,
+        color: "#7FBF9F",
+        backgroundColor: "#EFF7F4",
+      };
+    }
+    if (i === 4) {
+      return {
+        ...m,
+        color: "#4ED26F",
+        /** Slightly richer wash than Good for hierarchy (still soft, premium). */
+        backgroundColor: "#E5F8EB",
+      };
+    }
+    const seg = ACTIVITY_STEP_TIER_BODY_SEGMENT_INDEX[i]!;
+    const chrome = MODULE_OVERVIEW_STRENGTH_TIER_PILL_CHROME[seg];
+    return {
+      ...m,
+      color: chrome.pillFg,
+      backgroundColor: chrome.pillBg,
+    };
+  });
+
+export type ActivityStepRating = {
+  label: string;
+  /** Pill text color (darker). */
+  color: string;
+  /** Soft pill fill. */
+  backgroundColor: string;
+};
+
+/**
+ * Tier index 0–5 for `steps` (Low → Elite).
+ */
+export function getStepRatingTierIndex(steps: number): number {
+  const n = Number.isFinite(steps) ? Math.max(0, Math.floor(steps)) : 0;
+  if (n < 5000) return 0;
+  if (n < 7500) return 1;
+  if (n < 10000) return 2;
+  if (n < 12500) return 3;
+  if (n < 15000) return 4;
+  return 5;
+}
+
+/** Marker position along the 6-band ladder (center of the active band), 0–1. */
+export function stepRatingTierMarkerPosition01(steps: number): number {
+  const i = getStepRatingTierIndex(steps);
+  return (i + 0.5) / ACTIVITY_STEP_RATING_TIERS.length;
+}
+
+/**
+ * Maps a step count to a display rating. Thresholds are daily-step benchmarks (same scale for
+ * “today total” and “average steps/day” rows).
+ */
+export function getStepRating(steps: number): ActivityStepRating {
+  const d = ACTIVITY_STEP_RATING_TIERS[getStepRatingTierIndex(steps)]!;
+  return {
+    label: d.label,
+    color: d.color,
+    backgroundColor: d.backgroundColor,
+  };
+}

--- a/lib/utils/activityStepTierVisual.ts
+++ b/lib/utils/activityStepTierVisual.ts
@@ -1,0 +1,68 @@
+import { ACTIVITY_STEP_TIER_BAR_FILL } from "@/lib/ui/overview/activityStepTierBarFills";
+import { getStepRatingTierIndex } from "@/lib/utils/activityStepRating";
+
+/**
+ * Display-only tier visuals. Bar fills come from {@link ACTIVITY_STEP_TIER_BAR_FILL} (Body segments for
+ * most tiers; distinct Good / Great greens; Elite = Body optimal blue).
+ * Thresholds live in {@link getStepRatingTierIndex}.
+ */
+
+/** Canonical tier keys (order matches {@link getStepRatingTierIndex} 0–5). */
+export const ACTIVITY_STEP_TIER_KEYS = ["low", "belowAvg", "average", "good", "great", "elite"] as const;
+
+export type ActivityStepTierKey = (typeof ACTIVITY_STEP_TIER_KEYS)[number];
+
+/** Single fill per tier — bars + Step Ratings dots ({@link ACTIVITY_STEP_TIER_BAR_FILL}). */
+export const STEP_TIER_COLORS = {
+  low: ACTIVITY_STEP_TIER_BAR_FILL[0],
+  belowAvg: ACTIVITY_STEP_TIER_BAR_FILL[1],
+  average: ACTIVITY_STEP_TIER_BAR_FILL[2],
+  good: ACTIVITY_STEP_TIER_BAR_FILL[3],
+  great: ACTIVITY_STEP_TIER_BAR_FILL[4],
+  elite: ACTIVITY_STEP_TIER_BAR_FILL[5],
+} as const satisfies Record<ActivityStepTierKey, string>;
+
+/**
+ * Fixed bar-fill extent per tier (not raw step count). Display-only; thresholds unchanged in
+ * {@link getStepRatingTierIndex}.
+ */
+export const STEP_TIER_FILL = {
+  low: 0.16,
+  belowAvg: 0.33,
+  average: 0.5,
+  good: 0.66,
+  great: 0.83,
+  elite: 1.0,
+} as const satisfies Record<ActivityStepTierKey, number>;
+
+/** Neutral track trough — warm, light, same family as Activity/Body elevated cards. */
+export const STEP_TIER_TRACK_INNER_BACKGROUND = "#F4F2EE";
+
+/** Hairline rim — SegmentedZoneTrack-adjacent neutral. */
+export const STEP_TIER_TRACK_RIM_BORDER = "rgba(60, 60, 67, 0.09)";
+
+/**
+ * Tier key from steps using existing tier index only (no threshold changes).
+ * Alias name requested for call-site clarity.
+ */
+export function getStepTier(steps: number): ActivityStepTierKey {
+  return ACTIVITY_STEP_TIER_KEYS[getStepRatingTierIndex(steps)]!;
+}
+
+export function activityStepTierFill01(key: ActivityStepTierKey): number {
+  return STEP_TIER_FILL[key];
+}
+
+export function activityStepTierColor(key: ActivityStepTierKey): string {
+  return STEP_TIER_COLORS[key];
+}
+
+/** Bar chrome from numeric tier index; null → no colored fill (insufficient / non-numeric row). */
+export function activityStepTierBarVisual(tierIndex: number | null): {
+  fill01: number;
+  fillColor: string;
+} | null {
+  if (tierIndex == null || tierIndex < 0 || tierIndex >= ACTIVITY_STEP_TIER_KEYS.length) return null;
+  const key = ACTIVITY_STEP_TIER_KEYS[tierIndex]!;
+  return { fill01: STEP_TIER_FILL[key], fillColor: STEP_TIER_COLORS[key] };
+}

--- a/scripts/admin/reingest-apple-steps-day.mjs
+++ b/scripts/admin/reingest-apple-steps-day.mjs
@@ -1,0 +1,310 @@
+#!/usr/bin/env node
+/**
+ * Targeted one-day Apple Health steps re-ingest via POST /ingest (same body shape as
+ * {@link ../../lib/integrations/appleHealth/appleHealthStepsIngestBody.ts buildAppleHealthStepsIngestBody}).
+ *
+ * Local calendar window [start, end] for the given day + IANA timezone matches
+ * {@link ../../lib/events/manualNutrition.ts localNutritionDayWindowIsoUtc} (UTC ISO instants).
+ *
+ * Idempotency / rawEvents doc id (must match {@link ../../lib/integrations/appleHealth/idempotency.ts stepsIdempotencyKey}):
+ *   appleHealth:v2:steps:<YYYY-MM-DD>
+ *
+ * Usage (repo root) — timezone MUST be copied from the user’s existing Apple steps raw doc
+ * (`payload.timezone` / top-level ingest contract), not guessed:
+ *
+ *   export BACKEND_BASE_URL='https://…'   # same host pattern as app (e.g. *.uc.gateway.dev)
+ *   export GATEWAY_API_KEY='…'            # required when BACKEND_BASE_URL is API Gateway
+ *   export FIREBASE_ID_TOKEN='…'          # ID token for user 1Uwh… (that user must sign in)
+ *
+ *   node scripts/admin/reingest-apple-steps-day.mjs \
+ *     --day 2026-04-14 \
+ *     --steps 15285 \
+ *     --timezone America/New_York
+ *
+ *   # Print payload only (no network):
+ *   node scripts/admin/reingest-apple-steps-day.mjs --dry-run --day 2026-04-14 --steps 15285 --timezone America/New_York
+ *
+ * After a successful ingest, rerun admin recompute for adjacent days (existing script):
+ *   node scripts/admin/recompute-steps-ytd.mjs --userId <uid> --startDate 2026-04-13 --endDate 2026-04-15
+ */
+
+import process from "node:process";
+
+/** @param {string} dayKey @param {number} deltaDays */
+function addCalendarDaysToDayKey(dayKey, deltaDays) {
+  const d = new Date(`${dayKey}T12:00:00.000Z`);
+  d.setUTCDate(d.getUTCDate() + deltaDays);
+  return d.toISOString().slice(0, 10);
+}
+
+/** @param {number} ms @param {string} timeZone */
+function ymdInTimeZone(ms, timeZone) {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(new Date(ms));
+}
+
+/**
+ * First UTC instant where the user's local calendar reads `dayKey` in `timeZone`.
+ * (Aligned with lib/events/manualNutrition.ts `utcInstantForLocalCalendarDayStart`.)
+ * @param {string} dayKey
+ * @param {string} timeZone
+ */
+function utcInstantForLocalCalendarDayStart(dayKey, timeZone) {
+  const parts = dayKey.split("-");
+  const y = Number(parts[0]);
+  const mo = Number(parts[1]);
+  const da = Number(parts[2]);
+  if (!y || !mo || !da) throw new Error(`Invalid dayKey: ${dayKey}`);
+
+  const fmt = (ms) => ymdInTimeZone(ms, timeZone);
+
+  let found = null;
+  for (let h = -48; h <= 48; h += 1) {
+    const cand = Date.UTC(y, mo - 1, da, 12 + h, 0, 0, 0);
+    if (fmt(cand) === dayKey) {
+      found = cand;
+      break;
+    }
+  }
+  if (found == null) {
+    throw new Error(`Could not resolve local calendar day ${dayKey} in ${timeZone}`);
+  }
+
+  let start = found;
+  const coarse = 60_000;
+  for (let i = 0; i < 2000; i += 1) {
+    const prev = start - coarse;
+    if (fmt(prev) !== dayKey) break;
+    start = prev;
+  }
+  while (start > 0 && fmt(start - 1) === dayKey) start -= 1;
+  return start;
+}
+
+/** @param {string} dayKey @param {string} timeZone */
+function localDayWindowIsoUtc(dayKey, timeZone) {
+  const startMs = utcInstantForLocalCalendarDayStart(dayKey, timeZone);
+  const nextDay = addCalendarDaysToDayKey(dayKey, 1);
+  const nextStartMs = utcInstantForLocalCalendarDayStart(nextDay, timeZone);
+  const endMs = nextStartMs - 1;
+  return {
+    start: new Date(startMs).toISOString(),
+    end: new Date(endMs).toISOString(),
+  };
+}
+
+/**
+ * Same return shape as lib/integrations/appleHealth/appleHealthStepsIngestBody.ts
+ * @param {{ start: string; end: string; day: string; timezone: string; steps: number }} params
+ */
+function buildAppleHealthStepsIngestBody(params) {
+  const { start, end, day, timezone, steps } = params;
+  return {
+    provider: "apple_health",
+    sourceId: "apple_health",
+    kind: "steps",
+    observedAt: start,
+    timeZone: timezone,
+    payload: {
+      start,
+      end,
+      timezone,
+      day,
+      steps,
+      sync: { mode: "range", anchorVersion: 1, anchorUsed: false },
+    },
+  };
+}
+
+/** @param {string} iso @param {string} ianaTimeZone */
+function localCalendarDayKeyFromIsoInTimeZone(iso, ianaTimeZone) {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  try {
+    return new Intl.DateTimeFormat("en-CA", { timeZone: ianaTimeZone }).format(d);
+  } catch {
+    return null;
+  }
+}
+
+function stepsIdempotencyKey(day) {
+  const safe = String(day).replace(/\//g, "_").trim();
+  if (!safe) throw new Error("stepsIdempotencyKey: day is required");
+  return `appleHealth:v2:steps:${safe}`;
+}
+
+function isGatewayBaseUrl(base) {
+  try {
+    return new URL(base).hostname.endsWith(".uc.gateway.dev");
+  } catch {
+    return false;
+  }
+}
+
+function parseArgs(argv) {
+  const out = {
+    day: null,
+    steps: null,
+    timezone: null,
+    dryRun: false,
+    help: false,
+  };
+  for (let i = 2; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === "--help" || a === "-h") out.help = true;
+    else if (a === "--day") out.day = argv[++i] ?? null;
+    else if (a === "--steps") out.steps = argv[++i] != null ? Number(argv[i]) : NaN;
+    else if (a === "--timezone") out.timezone = argv[++i] ?? null;
+    else if (a === "--dry-run") out.dryRun = true;
+  }
+  return out;
+}
+
+function printUsage() {
+  console.error(`
+Usage:
+  export BACKEND_BASE_URL='https://…'
+  export GATEWAY_API_KEY='…'    # if using *.uc.gateway.dev
+  export FIREBASE_ID_TOKEN='…'  # signed-in as the target user
+
+  node scripts/admin/reingest-apple-steps-day.mjs \\
+    --day YYYY-MM-DD \\
+    --steps <number> \\
+    --timezone <IANA>     # REQUIRED: from existing raw payload / app integration, do not guess
+
+  --dry-run   Print JSON body + idempotency key only (no POST)
+`);
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) {
+    printUsage();
+    process.exit(0);
+  }
+
+  if (!args.day || !/^\d{4}-\d{2}-\d{2}$/.test(args.day)) {
+    console.error(JSON.stringify({ level: "error", msg: "invalid_or_missing_day", day: args.day }));
+    printUsage();
+    process.exit(1);
+  }
+  if (!Number.isFinite(args.steps) || args.steps < 0) {
+    console.error(JSON.stringify({ level: "error", msg: "invalid_or_missing_steps", steps: args.steps }));
+    process.exit(1);
+  }
+  if (!args.timezone || typeof args.timezone !== "string" || !args.timezone.trim()) {
+    console.error(
+      JSON.stringify({
+        level: "error",
+        msg: "missing_timezone",
+        hint: "Pass --timezone from Firestore users/{uid}/rawEvents/appleHealth:v2:steps:… payload.timezone (same as top-level timeZone for ingest).",
+      }),
+    );
+    process.exit(1);
+  }
+
+  const tz = args.timezone.trim();
+  const { start, end } = localDayWindowIsoUtc(args.day, tz);
+  const body = buildAppleHealthStepsIngestBody({
+    start,
+    end,
+    day: args.day,
+    timezone: tz,
+    steps: Math.round(args.steps),
+  });
+
+  const derivedDay = localCalendarDayKeyFromIsoInTimeZone(body.payload.start, body.payload.timezone);
+  if (derivedDay !== args.day) {
+    console.error(
+      JSON.stringify({
+        level: "error",
+        msg: "day_key_mismatch_after_build",
+        expectedDay: args.day,
+        derivedDayFromPayloadStartTz: derivedDay,
+        payloadStart: body.payload.start,
+        payloadTimezone: body.payload.timezone,
+      }),
+    );
+    process.exit(1);
+  }
+
+  const idempotencyKey = stepsIdempotencyKey(args.day);
+
+  const meta = {
+    level: "info",
+    msg: "reingest_apple_steps_day_prepared",
+    idempotencyKey,
+    idempotencyKeyMatchesRepo: idempotencyKey === `appleHealth:v2:steps:${args.day}`,
+    payloadShape: "buildAppleHealthStepsIngestBody (see lib/integrations/appleHealth/appleHealthStepsIngestBody.ts)",
+    sampleIdentityFields: "none in builder (repo truth: optional sourceSampleId not set by this path)",
+    body,
+  };
+  console.log(JSON.stringify(meta, null, 2));
+
+  if (args.dryRun) {
+    console.log(JSON.stringify({ level: "info", msg: "dry_run_no_post" }));
+    process.exit(0);
+  }
+
+  const base = (process.env.BACKEND_BASE_URL ?? "").trim().replace(/\/+$/, "");
+  const token = (process.env.FIREBASE_ID_TOKEN ?? "").trim();
+  if (!base || !token) {
+    console.error(JSON.stringify({ level: "error", msg: "missing_BACKEND_BASE_URL_or_FIREBASE_ID_TOKEN" }));
+    process.exit(1);
+  }
+
+  let url = `${base}/ingest`;
+  if (isGatewayBaseUrl(base)) {
+    const apiKey = (process.env.GATEWAY_API_KEY ?? "").trim();
+    if (!apiKey) {
+      console.error(JSON.stringify({ level: "error", msg: "missing_GATEWAY_API_KEY_for_gateway_host" }));
+      process.exit(1);
+    }
+    const u = new URL(url);
+    u.searchParams.set("key", apiKey);
+    url = u.toString();
+  }
+
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+      "Idempotency-Key": idempotencyKey,
+    },
+    body: JSON.stringify(body),
+  });
+
+  const text = await res.text();
+  let json = null;
+  try {
+    json = text ? JSON.parse(text) : null;
+  } catch {
+    json = { _parseError: true, rawBody: text.slice(0, 2000) };
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        level: res.ok ? "info" : "error",
+        msg: "ingest_response",
+        httpStatus: res.status,
+        json,
+      },
+      null,
+      2,
+    ),
+  );
+
+  process.exit(res.ok && res.status >= 200 && res.status < 300 ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error(JSON.stringify({ level: "error", msg: "fatal", error: String(err) }));
+  process.exit(1);
+});

--- a/services/api/src/lib/activityFactsSynthesizeFromCanonical.ts
+++ b/services/api/src/lib/activityFactsSynthesizeFromCanonical.ts
@@ -1,7 +1,7 @@
 /**
- * When users/me/dailyFacts/{day} is missing (or activity is merged), synthesize `activity.steps`
- * from canonical `events` for that day — same resolution rules as {@link aggregateDailyFactsForDay}.
- * Read-only; does not write Firestore.
+ * Read-only helper: resolve `activity.steps` from canonical `events` for a day using the same rules
+ * as `aggregateDailyFactsForDay` (including Apple per-identity dedupe in `@oli/contracts`).
+ * Optional tooling / non-GET-daily-facts callers only; `GET /users/me/daily-facts` does not use this.
  */
 
 import {
@@ -21,7 +21,14 @@ export async function loadActivityStepsFromCanonicalForApi(
 ): Promise<ActivityStepsSynthesized | undefined> {
   const snap = await userCollection(uid, "events").where("day", "==", dayKey).get();
 
-  const likes: { id: string; sourceId: string; steps: number }[] = [];
+  const likes: {
+    id: string;
+    sourceId: string;
+    steps: number;
+    updatedAt?: string;
+    createdAt?: string;
+    sourceSampleId?: string | null;
+  }[] = [];
   for (const d of snap.docs) {
     const data = d.data() as Record<string, unknown>;
     if (data["kind"] !== "steps") continue;
@@ -30,7 +37,18 @@ export async function loadActivityStepsFromCanonicalForApi(
     const rawSource = data["sourceId"];
     const sourceId =
       typeof rawSource === "string" && rawSource.length > 0 ? rawSource : "unknown_source";
-    likes.push({ id: d.id, sourceId, steps: s });
+    const updatedAt = typeof data["updatedAt"] === "string" ? data["updatedAt"] : undefined;
+    const createdAt = typeof data["createdAt"] === "string" ? data["createdAt"] : undefined;
+    const rawSid = data["sourceSampleId"];
+    const sourceSampleId = typeof rawSid === "string" && rawSid.trim().length > 0 ? rawSid.trim() : null;
+    likes.push({
+      id: d.id,
+      sourceId,
+      steps: s,
+      sourceSampleId,
+      ...(updatedAt !== undefined ? { updatedAt } : {}),
+      ...(createdAt !== undefined ? { createdAt } : {}),
+    });
   }
 
   const contributing = pickContributingStepEventsForDailyFacts(likes);

--- a/services/api/src/routes/__tests__/events.ingest.steps-idempotent-replay.test.ts
+++ b/services/api/src/routes/__tests__/events.ingest.steps-idempotent-replay.test.ts
@@ -16,7 +16,7 @@ const mockColRef = {
 };
 
 jest.mock("../../db", () => ({
-  userCollection: (_uid: string, name: string) => {
+  userCollection: (_uid, name) => {
     if (name === "rawEvents") return mockColRef;
     return {};
   },
@@ -34,15 +34,18 @@ function createIngestApp(): express.Express {
   return app;
 }
 
+const stepStartIso = "2026-04-07T00:00:00.000Z";
+
 const baseBody = {
   provider: "apple_health",
   kind: "steps",
-  occurredAt: "2026-04-07T12:00:00.000Z",
-  timeZone: "America/New_York",
+  /** Envelope instant; Apple steps `day` in the response follows payload.start + payload.timezone only. */
+  occurredAt: stepStartIso,
+  timeZone: "Etc/UTC",
   payload: {
-    start: "2026-04-07T00:00:00.000Z",
-    end: "2026-04-07T23:59:59.000Z",
-    timezone: "America/New_York",
+    start: stepStartIso,
+    end: "2026-04-07T23:59:59.999Z",
+    timezone: "Etc/UTC",
     day: "2026-04-07",
     steps: 5000,
   },
@@ -133,6 +136,119 @@ describe("POST /ingest — steps idempotent replay", () => {
       expect(res.status).toBe(202);
       const patch = mockDocRef.update.mock.calls[0][0] as { payload?: { steps?: number } };
       expect(patch.payload?.steps).toBe(5000);
+    } finally {
+      server.close();
+    }
+  });
+});
+
+describe("POST /ingest — apple_health steps envelope/payload parity", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDocRef.create.mockResolvedValue(undefined);
+    mockDocRef.get.mockResolvedValue({ exists: false });
+  });
+
+  it("returns 202 and response day from payload.start+timezone when observedAt differs (no envelope drift)", async () => {
+    const app = createIngestApp();
+    const server = app.listen(0);
+    const addr = server.address();
+    if (!addr || typeof addr === "string") {
+      server.close();
+      throw new Error("Failed to bind");
+    }
+    try {
+      const res = await fetch(`http://127.0.0.1:${addr.port}/ingest`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "Idempotency-Key": "idem_steps_payload_day_authority",
+        },
+        body: JSON.stringify({
+          provider: "apple_health",
+          kind: "steps",
+          sourceId: "apple_health",
+          timeZone: "Etc/UTC",
+          observedAt: "2026-04-07T12:00:00.000Z",
+          payload: {
+            ...baseBody.payload,
+            start: "2026-04-07T00:00:00.000Z",
+          },
+        }),
+      });
+      expect(res.status).toBe(202);
+      const json = (await res.json()) as { day?: string };
+      expect(json.day).toBe("2026-04-07");
+      expect(mockDocRef.create).toHaveBeenCalled();
+    } finally {
+      server.close();
+    }
+  });
+
+  it("prefers observedAt over occurredAt for envelope when both are strings (stored observedAt)", async () => {
+    const app = createIngestApp();
+    const server = app.listen(0);
+    const addr = server.address();
+    if (!addr || typeof addr === "string") {
+      server.close();
+      throw new Error("Failed to bind");
+    }
+    try {
+      const res = await fetch(`http://127.0.0.1:${addr.port}/ingest`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "Idempotency-Key": "idem_steps_observed_wins",
+        },
+        body: JSON.stringify({
+          provider: "apple_health",
+          kind: "steps",
+          sourceId: "apple_health",
+          timeZone: "Etc/UTC",
+          observedAt: "2026-04-07T15:00:00.000Z",
+          occurredAt: "2026-04-07T03:00:00.000Z",
+          payload: {
+            ...baseBody.payload,
+            start: "2026-04-07T00:00:00.000Z",
+          },
+        }),
+      });
+      expect(res.status).toBe(202);
+      const createArg = mockDocRef.create.mock.calls[0][0] as { observedAt?: string };
+      expect(createArg.observedAt).toBe("2026-04-07T15:00:00.000Z");
+    } finally {
+      server.close();
+    }
+  });
+
+  it("returns 400 when payload.timezone does not match top-level timeZone", async () => {
+    const app = createIngestApp();
+    const server = app.listen(0);
+    const addr = server.address();
+    if (!addr || typeof addr === "string") {
+      server.close();
+      throw new Error("Failed to bind");
+    }
+    try {
+      const res = await fetch(`http://127.0.0.1:${addr.port}/ingest`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "Idempotency-Key": "idem_steps_mismatch_tz",
+        },
+        body: JSON.stringify({
+          ...baseBody,
+          timeZone: "Etc/UTC",
+          payload: {
+            ...baseBody.payload,
+            timezone: "America/New_York",
+          },
+        }),
+      });
+      expect(res.status).toBe(400);
+      const json = (await res.json()) as { error?: { code?: string } };
+      expect(json.error?.code).toBe("STEPS_PAYLOAD_TIMEZONE_MISMATCH");
+      expect(mockDocRef.create).not.toHaveBeenCalled();
     } finally {
       server.close();
     }

--- a/services/api/src/routes/__tests__/usersMe.daily-facts.test.ts
+++ b/services/api/src/routes/__tests__/usersMe.daily-facts.test.ts
@@ -1,4 +1,4 @@
-// GET /users/me/daily-facts — synthetic body when doc missing but raw exists
+// GET /users/me/daily-facts — stored DailyFacts only for activity; optional body-only synthesis when doc missing
 import express from "express";
 import type http from "http";
 import { AddressInfo } from "net";
@@ -20,7 +20,7 @@ function emptyEventsQueryMock() {
   return chain;
 }
 
-/** rawEvents: query path for body synthesis + doc(id) for steps raw synthesis */
+/** rawEvents: query path for body synthesis when dailyFacts doc is missing */
 function rawEventsMockWithDoc(
   opts: {
     whereDocs?: { data: () => unknown }[];
@@ -137,7 +137,7 @@ describe("GET /users/me/daily-facts", () => {
     expect(res.status).toBe(404);
   });
 
-  test("returns 200 with synthesized activity.steps when dailyFacts missing and canonical steps exist", async () => {
+  test("returns 404 when dailyFacts missing and only canonical steps exist (no activity synthesis)", async () => {
     const stepsCanonical = {
       kind: "steps",
       day: "2026-04-02",
@@ -170,15 +170,13 @@ describe("GET /users/me/daily-facts", () => {
     });
 
     const res = await fetch(`${baseUrl}/users/me/daily-facts?day=2026-04-02`);
-    expect(res.status).toBe(200);
-    const json = (await res.json()) as { activity?: { steps?: number }; meta?: { source?: unknown } };
-    expect(json.activity?.steps).toBe(9500);
-    expect(json.meta?.source).toEqual(
-      expect.objectContaining({ synthesizedActivityFromCanonical: true }),
-    );
+    expect(res.status).toBe(404);
+    const json = (await res.json()) as { error?: { code?: string; resource?: string } };
+    expect(json.error?.code).toBe("NOT_FOUND");
+    expect(json.error?.resource).toBe("dailyFacts");
   });
 
-  test("returns 200 with synthesized activity.steps from apple_health raw doc when canonical is missing", async () => {
+  test("returns 404 when dailyFacts missing and only apple_health raw steps exist (no raw steps synthesis)", async () => {
     const stepsRaw = {
       kind: "steps",
       provider: "apple_health",
@@ -214,68 +212,16 @@ describe("GET /users/me/daily-facts", () => {
     });
 
     const res = await fetch(`${baseUrl}/users/me/daily-facts?day=2026-04-05`);
-    expect(res.status).toBe(200);
-    const json = (await res.json()) as { activity?: { steps?: number }; meta?: { source?: unknown } };
-    expect(json.activity?.steps).toBe(8421);
-    expect(json.meta?.source).toEqual(
-      expect.objectContaining({ synthesizedActivityFromRaw: true }),
-    );
+    expect(res.status).toBe(404);
   });
 
-  test("synthesized steps prefer apple_health when multiple canonical step events exist", async () => {
-    const stepsApple = { kind: "steps", day: "2026-04-21", sourceId: "apple_health", steps: 4000 };
-    const stepsManual = { kind: "steps", day: "2026-04-21", sourceId: "manual", steps: 9999 };
-
-    (userCollection as jest.Mock).mockImplementation((_uid: string, name: string) => {
-      if (name === "dailyFacts") {
-        return {
-          doc: () => ({
-            get: async () => ({ exists: false }),
-          }),
-        };
-      }
-      if (name === "rawEvents") {
-        return rawEventsMockWithDoc({});
-      }
-      if (name === "events") {
-        const eventsQuery = {
-          where: (): typeof eventsQuery => eventsQuery,
-          get: async () => ({
-            docs: [
-              { data: () => stepsManual },
-              { data: () => stepsApple },
-            ],
-          }),
-        };
-        return eventsQuery;
-      }
-      return {};
-    });
-
-    (userDoc as jest.Mock).mockReturnValue({
-      get: async () => ({ data: () => ({}) }),
-    });
-
-    const res = await fetch(`${baseUrl}/users/me/daily-facts?day=2026-04-21`);
-    expect(res.status).toBe(200);
-    const json = (await res.json()) as { activity?: { steps?: number } };
-    expect(json.activity?.steps).toBe(4000);
-  });
-
-  test("merges activity.steps when dailyFacts has activity object but no numeric steps field", async () => {
+  test("returns stored dailyFacts activity.steps unchanged when doc omits merge with canonical", async () => {
     const storedFacts = {
       schemaVersion: 1,
       userId: "user_body_test",
       date: "2026-04-22",
       computedAt: "2026-04-22T10:00:00.000Z",
-      activity: { distanceKm: 3.2 },
-    };
-
-    const stepsCanonical = {
-      kind: "steps",
-      day: "2026-04-22",
-      sourceId: "apple_health",
-      steps: 6060,
+      activity: { distanceKm: 3.2, steps: 120 },
     };
 
     (userCollection as jest.Mock).mockImplementation((_uid: string, name: string) => {
@@ -289,7 +235,9 @@ describe("GET /users/me/daily-facts", () => {
       if (name === "events") {
         const eventsQuery = {
           where: (): typeof eventsQuery => eventsQuery,
-          get: async () => ({ docs: [{ id: "e1", data: () => stepsCanonical }] }),
+          get: async () => ({
+            docs: [{ id: "e1", data: () => ({ kind: "steps", day: "2026-04-22", sourceId: "apple_health", steps: 6060 }) }],
+          }),
         };
         return eventsQuery;
       }
@@ -304,27 +252,18 @@ describe("GET /users/me/daily-facts", () => {
     expect(res.status).toBe(200);
     const json = (await res.json()) as {
       activity?: { steps?: number; distanceKm?: number };
-      meta?: { source?: Record<string, unknown> };
     };
-    expect(json.activity?.steps).toBe(6060);
+    expect(json.activity?.steps).toBe(120);
     expect(json.activity?.distanceKm).toBe(3.2);
-    expect(json.meta?.source?.activityStepsFilledOnRead).toBe(true);
   });
 
-  test("merges activity.steps when dailyFacts exists but omits numeric steps and canonical has steps", async () => {
+  test("returns stored doc without adding activity.steps from canonical when sleep-only doc", async () => {
     const storedFacts = {
       schemaVersion: 1,
       userId: "user_body_test",
       date: "2026-04-20",
       computedAt: "2026-04-20T10:00:00.000Z",
       sleep: { totalMinutes: 420 },
-    };
-
-    const stepsCanonical = {
-      kind: "steps",
-      day: "2026-04-20",
-      sourceId: "apple_health",
-      steps: 7777,
     };
 
     (userCollection as jest.Mock).mockImplementation((_uid: string, name: string) => {
@@ -338,7 +277,7 @@ describe("GET /users/me/daily-facts", () => {
       if (name === "events") {
         const eventsQuery = {
           where: (): typeof eventsQuery => eventsQuery,
-          get: async () => ({ docs: [{ id: "appleHealth:v2:steps:2026-04-20", data: () => stepsCanonical }] }),
+          get: async () => ({ docs: [{ id: "appleHealth:v2:steps:2026-04-20", data: () => ({ kind: "steps", steps: 7777 }) }] }),
         };
         return eventsQuery;
       }
@@ -351,8 +290,8 @@ describe("GET /users/me/daily-facts", () => {
 
     const res = await fetch(`${baseUrl}/users/me/daily-facts?day=2026-04-20`);
     expect(res.status).toBe(200);
-    const json = (await res.json()) as { activity?: { steps?: number }; meta?: { source?: Record<string, unknown> } };
-    expect(json.activity?.steps).toBe(7777);
-    expect(json.meta?.source?.activityStepsFilledOnRead).toBe(true);
+    const json = (await res.json()) as { activity?: { steps?: number }; sleep?: { totalMinutes?: number } };
+    expect(json.sleep?.totalMinutes).toBe(420);
+    expect(json.activity).toBeUndefined();
   });
 });

--- a/services/api/src/routes/events.ts
+++ b/services/api/src/routes/events.ts
@@ -1,7 +1,7 @@
 // services/api/src/routes/events.ts
 import { Router, type Response } from "express";
 
-import { rawEventDocSchema } from "@oli/contracts";
+import { localCalendarDayKeyFromIsoInTimeZone, rawEventDocSchema } from "@oli/contracts";
 import type { AuthedRequest } from "../middleware/auth";
 import type { RequestWithRid } from "../lib/logger";
 import { writeFailure } from "../lib/writeFailure";
@@ -60,10 +60,12 @@ const requireValidTimeZone = (reqBody: unknown): string | undefined => {
 };
 
 /**
- * Single source-of-truth dayKey algorithm (must match canonical normalization):
- * Intl.DateTimeFormat("en-CA", { timeZone }).format(new Date(observedAt))
+ * Ingest `day` for non–Apple-steps events: local calendar key from envelope `observedAt` + `timeZone`.
+ * Apple Health `steps` uses {@link localCalendarDayKeyFromIsoInTimeZone} on `payload.start` + `payload.timezone` only.
  */
 const canonicalDayKeyFromObservedAt = (observedAtIso: string, timeZone: string): string => {
+  const key = localCalendarDayKeyFromIsoInTimeZone(observedAtIso, timeZone);
+  if (key) return key;
   const formatter = new Intl.DateTimeFormat("en-CA", { timeZone });
   return formatter.format(new Date(observedAtIso));
 };
@@ -194,8 +196,9 @@ router.post("/", async (req: AuthedRequest, res: Response) => {
 
   const body: IngestRawEventBody = parsed.data;
 
-  // Canonicalize timestamps (observedAt preferred; occurredAt can be exact or range)
-  const occurredAtRaw = body.occurredAt ?? body.observedAt;
+  // Canonicalize timestamps: `observedAt` wins over `occurredAt` when both are present (explicit envelope).
+  // `occurredAt` may still be a string or { start, end } range for legacy clients.
+  const occurredAtRaw = body.observedAt ?? body.occurredAt;
   if (!occurredAtRaw) {
     try {
       await writeFailure({
@@ -251,8 +254,115 @@ router.post("/", async (req: AuthedRequest, res: Response) => {
 
   const receivedAt = new Date().toISOString();
 
-  // ✅ Must match canonical dayKey semantics (use observedAt for day derivation)
-  const day = canonicalDayKeyFromObservedAt(observedAt, timeZone);
+  let day: string;
+  if (body.provider === "apple_health" && body.kind === "steps") {
+    const p = body.payload;
+    if (typeof p !== "object" || p === null || Array.isArray(p)) {
+      try {
+        await writeFailure({
+          userId: uid,
+          source: "ingestion",
+          stage: "ingest",
+          reasonCode: "STEPS_PAYLOAD_INVALID",
+          message: "apple_health steps requires a JSON object payload with start, end, timezone, steps",
+          day: dayUtcNow(),
+          requestId,
+          details: {},
+        });
+      } catch {
+        // do not throw
+      }
+      return res.status(400).json({
+        ok: false as const,
+        error: {
+          code: "STEPS_PAYLOAD_INVALID" as const,
+          message: "apple_health steps requires a JSON object payload with start, end, timezone, steps",
+        },
+        requestId,
+      });
+    }
+    const pr = p as Record<string, unknown>;
+    const pStart = pr["start"];
+    const pTz = pr["timezone"];
+    if (typeof pStart !== "string" || typeof pTz !== "string") {
+      try {
+        await writeFailure({
+          userId: uid,
+          source: "ingestion",
+          stage: "ingest",
+          reasonCode: "STEPS_PAYLOAD_INVALID",
+          message: "apple_health steps payload must include string start and timezone",
+          day: dayUtcNow(),
+          requestId,
+          details: {},
+        });
+      } catch {
+        // do not throw
+      }
+      return res.status(400).json({
+        ok: false as const,
+        error: {
+          code: "STEPS_PAYLOAD_INVALID" as const,
+          message: "apple_health steps payload must include string start and timezone",
+        },
+        requestId,
+      });
+    }
+    if (pTz !== timeZone) {
+      try {
+        await writeFailure({
+          userId: uid,
+          source: "ingestion",
+          stage: "ingest",
+          reasonCode: "STEPS_PAYLOAD_TIMEZONE_MISMATCH",
+          message:
+            "steps payload.timezone must match top-level timeZone (single IANA source for ingest + normalization)",
+          day: dayUtcNow(),
+          requestId,
+          details: { payloadTimezone: pTz, envelopeTimeZone: timeZone },
+        });
+      } catch {
+        // do not throw
+      }
+      return res.status(400).json({
+        ok: false as const,
+        error: {
+          code: "STEPS_PAYLOAD_TIMEZONE_MISMATCH" as const,
+          message:
+            "steps payload.timezone must match top-level timeZone (single IANA source for ingest + normalization)",
+        },
+        requestId,
+      });
+    }
+    const payloadDay = localCalendarDayKeyFromIsoInTimeZone(pStart, pTz);
+    if (!payloadDay) {
+      try {
+        await writeFailure({
+          userId: uid,
+          source: "ingestion",
+          stage: "ingest",
+          reasonCode: "STEPS_PAYLOAD_DAY_INVALID",
+          message: "Could not derive local calendar day from steps payload.start and payload.timezone",
+          day: dayUtcNow(),
+          requestId,
+          details: { payloadStart: pStart, payloadTimezone: pTz },
+        });
+      } catch {
+        // do not throw
+      }
+      return res.status(400).json({
+        ok: false as const,
+        error: {
+          code: "STEPS_PAYLOAD_DAY_INVALID" as const,
+          message: "Could not derive local calendar day from steps payload.start and payload.timezone",
+        },
+        requestId,
+      });
+    }
+    day = payloadDay;
+  } else {
+    day = canonicalDayKeyFromObservedAt(observedAt, timeZone);
+  }
 
   // Phase 1: gateway currently represents manual ingestion
   const sourceType = "manual" as const;

--- a/services/api/src/routes/usersMe.ts
+++ b/services/api/src/routes/usersMe.ts
@@ -26,8 +26,6 @@ import {
 
 import type { AuthedRequest } from "../middleware/auth";
 import { asyncHandler } from "../lib/asyncHandler";
-import { loadActivityStepsFromCanonicalForApi } from "../lib/activityFactsSynthesizeFromCanonical";
-import { loadActivityStepsFromRawForApi } from "../lib/activityStepsSynthesizeFromRaw";
 import { loadBodyFactsFromRawForApi } from "../lib/bodyFactsSynthesizeFromRaw";
 import type { RequestWithRid } from "../lib/logger";
 import { logger } from "../lib/logger";
@@ -1596,42 +1594,8 @@ router.get(
         });
       }
 
-      let synthesizedActivity: Awaited<ReturnType<typeof loadActivityStepsFromCanonicalForApi>> | undefined;
-      let activitySynthesisSource: "canonical" | "raw" | undefined;
-      try {
-        synthesizedActivity = await loadActivityStepsFromCanonicalForApi(uid, day);
-        if (synthesizedActivity) activitySynthesisSource = "canonical";
-      } catch (err) {
-        logger.info({
-          msg: "daily_facts_synthesize_activity_from_canonical_failed",
-          level: "warn",
-          rid: getRid(req),
-          day,
-          error: err instanceof Error ? err.message : String(err),
-        });
-      }
-      if (!synthesizedActivity) {
-        try {
-          synthesizedActivity = await loadActivityStepsFromRawForApi(uid, day);
-          if (synthesizedActivity) activitySynthesisSource = "raw";
-        } catch (err) {
-          logger.info({
-            msg: "daily_facts_synthesize_activity_from_raw_failed",
-            level: "warn",
-            rid: getRid(req),
-            day,
-            error: err instanceof Error ? err.message : String(err),
-          });
-        }
-      }
-
-      if (synthesizedBody || synthesizedActivity) {
+      if (synthesizedBody) {
         const computedAt = new Date().toISOString();
-        const source: Record<string, unknown> = {};
-        if (synthesizedBody) source.synthesizedFromRaw = true;
-        if (activitySynthesisSource === "canonical") source.synthesizedActivityFromCanonical = true;
-        if (activitySynthesisSource === "raw") source.synthesizedActivityFromRaw = true;
-
         const draft = {
           schemaVersion: 1 as const,
           userId: uid,
@@ -1640,10 +1604,9 @@ router.get(
           meta: {
             computedAt,
             pipelineVersion: 1,
-            source,
+            source: { synthesizedFromRaw: true as const },
           },
-          ...(synthesizedBody ? { body: synthesizedBody } : {}),
-          ...(synthesizedActivity ? { activity: { steps: synthesizedActivity.steps } } : {}),
+          body: synthesizedBody,
         };
         const synParsed = dailyFactsDtoSchema.safeParse(draft);
         if (synParsed.success) {
@@ -1662,59 +1625,7 @@ router.get(
       return;
     }
 
-    let out = parsed.data;
-    const stepsVal = out.activity?.steps;
-    const hasNumericActivitySteps =
-      typeof stepsVal === "number" && Number.isFinite(stepsVal) && stepsVal >= 0;
-
-    if (!hasNumericActivitySteps) {
-      let synthesizedActivity: Awaited<ReturnType<typeof loadActivityStepsFromCanonicalForApi>> | undefined;
-      try {
-        synthesizedActivity = await loadActivityStepsFromCanonicalForApi(uid, day);
-      } catch (err) {
-        logger.info({
-          msg: "daily_facts_merge_activity_from_canonical_failed",
-          level: "warn",
-          rid: getRid(req),
-          day,
-          error: err instanceof Error ? err.message : String(err),
-        });
-      }
-      if (!synthesizedActivity) {
-        try {
-          synthesizedActivity = await loadActivityStepsFromRawForApi(uid, day);
-        } catch (err) {
-          logger.info({
-            msg: "daily_facts_merge_activity_from_raw_failed",
-            level: "warn",
-            rid: getRid(req),
-            day,
-            error: err instanceof Error ? err.message : String(err),
-          });
-        }
-      }
-      if (synthesizedActivity) {
-        const priorSource =
-          typeof out.meta?.source === "object" && out.meta.source !== null && !Array.isArray(out.meta.source)
-            ? { ...(out.meta.source as Record<string, unknown>) }
-            : {};
-        const merged = {
-          ...out,
-          activity: { ...(out.activity ?? {}), steps: synthesizedActivity.steps },
-          meta: {
-            computedAt: out.meta?.computedAt ?? out.computedAt,
-            pipelineVersion: out.meta?.pipelineVersion ?? 1,
-            source: { ...priorSource, activityStepsFilledOnRead: true },
-          },
-        };
-        const mergedParsed = dailyFactsDtoSchema.safeParse(merged);
-        if (mergedParsed.success) {
-          out = mergedParsed.data;
-        }
-      }
-    }
-
-    res.status(200).json(out);
+    res.status(200).json(parsed.data);
   }),
 );
 

--- a/services/api/src/types/events.ts
+++ b/services/api/src/types/events.ts
@@ -69,9 +69,11 @@ const isoDateTimeString = z
  * RawEvent ingestion request body for the Cloud Run gateway.
  *
  * Time semantics:
- * - `observedAt` is preferred and canonical.
+ * - `observedAt` is preferred over `occurredAt` when both are present (envelope instant for storage).
  * - `occurredAt` is accepted for backward compatibility.
- * - Exactly one of them MUST be present.
+ * - Exactly one of them MUST be present unless both are sent; then `observedAt` wins.
+ * - Apple Health `steps`: local calendar `day` is derived only from `payload.start` + `payload.timezone`
+ *   (must match top-level `timeZone`); envelope instants must not override that day mapping.
  *
  * Payload semantics:
  * - Payload is intentionally opaque at the ingestion boundary.

--- a/services/functions/src/dailyFacts/__tests__/aggregateDailyFacts.test.ts
+++ b/services/functions/src/dailyFacts/__tests__/aggregateDailyFacts.test.ts
@@ -155,7 +155,7 @@ describe('aggregateDailyFactsForDay', () => {
     expect(sleep.mainSleepMinutes).toBe(480);
 
     const activity = result.activity!;
-    // Two non-apple step events: pick higher (8000), do not sum (avoids duplicate sources)
+    // Two non-apple step events, same updatedAt: lexicographic id tie-break (steps_1 before steps_2), do not sum
     expect(activity.steps).toBe(8000);
     // training load from single workout
     expect(activity.trainingLoad).toBe(50);
@@ -290,6 +290,32 @@ describe('aggregateDailyFactsForDay', () => {
       events,
     });
     expect(result.activity?.steps).toBe(5012);
+  });
+
+  it('collapses duplicate apple_health rows sharing sourceSampleId to latest updatedAt', () => {
+    const events: CanonicalEvent[] = [
+      makeSteps({
+        id: 'raw_early',
+        sourceId: 'apple_health',
+        sourceSampleId: 'HK-1',
+        steps: 15577,
+        updatedAt: '2025-01-01T08:00:00.000Z',
+      }),
+      makeSteps({
+        id: 'raw_late',
+        sourceId: 'apple_health',
+        sourceSampleId: 'HK-1',
+        steps: 148,
+        updatedAt: '2025-01-01T18:00:00.000Z',
+      }),
+    ];
+    const result = aggregateDailyFactsForDay({
+      userId: 'user_123',
+      date: '2025-01-01',
+      computedAt: '2025-01-02T03:00:00.000Z',
+      events,
+    });
+    expect(result.activity?.steps).toBe(148);
   });
 
   it('returns minimal DailyFacts when no events exist', () => {

--- a/services/functions/src/dailyFacts/aggregateDailyFacts.ts
+++ b/services/functions/src/dailyFacts/aggregateDailyFacts.ts
@@ -20,6 +20,7 @@ import type {
   NutritionCanonicalEvent,
 } from '../types/health';
 
+// Steps scalar uses {@link pickContributingStepEventsForDailyFacts} (time + id dedupe, not max(steps)).
 import {
   pickContributingStepEventsForDailyFacts,
   resolvedStepsTotalFromContributing,

--- a/services/functions/src/normalization/__tests__/mapRawEventToCanonical.test.ts
+++ b/services/functions/src/normalization/__tests__/mapRawEventToCanonical.test.ts
@@ -115,6 +115,56 @@ describe("mapRawEventToCanonical", () => {
     expect(stepsEvent.steps).toBe(8421);
   });
 
+  it("maps sampleId on apple_health steps payload to canonical sourceSampleId", () => {
+    const raw: RawEvent = {
+      ...baseRawEvent,
+      id: "raw_ah_steps_sample",
+      sourceId: "healthkit",
+      provider: "apple_health",
+      kind: "steps",
+      payload: {
+        start: "2025-01-01T05:00:00.000Z",
+        end: "2025-01-02T04:59:59.999Z",
+        timezone: "America/New_York",
+        steps: 100,
+        sampleId: "  hk-uuid-1  ",
+      } as unknown,
+    };
+
+    const result = mapRawEventToCanonical(raw);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected mapping success");
+    const stepsEvent = result.canonical as Extract<CanonicalEvent, { kind: "steps" }>;
+    expect(stepsEvent.sourceSampleId).toBe("hk-uuid-1");
+  });
+
+  it("apple_health steps: canonical day follows payload.start+timezone, not raw observedAt", () => {
+    const raw: RawEvent = {
+      ...baseRawEvent,
+      id: "raw_ah_steps_drift",
+      sourceId: "apple_health",
+      provider: "apple_health",
+      kind: "steps",
+      observedAt: "2025-01-02T12:00:00.000Z",
+      payload: {
+        start: "2025-01-01T05:00:00.000Z",
+        end: "2025-01-02T04:59:59.999Z",
+        timezone: "America/New_York",
+        day: "2099-12-31",
+        steps: 100,
+      } as unknown,
+    };
+
+    const result = mapRawEventToCanonical(raw);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected mapping success");
+    const canonical = result.canonical as Extract<CanonicalEvent, { kind: "steps" }>;
+    expect(canonical.day).toBe(
+      new Intl.DateTimeFormat("en-CA", { timeZone: "America/New_York" }).format(new Date("2025-01-01T05:00:00.000Z")),
+    );
+    expect(canonical.day).not.toBe("2099-12-31");
+  });
+
   it("returns fact-only for weight (no canonical event, trigger recompute via onRawEventCreated)", () => {
     const raw: RawEvent = {
       ...baseRawEvent,

--- a/services/functions/src/normalization/__tests__/writeCanonicalEventImmutable.steps-intraday.test.ts
+++ b/services/functions/src/normalization/__tests__/writeCanonicalEventImmutable.steps-intraday.test.ts
@@ -71,7 +71,7 @@ jest.mock("../../firebaseAdmin", () => ({
 import type { StepsCanonicalEvent } from "../../types/health";
 import { writeCanonicalEventImmutable } from "../writeCanonicalEventImmutable";
 
-function stepsCanonical(steps: number, updatedAt: string): StepsCanonicalEvent {
+function stepsCanonical(steps: number, updatedAt: string, sourceSampleId?: string | null): StepsCanonicalEvent {
   return {
     id: "appleHealth:v2:steps:2026-04-08",
     userId: "u_steps",
@@ -85,6 +85,7 @@ function stepsCanonical(steps: number, updatedAt: string): StepsCanonicalEvent {
     updatedAt,
     schemaVersion: 1,
     steps,
+    ...(sourceSampleId !== undefined ? { sourceSampleId } : {}),
     distanceKm: null,
     moveMinutes: null,
   };
@@ -125,7 +126,7 @@ describe("writeCanonicalEventImmutable — steps intraday", () => {
     expect(res).toEqual({ ok: true, mode: "identical_noop" });
   });
 
-  it("does not reduce steps when a lower cumulative total arrives out of order", async () => {
+  it("ignores out-of-order ingest when incoming updatedAt is older than existing", async () => {
     const path = "users/u_steps/events/appleHealth:v2:steps:2026-04-08";
     mockTransactionStore.set(path, { ...stepsCanonical(5000, "2026-04-08T20:00:00.000Z") } as Record<string, unknown>);
 
@@ -138,5 +139,52 @@ describe("writeCanonicalEventImmutable — steps intraday", () => {
 
     expect(res).toEqual({ ok: true, mode: "identical_noop" });
     expect((mockTransactionStore.get(path) as { steps?: number }).steps).toBe(5000);
+  });
+
+  it("same updatedAt: incoming steps replace existing (idempotent correction replay)", async () => {
+    const path = "users/u_steps/events/appleHealth:v2:steps:2026-04-08";
+    mockTransactionStore.set(path, { ...stepsCanonical(15577, "2026-04-08T18:00:00.000Z") } as Record<string, unknown>);
+
+    const res = await writeCanonicalEventImmutable({
+      userId: "u_steps",
+      canonical: { ...stepsCanonical(148, "2026-04-08T18:00:00.000Z") },
+      sourceRawEventId: "appleHealth:v2:steps:2026-04-08",
+      sourceRawEventPath: "x",
+    });
+
+    expect(res).toEqual({ ok: true, mode: "replaced" });
+    expect((mockTransactionStore.get(path) as { steps?: number }).steps).toBe(148);
+  });
+
+  it("merges sourceSampleId from incoming when newer updatedAt replaces steps", async () => {
+    const path = "users/u_steps/events/appleHealth:v2:steps:2026-04-08";
+    mockTransactionStore.set(path, { ...stepsCanonical(100, "2026-04-08T08:00:00.000Z", null) } as Record<string, unknown>);
+
+    const res = await writeCanonicalEventImmutable({
+      userId: "u_steps",
+      canonical: { ...stepsCanonical(120, "2026-04-08T18:00:00.000Z", "hk-99") },
+      sourceRawEventId: "appleHealth:v2:steps:2026-04-08",
+      sourceRawEventPath: "x",
+    });
+
+    expect(res).toEqual({ ok: true, mode: "replaced" });
+    const stored = mockTransactionStore.get(path) as { steps?: number; sourceSampleId?: string | null };
+    expect(stored.steps).toBe(120);
+    expect(stored.sourceSampleId).toBe("hk-99");
+  });
+
+  it("applies Apple downward correction when newer updatedAt carries a lower total", async () => {
+    const path = "users/u_steps/events/appleHealth:v2:steps:2026-04-08";
+    mockTransactionStore.set(path, { ...stepsCanonical(15577, "2026-04-08T10:00:00.000Z") } as Record<string, unknown>);
+
+    const res = await writeCanonicalEventImmutable({
+      userId: "u_steps",
+      canonical: { ...stepsCanonical(148, "2026-04-08T18:00:00.000Z") },
+      sourceRawEventId: "appleHealth:v2:steps:2026-04-08",
+      sourceRawEventPath: "x",
+    });
+
+    expect(res).toEqual({ ok: true, mode: "replaced" });
+    expect((mockTransactionStore.get(path) as { steps?: number }).steps).toBe(148);
   });
 });

--- a/services/functions/src/normalization/mapRawEventToCanonical.ts
+++ b/services/functions/src/normalization/mapRawEventToCanonical.ts
@@ -1,9 +1,9 @@
 // services/functions/src/normalization/mapRawEventToCanonical.ts
+import { localCalendarDayKeyFromIsoInTimeZone } from "@oli/contracts";
 import type {
   CanonicalEvent,
   RawEvent,
   IsoDateTimeString,
-  YmdDateString,
   SleepCanonicalEvent,
   StepsCanonicalEvent,
   WorkoutCanonicalEvent,
@@ -62,35 +62,6 @@ export type MappingSuccess = {
 export type MappingResult = MappingSuccess | MappingFailure;
 
 // -----------------------------------------------------------------------------
-// Canonical dayKey derivation (AUTHORITATIVE)
-// -----------------------------------------------------------------------------
-
-/**
- * Canonical dayKey derivation using IANA timezone.
- *
- * Algorithm must match the ingestion acknowledgement semantics:
- *   Intl.DateTimeFormat("en-CA", { timeZone }).format(new Date(iso))
- *
- * Returns null if:
- * - ISO timestamp is invalid, OR
- * - timeZone is invalid (fail closed; no UTC fallback here)
- */
-const ymdInTimeZoneFromIso = (
-  iso: string,
-  timeZone: string,
-): YmdDateString | null => {
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return null;
-
-  try {
-    const fmt = new Intl.DateTimeFormat("en-CA", { timeZone });
-    return fmt.format(d) as YmdDateString;
-  } catch {
-    return null;
-  }
-};
-
-// -----------------------------------------------------------------------------
 // Manual payload shapes & guards
 // -----------------------------------------------------------------------------
 
@@ -112,6 +83,9 @@ type ManualStepsPayload = ManualWindowBase & {
   steps: number;
   distanceKm?: number | null;
   moveMinutes?: number | null;
+  sourceSampleId?: string;
+  sampleId?: string;
+  sourceUUID?: string;
 };
 
 type ManualWorkoutPayload = ManualWindowBase & {
@@ -309,7 +283,7 @@ const mapManualSleep = (
   raw: RawEvent,
   payload: ManualSleepPayload,
 ): SleepCanonicalEvent | null => {
-  const day = ymdInTimeZoneFromIso(payload.start, payload.timezone);
+  const day = localCalendarDayKeyFromIsoInTimeZone(payload.start, payload.timezone);
   if (!day) return null;
 
   return {
@@ -332,12 +306,24 @@ const mapManualSleep = (
   };
 };
 
+function stepsPayloadSourceSampleId(payload: ManualStepsPayload): string | undefined {
+  const a = payload.sourceSampleId?.trim();
+  if (a) return a;
+  const b = payload.sampleId?.trim();
+  if (b) return b;
+  const c = payload.sourceUUID?.trim();
+  if (c) return c;
+  return undefined;
+}
+
 const mapManualSteps = (
   raw: RawEvent,
   payload: ManualStepsPayload,
 ): StepsCanonicalEvent | null => {
-  const day = ymdInTimeZoneFromIso(payload.start, payload.timezone);
+  const day = localCalendarDayKeyFromIsoInTimeZone(payload.start, payload.timezone);
   if (!day) return null;
+
+  const sourceSampleId = stepsPayloadSourceSampleId(payload);
 
   return {
     id: raw.id,
@@ -352,6 +338,7 @@ const mapManualSteps = (
     updatedAt: raw.receivedAt,
     schemaVersion: 1,
     steps: payload.steps,
+    ...(sourceSampleId ? { sourceSampleId } : {}),
     distanceKm: payload.distanceKm ?? null,
     moveMinutes: payload.moveMinutes ?? null,
   };
@@ -361,7 +348,7 @@ const mapManualWorkout = (
   raw: RawEvent,
   payload: ManualWorkoutPayload,
 ): WorkoutCanonicalEvent | null => {
-  const day = ymdInTimeZoneFromIso(payload.start, payload.timezone);
+  const day = localCalendarDayKeyFromIsoInTimeZone(payload.start, payload.timezone);
   if (!day) return null;
 
   const base: WorkoutCanonicalEvent = {
@@ -392,7 +379,7 @@ const mapManualHrv = (
   raw: RawEvent,
   payload: ManualHrvPayload,
 ): HrvCanonicalEvent | null => {
-  const day = ymdInTimeZoneFromIso(payload.time, payload.timezone);
+  const day = localCalendarDayKeyFromIsoInTimeZone(payload.time, payload.timezone);
   if (!day) return null;
 
   const base: HrvCanonicalEvent = {
@@ -419,7 +406,7 @@ const mapManualHrv = (
 };
 
 const mapManualNutrition = (raw: RawEvent, payload: ManualNutritionPayload): NutritionCanonicalEvent | null => {
-  const day = ymdInTimeZoneFromIso(payload.start, payload.timezone);
+  const day = localCalendarDayKeyFromIsoInTimeZone(payload.start, payload.timezone);
   if (!day) return null;
 
   const canonical: NutritionCanonicalEvent = {
@@ -449,7 +436,7 @@ const mapManualStrengthWorkout = (
   raw: RawEvent,
   payload: ManualStrengthWorkoutPayload,
 ): StrengthWorkoutCanonicalEvent | null => {
-  const day = ymdInTimeZoneFromIso(payload.startedAt, payload.timeZone);
+  const day = localCalendarDayKeyFromIsoInTimeZone(payload.startedAt, payload.timeZone);
   if (!day) return null;
 
   const exercises: StrengthWorkoutCanonicalSet[] = [];

--- a/services/functions/src/normalization/processRawEventForNormalization.ts
+++ b/services/functions/src/normalization/processRawEventForNormalization.ts
@@ -436,6 +436,7 @@ export async function processRawEventForNormalization(params: {
           db,
           userId: rawEvent.userId,
           dayKey,
+          canonicalAnchorDay: canonical.day as YmdDateString,
           trigger: {
             type: "realtime",
             eventId: `${canonical.id}:steps_norm_${writeRes.mode}`,

--- a/services/functions/src/normalization/writeCanonicalEventImmutable.ts
+++ b/services/functions/src/normalization/writeCanonicalEventImmutable.ts
@@ -6,37 +6,38 @@ import { admin, db } from "../firebaseAdmin";
 import type { CanonicalEvent, StepsCanonicalEvent } from "../types/health";
 import { canonicalEquals, canonicalHash } from "./canonicalImmutability";
 
-function lexIsoMax(a: string | undefined, b: string | undefined): string {
-  const aa = a ?? "";
-  const bb = b ?? "";
-  return aa >= bb ? aa : bb;
-}
-
 /**
- * Apple Health (and manual) daily steps reuse one canonical id per day; totals are cumulative intraday.
- * Out-of-order delivery must not reduce the stored total. When the count increases, the newer payload wins
- * for scalar fields; `updatedAt` is the lexicographic max of both.
+ * Same-day steps share one canonical document id (e.g. Apple Health daily aggregate). Ingest replays
+ * carry a newer `updatedAt` from the raw event's `receivedAt`. The **latest** ingest wins so Apple
+ * downward corrections (lower cumulative after sample removal) can replace a stale higher total.
+ * Older `updatedAt` deliveries are ignored as out-of-order.
  */
 function mergeIntradayStepsCanonical(
   existing: StepsCanonicalEvent,
   incoming: StepsCanonicalEvent,
 ): { merged: StepsCanonicalEvent; changed: boolean } {
-  if (incoming.steps < existing.steps) {
-    return { merged: existing, changed: false };
-  }
-  if (incoming.steps > existing.steps) {
+  const inT = incoming.updatedAt ?? "";
+  const exT = existing.updatedAt ?? "";
+  if (inT > exT) {
     const merged: StepsCanonicalEvent = {
       ...incoming,
-      steps: incoming.steps,
-      updatedAt: lexIsoMax(existing.updatedAt, incoming.updatedAt),
+      updatedAt: incoming.updatedAt,
+      createdAt: existing.createdAt ?? incoming.createdAt,
+      sourceSampleId: incoming.sourceSampleId ?? existing.sourceSampleId ?? null,
     };
     return { merged, changed: !canonicalEquals(existing, merged) };
   }
+  if (inT < exT) {
+    return { merged: existing, changed: false };
+  }
+  // Same `updatedAt` (rare): treat incoming as authoritative for idempotent replay / correction tie.
   const merged: StepsCanonicalEvent = {
     ...existing,
     ...incoming,
-    steps: existing.steps,
-    updatedAt: lexIsoMax(existing.updatedAt, incoming.updatedAt),
+    steps: incoming.steps,
+    updatedAt: inT || exT,
+    createdAt: existing.createdAt,
+    sourceSampleId: incoming.sourceSampleId ?? existing.sourceSampleId ?? null,
   };
   return { merged, changed: !canonicalEquals(existing, merged) };
 }

--- a/services/functions/src/pipeline/__tests__/recomputeForDay.dayGuard.test.ts
+++ b/services/functions/src/pipeline/__tests__/recomputeForDay.dayGuard.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Hard invariants on recompute dayKey vs canonical.day (Apple steps safety).
+ */
+import { describe, it, expect } from "@jest/globals";
+import type { Firestore } from "firebase-admin/firestore";
+
+import { recomputeDerivedTruthForDay } from "../recomputeForDay";
+import type { StepsCanonicalEvent } from "../../types/health";
+
+describe("recomputeDerivedTruthForDay — day guards", () => {
+  it("throws RECOMPUTE_DAY_MISMATCH when canonicalAnchorDay disagrees with dayKey", async () => {
+    await expect(
+      recomputeDerivedTruthForDay({
+        db: {} as Firestore,
+        userId: "u1",
+        dayKey: "2026-01-01",
+        canonicalAnchorDay: "2026-01-02",
+        trigger: { type: "admin", source: "unit_test" },
+      }),
+    ).rejects.toThrow(/RECOMPUTE_DAY_MISMATCH/);
+  });
+
+  it("throws RECOMPUTE_CANONICAL_DAY_DRIFT when loaded event.day disagrees with dayKey", async () => {
+    const bad: StepsCanonicalEvent = {
+      kind: "steps",
+      id: "corrupt_row",
+      userId: "u1",
+      sourceId: "apple_health",
+      start: "2026-01-04T00:00:00.000Z",
+      end: "2026-01-04T23:59:59.999Z",
+      day: "2099-01-01",
+      timezone: "Etc/UTC",
+      createdAt: "2026-01-04T12:00:00.000Z",
+      updatedAt: "2026-01-04T12:00:00.000Z",
+      schemaVersion: 1,
+      steps: 10,
+    };
+
+    const mockDb = {
+      collection: () => ({
+        doc: () => ({
+          collection: (name: string) => {
+            if (name === "events") {
+              return {
+                where: () => ({
+                  get: async () => ({
+                    docs: [{ data: () => bad }],
+                  }),
+                }),
+              };
+            }
+            return { where: () => ({ get: async () => ({ docs: [] }) }) };
+          },
+        }),
+      }),
+    } as unknown as Firestore;
+
+    await expect(
+      recomputeDerivedTruthForDay({
+        db: mockDb,
+        userId: "u1",
+        dayKey: "2026-01-04",
+        trigger: { type: "admin", source: "unit_test" },
+      }),
+    ).rejects.toThrow(/RECOMPUTE_CANONICAL_DAY_DRIFT/);
+  });
+});

--- a/services/functions/src/pipeline/recomputeForDay.ts
+++ b/services/functions/src/pipeline/recomputeForDay.ts
@@ -72,6 +72,11 @@ export interface RecomputeForDayInput {
   db: Firestore;
   userId: string;
   dayKey: YmdDateString;
+  /**
+   * Hard lock from normalization: mapped canonical `day` for the raw event that triggered recompute.
+   * When set, must equal `dayKey` or the function throws before any reads/writes (no silent wrong-day DailyFacts).
+   */
+  canonicalAnchorDay?: YmdDateString;
   /** Body facts from fact-only raw events (e.g. weight). When provided, merged into dailyFacts when no canonical weight events exist. */
   factOnlyBody?: DailyBodyFacts;
   trigger: { type: "factOnly"; rawEventId: string } | { type: "realtime"; eventId: string } | { type: "admin"; source: string };
@@ -82,8 +87,14 @@ export interface RecomputeForDayInput {
  * Idempotent; overwrites are allowed.
  */
 export async function recomputeDerivedTruthForDay(input: RecomputeForDayInput): Promise<void> {
-  const { db, userId, dayKey, trigger } = input;
+  const { db, userId, dayKey, trigger, canonicalAnchorDay } = input;
   const computedAt: IsoDateTimeString = new Date().toISOString();
+
+  if (canonicalAnchorDay !== undefined && canonicalAnchorDay !== dayKey) {
+    throw new Error(
+      `recomputeDerivedTruthForDay: RECOMPUTE_DAY_MISMATCH dayKey=${dayKey} canonicalAnchorDay=${canonicalAnchorDay}`,
+    );
+  }
 
   const userRef = db.collection("users").doc(userId);
 
@@ -97,6 +108,13 @@ export async function recomputeDerivedTruthForDay(input: RecomputeForDayInput): 
     const fp = canonicalEventsFingerprint(eventsForDay);
     if (fp === fpPrev) break;
     fpPrev = fp;
+  }
+
+  const drift = eventsForDay.find((e) => e.day !== dayKey);
+  if (drift) {
+    throw new Error(
+      `recomputeDerivedTruthForDay: RECOMPUTE_CANONICAL_DAY_DRIFT dayKey=${dayKey} eventId=${drift.id} event.day=${drift.day}`,
+    );
   }
 
   const latestCanonicalEventAt: IsoDateTimeString | undefined =

--- a/services/functions/src/types/health.ts
+++ b/services/functions/src/types/health.ts
@@ -192,6 +192,12 @@ export interface StepsCanonicalEvent extends BaseCanonicalEvent {
   /** Total steps in this window */
   steps: number;
 
+  /**
+   * Stable logical sample identity from the raw payload (e.g. HealthKit sample id), when present.
+   * Dedupe / aggregation groups same-day Apple-class rows by this key before timestamp ordering.
+   */
+  sourceSampleId?: string | null;
+
   /** Optional travel distance in km */
   distanceKm?: number | null;
 


### PR DESCRIPTION
…y refresh, UI loading polish, and tier color refinement

- move forced yesterday refresh to global app lifecycle
- replace throttle with correctness-based ingest check + polling
- fix stale dailyFacts display on detail screen
- implement stale-while-revalidate for activity rollup
- remove calendar ring flicker
- align readiness state to canonical values (no 'pending')
- fix navigation context in tests
- clean lint + invariant violations
- refine activity tier visuals (Good vs Great separation)