### PR TITLE
feat(sleep): fix Oura ingestion pagination, wake-day assignment, and …

### DIFF
--- a/app/(app)/recovery/__tests__/sleep-screen.test.tsx
+++ b/app/(app)/recovery/__tests__/sleep-screen.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import renderer, { act } from "react-test-renderer";
 
 const mockRouterPush = jest.fn();
+const mockUseLocalSearchParams = jest.fn(() => ({}));
 let navigationOptions: { headerRight?: () => React.ReactElement } = {};
 
 jest.mock("expo-router", () => ({
@@ -12,6 +13,7 @@ jest.mock("expo-router", () => ({
     goBack: jest.fn(),
   }),
   useRouter: () => ({ push: mockRouterPush }),
+  useLocalSearchParams: () => mockUseLocalSearchParams(),
 }));
 
 jest.mock("@react-navigation/native", () => ({
@@ -37,25 +39,14 @@ jest.mock("@/lib/ui/calendar/dateUtils", () => ({
   ],
 }));
 
-jest.mock("@/lib/data/useSleepView", () => ({
-  useSleepView: () => ({
-    status: "ready" as const,
-    data: {
-      requestedDay: "2026-04-06",
-      resolvedDay: "2026-04-06",
-      isFallback: false,
-      day: "2026-04-06",
-      score: 72,
-      contributors: {},
-    },
-    refetch: jest.fn(),
-  }),
+jest.mock("@/lib/data/useSleepDayView", () => ({
+  useSleepDayView: jest.fn(),
 }));
 
-jest.mock("@/lib/data/oura/useOuraViewWeekSnapshotPresence", () => ({
-  useOuraViewWeekSnapshotPresence: () => ({
+jest.mock("@/lib/data/useSleepWeekDataPresence", () => ({
+  useSleepWeekDataPresence: () => ({
     status: "ready" as const,
-    hasSnapshotByDay: {
+    hasSleepDataByDay: {
       "2026-04-05": false,
       "2026-04-06": true,
       "2026-04-07": true,
@@ -79,12 +70,50 @@ jest.mock("@/lib/data/useOuraPresence", () => ({
   }),
 }));
 
+/** Avoid ScrollView/RefreshControl JSON serialization issues in react-test-renderer. */
+jest.mock("@/lib/ui/ModuleScreenShell", () => {
+  const React = require("react");
+  const { View } = require("react-native");
+  return {
+    ModuleScreenShell: ({
+      children,
+      headerContent,
+    }: {
+      children: React.ReactNode;
+      headerContent?: React.ReactNode;
+    }) =>
+      React.createElement(
+        View,
+        null,
+        headerContent ?? null,
+        children,
+      ),
+  };
+});
+
+import { useSleepDayView } from "@/lib/data/useSleepDayView";
 import SleepScreen from "../sleep";
+
+const defaultOuraFallbackState = {
+  status: "oura_fallback" as const,
+  data: {
+    requestedDay: "2026-04-06",
+    resolvedDay: "2026-04-06",
+    isFallback: false,
+    day: "2026-04-06",
+    score: 72,
+    contributors: {},
+  },
+  refetch: jest.fn(),
+};
 
 describe("SleepScreen", () => {
   beforeEach(() => {
     mockRouterPush.mockClear();
+    mockUseLocalSearchParams.mockReset();
+    mockUseLocalSearchParams.mockReturnValue({});
     navigationOptions = {};
+    jest.mocked(useSleepDayView).mockReturnValue(defaultOuraFallbackState);
   });
 
   it("header exposes calendar and settings routes via HeaderControls", async () => {
@@ -120,5 +149,249 @@ describe("SleepScreen", () => {
     expect(str).toContain("sleep-weekly-ring-2026-04-06");
     expect(str).toContain("sleep-weekly-ring-2026-04-07");
     expect(str).not.toContain("sleep-weekly-ring-2026-04-05");
+  });
+
+  it("Oli branch titles the score card and prefers vendor score when API returns one", async () => {
+    jest.mocked(useSleepDayView).mockReturnValue({
+      status: "oli",
+      requestedDay: "2026-04-06",
+      resolvedDay: "2026-04-06",
+      facts: { schemaVersion: 1, userId: "u", date: "2026-04-06", computedAt: "2026-01-01T00:00:00.000Z" },
+      sleep: {
+        totalMinutes: 420,
+        mainSleepMinutes: 420,
+        efficiency: 0.9,
+        oliSleepScore: {
+          value: 81,
+          version: "sleep-score-v1.0.0",
+          computedAt: "2026-01-01T00:00:00.000Z",
+          confidence: 0.85,
+          components: {
+            duration: 0.9,
+            efficiency: 0.8,
+            latency: 0.7,
+            rem: 0.6,
+            deep: 0.5,
+          },
+          weights: {
+            duration: 0.4,
+            efficiency: 0.2,
+            latency: 0.15,
+            rem: 0.125,
+            deep: 0.125,
+          },
+          reasons: ["Sleep duration was strong."],
+        },
+      },
+      insights: null,
+      vendorSleepView: {
+        requestedDay: "2026-04-06",
+        resolvedDay: "2026-04-06",
+        isFallback: false,
+        day: "2026-04-06",
+        score: 88,
+        contributors: {},
+      },
+      refetch: jest.fn(),
+    });
+    let tree!: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<SleepScreen />);
+      await Promise.resolve();
+    });
+    const str = JSON.stringify(tree!.toJSON());
+    expect(str).toContain("Sleep Score");
+    expect(str).toContain("88");
+    expect(str).not.toContain("81");
+    expect(str).not.toContain("Computed by Oli from your sleep facts");
+    expect(str).not.toContain("Oli sleep facts");
+  });
+
+  it("Oli branch falls back honestly when vendor and Oli scores are unavailable", async () => {
+    jest.mocked(useSleepDayView).mockReturnValue({
+      status: "oli",
+      requestedDay: "2026-04-06",
+      resolvedDay: "2026-04-06",
+      facts: { schemaVersion: 1, userId: "u", date: "2026-04-06", computedAt: "2026-01-01T00:00:00.000Z" },
+      sleep: {
+        totalMinutes: 420,
+        oliSleepScore: {
+          value: null,
+          version: "sleep-score-v1.0.0",
+          computedAt: "2026-01-01T00:00:00.000Z",
+          confidence: 0.35,
+          components: {
+            duration: 0.5,
+            efficiency: null,
+            latency: null,
+            rem: null,
+            deep: null,
+          },
+          weights: {
+            duration: 1,
+            efficiency: 0,
+            latency: 0,
+            rem: 0,
+            deep: 0,
+          },
+          reasons: ["Stage data was incomplete, so no Oli score is shown."],
+        },
+      },
+      insights: null,
+      vendorSleepView: null,
+      refetch: jest.fn(),
+    });
+    let tree!: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<SleepScreen />);
+      await Promise.resolve();
+    });
+    const str = JSON.stringify(tree!.toJSON());
+    expect(str).toContain("Stage data was incomplete");
+    expect(str).not.toContain("We'll show a score when Oura provides one.");
+  });
+
+  it("metrics card titles Last night's sleep, omits rollup copy and awakenings, renders metric bars", async () => {
+    jest.mocked(useSleepDayView).mockReturnValue({
+      status: "oli",
+      requestedDay: "2026-04-06",
+      resolvedDay: "2026-04-06",
+      facts: { schemaVersion: 1, userId: "u", date: "2026-04-06", computedAt: "2026-01-01T00:00:00.000Z" },
+      sleep: {
+        totalMinutes: 420,
+        mainSleepMinutes: 420,
+        efficiency: 0.88,
+        latencyMinutes: 10,
+        remSleepMinutes: 75,
+        deepSleepMinutes: 55,
+        awakenings: 3,
+        oliSleepScore: {
+          value: 80,
+          version: "sleep-score-v1.0.0",
+          computedAt: "2026-01-01T00:00:00.000Z",
+          confidence: 0.9,
+          components: {
+            duration: 0.9,
+            efficiency: 0.85,
+            latency: 0.8,
+            rem: 0.75,
+            deep: 0.7,
+          },
+          weights: {
+            duration: 0.4,
+            efficiency: 0.2,
+            latency: 0.15,
+            rem: 0.125,
+            deep: 0.125,
+          },
+          reasons: [],
+        },
+      },
+      insights: null,
+      vendorSleepView: null,
+      refetch: jest.fn(),
+    });
+    let tree!: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<SleepScreen />);
+      await Promise.resolve();
+    });
+    const str = JSON.stringify(tree!.toJSON());
+    expect(str).toContain("Last night's sleep");
+    expect(str).not.toContain("Rollup from");
+    expect(str).not.toContain("Awakenings");
+    expect(str).toContain("sleep-oli-metric-bar-total");
+    expect(str).toContain("sleep-oli-metric-bar-efficiency");
+    expect(str).toContain("sleep-oli-metric-bar-latency");
+    expect(str).toContain("sleep-oli-metric-bar-rem");
+    expect(str).toContain("sleep-oli-metric-bar-deep");
+    expect(str).toContain("sleep-oli-metric-pill-total");
+    expect(str).toContain("sleep-oli-metric-pill-efficiency");
+    expect(str).toContain("Optimal");
+  });
+
+  it("applies route day param when returning from calendar", async () => {
+    mockUseLocalSearchParams.mockReturnValue({ day: "2026-04-07" });
+    jest.mocked(useSleepDayView).mockReturnValue({
+      status: "oli",
+      requestedDay: "2026-04-07",
+      resolvedDay: "2026-04-07",
+      facts: { schemaVersion: 1, userId: "u", date: "2026-04-07", computedAt: "2026-01-01T00:00:00.000Z" },
+      sleep: {
+        totalMinutes: 400,
+        mainSleepMinutes: 400,
+        oliSleepScore: {
+          value: 70,
+          version: "sleep-score-v1.0.0",
+          computedAt: "2026-01-01T00:00:00.000Z",
+          confidence: 0.8,
+          components: {
+            duration: 0.7,
+            efficiency: 0.7,
+            latency: 0.7,
+            rem: 0.7,
+            deep: 0.7,
+          },
+          weights: {
+            duration: 0.4,
+            efficiency: 0.2,
+            latency: 0.15,
+            rem: 0.125,
+            deep: 0.125,
+          },
+          reasons: [],
+        },
+      },
+      insights: null,
+      vendorSleepView: null,
+      refetch: jest.fn(),
+    });
+    await act(async () => {
+      renderer.create(<SleepScreen />);
+      await Promise.resolve();
+    });
+    expect(useSleepDayView).toHaveBeenCalledWith("2026-04-07");
+  });
+
+  it("shows loading shell while sleep view is partial", async () => {
+    jest.mocked(useSleepDayView).mockReturnValue({
+      status: "partial",
+      refetch: jest.fn(),
+    });
+    let tree!: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<SleepScreen />);
+      await Promise.resolve();
+    });
+    expect(JSON.stringify(tree!.toJSON())).toContain("Loading sleep data");
+  });
+
+  it("shows error retry when sleep view errors", async () => {
+    jest.mocked(useSleepDayView).mockReturnValue({
+      status: "error",
+      error: "nope",
+      requestId: null,
+      refetch: jest.fn(),
+    });
+    let tree!: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<SleepScreen />);
+      await Promise.resolve();
+    });
+    const str = JSON.stringify(tree!.toJSON());
+    expect(str).toContain("Couldn't load sleep data");
+    expect(str).toContain("Try again");
+  });
+
+  it("Oura fallback branch uses Sleep Score title without legacy footnote", async () => {
+    let tree!: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<SleepScreen />);
+      await Promise.resolve();
+    });
+    const str = JSON.stringify(tree!.toJSON());
+    expect(str).toContain("Sleep Score");
+    expect(str).not.toContain("Oura nightly score");
+    expect(str).not.toContain("Legacy Oura detail");
   });
 });

--- a/app/(app)/recovery/sleep.tsx
+++ b/app/(app)/recovery/sleep.tsx
@@ -1,14 +1,25 @@
-import React, { useCallback, useLayoutEffect, useMemo, useState } from "react";
-import { View, Text, StyleSheet, ActivityIndicator } from "react-native";
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useState } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  ActivityIndicator,
+  RefreshControl,
+  Pressable,
+  type RefreshControlProps,
+} from "react-native";
 import { useFocusEffect } from "@react-navigation/native";
-import { useNavigation, useRouter } from "expo-router";
+import { useLocalSearchParams, useNavigation, useRouter } from "expo-router";
 import { HeaderBackButton } from "@/lib/ui/HeaderBackButton";
 import { HeaderControls } from "@/lib/ui/HeaderControls";
-import { workoutsStackNavigationOptions } from "@/lib/ui/headers/workoutsStackHeader";
+import {
+  WORKOUTS_HEADER_TITLE_COLOR,
+  workoutsStackNavigationOptions,
+} from "@/lib/ui/headers/workoutsStackHeader";
 import { ModuleScreenShell } from "@/lib/ui/ModuleScreenShell";
-import { useSleepView } from "@/lib/data/useSleepView";
+import { useSleepDayView } from "@/lib/data/useSleepDayView";
 import { useOuraPresence } from "@/lib/data/useOuraPresence";
-import { useOuraViewWeekSnapshotPresence } from "@/lib/data/oura/useOuraViewWeekSnapshotPresence";
+import { useSleepWeekDataPresence } from "@/lib/data/useSleepWeekDataPresence";
 import { deriveOuraImportState } from "@/lib/integrations/oura/importState";
 import { RecoveryScoreCard } from "@/lib/ui/recovery/RecoveryScoreCard";
 import {
@@ -16,6 +27,8 @@ import {
   type ContributorRowProps,
 } from "@/lib/ui/recovery/RecoveryContributorsCard";
 import { RecoveryOuraWeeklyStrip } from "@/lib/ui/recovery/RecoveryOuraWeeklyStrip";
+import { SleepOliMetricsCard } from "@/lib/ui/recovery/SleepOliMetricsCard";
+import { SleepInsightsCard } from "@/lib/ui/recovery/SleepInsightsCard";
 import {
   scoreToRatingLabel,
   contributorValueToProgress,
@@ -26,6 +39,12 @@ import {
 } from "@/lib/format/ouraScore";
 import { getTodayDayKeyLocal, getWeekDaysForAnchor } from "@/lib/ui/calendar/dateUtils";
 import type { CalendarDay } from "@/lib/ui/calendar/types";
+
+function parseDayRouteParam(raw: string | string[] | undefined): string | null {
+  const v = Array.isArray(raw) ? raw[0] : raw;
+  if (v && /^\d{4}-\d{2}-\d{2}$/.test(v)) return v;
+  return null;
+}
 
 /** Format YYYY-MM-DD as "Mar 13" for fallback banner. */
 function formatResolvedDay(day: string): string {
@@ -42,14 +61,22 @@ function formatResolvedDay(day: string): string {
 function RecoveryShell({
   title,
   headerContent,
+  refreshControl,
   children,
 }: {
   title: string;
   headerContent: React.ReactNode;
+  refreshControl?: React.ReactElement<RefreshControlProps>;
   children: React.ReactNode;
 }) {
   return (
-    <ModuleScreenShell title={title} hideTitleChrome compactHeader headerContent={headerContent}>
+    <ModuleScreenShell
+      title={title}
+      hideTitleChrome
+      compactHeader
+      headerContent={headerContent}
+      {...(refreshControl ? { refreshControl } : {})}
+    >
       {children}
     </ModuleScreenShell>
   );
@@ -58,16 +85,49 @@ function RecoveryShell({
 export default function SleepScreen() {
   const navigation = useNavigation();
   const router = useRouter();
-  const [selectedDay, setSelectedDay] = useState(() => getTodayDayKeyLocal());
+  const params = useLocalSearchParams<{ day?: string | string[] }>();
+  const dayFromRoute = parseDayRouteParam(params.day);
+  const [selectedDay, setSelectedDay] = useState(() => dayFromRoute ?? getTodayDayKeyLocal());
+
+  useEffect(() => {
+    const d = parseDayRouteParam(params.day);
+    if (d != null) setSelectedDay(d);
+  }, [params.day]);
   const weekDayKeys = useMemo(() => getWeekDaysForAnchor(selectedDay), [selectedDay]);
-  const weekStripPresence = useOuraViewWeekSnapshotPresence(weekDayKeys, "sleep");
+  const weekStripPresence = useSleepWeekDataPresence(weekDayKeys);
   const refetchWeekStrip = weekStripPresence.refetch;
-  const { refetch: refetchSleep, ...sleepState } = useSleepView(selectedDay);
+  const { refetch: refetchSleep, ...sleepState } = useSleepDayView(selectedDay);
   const ouraPresence = useOuraPresence();
+
+  const [refreshing, setRefreshing] = useState(false);
+
+  const runSleepRefresh = useCallback(async () => {
+    const bust = Date.now();
+    await Promise.all([
+      refetchSleep({ cacheBust: `sleep:pull:${bust}` }),
+      refetchWeekStrip(),
+    ]);
+  }, [refetchSleep, refetchWeekStrip]);
+
+  const onSleepRefresh = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      await runSleepRefresh();
+    } finally {
+      setRefreshing(false);
+    }
+  }, [runSleepRefresh]);
+
+  const sleepRefreshControl = useMemo(
+    () => (
+      <RefreshControl refreshing={refreshing} onRefresh={onSleepRefresh} tintColor="#8E8E93" />
+    ),
+    [refreshing, onSleepRefresh],
+  );
 
   const stripDays: CalendarDay<{ hasOuraSnapshot: boolean }>[] = useMemo(() => {
     const map =
-      weekStripPresence.status === "ready" ? weekStripPresence.hasSnapshotByDay : {};
+      weekStripPresence.status === "ready" ? weekStripPresence.hasSleepDataByDay : {};
     return weekDayKeys.map((day) => ({
       day,
       meta: { hasOuraSnapshot: map[day] === true },
@@ -80,6 +140,7 @@ export default function SleepScreen() {
       selectedDay={selectedDay}
       onDayPress={setSelectedDay}
       categoryLabel="sleep"
+      stripVariant="sleep"
       testIDPrefix="sleep-weekly"
     />
   );
@@ -96,6 +157,11 @@ export default function SleepScreen() {
     navigation.setOptions({
       ...workoutsStackNavigationOptions("module"),
       title: "Sleep",
+      headerTitleStyle: {
+        fontSize: 21,
+        fontWeight: "600",
+        color: WORKOUTS_HEADER_TITLE_COLOR,
+      },
       headerLeft: () => <HeaderBackButton onPress={() => navigation.goBack()} />,
       headerRight: () => (
         <HeaderControls
@@ -110,7 +176,7 @@ export default function SleepScreen() {
 
   if (sleepState.status === "partial") {
     return (
-      <RecoveryShell title="Sleep" headerContent={headerStrip}>
+      <RecoveryShell title="Sleep" headerContent={headerStrip} refreshControl={sleepRefreshControl}>
         <View style={styles.centered}>
           <ActivityIndicator size="large" />
           <Text style={styles.loadingText}>Loading sleep data…</Text>
@@ -120,8 +186,7 @@ export default function SleepScreen() {
   }
 
   if (sleepState.status === "missing") {
-    const ouraConnected =
-      ouraPresence.status === "ready" && ouraPresence.data.connected;
+    const ouraConnected = ouraPresence.status === "ready" && ouraPresence.data.connected;
     const importState = ouraConnected
       ? deriveOuraImportState({
           connected: ouraPresence.data.connected,
@@ -131,20 +196,21 @@ export default function SleepScreen() {
       : null;
     let subtitle2: string;
     if (importState === "running") {
-      subtitle2 = "Oura history is importing. Data should appear when import completes.";
+      subtitle2 =
+        "Sleep history is importing. Pipeline rollups appear after sync and processing complete.";
     } else if (importState === "failed") {
-      subtitle2 = "Oura import failed. Pull to refresh and try again.";
+      subtitle2 = "Device sync failed. Pull to refresh or reconnect in Settings → Devices.";
     } else if (importState === "connected_no_data" || importState === "ready") {
       subtitle2 =
-        "Oura is connected, but there is no sleep snapshot stored for this day yet.";
+        "Device is connected; no sleep rollup or vendor snapshot for this day yet. Try syncing.";
     } else {
       subtitle2 =
-        "Connect Oura in Settings → Devices and sync to see your sleep score and contributors here.";
+        "Connect a sleep-capable source in Settings → Devices and sync to populate sleep.";
     }
     return (
-      <RecoveryShell title="Sleep" headerContent={headerStrip}>
+      <RecoveryShell title="Sleep" headerContent={headerStrip} refreshControl={sleepRefreshControl}>
         <View style={styles.messageCard}>
-          <Text style={styles.emptyTitle}>No Oura sleep for {formatResolvedDay(selectedDay)}</Text>
+          <Text style={styles.emptyTitle}>No sleep data for {formatResolvedDay(selectedDay)}</Text>
           <Text style={styles.emptySubtitle}>{subtitle2}</Text>
         </View>
       </RecoveryShell>
@@ -153,17 +219,71 @@ export default function SleepScreen() {
 
   if (sleepState.status === "error") {
     return (
-      <RecoveryShell title="Sleep" headerContent={headerStrip}>
+      <RecoveryShell title="Sleep" headerContent={headerStrip} refreshControl={sleepRefreshControl}>
         <View style={styles.messageCard}>
-          <Text style={styles.errorText}>Could not load sleep data. Try again later.</Text>
+          <Text style={styles.errorTitle}>Couldn&apos;t load sleep data</Text>
+          <Text style={styles.errorSubtitle}>
+            Check your connection. Pull down to refresh or try again below.
+          </Text>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Retry loading sleep data"
+            onPress={() => void runSleepRefresh()}
+            style={({ pressed }) => [styles.retryButton, pressed && styles.retryButtonPressed]}
+          >
+            <Text style={styles.retryLabel}>Try again</Text>
+          </Pressable>
         </View>
       </RecoveryShell>
     );
   }
 
-  if (sleepState.status !== "ready") {
+  if (sleepState.status === "oli") {
+    const vendorRaw = sleepState.vendorSleepView?.score;
+    const vendorScore =
+      typeof vendorRaw === "number" && Number.isFinite(vendorRaw) ? vendorRaw : null;
+
+    const oliScore = sleepState.sleep.oliSleepScore;
+    const hasOliScoreDoc = oliScore != null;
+    const oliScoreValue =
+      oliScore?.value != null && typeof oliScore.value === "number" ? oliScore.value : null;
+
+    /** Vendor snapshot wins for side-by-side compare when the API returned a score. */
+    const displayScore = vendorScore ?? oliScoreValue;
+    const ratingLabel = displayScore != null ? scoreToRatingLabel(displayScore) : null;
+
+    const scoreUnavailableSubtitle =
+      displayScore == null
+        ? !hasOliScoreDoc
+          ? "Sleep score isn’t available for this day yet."
+          : (oliScore?.reasons?.[0] ??
+            "Score isn’t available — insufficient sleep data for this day.")
+        : null;
+
+    const sleepInsightItems =
+      sleepState.insights?.items.filter((i) => i.tags?.includes("sleep")) ?? [];
+
     return (
-      <RecoveryShell title="Sleep" headerContent={headerStrip}>
+      <RecoveryShell title="Sleep" headerContent={headerStrip} refreshControl={sleepRefreshControl}>
+        <View style={styles.content}>
+          <RecoveryScoreCard
+            title="Sleep Score"
+            score={displayScore}
+            ratingLabel={ratingLabel}
+            fallbackMessage={null}
+            scoreFootnote={null}
+            scoreUnavailableSubtitle={scoreUnavailableSubtitle}
+          />
+          <SleepOliMetricsCard sleep={sleepState.sleep} />
+          <SleepInsightsCard items={sleepInsightItems} />
+        </View>
+      </RecoveryShell>
+    );
+  }
+
+  if (sleepState.status !== "oura_fallback") {
+    return (
+      <RecoveryShell title="Sleep" headerContent={headerStrip} refreshControl={sleepRefreshControl}>
         <View style={styles.messageCard}>
           <Text style={styles.emptySubtitle}>No sleep data available.</Text>
         </View>
@@ -194,12 +314,19 @@ export default function SleepScreen() {
     : null;
 
   return (
-    <RecoveryShell title="Sleep" headerContent={headerStrip}>
+    <RecoveryShell title="Sleep" headerContent={headerStrip} refreshControl={sleepRefreshControl}>
       <View style={styles.content}>
         <RecoveryScoreCard
+          title="Sleep Score"
           score={score}
           ratingLabel={score != null ? scoreToRatingLabel(score) : null}
           fallbackMessage={fallbackMessage}
+          scoreFootnote={null}
+          scoreUnavailableSubtitle={
+            score == null
+              ? "No score in this Oura snapshot for this day. Try syncing or choose another day."
+              : null
+          }
         />
         <RecoveryContributorsCard rows={contributorRows} />
         {score == null && Object.keys(contributors).length === 0 && (
@@ -236,5 +363,18 @@ const styles = StyleSheet.create({
   },
   emptyTitle: { fontSize: 18, fontWeight: "700", color: "#1C1C1E", marginBottom: 8 },
   emptySubtitle: { fontSize: 15, color: "#6E6E73", lineHeight: 22 },
-  errorText: { fontSize: 15, color: "#6E6E73" },
+  errorTitle: { fontSize: 17, fontWeight: "600", color: "#1C1C1E", marginBottom: 8 },
+  errorSubtitle: { fontSize: 15, color: "#6E6E73", lineHeight: 22 },
+  retryButton: {
+    marginTop: 16,
+    alignSelf: "flex-start",
+    backgroundColor: "#FFFFFF",
+    paddingVertical: 12,
+    paddingHorizontal: 20,
+    borderRadius: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: "#C6C6C8",
+  },
+  retryButtonPressed: { opacity: 0.85 },
+  retryLabel: { fontSize: 16, fontWeight: "600", color: "#007AFF" },
 });

--- a/app/(app)/recovery/sleep/calendar.tsx
+++ b/app/(app)/recovery/sleep/calendar.tsx
@@ -1,12 +1,134 @@
-import React from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { FlatList, Platform, StyleSheet, View, type ViewToken } from "react-native";
+import { useNavigation, useRouter } from "expo-router";
 
-import { ModuleCalendarPlaceholderScreen } from "@/lib/ui/ModuleCalendarPlaceholderScreen";
+import { ScreenContainer } from "@/lib/ui/ScreenStates";
+import { MonthGrid } from "@/lib/ui/calendar/MonthGrid";
+import {
+  clampMonthYear,
+  getTodayDayKeyLocal,
+  type MonthYear,
+} from "@/lib/ui/calendar/dateUtils";
+import { headerYearFromViewableMonthItems } from "@/lib/ui/calendar/moduleCalendarHeaderYear";
+import { useModuleCalendarYearNavigationHeader } from "@/lib/ui/calendar/useModuleCalendarYearNavigationHeader";
+import { UI_APP_SCREEN_BG } from "@/lib/ui/theme/uiTokens";
+import { replaceSleepDayFromCalendarPick } from "@/lib/ui/recovery/sleepCalendarDayNavigation";
 
+type MonthModel = { key: string; monthYear: MonthYear };
+
+const MONTHS_BACK = 12;
+const MONTHS_FORWARD = 12;
+const CALENDAR_MONTH_ITEM_HEIGHT = 372;
+
+function monthYearFromToday(): MonthYear {
+  const d = getTodayDayKeyLocal();
+  const y = Number(d.slice(0, 4));
+  const m = Number(d.slice(5, 7));
+  return clampMonthYear({ year: y, month: m });
+}
+
+function shiftMonth(monthYear: MonthYear, delta: number): MonthYear {
+  return clampMonthYear({ year: monthYear.year, month: monthYear.month + delta });
+}
+
+function buildMonthRange(center: MonthYear): MonthModel[] {
+  const out: MonthModel[] = [];
+  for (let i = -MONTHS_BACK; i <= MONTHS_FORWARD; i += 1) {
+    const m = shiftMonth(center, i);
+    out.push({ key: `${m.year}-${String(m.month).padStart(2, "0")}`, monthYear: m });
+  }
+  return out;
+}
+
+/**
+ * Full-screen month picker for Sleep — same scroll/grid structure as Activity calendar.
+ */
 export default function SleepCalendarScreen() {
+  const router = useRouter();
+  const navigation = useNavigation();
+  const todayMonth = monthYearFromToday();
+  const months = useMemo(() => buildMonthRange(todayMonth), [todayMonth.year, todayMonth.month]);
+  const todayMonthIndex = MONTHS_BACK;
+  const flatListRef = useRef<FlatList<MonthModel>>(null);
+  const [headerYear, setHeaderYear] = useState(todayMonth.year);
+
+  useModuleCalendarYearNavigationHeader(navigation, headerYear);
+
+  useEffect(() => {
+    if (process.env.JEST_WORKER_ID) return;
+    const id = requestAnimationFrame(() => {
+      flatListRef.current?.scrollToIndex({
+        index: todayMonthIndex,
+        animated: false,
+        viewPosition: 0,
+      });
+    });
+    return () => cancelAnimationFrame(id);
+  }, [todayMonthIndex]);
+
+  const onViewableItemsChanged = useCallback(
+    ({ viewableItems }: { viewableItems: ViewToken[] }) => {
+      const y = headerYearFromViewableMonthItems(viewableItems, months);
+      if (y != null) setHeaderYear(y);
+    },
+    [months],
+  );
+
+  const viewabilityConfig = useRef({
+    itemVisiblePercentThreshold: 20,
+  }).current;
+
+  const screenEdges = ["left", "right", "bottom"] as const;
+
+  const onDayPress = useCallback(
+    (day: string) => {
+      replaceSleepDayFromCalendarPick(router, day);
+    },
+    [router],
+  );
+
   return (
-    <ModuleCalendarPlaceholderScreen
-      title="Sleep calendar"
-      description="A day-by-day sleep calendar will appear here when this module is expanded. For now, use Sleep overview for your latest score."
-    />
+    <ScreenContainer backgroundColor={UI_APP_SCREEN_BG} padded={false} edges={[...screenEdges]}>
+      <FlatList
+        ref={flatListRef}
+        data={months}
+        keyExtractor={(item) => item.key}
+        contentContainerStyle={styles.scroll}
+        initialScrollIndex={todayMonthIndex}
+        initialNumToRender={5}
+        maxToRenderPerBatch={6}
+        windowSize={7}
+        getItemLayout={(_, index) => ({
+          length: CALENDAR_MONTH_ITEM_HEIGHT,
+          offset: CALENDAR_MONTH_ITEM_HEIGHT * index,
+          index,
+        })}
+        viewabilityConfig={viewabilityConfig}
+        onViewableItemsChanged={onViewableItemsChanged}
+        onScrollToIndexFailed={() => {
+          flatListRef.current?.scrollToOffset({
+            offset: todayMonthIndex * CALENDAR_MONTH_ITEM_HEIGHT,
+            animated: false,
+          });
+        }}
+        {...(Platform.OS === "ios" ? { contentInsetAdjustmentBehavior: "never" as const } : {})}
+        renderItem={({ item }) => (
+          <View style={styles.monthItem}>
+            <MonthGrid
+              monthYear={item.monthYear}
+              dayKeyBasis="local"
+              ringSemantics="workout"
+              markerForDay={() => null}
+              onDayPress={onDayPress}
+            />
+          </View>
+        )}
+      />
+    </ScreenContainer>
   );
 }
+
+const styles = StyleSheet.create({
+  scroll: { paddingBottom: 32 },
+  monthItem: { height: CALENDAR_MONTH_ITEM_HEIGHT },
+});

--- a/lib/contracts/dailyFacts.ts
+++ b/lib/contracts/dailyFacts.ts
@@ -1,6 +1,7 @@
 // lib/contracts/dailyFacts.ts
 import { z } from "zod";
 import { dayKeySchema } from "./day";
+import { oliSleepScoreV1Schema } from "./oliSleepScore";
 
 const isoString = z.string().min(1);
 const confidenceSchema = z.record(z.string(), z.number().finite().min(0).max(1)).optional();
@@ -27,7 +28,21 @@ export const dailyFactsDtoSchema = z
     // new (contract)
     meta: computeMetaSchema.optional(),
 
-    sleep: z.object({ totalMinutes: z.number().finite().optional() }).strip().optional(),
+    sleep: z
+      .object({
+        totalMinutes: z.number().finite().optional(),
+        mainSleepMinutes: z.number().finite().optional(),
+        /** Aggregate mean of episode efficiencies (0–1), matches canonical sleep */
+        efficiency: z.number().finite().optional(),
+        latencyMinutes: z.number().finite().optional(),
+        awakenings: z.number().finite().optional(),
+        remSleepMinutes: z.number().finite().optional(),
+        deepSleepMinutes: z.number().finite().optional(),
+        primarySourceId: z.string().min(1).optional(),
+        oliSleepScore: oliSleepScoreV1Schema.optional(),
+      })
+      .strip()
+      .optional(),
     activity: z
       .object({
         steps: z.number().finite().optional(),

--- a/lib/contracts/index.ts
+++ b/lib/contracts/index.ts
@@ -51,3 +51,6 @@ export * from "./provenance";
 
 // Oura Tier 1 — vendor snapshots and view DTOs (Sleep & Readiness)
 export * from "./ouraVendor";
+
+// Oli Sleep Score v1 (derived from DailyFacts.sleep)
+export * from "./oliSleepScore";

--- a/lib/contracts/oliSleepScore.ts
+++ b/lib/contracts/oliSleepScore.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+
+export const OLI_SLEEP_SCORE_VERSION = "sleep-score-v1.0.0" as const;
+
+const scoreComponentsSchema = z.object({
+  duration: z.number().finite().min(0).max(1).nullable(),
+  efficiency: z.number().finite().min(0).max(1).nullable(),
+  latency: z.number().finite().min(0).max(1).nullable(),
+  rem: z.number().finite().min(0).max(1).nullable(),
+  deep: z.number().finite().min(0).max(1).nullable(),
+});
+
+const scoreWeightsSchema = z.object({
+  duration: z.number().finite().nonnegative(),
+  efficiency: z.number().finite().nonnegative(),
+  latency: z.number().finite().nonnegative(),
+  rem: z.number().finite().nonnegative(),
+  deep: z.number().finite().nonnegative(),
+});
+
+/** Derived Oli Sleep Score v1 — persisted under DailyFacts.sleep.oliSleepScore */
+export const oliSleepScoreV1Schema = z.object({
+  value: z.number().int().min(0).max(100).nullable(),
+  version: z.literal(OLI_SLEEP_SCORE_VERSION),
+  computedAt: z.string().min(1),
+  confidence: z.number().finite().min(0).max(1),
+  components: scoreComponentsSchema,
+  weights: scoreWeightsSchema,
+  reasons: z.array(z.string().min(1)).max(8),
+});
+
+export type OliSleepScoreV1 = z.infer<typeof oliSleepScoreV1Schema>;

--- a/lib/contracts/rawEvent.ts
+++ b/lib/contracts/rawEvent.ts
@@ -119,6 +119,9 @@ const manualSleepPayloadSchema = manualWindowBaseSchema
     latencyMinutes: z.number().finite().nonnegative().nullable().optional(),
     awakenings: z.number().finite().nonnegative().nullable().optional(),
     isMainSleep: z.boolean(),
+    /** Derived from vendor stage durations when available; minutes in-sleep */
+    remSleepMinutes: z.number().finite().nonnegative().nullable().optional(),
+    deepSleepMinutes: z.number().finite().nonnegative().nullable().optional(),
   })
   .strip();
 

--- a/lib/data/__tests__/sleepFactsSignal.test.ts
+++ b/lib/data/__tests__/sleepFactsSignal.test.ts
@@ -1,0 +1,27 @@
+import { dailyFactsHasSleepSignal } from "@/lib/data/sleep/sleepFactsSignal";
+
+describe("dailyFactsHasSleepSignal", () => {
+  it("is false when sleep is absent", () => {
+    expect(dailyFactsHasSleepSignal(undefined)).toBe(false);
+  });
+
+  it("is true when totalMinutes > 0", () => {
+    expect(dailyFactsHasSleepSignal({ totalMinutes: 420 })).toBe(true);
+  });
+
+  it("is true when only mainSleepMinutes > 0", () => {
+    expect(dailyFactsHasSleepSignal({ mainSleepMinutes: 400 })).toBe(true);
+  });
+
+  it("is false when minutes are zero", () => {
+    expect(dailyFactsHasSleepSignal({ totalMinutes: 0 })).toBe(false);
+  });
+
+  it("is true when totalMinutes is 0 but mainSleepMinutes is positive (no ?? bug)", () => {
+    expect(dailyFactsHasSleepSignal({ totalMinutes: 0, mainSleepMinutes: 400 })).toBe(true);
+  });
+
+  it("is true when mainSleepMinutes is 0 but totalMinutes is positive", () => {
+    expect(dailyFactsHasSleepSignal({ mainSleepMinutes: 0, totalMinutes: 420 })).toBe(true);
+  });
+});

--- a/lib/data/sleep/sleepFactsSignal.ts
+++ b/lib/data/sleep/sleepFactsSignal.ts
@@ -1,0 +1,16 @@
+import type { DailyFactsDto } from "@oli/contracts";
+
+function isPositiveMinutes(v: unknown): v is number {
+  return typeof v === "number" && Number.isFinite(v) && v > 0;
+}
+
+/**
+ * True when DailyFacts.sleep exists and at least one duration field is positive.
+ *
+ * Must NOT use `totalMinutes ?? mainSleepMinutes`: a stored `totalMinutes: 0` is a valid number
+ * and would block picking a positive `mainSleepMinutes` (wrong Oura fallback).
+ */
+export function dailyFactsHasSleepSignal(sleep: DailyFactsDto["sleep"]): boolean {
+  if (!sleep) return false;
+  return isPositiveMinutes(sleep.mainSleepMinutes) || isPositiveMinutes(sleep.totalMinutes);
+}

--- a/lib/data/useSleepDayView.ts
+++ b/lib/data/useSleepDayView.ts
@@ -1,0 +1,161 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { useAuth } from "@/lib/auth/AuthProvider";
+import {
+  getDailyFacts,
+  getInsights,
+  getOuraSleepView,
+  type TruthGetOptions,
+} from "@/lib/api/usersMe";
+import type { DailyFactsDto, InsightsResponseDto, SleepViewDto } from "@oli/contracts";
+import { truthOutcomeFromApiResult } from "@/lib/data/truthOutcome";
+import { dailyFactsHasSleepSignal } from "@/lib/data/sleep/sleepFactsSignal";
+
+export type SleepDayViewState =
+  | { status: "partial" }
+  | { status: "missing" }
+  | { status: "error"; error: string; requestId: string | null }
+  | {
+      status: "oli";
+      requestedDay: string;
+      resolvedDay: string;
+      facts: DailyFactsDto;
+      sleep: NonNullable<DailyFactsDto["sleep"]>;
+      insights: InsightsResponseDto | null;
+      /** Oura vendor view for the same day when the API returns it; display-only (e.g. score compare). */
+      vendorSleepView: SleepViewDto | null;
+    }
+  | { status: "oura_fallback"; data: SleepViewDto };
+
+function emptyInsights(day: string): InsightsResponseDto {
+  return { day, count: 0, items: [] };
+}
+
+function withUniqueCacheBust(opts: TruthGetOptions | undefined, seq: number): TruthGetOptions | undefined {
+  const cb = opts?.cacheBust;
+  if (!cb) return opts;
+  return { ...opts, cacheBust: `${cb}:${seq}` };
+}
+
+/**
+ * Sleep module read model: DailyFacts.sleep + Insights; Oura vendor view is fetched in parallel
+ * for the Oli path (display-only compare) and is the primary read when pipeline sleep is absent.
+ */
+export function useSleepDayView(
+  day: string,
+): SleepDayViewState & { refetch: (opts?: TruthGetOptions) => void } {
+  const { user, initializing, getIdToken } = useAuth();
+  const dayRef = useRef(day);
+  dayRef.current = day;
+  const requestSeq = useRef(0);
+  const [state, setState] = useState<SleepDayViewState>({ status: "partial" });
+  const stateRef = useRef<SleepDayViewState>(state);
+  useEffect(() => {
+    stateRef.current = state;
+  }, [state]);
+
+  const fetchOnce = useCallback(
+    async (opts?: TruthGetOptions) => {
+      const seq = ++requestSeq.current;
+      const safeSet = (next: SleepDayViewState) => {
+        if (seq === requestSeq.current) setState(next);
+      };
+
+      if (initializing || !user) {
+        if (stateRef.current.status !== "oli" && stateRef.current.status !== "oura_fallback") {
+          safeSet({ status: "partial" });
+        }
+        return;
+      }
+
+      const token = await getIdToken(false);
+      if (!token || seq !== requestSeq.current) return;
+
+      if (stateRef.current.status !== "oli" && stateRef.current.status !== "oura_fallback") {
+        safeSet({ status: "partial" });
+      }
+
+      const dayKey = dayRef.current;
+      const bust = withUniqueCacheBust(opts, seq);
+
+      const [factsRes, insightsRes, ouraParallelRes] = await Promise.all([
+        getDailyFacts(dayKey, token, bust),
+        getInsights(dayKey, token, bust),
+        getOuraSleepView(dayKey, token, bust),
+      ]);
+
+      if (seq !== requestSeq.current) return;
+
+      const factsOutcome = truthOutcomeFromApiResult(factsRes);
+      const insightsOutcome = truthOutcomeFromApiResult(insightsRes);
+      const ouraParallelOutcome = truthOutcomeFromApiResult(ouraParallelRes);
+
+      const sleepForSignal = factsOutcome.status === "ready" ? factsOutcome.data.sleep : undefined;
+      const hasSleepSignal = dailyFactsHasSleepSignal(sleepForSignal);
+
+      if (__DEV__ && typeof process.env.JEST_WORKER_ID === "undefined") {
+        // eslint-disable-next-line no-console
+        console.log("SLEEP_DEBUG", {
+          day: dayKey,
+          factsOutcome: factsOutcome.status,
+          hasSleepSignal,
+          hasScore: sleepForSignal?.oliSleepScore != null,
+          oliScoreValue: sleepForSignal?.oliSleepScore?.value ?? null,
+          mainSleepMinutes: sleepForSignal?.mainSleepMinutes,
+          totalMinutes: sleepForSignal?.totalMinutes,
+          chosenStatus:
+            factsOutcome.status === "ready" && hasSleepSignal
+              ? "oli"
+              : factsOutcome.status !== "ready"
+                ? `skip_oura_pending_facts_${factsOutcome.status}`
+                : "try_oura_fallback",
+        });
+      }
+
+      if (factsOutcome.status === "ready" && hasSleepSignal) {
+        const sleep = factsOutcome.data.sleep!;
+        const insights =
+          insightsOutcome.status === "ready"
+            ? insightsOutcome.data
+            : insightsOutcome.status === "missing"
+              ? emptyInsights(dayKey)
+              : null;
+        const vendorSleepView =
+          ouraParallelOutcome.status === "ready" ? ouraParallelOutcome.data : null;
+        safeSet({
+          status: "oli",
+          requestedDay: dayKey,
+          resolvedDay: dayKey,
+          facts: factsOutcome.data,
+          sleep,
+          insights,
+          vendorSleepView,
+        });
+        return;
+      }
+
+      if (ouraParallelOutcome.status === "ready") {
+        safeSet({ status: "oura_fallback", data: ouraParallelOutcome.data });
+        return;
+      }
+
+      if (ouraParallelOutcome.status === "missing") {
+        safeSet({ status: "missing" });
+        return;
+      }
+
+      safeSet({
+        status: "error",
+        error: ouraParallelOutcome.error,
+        requestId: ouraParallelOutcome.requestId,
+      });
+    },
+    [getIdToken, initializing, user],
+  );
+
+  useEffect(() => {
+    void fetchOnce();
+  }, [fetchOnce, day, user?.uid]);
+
+  return useMemo(() => ({ ...state, refetch: fetchOnce }), [state, fetchOnce]);
+}

--- a/lib/data/useSleepFacts.ts
+++ b/lib/data/useSleepFacts.ts
@@ -1,0 +1,74 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { useAuth } from "@/lib/auth/AuthProvider";
+import { getDailyFacts, type TruthGetOptions } from "@/lib/api/usersMe";
+import type { DailyFactsDto } from "@oli/contracts";
+import { truthOutcomeFromApiResult } from "@/lib/data/truthOutcome";
+
+type State =
+  | { status: "partial" }
+  | { status: "missing" }
+  | { status: "error"; error: string; requestId: string | null }
+  | { status: "ready"; data: DailyFactsDto };
+
+function withUniqueCacheBust(opts: TruthGetOptions | undefined, seq: number): TruthGetOptions | undefined {
+  const cb = opts?.cacheBust;
+  if (!cb) return opts;
+  return { ...opts, cacheBust: `${cb}:${seq}` };
+}
+
+/** GET /users/me/daily-facts — authoritative day rollup for Oli-native modules. */
+export function useSleepFacts(
+  day: string,
+): State & { refetch: (opts?: TruthGetOptions) => void } {
+  const { user, initializing, getIdToken } = useAuth();
+  const dayRef = useRef(day);
+  dayRef.current = day;
+  const requestSeq = useRef(0);
+  const [state, setState] = useState<State>({ status: "partial" });
+  const stateRef = useRef<State>(state);
+  useEffect(() => {
+    stateRef.current = state;
+  }, [state]);
+
+  const fetchOnce = useCallback(
+    async (opts?: TruthGetOptions) => {
+      const seq = ++requestSeq.current;
+      const safeSet = (next: State) => {
+        if (seq === requestSeq.current) setState(next);
+      };
+
+      if (initializing || !user) {
+        if (stateRef.current.status !== "ready") safeSet({ status: "partial" });
+        return;
+      }
+
+      const token = await getIdToken(false);
+      if (!token || seq !== requestSeq.current) return;
+
+      if (stateRef.current.status !== "ready") safeSet({ status: "partial" });
+
+      const res = await getDailyFacts(dayRef.current, token, withUniqueCacheBust(opts, seq));
+      if (seq !== requestSeq.current) return;
+
+      const outcome = truthOutcomeFromApiResult(res);
+
+      if (outcome.status === "ready") {
+        safeSet({ status: "ready", data: outcome.data });
+        return;
+      }
+      if (outcome.status === "missing") {
+        safeSet({ status: "missing" });
+        return;
+      }
+      safeSet({ status: "error", error: outcome.error, requestId: outcome.requestId });
+    },
+    [getIdToken, initializing, user],
+  );
+
+  useEffect(() => {
+    void fetchOnce();
+  }, [fetchOnce, day, user?.uid]);
+
+  return useMemo(() => ({ ...state, refetch: fetchOnce }), [state, fetchOnce]);
+}

--- a/lib/data/useSleepWeekDataPresence.ts
+++ b/lib/data/useSleepWeekDataPresence.ts
@@ -1,0 +1,92 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { useAuth } from "@/lib/auth/AuthProvider";
+import { getDailyFacts, getOuraSleepView } from "@/lib/api/usersMe";
+import { truthOutcomeFromApiResult } from "@/lib/data/truthOutcome";
+import { dailyFactsHasSleepSignal } from "@/lib/data/sleep/sleepFactsSignal";
+import { getTodayDayKeyLocal } from "@/lib/ui/calendar/dateUtils";
+
+import {
+  mergeOuraWeekPresenceMaps,
+  partitionOuraWeekPresenceDayKeys,
+} from "@/lib/data/oura/useOuraViewWeekSnapshotPresence";
+
+/**
+ * Per-day presence: DailyFacts sleep signal first, else legacy Oura vendor snapshot (transition).
+ */
+async function dayHasSleepData(day: string, token: string): Promise<boolean> {
+  const factsRes = await getDailyFacts(day, token);
+  const factsOutcome = truthOutcomeFromApiResult(factsRes);
+  if (factsOutcome.status === "ready" && dailyFactsHasSleepSignal(factsOutcome.data.sleep)) {
+    return true;
+  }
+  const ouraRes = await getOuraSleepView(day, token);
+  return truthOutcomeFromApiResult(ouraRes).status === "ready";
+}
+
+type State =
+  | { status: "partial" }
+  | {
+      status: "ready";
+      hasSleepDataByDay: Record<string, boolean>;
+    };
+
+export function useSleepWeekDataPresence(
+  dayKeys: readonly string[],
+): State & { refetch: () => void } {
+  const { user, initializing, getIdToken } = useAuth();
+  const dayKeysRef = useRef(dayKeys);
+  dayKeysRef.current = dayKeys;
+  const requestSeq = useRef(0);
+
+  const authRef = useRef({ initializing, userUid: user?.uid, getIdToken });
+  authRef.current = { initializing, userUid: user?.uid, getIdToken };
+
+  const [state, setState] = useState<State>({ status: "partial" });
+
+  const fetchAll = useCallback(async () => {
+    const seq = ++requestSeq.current;
+    const keys = [...dayKeysRef.current];
+    const { initializing: init, userUid, getIdToken: getToken } = authRef.current;
+
+    const safeSet = (next: State) => {
+      if (seq === requestSeq.current) setState(next);
+    };
+
+    if (init || !userUid || keys.length === 0) {
+      safeSet({ status: "ready", hasSleepDataByDay: {} });
+      return;
+    }
+
+    const todayDayKey = getTodayDayKeyLocal();
+    const { noSnapshotFutureDays, daysToFetch } = partitionOuraWeekPresenceDayKeys(keys, todayDayKey);
+
+    if (daysToFetch.length === 0) {
+      safeSet({ status: "ready", hasSleepDataByDay: { ...noSnapshotFutureDays } });
+      return;
+    }
+
+    safeSet({ status: "partial" });
+
+    const token = await getToken(false);
+    if (!token || seq !== requestSeq.current) return;
+
+    const results = await Promise.all(
+      daysToFetch.map(async (day) => {
+        const has = await dayHasSleepData(day, token);
+        return [day, has] as const;
+      }),
+    );
+
+    if (seq !== requestSeq.current) return;
+
+    const hasSleepDataByDay = mergeOuraWeekPresenceMaps(noSnapshotFutureDays, results);
+    safeSet({ status: "ready", hasSleepDataByDay });
+  }, []);
+
+  useEffect(() => {
+    void fetchAll();
+  }, [fetchAll, user?.uid, dayKeys.join(",")]);
+
+  return useMemo(() => ({ ...state, refetch: fetchAll }), [state, fetchAll]);
+}

--- a/lib/format/__tests__/sleepMetricBarProgress.test.ts
+++ b/lib/format/__tests__/sleepMetricBarProgress.test.ts
@@ -1,0 +1,33 @@
+import {
+  sleepDeepMinutesBarProgress,
+  sleepEfficiencyBarProgress,
+  sleepLatencyMinutesBarProgress,
+  sleepRemMinutesBarProgress,
+  sleepTotalMinutesBarProgress,
+} from "@/lib/format/sleepMetricBarProgress";
+
+describe("sleepMetricBarProgress", () => {
+  it("maps total sleep minutes into 0–1", () => {
+    expect(sleepTotalMinutesBarProgress(300)).toBe(0);
+    expect(sleepTotalMinutesBarProgress(540)).toBe(1);
+    expect(sleepTotalMinutesBarProgress(null)).toBeNull();
+  });
+
+  it("maps efficiency ratio 0–1", () => {
+    expect(sleepEfficiencyBarProgress(0)).toBe(0);
+    expect(sleepEfficiencyBarProgress(0.85)).toBe(0.85);
+    expect(sleepEfficiencyBarProgress(85)).toBe(0.85);
+  });
+
+  it("inverts latency (lower is better)", () => {
+    expect(sleepLatencyMinutesBarProgress(5)).toBe(1);
+    expect(sleepLatencyMinutesBarProgress(45)).toBe(0);
+  });
+
+  it("maps REM and deep minute bands", () => {
+    expect(sleepRemMinutesBarProgress(45)).toBe(0);
+    expect(sleepRemMinutesBarProgress(120)).toBe(1);
+    expect(sleepDeepMinutesBarProgress(30)).toBe(0);
+    expect(sleepDeepMinutesBarProgress(90)).toBe(1);
+  });
+});

--- a/lib/format/__tests__/sleepMetricQualityScore.test.ts
+++ b/lib/format/__tests__/sleepMetricQualityScore.test.ts
@@ -1,0 +1,19 @@
+import {
+  sleepEfficiencyToQualityScore,
+  sleepLatencyMinutesToQualityScore,
+  totalSleepMinutesToQualityScore,
+} from "@/lib/format/sleepMetricQualityScore";
+
+describe("sleepMetricQualityScore", () => {
+  it("returns null for missing inputs", () => {
+    expect(totalSleepMinutesToQualityScore(null)).toBeNull();
+    expect(sleepEfficiencyToQualityScore(undefined)).toBeNull();
+  });
+
+  it("maps bands consistently with bar helpers’ endpoints", () => {
+    expect(totalSleepMinutesToQualityScore(300)).toBe(0);
+    expect(totalSleepMinutesToQualityScore(540)).toBe(100);
+    expect(sleepLatencyMinutesToQualityScore(5)).toBe(100);
+    expect(sleepLatencyMinutesToQualityScore(45)).toBe(0);
+  });
+});

--- a/lib/format/__tests__/sleepMetricRowQueries.test.ts
+++ b/lib/format/__tests__/sleepMetricRowQueries.test.ts
@@ -1,0 +1,21 @@
+import {
+  getSleepMetricProgress,
+  getSleepMetricRating,
+} from "@/lib/format/sleepMetricRowQueries";
+import { buildSleepOliMetricRows } from "@/lib/format/sleepOliMetricRows";
+
+describe("sleepMetricRowQueries", () => {
+  it("reads rating and progress from row models", () => {
+    const rows = buildSleepOliMetricRows({
+      totalMinutes: 420,
+      mainSleepMinutes: 420,
+      efficiency: 0.9,
+      latencyMinutes: 10,
+      remSleepMinutes: 90,
+      deepSleepMinutes: 60,
+    });
+    const total = rows.find((r) => r.key === "total")!;
+    expect(getSleepMetricRating(total)).toBe(total.pill?.label ?? null);
+    expect(getSleepMetricProgress(total)).toBe(total.barProgress);
+  });
+});

--- a/lib/format/__tests__/sleepOliMetricRows.test.ts
+++ b/lib/format/__tests__/sleepOliMetricRows.test.ts
@@ -1,0 +1,17 @@
+import { buildSleepOliMetricRows } from "@/lib/format/sleepOliMetricRows";
+
+describe("buildSleepOliMetricRows", () => {
+  it("returns five rows without awakenings, with pills when values exist", () => {
+    const rows = buildSleepOliMetricRows({
+      totalMinutes: 420,
+      mainSleepMinutes: 420,
+      efficiency: 0.88,
+      latencyMinutes: 12,
+      remSleepMinutes: 90,
+      deepSleepMinutes: 70,
+    });
+    expect(rows.map((r) => r.key)).toEqual(["total", "efficiency", "latency", "rem", "deep"]);
+    expect(rows.every((r) => !r.label.toLowerCase().includes("awaken"))).toBe(true);
+    expect(rows.every((r) => r.pill != null)).toBe(true);
+  });
+});

--- a/lib/format/sleepDisplay.ts
+++ b/lib/format/sleepDisplay.ts
@@ -1,0 +1,16 @@
+/**
+ * Presentation helpers for DailyFacts-backed sleep (minutes and ratios).
+ */
+
+import { formatSleepDurationMinutes } from "@/lib/format/ouraScore";
+
+/** Efficiency stored in DailyFacts as aggregate mean of canonical episodes (0–1). */
+export function formatEfficiencyRatio(ratio: number | undefined): string {
+  if (ratio == null || typeof ratio !== "number" || !Number.isFinite(ratio)) return "—";
+  const pct = ratio <= 1 ? Math.round(ratio * 100) : Math.round(ratio);
+  return `${pct}%`;
+}
+
+export function formatMinutesValue(minutes: number | undefined): string {
+  return formatSleepDurationMinutes(minutes);
+}

--- a/lib/format/sleepMetricBarProgress.ts
+++ b/lib/format/sleepMetricBarProgress.ts
@@ -1,0 +1,58 @@
+/**
+ * Display-only progress (0–1) for Oli sleep fact metrics. For UI quality hints, not clinical labels.
+ * Each rule is fixed and deterministic; safe to show on a phone for day-to-day scan.
+ */
+
+/**
+ * Main/total sleep duration: 5h (300m) → 0, 9h (540m) → 1, linear, clamped.
+ * Slightly below 5h reads as low; 7.5h+ reads as strong in the bar.
+ */
+export function sleepTotalMinutesBarProgress(totalMinutes: number | null | undefined): number | null {
+  if (totalMinutes == null || !Number.isFinite(totalMinutes)) return null;
+  const low = 300;
+  const high = 540;
+  const t = (totalMinutes - low) / (high - low);
+  return Math.max(0, Math.min(1, t));
+}
+
+/**
+ * Sleep efficiency: Oli stores 0–1 (aggregate mean). If a 0–100 value appears, it is treated as a percent.
+ */
+export function sleepEfficiencyBarProgress(efficiency: number | null | undefined): number | null {
+  if (efficiency == null || !Number.isFinite(efficiency)) return null;
+  const r = efficiency > 1 ? efficiency / 100 : efficiency;
+  return Math.max(0, Math.min(1, r));
+}
+
+/**
+ * Sleep latency: lower is better. ~5m or less → full bar, ~45m+ → empty, linear between, clamped.
+ */
+export function sleepLatencyMinutesBarProgress(latencyMinutes: number | null | undefined): number | null {
+  if (latencyMinutes == null || !Number.isFinite(latencyMinutes)) return null;
+  const good = 5;
+  const bad = 45;
+  const t = (latencyMinutes - good) / (bad - good);
+  return Math.max(0, Math.min(1, 1 - t));
+}
+
+/**
+ * REM sleep minutes: 45m → 0, 120m → 1, linear, clamped (broad “typical night” display band).
+ */
+export function sleepRemMinutesBarProgress(remMinutes: number | null | undefined): number | null {
+  if (remMinutes == null || !Number.isFinite(remMinutes)) return null;
+  const low = 45;
+  const high = 120;
+  const t = (remMinutes - low) / (high - low);
+  return Math.max(0, Math.min(1, t));
+}
+
+/**
+ * Deep sleep minutes: 30m → 0, 90m → 1, linear, clamped.
+ */
+export function sleepDeepMinutesBarProgress(deepMinutes: number | null | undefined): number | null {
+  if (deepMinutes == null || !Number.isFinite(deepMinutes)) return null;
+  const low = 30;
+  const high = 90;
+  const t = (deepMinutes - low) / (high - low);
+  return Math.max(0, Math.min(1, t));
+}

--- a/lib/format/sleepMetricQualityScore.ts
+++ b/lib/format/sleepMetricQualityScore.ts
@@ -1,0 +1,58 @@
+/**
+ * Display-only 0–100 “quality” scores for sleep facts, mapped to Oura-style tier labels
+ * via {@link scoreToRatingLabel}. Bands align with {@link sleepMetricBarProgress} endpoints where noted.
+ */
+
+/**
+ * Total sleep minutes → 0–100 (same endpoints as {@link sleepTotalMinutesBarProgress}: 300→0, 540→1).
+ */
+export function totalSleepMinutesToQualityScore(totalMinutes: number | null | undefined): number | null {
+  if (totalMinutes == null || !Number.isFinite(totalMinutes)) return null;
+  const low = 300;
+  const high = 540;
+  const t = (totalMinutes - low) / (high - low);
+  return Math.max(0, Math.min(100, Math.round(t * 100)));
+}
+
+/**
+ * Efficiency ratio (0–1 or 0–100) → 0–100 on the Oura score scale for label bucketing.
+ */
+export function sleepEfficiencyToQualityScore(ratio: number | null | undefined): number | null {
+  if (ratio == null || !Number.isFinite(ratio)) return null;
+  const pct = ratio > 1 ? ratio : ratio * 100;
+  return Math.max(0, Math.min(100, Math.round(pct)));
+}
+
+/**
+ * Latency minutes → 0–100 where lower latency scores higher (same invert band as latency bar: 5→100, 45→0).
+ */
+export function sleepLatencyMinutesToQualityScore(latencyMinutes: number | null | undefined): number | null {
+  if (latencyMinutes == null || !Number.isFinite(latencyMinutes)) return null;
+  const good = 5;
+  const bad = 45;
+  const raw = (latencyMinutes - good) / (bad - good);
+  const inverted = 1 - Math.max(0, Math.min(1, raw));
+  return Math.round(inverted * 100);
+}
+
+/**
+ * REM minutes → 0–100 (45→0, 120→100, same span as REM bar).
+ */
+export function remSleepMinutesToQualityScore(remMinutes: number | null | undefined): number | null {
+  if (remMinutes == null || !Number.isFinite(remMinutes)) return null;
+  const low = 45;
+  const high = 120;
+  const t = (remMinutes - low) / (high - low);
+  return Math.max(0, Math.min(100, Math.round(t * 100)));
+}
+
+/**
+ * Deep sleep minutes → 0–100 (30→0, 90→100, same span as deep bar).
+ */
+export function deepSleepMinutesToQualityScore(deepMinutes: number | null | undefined): number | null {
+  if (deepMinutes == null || !Number.isFinite(deepMinutes)) return null;
+  const low = 30;
+  const high = 90;
+  const t = (deepMinutes - low) / (high - low);
+  return Math.max(0, Math.min(100, Math.round(t * 100)));
+}

--- a/lib/format/sleepMetricRowQueries.ts
+++ b/lib/format/sleepMetricRowQueries.ts
@@ -1,0 +1,12 @@
+import type { OuraRatingLabel } from "@/lib/format/ouraScore";
+import type { SleepOliMetricRowModel } from "@/lib/format/sleepOliMetricRows";
+
+/** Deterministic rating label for a built row (null when no pill / no invented tier). */
+export function getSleepMetricRating(row: SleepOliMetricRowModel): OuraRatingLabel | null {
+  return row.pill?.label ?? null;
+}
+
+/** Normalized bar progress (0–1) or null when there is no numeric basis. */
+export function getSleepMetricProgress(row: SleepOliMetricRowModel): number | null {
+  return row.barProgress;
+}

--- a/lib/format/sleepOliMetricRows.ts
+++ b/lib/format/sleepOliMetricRows.ts
@@ -1,0 +1,106 @@
+import type { DailyFactsDto } from "@oli/contracts";
+import {
+  deepSleepMinutesToQualityScore,
+  remSleepMinutesToQualityScore,
+  sleepEfficiencyToQualityScore,
+  sleepLatencyMinutesToQualityScore,
+  totalSleepMinutesToQualityScore,
+} from "@/lib/format/sleepMetricQualityScore";
+import { ouraRatingLabelToPillColors } from "@/lib/format/sleepOuraRatingPillColors";
+import { formatEfficiencyRatio, formatMinutesValue } from "@/lib/format/sleepDisplay";
+import type { OuraRatingLabel } from "@/lib/format/ouraScore";
+import { scoreToRatingLabel } from "@/lib/format/ouraScore";
+import {
+  sleepDeepMinutesBarProgress,
+  sleepEfficiencyBarProgress,
+  sleepLatencyMinutesBarProgress,
+  sleepRemMinutesBarProgress,
+  sleepTotalMinutesBarProgress,
+} from "@/lib/format/sleepMetricBarProgress";
+
+export type SleepOliMetricPillModel = {
+  label: OuraRatingLabel;
+  color: string;
+  backgroundColor: string;
+};
+
+export type SleepOliMetricRowModel = {
+  key: string;
+  label: string;
+  valueDisplay: string;
+  /** null = no numeric basis; show value as "—" and an empty track. */
+  barProgress: number | null;
+  /** null when the underlying metric is missing — no invented pill. */
+  pill: SleepOliMetricPillModel | null;
+};
+
+type SleepBlock = NonNullable<DailyFactsDto["sleep"]>;
+
+function pillFromQualityScore(score: number | null): SleepOliMetricPillModel | null {
+  if (score == null) return null;
+  const label = scoreToRatingLabel(score);
+  const { color, backgroundColor } = ouraRatingLabelToPillColors(label);
+  return { label, color, backgroundColor };
+}
+
+/**
+ * Fixed set of Oli sleep fact rows for the sleep detail “last night” card (no vendor mix-in).
+ */
+export function buildSleepOliMetricRows(sleep: SleepBlock): SleepOliMetricRowModel[] {
+  const totalMinutes = sleep.mainSleepMinutes ?? sleep.totalMinutes;
+  const totalDisplay =
+    sleep.mainSleepMinutes != null
+      ? formatMinutesValue(sleep.mainSleepMinutes)
+      : sleep.totalMinutes != null
+        ? formatMinutesValue(sleep.totalMinutes)
+        : "—";
+
+  const efficiencyDisplay = formatEfficiencyRatio(sleep.efficiency);
+  const latencyDisplay =
+    sleep.latencyMinutes != null && Number.isFinite(sleep.latencyMinutes)
+      ? `${Math.round(sleep.latencyMinutes)} min`
+      : "—";
+  const remDisplay = formatMinutesValue(sleep.remSleepMinutes);
+  const deepDisplay = formatMinutesValue(sleep.deepSleepMinutes);
+
+  const totalMinArg =
+    totalMinutes != null && Number.isFinite(totalMinutes) ? totalMinutes : null;
+
+  return [
+    {
+      key: "total",
+      label: "Total sleep",
+      valueDisplay: totalDisplay,
+      barProgress: sleepTotalMinutesBarProgress(totalMinArg),
+      pill: pillFromQualityScore(totalSleepMinutesToQualityScore(totalMinArg)),
+    },
+    {
+      key: "efficiency",
+      label: "Sleep efficiency",
+      valueDisplay: efficiencyDisplay,
+      barProgress: sleepEfficiencyBarProgress(sleep.efficiency),
+      pill: pillFromQualityScore(sleepEfficiencyToQualityScore(sleep.efficiency)),
+    },
+    {
+      key: "latency",
+      label: "Sleep latency",
+      valueDisplay: latencyDisplay,
+      barProgress: sleepLatencyMinutesBarProgress(sleep.latencyMinutes),
+      pill: pillFromQualityScore(sleepLatencyMinutesToQualityScore(sleep.latencyMinutes)),
+    },
+    {
+      key: "rem",
+      label: "REM sleep",
+      valueDisplay: remDisplay,
+      barProgress: sleepRemMinutesBarProgress(sleep.remSleepMinutes),
+      pill: pillFromQualityScore(remSleepMinutesToQualityScore(sleep.remSleepMinutes)),
+    },
+    {
+      key: "deep",
+      label: "Deep sleep",
+      valueDisplay: deepDisplay,
+      barProgress: sleepDeepMinutesBarProgress(sleep.deepSleepMinutes),
+      pill: pillFromQualityScore(deepSleepMinutesToQualityScore(sleep.deepSleepMinutes)),
+    },
+  ];
+}

--- a/lib/format/sleepOuraRatingPillColors.ts
+++ b/lib/format/sleepOuraRatingPillColors.ts
@@ -1,0 +1,24 @@
+import type { OuraRatingLabel } from "@/lib/format/ouraScore";
+
+/**
+ * Pill chrome aligned with Strength overview tiers (Low → Optimal chroma) for Oura-style labels.
+ */
+export function ouraRatingLabelToPillColors(label: OuraRatingLabel): {
+  color: string;
+  backgroundColor: string;
+} {
+  switch (label) {
+    case "Pay attention":
+      return { color: "#E57373", backgroundColor: "#FDF5F5" };
+    case "Fair":
+      return { color: "#E6A15C", backgroundColor: "#FFFAF4" };
+    case "Good":
+      return { color: "#5EC08C", backgroundColor: "#F0F8F4" };
+    case "Optimal":
+      return { color: "#5C8FE6", backgroundColor: "#F2F6FC" };
+    default: {
+      const _x: never = label;
+      return _x;
+    }
+  }
+}

--- a/lib/ui/ModuleScreenShell.tsx
+++ b/lib/ui/ModuleScreenShell.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ScrollView, View, Text, StyleSheet } from "react-native";
+import { ScrollView, View, Text, StyleSheet, type RefreshControlProps } from "react-native";
 
 export type ModuleScreenShellProps = {
   title: string;
@@ -10,6 +10,8 @@ export type ModuleScreenShellProps = {
   compactHeader?: boolean;
   /** Optional sticky header content rendered under the title/subtitle and pinned while body scrolls. */
   headerContent?: React.ReactNode;
+  /** Passed to ScrollView (e.g. RefreshControl). */
+  refreshControl?: React.ReactElement<RefreshControlProps>;
   children: React.ReactNode;
 };
 
@@ -19,6 +21,7 @@ export function ModuleScreenShell({
   hideTitleChrome = false,
   compactHeader = false,
   headerContent,
+  refreshControl,
   children,
 }: ModuleScreenShellProps) {
   return (
@@ -35,7 +38,11 @@ export function ModuleScreenShell({
         </View>
       )}
 
-      <ScrollView style={styles.scroll} contentContainerStyle={styles.container}>
+      <ScrollView
+        style={styles.scroll}
+        contentContainerStyle={styles.container}
+        {...(refreshControl ? { refreshControl } : {})}
+      >
         <View style={styles.content}>{children}</View>
       </ScrollView>
     </View>

--- a/lib/ui/activity/ActivityRatingPill.tsx
+++ b/lib/ui/activity/ActivityRatingPill.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Platform, StyleSheet, Text, View } from "react-native";
+import { Platform, StyleSheet, Text, View, type TextStyle } from "react-native";
 
 export type ActivityRatingPillProps = {
   label: string;
@@ -9,6 +9,8 @@ export type ActivityRatingPillProps = {
   backgroundColor: string;
   /** Smaller, quieter chrome for Activity tier labels (bars carry color). */
   emphasis?: "default" | "subtle";
+  /** Optional override for label typography (e.g. Sleep metric pills). */
+  labelTypography?: Pick<TextStyle, "fontSize" | "fontWeight" | "letterSpacing">;
   testID?: string;
 };
 
@@ -21,6 +23,7 @@ export function ActivityRatingPill({
   color,
   backgroundColor,
   emphasis = "default",
+  labelTypography,
   testID,
 }: ActivityRatingPillProps) {
   const subtle = emphasis === "subtle";
@@ -50,7 +53,11 @@ export function ActivityRatingPill({
         },
       ]}
     >
-      <Text style={[subtle ? styles.textSubtle : styles.text, { color }]} numberOfLines={1} testID={testID}>
+      <Text
+        style={[subtle ? styles.textSubtle : styles.text, { color }, labelTypography]}
+        numberOfLines={1}
+        testID={testID}
+      >
         {label}
       </Text>
     </View>

--- a/lib/ui/calendar/CalendarDayCell.tsx
+++ b/lib/ui/calendar/CalendarDayCell.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Pressable, Text, View } from "react-native";
 
 import { calendarWeeklyStripStyles } from "@/lib/ui/calendar/calendarWeeklyStripStyles";
+import { UI_TEXT_PRIMARY } from "@/lib/ui/theme/uiTokens";
 
 export type CalendarDayCellProps = {
   dayOfWeekLabel: string;
@@ -15,6 +16,8 @@ export type CalendarDayCellProps = {
   ring: React.ReactNode;
   /** Slightly stronger weekday + date weight when selected (Activity strip). */
   emphasizeSelectedTypography?: boolean;
+  /** Sleep: softer unselected weekday/date ink for clearer selection contrast. */
+  stripVariant?: "default" | "sleep";
 };
 
 /**
@@ -29,6 +32,7 @@ export function CalendarDayCell({
   accessibilityLabel,
   ring,
   emphasizeSelectedTypography = false,
+  stripVariant = "default",
 }: CalendarDayCellProps) {
   const selectedType = emphasizeSelectedTypography && isSelected;
   const todayOrSelectedCircle = isSelected || isToday;
@@ -47,7 +51,11 @@ export function CalendarDayCell({
       <Text
         style={[
           calendarWeeklyStripStyles.dayOfWeek,
+          stripVariant === "sleep" &&
+            !isSelected &&
+            calendarWeeklyStripStyles.dayOfWeekSleepMuted,
           selectedType && calendarWeeklyStripStyles.dayOfWeekWhenSelected,
+          selectedType && stripVariant === "sleep" && { color: UI_TEXT_PRIMARY },
         ]}
       >
         {dayOfWeekLabel}
@@ -64,6 +72,9 @@ export function CalendarDayCell({
         <Text
           style={[
             calendarWeeklyStripStyles.dayNumber,
+            stripVariant === "sleep" &&
+              !isSelected &&
+              calendarWeeklyStripStyles.dayNumberSleepMuted,
             selectedType && calendarWeeklyStripStyles.dayNumberWhenSelected,
           ]}
         >

--- a/lib/ui/calendar/calendarWeeklyStripStyles.ts
+++ b/lib/ui/calendar/calendarWeeklyStripStyles.ts
@@ -36,6 +36,12 @@ export const calendarWeeklyStripStyles = StyleSheet.create({
     fontWeight: "700",
     letterSpacing: -0.12,
   },
+  /** Sleep strip: quieter weekdays when not selected. */
+  dayOfWeekSleepMuted: {
+    fontSize: 12,
+    fontWeight: "500",
+    color: "#AEAEB2",
+  },
   dayCircle: {
     width: 40,
     height: 40,
@@ -61,5 +67,11 @@ export const calendarWeeklyStripStyles = StyleSheet.create({
     fontWeight: "700",
     fontSize: 19,
     letterSpacing: -0.35,
+  },
+  /** Sleep strip: quieter date numerals when not selected. */
+  dayNumberSleepMuted: {
+    fontSize: 17,
+    fontWeight: "500",
+    color: "#AEAEB2",
   },
 });

--- a/lib/ui/recovery/RecoveryOuraWeeklyStrip.tsx
+++ b/lib/ui/recovery/RecoveryOuraWeeklyStrip.tsx
@@ -18,6 +18,8 @@ export type RecoveryOuraWeeklyStripProps = {
   /** Used for accessibility strings only. */
   categoryLabel: "sleep" | "readiness";
   testIDPrefix?: string;
+  /** Stronger selected-day typography + softer unselected labels (Sleep polish). */
+  stripVariant?: "default" | "sleep";
 };
 
 export function RecoveryOuraWeeklyStrip({
@@ -26,6 +28,7 @@ export function RecoveryOuraWeeklyStrip({
   onDayPress,
   categoryLabel,
   testIDPrefix = "recovery-oura-weekly",
+  stripVariant = "default",
 }: RecoveryOuraWeeklyStripProps) {
   return (
     <View style={calendarWeeklyStripStyles.container}>
@@ -33,19 +36,24 @@ export function RecoveryOuraWeeklyStrip({
         {days.map((d) => {
           const hasOuraSnapshot = d.meta?.hasOuraSnapshot === true;
           const isSelected = selectedDay === d.day;
-          const noun = categoryLabel === "sleep" ? "sleep data" : "readiness data";
+          const accessibilityLabel =
+            categoryLabel === "sleep"
+              ? hasOuraSnapshot
+                ? `${d.day}, has sleep data`
+                : `${d.day}, no sleep data`
+              : hasOuraSnapshot
+                ? `${d.day}, has Oura readiness data`
+                : `${d.day}, no Oura readiness data`;
           return (
             <CalendarDayCell
               key={d.day}
               dayOfWeekLabel={calendarStripDayOfWeekLabel(d.day)}
               dayOfMonthLabel={calendarStripDayOfMonth(d.day)}
               isSelected={isSelected}
+              emphasizeSelectedTypography={stripVariant === "sleep"}
+              stripVariant={stripVariant === "sleep" ? "sleep" : "default"}
               onPress={() => onDayPress(d.day)}
-              accessibilityLabel={
-                hasOuraSnapshot
-                  ? `${d.day}, has Oura ${noun}`
-                  : `${d.day}, no Oura ${noun}`
-              }
+              accessibilityLabel={accessibilityLabel}
               ring={
                 <BodyDayRing
                   size={40}

--- a/lib/ui/recovery/RecoveryScoreCard.tsx
+++ b/lib/ui/recovery/RecoveryScoreCard.tsx
@@ -1,18 +1,38 @@
 import React from "react";
 import { View, Text, StyleSheet, type ViewStyle } from "react-native";
 
+import { elevatedCardSurfaceStyle } from "@/lib/ui/theme/elevatedCardSurface";
+
 type Props = {
+  /** Optional heading above the score block (e.g. Sleep detail validation title). */
+  title?: string | null;
   score: number | null;
   ratingLabel: string | null;
   fallbackMessage?: string | null;
+  /** When score is absent; defaults to Oura-oriented copy for backward compatibility. */
+  scoreUnavailableSubtitle?: string | null;
+  /** Shown under the numeric score when present (e.g. provenance copy). */
+  scoreFootnote?: string | null;
   style?: ViewStyle;
 };
 
-export function RecoveryScoreCard({ score, ratingLabel, fallbackMessage, style }: Props) {
+export function RecoveryScoreCard({
+  title,
+  score,
+  ratingLabel,
+  fallbackMessage,
+  scoreUnavailableSubtitle,
+  scoreFootnote,
+  style,
+}: Props) {
   const hasScore = typeof score === "number";
+  const noScoreHelp =
+    scoreUnavailableSubtitle ??
+    "We’ll show a score when Oura provides one.";
 
   return (
     <View style={[styles.card, style]}>
+      {title ? <Text style={styles.cardTitle}>{title}</Text> : null}
       {fallbackMessage ? <Text style={styles.fallback}>{fallbackMessage}</Text> : null}
       <View style={styles.row}>
         <View style={styles.scoreBlock}>
@@ -20,11 +40,12 @@ export function RecoveryScoreCard({ score, ratingLabel, fallbackMessage, style }
             <>
               <Text style={styles.score}>{Math.round(score ?? 0)}</Text>
               {ratingLabel ? <Text style={styles.rating}>{ratingLabel}</Text> : null}
+              {scoreFootnote ? <Text style={styles.ratingMuted}>{scoreFootnote}</Text> : null}
             </>
           ) : (
             <>
               <Text style={styles.scoreUnavailable}>Score unavailable</Text>
-              <Text style={styles.ratingMuted}>We’ll show a score when Oura provides one.</Text>
+              <Text style={styles.ratingMuted}>{noScoreHelp}</Text>
             </>
           )}
         </View>
@@ -36,14 +57,21 @@ export function RecoveryScoreCard({ score, ratingLabel, fallbackMessage, style }
 const styles = StyleSheet.create({
   card: {
     backgroundColor: "#FFFFFF",
-    borderRadius: 20,
-    paddingVertical: 20,
-    paddingHorizontal: 20,
+    borderRadius: 18,
+    padding: 18,
+    gap: 14,
+    ...elevatedCardSurfaceStyle,
+  },
+  cardTitle: {
+    fontSize: 18,
+    fontWeight: "600",
+    color: "#1C1C1E",
+    letterSpacing: -0.35,
+    marginBottom: 0,
   },
   fallback: {
     fontSize: 13,
     color: "#8E8E93",
-    marginBottom: 8,
   },
   row: {
     flexDirection: "row",
@@ -55,15 +83,17 @@ const styles = StyleSheet.create({
     justifyContent: "center",
   },
   score: {
-    fontSize: 56,
-    fontWeight: "800",
+    fontSize: 52,
+    fontWeight: "700",
     color: "#1C1C1E",
+    letterSpacing: -1.2,
+    lineHeight: 56,
   },
   rating: {
     marginTop: 4,
     fontSize: 16,
-    fontWeight: "600",
-    color: "#6E6E73",
+    fontWeight: "500",
+    color: "#636366",
   },
   scoreUnavailable: {
     fontSize: 18,

--- a/lib/ui/recovery/SleepInsightsCard.tsx
+++ b/lib/ui/recovery/SleepInsightsCard.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { View, Text, StyleSheet } from "react-native";
+
+import type { InsightDto } from "@oli/contracts";
+
+type Props = {
+  items: InsightDto[];
+};
+
+/** Renders pipeline-generated insights tagged for sleep (Oli Intelligence). */
+export function SleepInsightsCard({ items }: Props) {
+  if (items.length === 0) return null;
+
+  return (
+    <View style={styles.card}>
+      <Text style={styles.title}>Insights</Text>
+      <View style={styles.list}>
+        {items.map((it) => (
+          <View key={it.id} style={styles.block}>
+            <Text style={styles.insightTitle}>{it.title}</Text>
+            <Text style={styles.body}>{it.message}</Text>
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: "#FFFFFF",
+    borderRadius: 20,
+    paddingVertical: 20,
+    paddingHorizontal: 20,
+  },
+  title: {
+    fontSize: 17,
+    fontWeight: "700",
+    color: "#1C1C1E",
+    marginBottom: 12,
+  },
+  list: { gap: 16 },
+  block: { gap: 6 },
+  insightTitle: { fontSize: 15, fontWeight: "600", color: "#1C1C1E" },
+  body: { fontSize: 14, color: "#6E6E73", lineHeight: 20 },
+});

--- a/lib/ui/recovery/SleepOliMetricRow.tsx
+++ b/lib/ui/recovery/SleepOliMetricRow.tsx
@@ -1,0 +1,123 @@
+import React from "react";
+import { View, Text, StyleSheet, type TextStyle } from "react-native";
+
+import { ActivityRatingPill } from "@/lib/ui/activity/ActivityRatingPill";
+import type { SleepOliMetricRowModel } from "@/lib/format/sleepOliMetricRows";
+import { getSleepMetricProgress, getSleepMetricRating } from "@/lib/format/sleepMetricRowQueries";
+import { getSleepMetricColor } from "@/lib/ui/recovery/getSleepMetricColor";
+import { LinearProgressBar } from "@/lib/ui/primitives/LinearProgressBar";
+import { MODULE_OVERVIEW_SEGMENTED_TRACK } from "@/lib/ui/overview/moduleOverviewSegmentedTrackMetrics";
+
+export type SleepOliMetricRowProps = {
+  row: SleepOliMetricRowModel;
+};
+
+const BAR_TOP_SPACING = 10;
+
+/**
+ * Single Last night’s sleep metric: label + optional pill + value + semantic progress bar.
+ * Presentation only — all values come from the row model + shared color helper.
+ */
+export function SleepOliMetricRow({ row }: SleepOliMetricRowProps) {
+  const rating = getSleepMetricRating(row);
+  const progress = getSleepMetricProgress(row);
+  const colors = getSleepMetricColor(rating);
+  const isPlaceholder = row.valueDisplay === "—";
+
+  return (
+    <View
+      style={styles.block}
+      accessibilityLabel={`${row.label}, ${row.valueDisplay}`}
+      accessible
+    >
+      <View style={styles.topRow}>
+        <View style={styles.titleCluster}>
+          <Text style={styles.metricLabel} numberOfLines={1} ellipsizeMode="tail">
+            {row.label}
+          </Text>
+          {row.pill != null ? (
+            <ActivityRatingPill
+              label={row.pill.label}
+              color={row.pill.color}
+              backgroundColor={row.pill.backgroundColor}
+              emphasis="subtle"
+              labelTypography={SLEEP_PILL_LABEL_TYPOGRAPHY}
+              testID={`sleep-oli-metric-pill-${row.key}`}
+            />
+          ) : null}
+        </View>
+        <Text style={[styles.metricValue, isPlaceholder && styles.metricValueMuted]} numberOfLines={1}>
+          {row.valueDisplay}
+        </Text>
+      </View>
+      <View style={styles.barWrap}>
+        {progress != null ? (
+          <LinearProgressBar
+            progress={progress}
+            height={MODULE_OVERVIEW_SEGMENTED_TRACK.barHeight}
+            borderRadius={MODULE_OVERVIEW_SEGMENTED_TRACK.trackRadius}
+            trackColor={colors.trackColor}
+            fillColor={colors.fillColor}
+            testID={`sleep-oli-metric-bar-${row.key}`}
+          />
+        ) : (
+          <View style={styles.barPlaceholder} testID={`sleep-oli-metric-bar-${row.key}-empty`} />
+        )}
+      </View>
+    </View>
+  );
+}
+
+const SLEEP_PILL_LABEL_TYPOGRAPHY: Pick<TextStyle, "fontSize" | "fontWeight" | "letterSpacing"> = {
+  fontSize: 13,
+  fontWeight: "500",
+  letterSpacing: -0.08,
+};
+
+const styles = StyleSheet.create({
+  block: {
+    gap: BAR_TOP_SPACING,
+  },
+  topRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 12,
+  },
+  titleCluster: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    flex: 1,
+    minWidth: 0,
+  },
+  metricLabel: {
+    fontSize: 16,
+    fontWeight: "500",
+    color: "#1C1C1E",
+    letterSpacing: -0.24,
+    flexShrink: 1,
+    minWidth: 0,
+  },
+  metricValue: {
+    fontSize: 16,
+    fontWeight: "600",
+    color: "#1C1C1E",
+    letterSpacing: -0.26,
+    flexShrink: 0,
+    maxWidth: "42%",
+    textAlign: "right",
+  },
+  metricValueMuted: {
+    color: "#AEAEB2",
+  },
+  barWrap: {
+    width: "100%",
+  },
+  barPlaceholder: {
+    height: MODULE_OVERVIEW_SEGMENTED_TRACK.barHeight,
+    borderRadius: MODULE_OVERVIEW_SEGMENTED_TRACK.trackRadius,
+    backgroundColor: "#E5E5EA",
+    width: "100%",
+  },
+});

--- a/lib/ui/recovery/SleepOliMetricsCard.tsx
+++ b/lib/ui/recovery/SleepOliMetricsCard.tsx
@@ -1,0 +1,50 @@
+import React, { useMemo } from "react";
+import { View, Text, StyleSheet } from "react-native";
+
+import type { DailyFactsDto } from "@oli/contracts";
+import { buildSleepOliMetricRows } from "@/lib/format/sleepOliMetricRows";
+import { SleepOliMetricRow } from "@/lib/ui/recovery/SleepOliMetricRow";
+import { elevatedCardSurfaceStyle } from "@/lib/ui/theme/elevatedCardSurface";
+
+type Props = {
+  sleep: NonNullable<DailyFactsDto["sleep"]>;
+};
+
+const ROW_GAP = 22;
+
+/**
+ * Oli-native sleep metrics from DailyFacts — composition only; rows delegate to {@link SleepOliMetricRow}.
+ */
+export function SleepOliMetricsCard({ sleep }: Props) {
+  const rows = useMemo(() => buildSleepOliMetricRows(sleep), [sleep]);
+
+  return (
+    <View style={styles.card}>
+      <Text style={styles.cardTitle}>{"Last night's sleep"}</Text>
+      <View style={styles.metricList}>
+        {rows.map((row) => (
+          <SleepOliMetricRow key={row.key} row={row} />
+        ))}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: "#FFFFFF",
+    borderRadius: 18,
+    padding: 18,
+    gap: 14,
+    ...elevatedCardSurfaceStyle,
+  },
+  cardTitle: {
+    fontSize: 18,
+    fontWeight: "600",
+    color: "#1C1C1E",
+    letterSpacing: -0.35,
+  },
+  metricList: {
+    gap: ROW_GAP,
+  },
+});

--- a/lib/ui/recovery/__tests__/getSleepMetricColor.test.ts
+++ b/lib/ui/recovery/__tests__/getSleepMetricColor.test.ts
@@ -1,0 +1,24 @@
+import { getSleepMetricColor, SLEEP_METRIC_TRACK_COLOR } from "@/lib/ui/recovery/getSleepMetricColor";
+
+describe("getSleepMetricColor", () => {
+  it("maps tiers to semantic fills and keeps a neutral track", () => {
+    const optimal = getSleepMetricColor("Optimal");
+    expect(optimal.trackColor).toBe(SLEEP_METRIC_TRACK_COLOR);
+    expect(optimal.fillColor).toBe("#4F7CFF");
+
+    const good = getSleepMetricColor("Good");
+    expect(good.fillColor).toBe("#34C759");
+
+    const fair = getSleepMetricColor("Fair");
+    expect(fair.fillColor).toBe("#FF9F0A");
+
+    const low = getSleepMetricColor("Pay attention");
+    expect(low.fillColor).toBe("#FF3B30");
+  });
+
+  it("uses neutral fill when rating is absent", () => {
+    const n = getSleepMetricColor(null);
+    expect(n.trackColor).toBe(SLEEP_METRIC_TRACK_COLOR);
+    expect(n.fillColor).toBe("#C7C7CC");
+  });
+});

--- a/lib/ui/recovery/__tests__/sleepCalendarDayNavigation.test.ts
+++ b/lib/ui/recovery/__tests__/sleepCalendarDayNavigation.test.ts
@@ -1,0 +1,15 @@
+import {
+  replaceSleepDayFromCalendarPick,
+  SLEEP_MAIN_SCREEN_PATHNAME,
+} from "@/lib/ui/recovery/sleepCalendarDayNavigation";
+
+describe("sleepCalendarDayNavigation", () => {
+  it("replaces Sleep route with chosen day param", () => {
+    const replace = jest.fn();
+    replaceSleepDayFromCalendarPick({ replace }, "2026-08-15");
+    expect(replace).toHaveBeenCalledWith({
+      pathname: SLEEP_MAIN_SCREEN_PATHNAME,
+      params: { day: "2026-08-15" },
+    });
+  });
+});

--- a/lib/ui/recovery/getSleepMetricColor.ts
+++ b/lib/ui/recovery/getSleepMetricColor.ts
@@ -1,0 +1,42 @@
+import type { OuraRatingLabel } from "@/lib/format/ouraScore";
+
+/** Neutral iOS-style track behind semantic fills. */
+export const SLEEP_METRIC_TRACK_COLOR = "#E5E5EA";
+
+export type SleepMetricSemanticColors = {
+  trackColor: string;
+  fillColor: string;
+  /** Stronger ink for labels/icons when pairing with the fill (optional). */
+  textColor?: string;
+};
+
+const SEMANTIC_FILL: Record<OuraRatingLabel, { fill: string; text: string }> = {
+  Optimal: { fill: "#4F7CFF", text: "#3D62CC" },
+  Good: { fill: "#34C759", text: "#248A3D" },
+  Fair: { fill: "#FF9F0A", text: "#CC7700" },
+  "Pay attention": { fill: "#FF3B30", text: "#D70015" },
+};
+
+/** Neutral bar when there is no rating / insufficient data for a semantic tier. */
+const NEUTRAL_FILL = "#C7C7CC";
+const NEUTRAL_TEXT = "#8E8E93";
+
+/**
+ * Semantic progress bar colors from the same Oura-style tier label used for pills.
+ * When `rating` is absent, fill stays neutral gray (still readable on #E5E5EA track).
+ */
+export function getSleepMetricColor(rating: OuraRatingLabel | null | undefined): SleepMetricSemanticColors {
+  if (rating == null) {
+    return {
+      trackColor: SLEEP_METRIC_TRACK_COLOR,
+      fillColor: NEUTRAL_FILL,
+      textColor: NEUTRAL_TEXT,
+    };
+  }
+  const row = SEMANTIC_FILL[rating];
+  return {
+    trackColor: SLEEP_METRIC_TRACK_COLOR,
+    fillColor: row.fill,
+    textColor: row.text,
+  };
+}

--- a/lib/ui/recovery/sleepCalendarDayNavigation.ts
+++ b/lib/ui/recovery/sleepCalendarDayNavigation.ts
@@ -1,0 +1,15 @@
+/**
+ * Deterministic navigation when user picks a day on the Sleep full-screen calendar.
+ */
+export const SLEEP_MAIN_SCREEN_PATHNAME = "/(app)/recovery/sleep" as const;
+
+export type SleepCalendarRouterLike = {
+  replace: (opts: {
+    pathname: typeof SLEEP_MAIN_SCREEN_PATHNAME;
+    params: { day: string };
+  }) => void;
+};
+
+export function replaceSleepDayFromCalendarPick(router: SleepCalendarRouterLike, dayKey: string): void {
+  router.replace({ pathname: SLEEP_MAIN_SCREEN_PATHNAME, params: { day: dayKey } });
+}

--- a/services/api/src/lib/__tests__/ouraApi.fetchOuraSleep.pagination.test.ts
+++ b/services/api/src/lib/__tests__/ouraApi.fetchOuraSleep.pagination.test.ts
@@ -1,0 +1,81 @@
+/**
+ * GET /usercollection/sleep must follow Oura JSON `next_token` or the newest rows are missing.
+ */
+import { describe, it, expect, beforeEach, afterEach, jest } from "@jest/globals";
+import { fetchOuraSleep } from "../ouraApi";
+
+const originalFetch = global.fetch;
+
+describe("fetchOuraSleep pagination", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("requests next_token until exhausted and merges all pages", async () => {
+    const sleepA = {
+      id: "older",
+      bed_time: "2026-04-10T22:00:00.000Z",
+      wake_time: "2026-04-11T06:00:00.000Z",
+      total_sleep_duration: 28800,
+      type: "long_sleep",
+    };
+    const sleepB = {
+      id: "newest",
+      bed_time: "2026-04-18T22:00:00.000Z",
+      wake_time: "2026-04-19T11:00:00.000Z",
+      total_sleep_duration: 29160,
+      type: "long_sleep",
+    };
+
+    const fetchMock = jest.fn().mockImplementation(async (url: string | URL) => {
+      const u = typeof url === "string" ? url : url.toString();
+      if (!u.includes("next_token")) {
+        return {
+          status: 200,
+          json: async () => ({
+            data: [sleepA],
+            next_token: "page2token",
+          }),
+        };
+      }
+      if (u.includes("next_token=page2token")) {
+        return {
+          status: 200,
+          json: async () => ({
+            data: [sleepB],
+          }),
+        };
+      }
+      throw new Error(`unexpected fetch url: ${u}`);
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const out = await fetchOuraSleep("token", "2026-03-20", "2026-04-20", {
+      requestId: "req-paginate",
+      uid: "u1",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(out.map((d) => d.id)).toEqual(["older", "newest"]);
+    const firstUrl = fetchMock.mock.calls[0]?.[0];
+    expect(String(firstUrl)).not.toContain("next_token");
+    expect(String(fetchMock.mock.calls[1]?.[0])).toContain("next_token=page2token");
+  });
+
+  it("single-page response without next_token returns one page only", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      status: 200,
+      json: async () => ({
+        data: [{ id: "only", bed_time: "2026-04-01T22:00:00.000Z", wake_time: "2026-04-02T06:00:00.000Z", total_sleep_duration: 28800, type: "long_sleep" }],
+      }),
+    }) as unknown as typeof fetch;
+
+    const out = await fetchOuraSleep("t", "2026-04-01", "2026-04-02");
+    expect(out).toHaveLength(1);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/services/api/src/lib/__tests__/ouraApi.sleep.test.ts
+++ b/services/api/src/lib/__tests__/ouraApi.sleep.test.ts
@@ -4,11 +4,37 @@
  */
 import {
   mapOuraSleepToIngestItem,
+  normalizeOuraLatencyRawToMinutes,
   type OuraSleepDocument,
   type OuraSleepIngestItem,
 } from "../ouraApi";
 
+describe("normalizeOuraLatencyRawToMinutes", () => {
+  it("treats values >= 60 as seconds (matches oura-sleep-view read path)", () => {
+    expect(normalizeOuraLatencyRawToMinutes(300)).toBe(5);
+    expect(normalizeOuraLatencyRawToMinutes(90)).toBe(2);
+  });
+
+  it("treats small values as minutes", () => {
+    expect(normalizeOuraLatencyRawToMinutes(12)).toBe(12);
+    expect(normalizeOuraLatencyRawToMinutes(45)).toBe(45);
+  });
+});
+
 describe("mapOuraSleepToIngestItem", () => {
+  it("prefers Oura sleep API day field over inferred rollup when present", () => {
+    const doc: OuraSleepDocument = {
+      id: "s_api_day",
+      day: "2026-04-19",
+      bed_time: "2026-04-18T22:00:00Z",
+      wake_time: "2026-04-19T11:00:00Z",
+      total_sleep_duration: 29160,
+      type: "long_sleep",
+    };
+    const result = mapOuraSleepToIngestItem(doc);
+    expect(result?.day).toBe("2026-04-19");
+  });
+
   it("maps doc with bed_time and wake_time to valid ingest item", () => {
     const doc: OuraSleepDocument = {
       id: "s1",
@@ -23,10 +49,38 @@ describe("mapOuraSleepToIngestItem", () => {
       idempotencyKey: "s1",
       start: "2025-03-13T22:00:00Z",
       end: "2025-03-14T06:00:00Z",
-      day: "2025-03-13",
+      day: "2025-03-14",
       totalMinutes: 480,
       isMainSleep: true,
     });
+  });
+
+  it("maps rem_sleep_duration and deep_sleep_duration seconds to minutes", () => {
+    const doc: OuraSleepDocument = {
+      id: "s_stages",
+      bed_time: "2025-03-13T22:00:00Z",
+      wake_time: "2025-03-14T06:00:00Z",
+      total_sleep_duration: 28800,
+      rem_sleep_duration: 7200,
+      deep_sleep_duration: 3600,
+      type: "long_sleep",
+    };
+    const result = mapOuraSleepToIngestItem(doc);
+    expect(result?.remSleepMinutes).toBe(120);
+    expect(result?.deepSleepMinutes).toBe(60);
+  });
+
+  it("maps latency >= 60 as seconds into latencyMinutes (Oura raw latency)", () => {
+    const doc: OuraSleepDocument = {
+      id: "s_lat",
+      bed_time: "2025-03-13T22:00:00Z",
+      wake_time: "2025-03-14T06:00:00Z",
+      total_sleep_duration: 28800,
+      latency: 300,
+      type: "long_sleep",
+    };
+    const result = mapOuraSleepToIngestItem(doc);
+    expect(result?.latencyMinutes).toBe(5);
   });
 
   it("maps doc with bedtime_start and bedtime_end to valid ingest item (Oura v2 variant)", () => {
@@ -43,7 +97,7 @@ describe("mapOuraSleepToIngestItem", () => {
       idempotencyKey: "s2",
       start: "2025-03-14T23:00:00Z",
       end: "2025-03-15T07:00:00Z",
-      day: "2025-03-14",
+      day: "2025-03-15",
       totalMinutes: 480,
       isMainSleep: true,
     });
@@ -62,7 +116,7 @@ describe("mapOuraSleepToIngestItem", () => {
       idempotencyKey: "s3",
       start: "2025-03-10T21:30:00Z",
       end: "2025-03-11T05:45:00Z",
-      day: "2025-03-10",
+      day: "2025-03-11",
       totalMinutes: 495,
     });
   });
@@ -84,6 +138,32 @@ describe("mapOuraSleepToIngestItem", () => {
     } as OuraSleepDocument;
     const result = mapOuraSleepToIngestItem(doc);
     expect(result).toBeNull();
+  });
+
+  it("infers end from start + total_sleep_duration when wake/bedtime_end are missing", () => {
+    const doc = {
+      id: "s_infer_end",
+      bed_time: "2025-03-13T22:00:00Z",
+      total_sleep_duration: 28800,
+      type: "long_sleep",
+    } as OuraSleepDocument;
+    const result = mapOuraSleepToIngestItem(doc);
+    expect(result).not.toBeNull();
+    expect(result!.end).toBe("2025-03-14T06:00:00.000Z");
+    expect(result!.totalMinutes).toBe(480);
+  });
+
+  it("treats efficiency in 0–1 as ratio (does not divide again)", () => {
+    const doc: OuraSleepDocument = {
+      id: "s_eff_ratio",
+      bed_time: "2025-03-13T22:00:00Z",
+      wake_time: "2025-03-14T06:00:00Z",
+      total_sleep_duration: 28800,
+      efficiency: 0.88,
+      type: "long_sleep",
+    };
+    const result = mapOuraSleepToIngestItem(doc);
+    expect(result?.efficiency).toBe(0.88);
   });
 
   it("regression: 38 docs with start/end only all map to ingest items (no mass drop)", () => {

--- a/services/api/src/lib/__tests__/ouraIngestWrite.test.ts
+++ b/services/api/src/lib/__tests__/ouraIngestWrite.test.ts
@@ -15,6 +15,7 @@ jest.mock("../writeFailure", () => ({
 
 const mockCreate = jest.fn().mockResolvedValue(undefined);
 const mockGet = jest.fn().mockResolvedValue({ exists: false });
+const mockSet = jest.fn().mockResolvedValue(undefined);
 
 describe("writeOuraRawEvents", () => {
   let infoSpy: jest.SpyInstance;
@@ -23,8 +24,9 @@ describe("writeOuraRawEvents", () => {
     jest.clearAllMocks();
     mockCreate.mockResolvedValue(undefined);
     mockGet.mockResolvedValue({ exists: false });
+    mockSet.mockResolvedValue(undefined);
     (userCollection as jest.Mock).mockReturnValue({
-      doc: () => ({ create: mockCreate, get: mockGet }),
+      doc: () => ({ create: mockCreate, get: mockGet, set: mockSet }),
     });
     infoSpy = jest.spyOn(logger, "info").mockImplementation(() => undefined);
   });

--- a/services/api/src/lib/__tests__/ouraPullSleepRange.test.ts
+++ b/services/api/src/lib/__tests__/ouraPullSleepRange.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Mirrors sleep-only date window math in {@link ../../routes/integrations/ouraPullNow.ts} — overlap refetch + forward end.
+ */
+import { describe, it, expect } from "@jest/globals";
+
+const WINDOW_DAYS = 30;
+const PULL_SLEEP_START_OVERLAP_DAYS = 2;
+const PULL_SLEEP_END_OVERLAP_DAYS = 1;
+
+function computeSleepPullRange(now: Date): {
+  sleepStartStr: string;
+  sleepEndStr: string;
+  coreStartStr: string;
+  coreEndStr: string;
+} {
+  const endDate = new Date(now);
+  const startDate = new Date(endDate);
+  startDate.setUTCDate(startDate.getUTCDate() - WINDOW_DAYS);
+
+  const sleepRangeEnd = new Date(endDate);
+  sleepRangeEnd.setUTCDate(sleepRangeEnd.getUTCDate() + PULL_SLEEP_END_OVERLAP_DAYS);
+  const sleepRangeStart = new Date(endDate);
+  sleepRangeStart.setUTCDate(
+    sleepRangeStart.getUTCDate() - WINDOW_DAYS - PULL_SLEEP_START_OVERLAP_DAYS,
+  );
+
+  const y = (d: Date) => d.toISOString().slice(0, 10);
+  return {
+    sleepStartStr: y(sleepRangeStart),
+    sleepEndStr: y(sleepRangeEnd),
+    coreStartStr: y(startDate),
+    coreEndStr: y(endDate),
+  };
+}
+
+describe("Oura pull-now sleep fetch window", () => {
+  it("extends end_date one UTC day past core end (wake-day rows indexed on next UTC day)", () => {
+    const now = new Date(Date.UTC(2026, 3, 19, 14, 30, 0));
+    const w = computeSleepPullRange(now);
+    expect(w.coreEndStr).toBe("2026-04-19");
+    expect(w.sleepEndStr).toBe("2026-04-20");
+  });
+
+  it("starts two UTC days before core window start for idempotent overlap", () => {
+    const now = new Date(Date.UTC(2026, 3, 19, 9, 0, 0));
+    const w = computeSleepPullRange(now);
+    expect(w.coreStartStr).toBe("2026-03-20");
+    expect(w.sleepStartStr).toBe("2026-03-18");
+  });
+
+  it("America/New_York wall-clock morning still uses UTC anchor for window (Apr 19 2026 10:00 NY == 14:00Z)", () => {
+    const now = new Date(Date.UTC(2026, 3, 19, 14, 0, 0));
+    const w = computeSleepPullRange(now);
+    expect(w.sleepEndStr).toBe("2026-04-20");
+  });
+});

--- a/services/api/src/lib/ouraApi.ts
+++ b/services/api/src/lib/ouraApi.ts
@@ -3,8 +3,14 @@
  * Used by POST /integrations/oura/pull-now. OAuth token URL and scopes match integrations.ts.
  */
 
+import { localCalendarDayKeyFromIsoInTimeZone } from "@oli/contracts";
+import { logger } from "./logger";
+
 const OURA_TOKEN_URL = "https://api.ouraring.com/oauth/token";
 const OURA_API_BASE = "https://api.ouraring.com/v2/usercollection";
+
+/** Follow `next_token` up to this many list API pages (Oura returns bounded `data` per call). */
+const OURA_SLEEP_FETCH_MAX_PAGES = 100;
 
 /** Oura token refresh returns new access_token and new refresh_token (single-use). */
 export type OuraTokenResult = {
@@ -16,6 +22,8 @@ export type OuraTokenResult = {
 /** Minimal Oura API v2 sleep document (from GET /v2/usercollection/sleep). */
 export type OuraSleepDocument = {
   id?: string;
+  /** Oura sleep period date (YYYY-MM-DD); aligns with app wake-day / nightly score row. */
+  day?: string;
   bed_time?: string;
   wake_time?: string;
   end_time?: string;
@@ -148,36 +156,81 @@ export async function refreshOuraAccessToken(
 }
 
 /**
- * GET /v2/usercollection/sleep?start_date=YYYY-MM-DD&end_date=YYYY-MM-DD
+ * GET /v2/usercollection/sleep?start_date=YYYY-MM-DD&end_date=YYYY-MM-DD[&next_token=...]
+ *
+ * Paginates with `next_token` from the JSON body until no further page. Repo bug was returning only
+ * the first page, so the newest sleep row was absent whenever it landed on page 2+.
  */
 export async function fetchOuraSleep(
   accessToken: string,
   startDate: string,
   endDate: string,
+  options?: { requestId?: string; uid?: string },
 ): Promise<OuraSleepDocument[]> {
-  const url = new URL(`${OURA_API_BASE}/sleep`);
-  url.searchParams.set("start_date", startDate);
-  url.searchParams.set("end_date", endDate);
+  const aggregated: OuraSleepDocument[] = [];
+  let nextRequestToken: string | undefined;
+  let pages = 0;
 
-  const res = await fetch(url.toString(), {
-    headers: { Authorization: `Bearer ${accessToken}` },
+  for (;;) {
+    const url = new URL(`${OURA_API_BASE}/sleep`);
+    url.searchParams.set("start_date", startDate);
+    url.searchParams.set("end_date", endDate);
+    if (nextRequestToken) {
+      url.searchParams.set("next_token", nextRequestToken);
+    }
+
+    const res = await fetch(url.toString(), {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+
+    if (res.status === 401) {
+      throw new OuraApiError("Unauthorized", "OURA_UNAUTHORIZED", 401);
+    }
+    if (res.status !== 200) {
+      const text = await res.text();
+      throw new OuraApiError(
+        text || `HTTP ${res.status}`,
+        "OURA_SLEEP_FETCH_FAILED",
+        res.status,
+      );
+    }
+
+    const json = (await res.json()) as { data?: OuraSleepDocument[]; next_token?: string };
+    const chunk = Array.isArray(json.data) ? json.data : [];
+    aggregated.push(...chunk);
+    pages += 1;
+
+    const responseNext =
+      typeof json.next_token === "string" && json.next_token.length > 0 ? json.next_token : undefined;
+
+    if (!responseNext) {
+      break;
+    }
+    if (pages >= OURA_SLEEP_FETCH_MAX_PAGES) {
+      logger.error({
+        msg: "oura_sleep_fetch_page_cap",
+        startDate,
+        endDate,
+        pages,
+        ...(options?.requestId ? { requestId: options.requestId } : {}),
+        ...(options?.uid ? { uid: options.uid } : {}),
+      });
+      break;
+    }
+    nextRequestToken = responseNext;
+  }
+
+  logger.info({
+    msg: "oura_sleep_fetch_complete",
+    startDate,
+    endDate,
+    pages,
+    rowCount: aggregated.length,
+    ...(options?.requestId ? { requestId: options.requestId } : {}),
+    ...(options?.uid ? { uid: options.uid } : {}),
   });
 
-  if (res.status === 401) {
-    throw new OuraApiError("Unauthorized", "OURA_UNAUTHORIZED", 401);
-  }
-  if (res.status !== 200) {
-    const text = await res.text();
-    throw new OuraApiError(
-      text || `HTTP ${res.status}`,
-      "OURA_SLEEP_FETCH_FAILED",
-      res.status,
-    );
-  }
-
-  const json = (await res.json()) as { data?: OuraSleepDocument[]; next_token?: string };
-  const data = Array.isArray(json.data) ? json.data : [];
-  return data;
+  return aggregated;
 }
 
 /**
@@ -373,6 +426,9 @@ export type OuraSleepIngestItem = {
   latencyMinutes?: number | null;
   awakenings?: number | null;
   isMainSleep: boolean;
+  /** Stage durations in minutes when Oura reports rem_sleep_duration / deep_sleep_duration */
+  remSleepMinutes?: number | null;
+  deepSleepMinutes?: number | null;
 };
 
 export type OuraHrvIngestItem = {
@@ -421,6 +477,10 @@ function toYmd(iso: string): string {
   return iso.slice(0, 10);
 }
 
+function isYmdDateString(value: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}$/.test(value);
+}
+
 /**
  * Normalize sleep window start from Oura sleep doc (supports bed_time, bedtime_start, start, end_time).
  * Oura API v2 can return bed_time/wake_time or bedtime_start/bedtime_end or start/end.
@@ -449,37 +509,85 @@ function getSleepEnd(doc: OuraSleepDocument): string | null {
   return typeof e === "string" && e.length > 0 ? e : null;
 }
 
+/**
+ * Wake-time ISO for pull-now diagnostics (same field resolution as ingest).
+ */
+export function ouraSleepWakeIsoForLog(doc: OuraSleepDocument): string | null {
+  return getSleepEnd(doc);
+}
+
+/**
+ * Align with GET /users/me/oura-sleep-view (`usersMe.ts`): Oura may return latency as seconds
+ * (typically ≥ 60); smaller values are treated as minutes.
+ */
+export function normalizeOuraLatencyRawToMinutes(latencyRaw: number): number {
+  return latencyRaw >= 60 ? Math.round(latencyRaw / 60) : Math.round(latencyRaw);
+}
+
 export function mapOuraSleepToIngestItem(doc: OuraSleepDocument): OuraSleepIngestItem | null {
   const start = getSleepStart(doc);
-  const end = getSleepEnd(doc);
+  let end = getSleepEnd(doc);
+  const totalSec = typeof doc.total_sleep_duration === "number" ? doc.total_sleep_duration : 0;
+  // When Oura omits wake/bedtime_end but provides duration, infer end so we still write a sleep rawEvent.
+  if (start && !end && totalSec > 0) {
+    const startMs = Date.parse(start);
+    if (!Number.isNaN(startMs)) {
+      end = new Date(startMs + totalSec * 1000).toISOString();
+    }
+  }
   if (!start || !end) return null;
 
-  const totalSec = doc.total_sleep_duration ?? 0;
   const totalMinutes = Math.round(totalSec / 60);
   const efficiencyRaw = doc.efficiency;
-  const efficiency =
-    typeof efficiencyRaw === "number" && efficiencyRaw >= 0 && efficiencyRaw <= 100
-      ? efficiencyRaw / 100
-      : null;
+  /** Oura may send 0–100 (percent) or 0–1 (ratio). */
+  let efficiency: number | null = null;
+  if (typeof efficiencyRaw === "number" && efficiencyRaw >= 0 && efficiencyRaw <= 100) {
+    efficiency = efficiencyRaw > 1 ? efficiencyRaw / 100 : efficiencyRaw;
+  }
   const latencyMinutes =
-    typeof doc.latency === "number" && doc.latency >= 0 ? Math.round(doc.latency) : null;
+    typeof doc.latency === "number" && doc.latency >= 0
+      ? normalizeOuraLatencyRawToMinutes(doc.latency)
+      : null;
   const awakenings =
     typeof (doc as { number_of_awakenings?: number }).number_of_awakenings === "number"
       ? (doc as { number_of_awakenings: number }).number_of_awakenings
       : null;
+
+  const remSec = typeof (doc as { rem_sleep_duration?: number }).rem_sleep_duration === "number"
+    ? (doc as { rem_sleep_duration: number }).rem_sleep_duration
+    : null;
+  const remSleepMinutes =
+    remSec != null && remSec >= 0 ? Math.round(remSec / 60) : null;
+
+  const deepSec = typeof (doc as { deep_sleep_duration?: number }).deep_sleep_duration === "number"
+    ? (doc as { deep_sleep_duration: number }).deep_sleep_duration
+    : null;
+  const deepSleepMinutes =
+    deepSec != null && deepSec >= 0 ? Math.round(deepSec / 60) : null;
+
   const id = doc.id ?? `oura_sleep_${start}`;
   const isMainSleep = doc.type === "long_sleep" || doc.type === "sleep";
+
+  const providerDay =
+    typeof doc.day === "string" && isYmdDateString(doc.day) ? doc.day : null;
+  /** Prefer Oura `day`; else wake calendar day in UTC (matches normalization fallback without API day). */
+  const rollupDay =
+    providerDay ??
+    localCalendarDayKeyFromIsoInTimeZone(end, "UTC") ??
+    toYmd(end);
 
   return {
     idempotencyKey: String(id),
     start,
     end,
     timezone: "UTC",
-    day: toYmd(start),
+    day: rollupDay,
     totalMinutes,
     ...(efficiency != null ? { efficiency } : {}),
     ...(latencyMinutes != null ? { latencyMinutes } : {}),
     ...(awakenings != null ? { awakenings } : {}),
+    ...(remSleepMinutes != null ? { remSleepMinutes } : {}),
+    ...(deepSleepMinutes != null ? { deepSleepMinutes } : {}),
     isMainSleep,
   };
 }

--- a/services/api/src/lib/ouraIngestWrite.ts
+++ b/services/api/src/lib/ouraIngestWrite.ts
@@ -128,6 +128,8 @@ async function writeSleepLoop(
       ...(item.efficiency != null ? { efficiency: item.efficiency } : {}),
       ...(item.latencyMinutes != null ? { latencyMinutes: item.latencyMinutes } : {}),
       ...(item.awakenings != null ? { awakenings: item.awakenings } : {}),
+      ...(item.remSleepMinutes != null ? { remSleepMinutes: item.remSleepMinutes } : {}),
+      ...(item.deepSleepMinutes != null ? { deepSleepMinutes: item.deepSleepMinutes } : {}),
       isMainSleep: item.isMainSleep,
     };
     const doc = {
@@ -162,21 +164,22 @@ async function writeSleepLoop(
       continue;
     }
     try {
-      await rawEventsCol.doc(item.idempotencyKey).create(validated.data);
-      created += 1;
-    } catch (err: unknown) {
-      const existing = await rawEventsCol.doc(item.idempotencyKey).get();
-      if (existing.exists) {
+      const ref = rawEventsCol.doc(item.idempotencyKey);
+      const prior = await ref.get();
+      await ref.set(validated.data, { merge: true });
+      if (prior.exists) {
         alreadyExists += 1;
       } else {
-        logger.error({
-          msg: "oura_ingest_sleep_write_error",
-          uid,
-          rawEventId: item.idempotencyKey,
-          requestId,
-          err: err instanceof Error ? err.message : String(err),
-        });
+        created += 1;
       }
+    } catch (err: unknown) {
+      logger.error({
+        msg: "oura_ingest_sleep_write_error",
+        uid,
+        rawEventId: item.idempotencyKey,
+        requestId,
+        err: err instanceof Error ? err.message : String(err),
+      });
     }
   }
   return { created, alreadyExists };

--- a/services/api/src/lib/ouraVendorSnapshot.ts
+++ b/services/api/src/lib/ouraVendorSnapshot.ts
@@ -120,7 +120,7 @@ export function fillSleepContributorsFromStored(data: StoredSleepSnapshotData): 
 
   const lat = data.latency;
   if (typeof lat === "number" && !Number.isNaN(lat) && lat >= 0 && !Object.prototype.hasOwnProperty.call(out, "latency")) {
-    const latMinutes = lat > 120 ? lat / 60 : lat;
+    const latMinutes = lat >= 60 ? lat / 60 : lat;
     out.latency = clampScore(Math.max(0, 100 - latMinutes * 2));
   }
 
@@ -180,7 +180,7 @@ function buildSleepContributors(doc: OuraSleepDocument): Record<string, number> 
 
   const lat = doc.latency;
   if (typeof lat === "number" && !Number.isNaN(lat) && lat >= 0 && !Object.prototype.hasOwnProperty.call(out, "latency")) {
-    const latMinutes = lat > 120 ? lat / 60 : lat;
+    const latMinutes = lat >= 60 ? lat / 60 : lat;
     out.latency = clampScore(Math.max(0, 100 - latMinutes * 2));
   }
 

--- a/services/api/src/routes/integrations/__tests__/ouraIngest.test.ts
+++ b/services/api/src/routes/integrations/__tests__/ouraIngest.test.ts
@@ -6,13 +6,14 @@ import express from "express";
 import request from "supertest";
 import ouraIngestRouter from "../ouraIngest";
 
-const docRefs: Record<string, { create: jest.Mock; get: jest.Mock }> = {};
+const docRefs: Record<string, { create: jest.Mock; get: jest.Mock; set: jest.Mock }> = {};
 
 function getDocRef(id: string) {
   if (!docRefs[id]) {
     docRefs[id] = {
       create: jest.fn().mockResolvedValue(undefined),
       get: jest.fn().mockResolvedValue({ exists: false }),
+      set: jest.fn().mockResolvedValue(undefined),
     };
   }
   return docRefs[id];
@@ -108,8 +109,8 @@ describe("POST /integrations/oura/ingest", () => {
     expect(res.body.ok).toBe(true);
     expect(res.body.eventsCreated).toBe(1);
     const docRef = getDocRef("oura_sleep_1");
-    expect(docRef.create).toHaveBeenCalledTimes(1);
-    const written = docRef.create.mock.calls[0][0];
+    expect(docRef.set).toHaveBeenCalledTimes(1);
+    const written = docRef.set.mock.calls[0][0];
     expect(written.provider).toBe("manual");
     expect(written.sourceId).toBe("oura");
     expect(written.sourceType).toBe("oura");
@@ -157,7 +158,6 @@ describe("POST /integrations/oura/ingest", () => {
 
   it("skips duplicate idempotency key (eventsAlreadyExists)", async () => {
     const docRef = getDocRef("dup_key");
-    docRef.create.mockReset().mockRejectedValueOnce(new Error("ALREADY_EXISTS"));
     docRef.get.mockReset().mockResolvedValue({ exists: true });
 
     const res = await request(app)

--- a/services/api/src/routes/integrations/__tests__/ouraPullNow.test.ts
+++ b/services/api/src/routes/integrations/__tests__/ouraPullNow.test.ts
@@ -55,6 +55,9 @@ jest.mock("../../../lib/ouraSecrets", () => ({
 jest.mock("../../../lib/ouraApi", () => ({
   refreshOuraAccessToken: jest.fn(),
   fetchOuraSleep: jest.fn(),
+  ouraSleepWakeIsoForLog: jest.fn((d: { wake_time?: string }) =>
+    typeof d?.wake_time === "string" ? d.wake_time : null,
+  ),
   fetchOuraDailyReadiness: jest.fn(),
   fetchOuraPersonalInfo: jest.fn().mockResolvedValue(null),
   fetchOuraDailyActivity: jest.fn().mockResolvedValue([]),

--- a/services/api/src/routes/integrations/ouraPullNow.ts
+++ b/services/api/src/routes/integrations/ouraPullNow.ts
@@ -34,6 +34,7 @@ import {
   type OuraSleepDocument,
   type OuraDailyReadinessDocument,
   OuraApiError,
+  ouraSleepWakeIsoForLog,
 } from "../../lib/ouraApi";
 import { writeOuraRawEvents } from "../../lib/ouraIngestWrite";
 import {
@@ -49,6 +50,11 @@ const router = Router();
 
 /** Pull last N days of data (sleep + readiness). */
 const WINDOW_DAYS = 30;
+
+/** Extra days before (today − WINDOW_DAYS) for sleep fetch only — idempotent refetch at rolling boundary. */
+const PULL_SLEEP_START_OVERLAP_DAYS = 2;
+/** Extend sleep `end_date` one UTC calendar day so wake-indexed rows land in range the same morning. */
+const PULL_SLEEP_END_OVERLAP_DAYS = 1;
 
 /** Backfill: total days to backfill and chunk size (idempotent, resumable). */
 const BACKFILL_TOTAL_DAYS = 90;
@@ -272,6 +278,27 @@ export async function performOuraPullNowCore(
   const startIso = startDate.toISOString();
   const endIso = endDate.toISOString();
 
+  const sleepRangeEnd = new Date(endDate);
+  sleepRangeEnd.setUTCDate(sleepRangeEnd.getUTCDate() + PULL_SLEEP_END_OVERLAP_DAYS);
+  const sleepRangeStart = new Date(endDate);
+  sleepRangeStart.setUTCDate(
+    sleepRangeStart.getUTCDate() - WINDOW_DAYS - PULL_SLEEP_START_OVERLAP_DAYS,
+  );
+  const sleepStartStr = toYmd(sleepRangeStart);
+  const sleepEndStr = toYmd(sleepRangeEnd);
+
+  logger.info({
+    msg: "oura_pull_sleep_date_window",
+    uid,
+    requestId,
+    sleepStartStr,
+    sleepEndStr,
+    coreStartStr: startStr,
+    coreEndStr: endStr,
+    sleepStartOverlapDays: PULL_SLEEP_START_OVERLAP_DAYS,
+    sleepEndOverlapDays: PULL_SLEEP_END_OVERLAP_DAYS,
+  });
+
   let sleepItems: OuraSleepIngestItem[] = [];
   let hrvItems: OuraHrvIngestItem[] = [];
   let stepsItems: OuraStepsIngestItem[] = [];
@@ -306,7 +333,7 @@ export async function performOuraPullNowCore(
       spo2Docs,
       heartrateDocs,
     ] = await Promise.all([
-      fetchOuraSleep(accessToken, startStr, endStr),
+      fetchOuraSleep(accessToken, sleepStartStr, sleepEndStr, { requestId, uid }),
       fetchOuraDailyReadiness(accessToken, startStr, endStr),
       safeFetch("personal_info", () => fetchOuraPersonalInfo(accessToken)),
       safeFetch("daily_activity", () => fetchOuraDailyActivity(accessToken, startStr, endStr)),
@@ -319,6 +346,28 @@ export async function performOuraPullNowCore(
 
     sleepDocs = sleepDocsFetched ?? [];
     readinessDocs = readinessDocsFetched ?? [];
+
+    let latestWakeIso: string | null = null;
+    let latestSleepId: string | null = null;
+    for (const d of sleepDocs) {
+      const w = ouraSleepWakeIsoForLog(d);
+      if (!w) continue;
+      const t = Date.parse(w);
+      if (Number.isNaN(t)) continue;
+      if (!latestWakeIso || t > Date.parse(latestWakeIso)) {
+        latestWakeIso = w;
+        latestSleepId = typeof d.id === "string" ? d.id : null;
+      }
+    }
+    logger.info({
+      msg: "oura_pull_sleep_latest_wake",
+      uid,
+      requestId,
+      latestWakeIso,
+      latestSleepId,
+      sleepDocCount: sleepDocs.length,
+    });
+
     logger.info({
       msg: "oura_fetch_counts",
       uid,
@@ -680,7 +729,7 @@ export async function triggerOuraBackfill(uid: string, requestId: string): Promi
 
     try {
       const [sleepDocsFetched, readinessDocsFetched] = await Promise.all([
-        fetchOuraSleep(accessToken, startStr, endStr),
+        fetchOuraSleep(accessToken, startStr, endStr, { requestId, uid }),
         fetchOuraDailyReadiness(accessToken, startStr, endStr),
       ]);
       const sleepDocs = sleepDocsFetched ?? [];

--- a/services/functions/src/dailyFacts/__tests__/aggregateDailyFacts.sleepWakeDay.test.ts
+++ b/services/functions/src/dailyFacts/__tests__/aggregateDailyFacts.sleepWakeDay.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Documents that DailyFacts sleep rollups follow canonical `day` on each SleepCanonicalEvent
+ * (recompute loads events with day === facts date).
+ */
+import { describe, it, expect } from "@jest/globals";
+import { aggregateDailyFactsForDay } from "../aggregateDailyFacts";
+import type { SleepCanonicalEvent } from "../../types/health";
+
+describe("aggregateDailyFacts — sleep wake-day canonical events", () => {
+  it("includes overnight sleep on the canonical wake / Oura sleep day", () => {
+    const night: SleepCanonicalEvent = {
+      id: "oura_n1",
+      userId: "u1",
+      sourceId: "oura",
+      kind: "sleep",
+      start: "2026-04-18T23:00:00.000Z",
+      end: "2026-04-19T12:00:00.000Z",
+      day: "2026-04-19",
+      timezone: "UTC",
+      createdAt: "2026-04-19T12:00:00.000Z",
+      updatedAt: "2026-04-19T12:00:00.000Z",
+      schemaVersion: 1,
+      totalMinutes: 486,
+      isMainSleep: true,
+      efficiency: 0.94,
+    };
+
+    const facts = aggregateDailyFactsForDay({
+      userId: "u1",
+      date: "2026-04-19",
+      computedAt: "2026-04-19T12:05:00.000Z",
+      events: [night],
+    });
+
+    expect(facts.sleep?.totalMinutes).toBe(486);
+    expect(facts.sleep?.efficiency).toBe(0.94);
+    expect(facts.date).toBe("2026-04-19");
+  });
+});

--- a/services/functions/src/dailyFacts/__tests__/aggregateDailyFacts.test.ts
+++ b/services/functions/src/dailyFacts/__tests__/aggregateDailyFacts.test.ts
@@ -153,6 +153,7 @@ describe('aggregateDailyFactsForDay', () => {
     expect(sleep.totalMinutes).toBe(510);
     // main sleep minutes only
     expect(sleep.mainSleepMinutes).toBe(480);
+    expect(sleep.primarySourceId).toBe("source_manual_1");
 
     const activity = result.activity!;
     // Two non-apple step events, same updatedAt: lexicographic id tie-break (steps_1 before steps_2), do not sum
@@ -167,6 +168,35 @@ describe('aggregateDailyFactsForDay', () => {
     const recovery = result.recovery!;
     // average of 80 and 60 = 70
     expect(recovery.hrvRmssd).toBe(70);
+  });
+
+  it("aggregates REM/deep minutes from main sleep episodes only", () => {
+    const events: CanonicalEvent[] = [
+      makeSleep({
+        id: "sleep_main",
+        totalMinutes: 480,
+        isMainSleep: true,
+        remSleepMinutes: 90,
+        deepSleepMinutes: 70,
+        sourceId: "oura",
+      }),
+      makeSleep({
+        id: "sleep_nap",
+        totalMinutes: 20,
+        isMainSleep: false,
+        remSleepMinutes: 5,
+        deepSleepMinutes: 5,
+      }),
+    ];
+    const result = aggregateDailyFactsForDay({
+      userId: "user_123",
+      date: "2025-01-01",
+      computedAt: "2025-01-02T03:00:00.000Z",
+      events,
+    });
+    expect(result.sleep?.remSleepMinutes).toBe(90);
+    expect(result.sleep?.deepSleepMinutes).toBe(70);
+    expect(result.sleep?.primarySourceId).toBe("oura");
   });
 
   it('prefers apple_health steps over other sources for the same day', () => {
@@ -334,6 +364,30 @@ describe('aggregateDailyFactsForDay', () => {
     expect(result.body).toBeUndefined();
     expect(result.recovery).toBeUndefined();
     expect(result.strength).toBeUndefined();
+  });
+
+  it('still includes sleep when canonical sleep episodes exist but summed minutes are zero', () => {
+    const events: CanonicalEvent[] = [
+      makeSleep({
+        id: 'sleep_zero',
+        totalMinutes: 0,
+        efficiency: null,
+        latencyMinutes: null,
+        awakenings: null,
+        isMainSleep: false,
+        remSleepMinutes: null,
+        deepSleepMinutes: null,
+      }),
+    ];
+    const result = aggregateDailyFactsForDay({
+      userId: 'user_123',
+      date: '2025-01-01',
+      computedAt: '2025-01-02T03:00:00.000Z',
+      events,
+    });
+    expect(result.sleep).toBeDefined();
+    expect(result.sleep!.totalMinutes).toBe(0);
+    expect(result.sleep!.primarySourceId).toBe('source_manual_1');
   });
 
   it('includes body from factOnlyBody when no canonical weight events exist', () => {

--- a/services/functions/src/dailyFacts/aggregateDailyFacts.ts
+++ b/services/functions/src/dailyFacts/aggregateDailyFacts.ts
@@ -61,15 +61,12 @@ const buildSleepFacts = (events: CanonicalEvent[]): DailySleepFacts | undefined 
   const facts: DailySleepFacts = {};
 
   const totalMinutes = sleepEvents.reduce((sum, e) => sum + e.totalMinutes, 0);
-  if (totalMinutes > 0) {
-    facts.totalMinutes = totalMinutes;
-  }
+  facts.totalMinutes = totalMinutes;
 
-  const mainSleepMinutes = sleepEvents.reduce(
-    (sum, e) => (e.isMainSleep ? sum + e.totalMinutes : sum),
-    0,
-  );
-  if (mainSleepMinutes > 0) {
+  const mainEpisodes = sleepEvents.filter((e) => e.isMainSleep);
+
+  const mainSleepMinutes = mainEpisodes.reduce((sum, e) => sum + e.totalMinutes, 0);
+  if (mainEpisodes.length > 0) {
     facts.mainSleepMinutes = mainSleepMinutes;
   }
 
@@ -94,7 +91,27 @@ const buildSleepFacts = (events: CanonicalEvent[]): DailySleepFacts | undefined 
     facts.awakenings = awakenings;
   }
 
-  return Object.keys(facts).length > 0 ? facts : undefined;
+  const remStages = mainEpisodes.map((e) => e.remSleepMinutes).filter(isNumber);
+  const remSum = remStages.reduce((sum, v) => sum + v, 0);
+  if (remSum > 0) {
+    facts.remSleepMinutes = remSum;
+  }
+
+  const deepStages = mainEpisodes.map((e) => e.deepSleepMinutes).filter(isNumber);
+  const deepSum = deepStages.reduce((sum, v) => sum + v, 0);
+  if (deepSum > 0) {
+    facts.deepSleepMinutes = deepSum;
+  }
+
+  const primaryPool: SleepCanonicalEvent[] =
+    mainEpisodes.length > 0 ? mainEpisodes : sleepEvents;
+  let primary: SleepCanonicalEvent = primaryPool[0]!;
+  for (const e of primaryPool) {
+    if (e.totalMinutes > primary.totalMinutes) primary = e;
+  }
+  facts.primarySourceId = primary.sourceId;
+
+  return facts;
 };
 
 const buildActivityFacts = (events: CanonicalEvent[]): DailyActivityFacts | undefined => {

--- a/services/functions/src/http/recomputeDailyFactsAdminHttp.ts
+++ b/services/functions/src/http/recomputeDailyFactsAdminHttp.ts
@@ -13,6 +13,7 @@ import type {
 import { aggregateDailyFactsForDay } from "../dailyFacts/aggregateDailyFacts";
 import { enrichDailyFactsWithBaselinesAndAverages } from "../dailyFacts/enrichDailyFacts";
 import { loadBodyFactsFromRawForDay } from "../dailyFacts/loadBodyFactsFromRawForDay";
+import { attachOliSleepScoreToSleepFacts } from "../sleep/computeOliSleepScoreV1";
 import { requireAdmin } from "./adminAuth";
 
 // ✅ Data Readiness Contract
@@ -160,6 +161,19 @@ export const recomputeDailyFactsAdminHttp = onRequest(
         history,
       });
 
+      const enrichedWithSleepScore: DailyFacts =
+        enriched.sleep !== undefined
+          ? {
+              ...enriched,
+              sleep: attachOliSleepScoreToSleepFacts(enriched.sleep, {
+                computedAt,
+                ...(enriched.confidence?.sleep !== undefined
+                  ? { domainConfidenceSleep: enriched.confidence.sleep }
+                  : {}),
+              }),
+            }
+          : enriched;
+
       /**
        * Write DailyFacts with readiness meta
        *
@@ -168,7 +182,7 @@ export const recomputeDailyFactsAdminHttp = onRequest(
        */
       const ref = userRef.collection("dailyFacts").doc(date);
       await ref.set({
-        ...enriched,
+        ...enrichedWithSleepScore,
         meta: buildPipelineMeta({
           computedAt: latestCanonicalEventAt,
           source: { eventsForDay: events.length },

--- a/services/functions/src/normalization/__tests__/mapRawEventToCanonical.test.ts
+++ b/services/functions/src/normalization/__tests__/mapRawEventToCanonical.test.ts
@@ -54,6 +54,111 @@ describe("mapRawEventToCanonical", () => {
     expect(sleep.isMainSleep).toBe(true);
   });
 
+  it("Oura-ingested sleep uses payload.day when valid (Oura API sleep day)", () => {
+    const raw: RawEvent = {
+      ...baseRawEvent,
+      id: "raw_oura_sleep_api_day",
+      sourceId: "oura",
+      sourceType: "wearable",
+      provider: "manual",
+      kind: "sleep",
+      payload: {
+        start: "2026-04-18T23:00:00.000Z",
+        end: "2026-04-19T12:00:00.000Z",
+        timezone: "UTC",
+        day: "2026-04-19",
+        totalMinutes: 486,
+        isMainSleep: true,
+      } as unknown,
+    };
+
+    const result = mapRawEventToCanonical(raw);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected mapping success");
+    expect(result.canonical.kind).toBe("sleep");
+    if (result.canonical.kind !== "sleep") throw new Error("Expected sleep");
+    expect(result.canonical.day).toBe("2026-04-19");
+  });
+
+  it("Oura-ingested sleep without payload.day attributes to wake instant (end) in payload timezone", () => {
+    const raw: RawEvent = {
+      ...baseRawEvent,
+      id: "raw_oura_sleep_wake_anchor",
+      sourceId: "oura",
+      sourceType: "wearable",
+      provider: "manual",
+      kind: "sleep",
+      payload: {
+        start: "2026-04-18T23:30:00.000Z",
+        end: "2026-04-19T11:30:00.000Z",
+        timezone: "UTC",
+        totalMinutes: 486,
+        isMainSleep: true,
+      } as unknown,
+    };
+
+    const result = mapRawEventToCanonical(raw);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected mapping success");
+    expect(result.canonical.kind).toBe("sleep");
+    if (result.canonical.kind !== "sleep") throw new Error("Expected sleep");
+    expect(result.canonical.day).toBe("2026-04-19");
+  });
+
+  it("Oura-ingested sleep America/New_York: wake morning maps to local wake day", () => {
+    const raw: RawEvent = {
+      ...baseRawEvent,
+      id: "raw_oura_sleep_ny",
+      sourceId: "oura",
+      sourceType: "wearable",
+      provider: "manual",
+      kind: "sleep",
+      payload: {
+        start: "2026-04-19T04:00:00.000Z",
+        end: "2026-04-19T12:00:00.000Z",
+        timezone: "America/New_York",
+        totalMinutes: 450,
+        isMainSleep: true,
+      } as unknown,
+    };
+
+    const result = mapRawEventToCanonical(raw);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected mapping success");
+    if (result.canonical.kind !== "sleep") throw new Error("Expected sleep");
+    const expectedEndDay = new Intl.DateTimeFormat("en-CA", {
+      timeZone: "America/New_York",
+    }).format(new Date("2026-04-19T12:00:00.000Z"));
+    expect(result.canonical.day).toBe(expectedEndDay);
+  });
+
+  it("maps optional REM/deep stage minutes on manual sleep", () => {
+    const raw: RawEvent = {
+      ...baseRawEvent,
+      id: "raw_sleep_stages",
+      provider: "manual",
+      kind: "sleep",
+      payload: {
+        start: "2025-01-01T22:00:00.000Z",
+        end: "2025-01-02T06:00:00.000Z",
+        timezone: "America/New_York",
+        totalMinutes: 480,
+        isMainSleep: true,
+        remSleepMinutes: 100,
+        deepSleepMinutes: 80,
+      } as unknown,
+    };
+
+    const result = mapRawEventToCanonical(raw);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected mapping success");
+    const canonical = result.canonical;
+    if (canonical.kind !== "sleep") throw new Error("Expected sleep kind");
+    const sleep = canonical as Extract<CanonicalEvent, { kind: "sleep" }>;
+    expect(sleep.remSleepMinutes).toBe(100);
+    expect(sleep.deepSleepMinutes).toBe(80);
+  });
+
   it("maps manual steps payload to StepsCanonicalEvent", () => {
     const raw: RawEvent = {
       ...baseRawEvent,

--- a/services/functions/src/normalization/__tests__/writeCanonicalEventImmutable.sleep-supersede.test.ts
+++ b/services/functions/src/normalization/__tests__/writeCanonicalEventImmutable.sleep-supersede.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Sleep canonical documents share id with RawEvent; newer raw deliveries replace older canonical.
+ */
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+
+jest.mock("firebase-functions/logger", () => ({
+  error: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  debug: jest.fn(),
+}));
+
+const mockTransactionStore = new Map<string, Record<string, unknown>>();
+
+jest.mock("../../firebaseAdmin", () => ({
+  admin: {
+    firestore: {
+      FieldValue: {
+        serverTimestamp: () => ({}),
+      },
+    },
+  },
+  db: {
+    collection(col: string) {
+      return {
+        doc(id: string) {
+          const base = `${col}/${id}`;
+          return {
+            collection(sub: string) {
+              return {
+                doc(subId: string) {
+                  const path = `${base}/${sub}/${subId}`;
+                  return { path };
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+    runTransaction<T>(
+      fn: (tx: {
+        get: (ref: { path: string }) => Promise<{
+          exists: boolean;
+          data: () => Record<string, unknown> | undefined;
+        }>;
+        create: (ref: { path: string }, data: Record<string, unknown>) => void;
+        set: (ref: { path: string }, data: Record<string, unknown>) => void;
+      }) => Promise<T>,
+    ): Promise<T> {
+      const tx = {
+        async get(ref: { path: string }) {
+          const d = mockTransactionStore.get(ref.path);
+          return { exists: mockTransactionStore.has(ref.path), data: () => d };
+        },
+        create(ref: { path: string }, data: Record<string, unknown>) {
+          if (mockTransactionStore.has(ref.path)) {
+            throw new Error("ALREADY_EXISTS");
+          }
+          mockTransactionStore.set(ref.path, { ...data });
+        },
+        set(ref: { path: string }, data: Record<string, unknown>) {
+          mockTransactionStore.set(ref.path, { ...data });
+        },
+      };
+      return fn(tx);
+    },
+  },
+}));
+
+import type { SleepCanonicalEvent } from "../../types/health";
+import { writeCanonicalEventImmutable } from "../writeCanonicalEventImmutable";
+
+function sleepCanon(
+  updatedAt: string,
+  extra: Partial<SleepCanonicalEvent> = {},
+): SleepCanonicalEvent {
+  return {
+    id: "oura_sleep_1",
+    userId: "u1",
+    sourceId: "oura",
+    kind: "sleep",
+    start: "2025-01-01T22:00:00.000Z",
+    end: "2025-01-02T06:00:00.000Z",
+    day: "2025-01-01",
+    timezone: "UTC",
+    createdAt: "2025-01-02T01:00:00.000Z",
+    updatedAt,
+    schemaVersion: 1,
+    totalMinutes: 480,
+    isMainSleep: true,
+    ...extra,
+  };
+}
+
+describe("writeCanonicalEventImmutable — sleep supersede", () => {
+  beforeEach(() => {
+    mockTransactionStore.clear();
+  });
+
+  it("replaces sleep when incoming updatedAt is newer", async () => {
+    const path = "users/u1/events/oura_sleep_1";
+    mockTransactionStore.set(path, sleepCanon("2025-01-02T01:00:00.000Z") as unknown as Record<string, unknown>);
+
+    const incoming = sleepCanon("2025-01-03T01:00:00.000Z", {
+      remSleepMinutes: 90,
+      deepSleepMinutes: 70,
+    });
+
+    const res = await writeCanonicalEventImmutable({
+      userId: "u1",
+      canonical: incoming,
+      sourceRawEventId: "oura_sleep_1",
+      sourceRawEventPath: "users/u1/rawEvents/oura_sleep_1",
+    });
+
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error("expected ok");
+    expect(res.mode).toBe("replaced");
+    const stored = mockTransactionStore.get(path) as unknown as SleepCanonicalEvent;
+    expect(stored.remSleepMinutes).toBe(90);
+    expect(stored.deepSleepMinutes).toBe(70);
+  });
+
+  it("returns sleepDayMovedFrom when canonical day changes on supersede", async () => {
+    const path = "users/u1/events/oura_sleep_1";
+    mockTransactionStore.set(
+      path,
+      sleepCanon("2025-01-02T01:00:00.000Z", { day: "2026-04-18" }) as unknown as Record<string, unknown>,
+    );
+
+    const incoming = sleepCanon("2025-01-03T01:00:00.000Z", { day: "2026-04-19" });
+
+    const res = await writeCanonicalEventImmutable({
+      userId: "u1",
+      canonical: incoming,
+      sourceRawEventId: "oura_sleep_1",
+      sourceRawEventPath: "users/u1/rawEvents/oura_sleep_1",
+    });
+
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error("expected ok");
+    expect(res.mode).toBe("replaced");
+    expect(res.sleepDayMovedFrom).toBe("2026-04-18");
+  });
+
+  it("no-ops when incoming updatedAt is older", async () => {
+    const path = "users/u1/events/oura_sleep_1";
+    mockTransactionStore.set(
+      path,
+      sleepCanon("2025-01-03T01:00:00.000Z", { remSleepMinutes: 90 }) as unknown as Record<string, unknown>,
+    );
+
+    const stale = sleepCanon("2025-01-02T01:00:00.000Z", { remSleepMinutes: 0 });
+
+    const res = await writeCanonicalEventImmutable({
+      userId: "u1",
+      canonical: stale,
+      sourceRawEventId: "oura_sleep_1",
+      sourceRawEventPath: "users/u1/rawEvents/oura_sleep_1",
+    });
+
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error("expected ok");
+    expect(res.mode).toBe("identical_noop");
+    const stored = mockTransactionStore.get(path) as unknown as SleepCanonicalEvent;
+    expect(stored.remSleepMinutes).toBe(90);
+  });
+});

--- a/services/functions/src/normalization/mapRawEventToCanonical.ts
+++ b/services/functions/src/normalization/mapRawEventToCanonical.ts
@@ -1,16 +1,18 @@
 // services/functions/src/normalization/mapRawEventToCanonical.ts
 import { localCalendarDayKeyFromIsoInTimeZone } from "@oli/contracts";
-import type {
-  CanonicalEvent,
-  RawEvent,
-  IsoDateTimeString,
-  SleepCanonicalEvent,
-  StepsCanonicalEvent,
-  WorkoutCanonicalEvent,
-  HrvCanonicalEvent,
-  StrengthWorkoutCanonicalEvent,
-  StrengthWorkoutCanonicalSet,
-  NutritionCanonicalEvent,
+import {
+  isYmdDateString,
+  type CanonicalEvent,
+  type RawEvent,
+  type IsoDateTimeString,
+  type SleepCanonicalEvent,
+  type StepsCanonicalEvent,
+  type WorkoutCanonicalEvent,
+  type HrvCanonicalEvent,
+  type StrengthWorkoutCanonicalEvent,
+  type StrengthWorkoutCanonicalSet,
+  type NutritionCanonicalEvent,
+  type YmdDateString,
 } from "../types/health";
 
 /**
@@ -77,6 +79,10 @@ type ManualSleepPayload = ManualWindowBase & {
   latencyMinutes?: number | null;
   awakenings?: number | null;
   isMainSleep: boolean;
+  remSleepMinutes?: number | null;
+  deepSleepMinutes?: number | null;
+  /** Oura API sleep `day` (YYYY-MM-DD); authoritative wake/metrics day when present. */
+  day?: string;
 };
 
 type ManualStepsPayload = ManualWindowBase & {
@@ -283,7 +289,29 @@ const mapManualSleep = (
   raw: RawEvent,
   payload: ManualSleepPayload,
 ): SleepCanonicalEvent | null => {
-  const day = localCalendarDayKeyFromIsoInTimeZone(payload.start, payload.timezone);
+  /**
+   * Manual / general ingest: attribute sleep to local calendar day of **episode start**
+   * (`payload.start` + timezone). Matches historical manual entry expectations.
+   *
+   * Oura ingested sleeps (`sourceId === "oura"`): align with Oura's sleep record — prefer API
+   * `payload.day` when valid; otherwise **wake day** (`payload.end`), matching overnight sessions
+   * whose UTC **bedtime** falls on the previous UTC date but whose logical "sleep day" / Today row
+   * is the wake morning (see Oura app + GET /sleep `day`).
+   */
+  let day: YmdDateString | null = null;
+  if (raw.sourceId === "oura") {
+    const apiDay =
+      typeof payload.day === "string" && isYmdDateString(payload.day) ? payload.day : null;
+    if (apiDay) {
+      day = apiDay;
+    } else {
+      day =
+        localCalendarDayKeyFromIsoInTimeZone(payload.end, payload.timezone) ??
+        localCalendarDayKeyFromIsoInTimeZone(payload.start, payload.timezone);
+    }
+  } else {
+    day = localCalendarDayKeyFromIsoInTimeZone(payload.start, payload.timezone);
+  }
   if (!day) return null;
 
   return {
@@ -303,6 +331,8 @@ const mapManualSleep = (
     latencyMinutes: payload.latencyMinutes ?? null,
     awakenings: payload.awakenings ?? null,
     isMainSleep: payload.isMainSleep,
+    remSleepMinutes: payload.remSleepMinutes ?? null,
+    deepSleepMinutes: payload.deepSleepMinutes ?? null,
   };
 };
 

--- a/services/functions/src/normalization/onRawEventUpdatedForNormalization.ts
+++ b/services/functions/src/normalization/onRawEventUpdatedForNormalization.ts
@@ -1,13 +1,16 @@
 // services/functions/src/normalization/onRawEventUpdatedForNormalization.ts
 
 /**
- * Re-runs raw → canonical normalization when a steps rawEvent document is updated.
+ * Re-runs raw → canonical normalization when a steps or sleep rawEvent document is updated.
  *
  * Ingest uses deterministic raw doc ids (Idempotency-Key). After the first create,
  * replays return 202 without a second `onCreate`. If normalization failed under an
  * older mapper (e.g. apple_health steps), a subsequent replay must still be able to
  * produce canonical events. The API bumps `receivedAt` on steps replays; this
  * trigger picks up those writes.
+ *
+ * Sleep: payload may gain rem/deep stage minutes after mapper/ingest upgrades; operators patch
+ * raw docs with a newer `receivedAt` so canonical + DailyFacts can be refreshed.
  */
 import { onDocumentUpdated } from "firebase-functions/v2/firestore";
 import * as logger from "firebase-functions/logger";
@@ -28,7 +31,8 @@ export const onRawEventUpdatedForNormalization = onDocumentUpdated(TRIGGER_OPTIO
   if (!change) return;
 
   const after = change.after.data() as Record<string, unknown> | undefined;
-  if (after?.["kind"] !== "steps") return;
+  const kind = after?.["kind"];
+  if (kind !== "steps" && kind !== "sleep") return;
 
   try {
     await processRawEventForNormalization({

--- a/services/functions/src/normalization/processRawEventForNormalization.ts
+++ b/services/functions/src/normalization/processRawEventForNormalization.ts
@@ -462,6 +462,48 @@ export async function processRawEventForNormalization(params: {
       }
     }
 
+    /**
+     * Sleep: first create is followed by onCanonicalEventCreated → recompute. Superseding canonical
+     * (mapper/stage fields) uses tx.set → no onCreate; must recompute here.
+     */
+    if (rawEvent.kind === "sleep" && writeRes.mode === "replaced") {
+      const dayKey = canonical.day as YmdDateString;
+      const priorDay = writeRes.sleepDayMovedFrom;
+      try {
+        await recomputeDerivedTruthForDay({
+          db,
+          userId: rawEvent.userId,
+          dayKey,
+          canonicalAnchorDay: canonical.day as YmdDateString,
+          trigger: {
+            type: "realtime",
+            eventId: `${canonical.id}:sleep_norm_replaced`,
+          },
+        });
+        if (priorDay && priorDay !== dayKey) {
+          await recomputeDerivedTruthForDay({
+            db,
+            userId: rawEvent.userId,
+            dayKey: priorDay,
+            trigger: {
+              type: "realtime",
+              eventId: `${canonical.id}:sleep_norm_prior_day`,
+            },
+          });
+        }
+      } catch (err) {
+        logger.error("sleep_normalization_recompute_failed", {
+          msg: "sleep_normalization_recompute_failed",
+          userId: rawEvent.userId,
+          rawEventId: rawEvent.id,
+          dayKey,
+          priorDay: priorDay ?? null,
+          trigger,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
     if (rawEvent.kind === "workout" || rawEvent.kind === "strength_workout") {
       try {
         const uiDay = deriveWorkoutDayKey({

--- a/services/functions/src/normalization/writeCanonicalEventImmutable.ts
+++ b/services/functions/src/normalization/writeCanonicalEventImmutable.ts
@@ -3,7 +3,7 @@
 import crypto from "node:crypto"; // ✅ ADD
 import * as logger from "firebase-functions/logger";
 import { admin, db } from "../firebaseAdmin";
-import type { CanonicalEvent, StepsCanonicalEvent } from "../types/health";
+import type { CanonicalEvent, StepsCanonicalEvent, YmdDateString } from "../types/health";
 import { canonicalEquals, canonicalHash } from "./canonicalImmutability";
 
 /**
@@ -43,7 +43,12 @@ function mergeIntradayStepsCanonical(
 }
 
 export type WriteCanonicalResult =
-  | { ok: true; mode: "created" | "identical_noop" | "replaced" }
+  | {
+      ok: true;
+      mode: "created" | "identical_noop" | "replaced";
+      /** When a sleep canonical doc is replaced and `day` changed, recompute this prior day too. */
+      sleepDayMovedFrom?: YmdDateString;
+    }
   | {
       ok: false;
       mode: "conflict";
@@ -106,6 +111,43 @@ export async function writeCanonicalEventImmutable(params: {
       }
       tx.set(ref, merged);
       return { ok: true, mode: "replaced" } as const;
+    }
+
+    /**
+     * Sleep uses the same canonical id as the RawEvent (Oura idempotency). Mapper upgrades may add
+     * optional stage fields; a newer raw `receivedAt` → canonical `updatedAt` must supersede stale docs.
+     */
+    if (
+      existing.kind === "sleep" &&
+      canonical.kind === "sleep" &&
+      existing.id === canonical.id
+    ) {
+      const inT = canonical.updatedAt ?? "";
+      const exT = existing.updatedAt ?? "";
+      if (inT > exT) {
+        tx.set(ref, canonical);
+        const sleepDayMovedFrom =
+          existing.day !== canonical.day ? existing.day : undefined;
+        return {
+          ok: true,
+          mode: "replaced",
+          ...(sleepDayMovedFrom ? { sleepDayMovedFrom } : {}),
+        } as const;
+      }
+      if (inT < exT) {
+        return { ok: true, mode: "identical_noop" } as const;
+      }
+      if (canonicalEquals(existing, canonical)) {
+        return { ok: true, mode: "identical_noop" } as const;
+      }
+      tx.set(ref, canonical);
+      const sleepDayMovedFrom =
+        existing.day !== canonical.day ? existing.day : undefined;
+      return {
+        ok: true,
+        mode: "replaced",
+        ...(sleepDayMovedFrom ? { sleepDayMovedFrom } : {}),
+      } as const;
     }
 
     const existingHash = canonicalHash(existing);

--- a/services/functions/src/pipeline/recomputeForDay.ts
+++ b/services/functions/src/pipeline/recomputeForDay.ts
@@ -25,6 +25,7 @@ import { generateInsightsForDailyFacts } from "../insights/rules";
 import { buildDailyIntelligenceContext } from "../intelligence/buildDailyIntelligenceContext";
 import { buildPipelineMeta } from "./pipelineMeta";
 import { makeLedgerRunIdFromSeed, writeDerivedLedgerRun } from "./derivedLedger";
+import { attachOliSleepScoreToSleepFacts } from "../sleep/computeOliSleepScoreV1";
 import { computeHealthScoreV1 } from "../healthScore/computeHealthScoreV1";
 import { writeHealthScoreImmutable } from "../healthScore/writeHealthScoreImmutable";
 import { BASELINE_WINDOW_DAYS, SIGNAL_THRESHOLDS } from "../healthSignals/constants";
@@ -153,8 +154,21 @@ export async function recomputeDerivedTruthForDay(input: RecomputeForDayInput): 
     history: historyFacts,
   });
 
+  const enrichedDailyFactsWithSleepScore: DailyFacts =
+    enrichedDailyFacts.sleep !== undefined
+      ? {
+          ...enrichedDailyFacts,
+          sleep: attachOliSleepScoreToSleepFacts(enrichedDailyFacts.sleep, {
+            computedAt,
+            ...(enrichedDailyFacts.confidence?.sleep !== undefined
+              ? { domainConfidenceSleep: enrichedDailyFacts.confidence.sleep }
+              : {}),
+          }),
+        }
+      : enrichedDailyFacts;
+
   const dailyFactsWithMeta = {
-    ...enrichedDailyFacts,
+    ...enrichedDailyFactsWithSleepScore,
     meta: buildPipelineMeta({
       computedAt: truthAnchor,
       source: {
@@ -170,7 +184,7 @@ export async function recomputeDerivedTruthForDay(input: RecomputeForDayInput): 
   const insights: Insight[] = generateInsightsForDailyFacts({
     userId,
     date: dayKey,
-    today: enrichedDailyFacts,
+    today: enrichedDailyFactsWithSleepScore,
     history: historyFacts,
     now: computedAt,
   });
@@ -183,7 +197,7 @@ export async function recomputeDerivedTruthForDay(input: RecomputeForDayInput): 
     userId,
     date: dayKey,
     computedAt,
-    today: enrichedDailyFacts,
+    today: enrichedDailyFactsWithSleepScore,
     insightsForDay: insights,
   });
 
@@ -204,7 +218,7 @@ export async function recomputeDerivedTruthForDay(input: RecomputeForDayInput): 
   const healthScoreDoc = computeHealthScoreV1({
     userId,
     date: dayKey,
-    today: enrichedDailyFacts,
+    today: enrichedDailyFactsWithSleepScore,
     history: historyFacts,
     computedAt,
     pipelineVersion: 1,

--- a/services/functions/src/sleep/__tests__/computeOliSleepScoreV1.test.ts
+++ b/services/functions/src/sleep/__tests__/computeOliSleepScoreV1.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "@jest/globals";
+import { OLI_SLEEP_SCORE_VERSION } from "@oli/contracts";
+import type { DailySleepFacts } from "../../types/health";
+import {
+  attachOliSleepScoreToSleepFacts,
+  computeOliSleepScoreV1,
+  normalizeDeepRatio,
+  normalizeRemRatio,
+  normalizeSleepDurationMinutes,
+  normalizeSleepEfficiencyRatio,
+  normalizeSleepLatencyMinutes,
+} from "../computeOliSleepScoreV1";
+
+const computedAt = "2026-04-18T12:00:00.000Z";
+
+describe("normalizeSleepDurationMinutes", () => {
+  it("matches piecewise anchors", () => {
+    expect(normalizeSleepDurationMinutes(240)).toBe(0);
+    expect(normalizeSleepDurationMinutes(300)).toBeCloseTo(0.35, 5);
+    expect(normalizeSleepDurationMinutes(360)).toBeCloseTo(0.65, 5);
+    expect(normalizeSleepDurationMinutes(420)).toBeCloseTo(0.9, 5);
+    expect(normalizeSleepDurationMinutes(480)).toBe(1);
+    expect(normalizeSleepDurationMinutes(600)).toBe(1);
+  });
+});
+
+describe("normalizeSleepEfficiencyRatio", () => {
+  it("treats percent-like values", () => {
+    expect(normalizeSleepEfficiencyRatio(85)).toBeCloseTo(normalizeSleepEfficiencyRatio(0.85), 5);
+  });
+
+  it("clamps below and above the curve", () => {
+    expect(normalizeSleepEfficiencyRatio(0.5)).toBe(0);
+    expect(normalizeSleepEfficiencyRatio(0.99)).toBe(1);
+  });
+});
+
+describe("normalizeSleepLatencyMinutes", () => {
+  it("prefers lower latency", () => {
+    expect(normalizeSleepLatencyMinutes(10)).toBe(1);
+    expect(normalizeSleepLatencyMinutes(60)).toBe(0);
+    expect(normalizeSleepLatencyMinutes(5)).toBe(1);
+    expect(normalizeSleepLatencyMinutes(90)).toBe(0);
+  });
+});
+
+describe("normalizeRemRatio / normalizeDeepRatio", () => {
+  it("interpolates mid bands", () => {
+    expect(normalizeRemRatio(0.175)).toBeGreaterThan(0.6);
+    expect(normalizeDeepRatio(0.15)).toBeGreaterThan(0.65);
+  });
+});
+
+describe("computeOliSleepScoreV1", () => {
+  it("returns null when sleep block is absent", () => {
+    expect(computeOliSleepScoreV1({ sleep: undefined, computedAt })).toBeNull();
+  });
+
+  it("returns null score document when duration is missing", () => {
+    const doc = computeOliSleepScoreV1({
+      sleep: { efficiency: 0.9 },
+      computedAt,
+    });
+    expect(doc).not.toBeNull();
+    expect(doc!.value).toBeNull();
+    expect(doc!.confidence).toBe(0);
+    expect(doc!.reasons[0]).toContain("no Oli score");
+  });
+
+  it("re-normalizes weights when optional components are missing", () => {
+    const sleep: DailySleepFacts = {
+      mainSleepMinutes: 420,
+      efficiency: 0.88,
+    };
+    const doc = computeOliSleepScoreV1({ sleep, computedAt });
+    expect(doc).not.toBeNull();
+    expect(doc!.weights.duration + doc!.weights.efficiency).toBeCloseTo(1, 5);
+    expect(doc!.weights.latency).toBe(0);
+    expect(doc!.components.latency).toBeNull();
+  });
+
+  it("subtracts confidence for missing inputs and nulls value when confidence < 0.5", () => {
+    const sleep: DailySleepFacts = {
+      mainSleepMinutes: 420,
+    };
+    const doc = computeOliSleepScoreV1({ sleep, computedAt });
+    expect(doc!.confidence).toBeCloseTo(0.35, 5);
+    expect(doc!.value).toBeNull();
+    expect(doc!.reasons[0]).toContain("incomplete");
+  });
+
+  it("subtracts confidence when domain sleep confidence is low", () => {
+    const sleep: DailySleepFacts = {
+      mainSleepMinutes: 420,
+      efficiency: 0.92,
+      latencyMinutes: 12,
+      remSleepMinutes: 90,
+      deepSleepMinutes: 70,
+    };
+    const doc = computeOliSleepScoreV1({
+      sleep,
+      computedAt,
+      domainConfidenceSleep: 0.4,
+    });
+    expect(doc!.confidence).toBeCloseTo(0.8, 5);
+    expect(doc!.value).not.toBeNull();
+  });
+
+  it("sets version and computedAt", () => {
+    const sleep: DailySleepFacts = { mainSleepMinutes: 480 };
+    const doc = computeOliSleepScoreV1({ sleep, computedAt });
+    expect(doc!.version).toBe(OLI_SLEEP_SCORE_VERSION);
+    expect(doc!.computedAt).toBe(computedAt);
+  });
+});
+
+describe("attachOliSleepScoreToSleepFacts", () => {
+  it("merges oliSleepScore onto sleep facts for API-shaped input", () => {
+    const sleep: DailySleepFacts = {
+      mainSleepMinutes: 400,
+      efficiency: 0.88,
+      latencyMinutes: 15,
+      remSleepMinutes: 80,
+      deepSleepMinutes: 90,
+    };
+    const merged = attachOliSleepScoreToSleepFacts(sleep, { computedAt });
+    expect(merged.oliSleepScore).toBeDefined();
+    expect(merged.oliSleepScore!.version).toBe(OLI_SLEEP_SCORE_VERSION);
+    expect(typeof merged.oliSleepScore!.value).toBe("number");
+  });
+});

--- a/services/functions/src/sleep/computeOliSleepScoreV1.ts
+++ b/services/functions/src/sleep/computeOliSleepScoreV1.ts
@@ -1,0 +1,256 @@
+/**
+ * Oli Sleep Score v1 — pure, deterministic. Inputs must come from DailyFacts.sleep only.
+ */
+
+import type { DailySleepFacts } from "../types/health";
+import type { OliSleepScoreV1 } from "@oli/contracts";
+import { OLI_SLEEP_SCORE_VERSION } from "@oli/contracts";
+
+const BASE_WEIGHTS = {
+  duration: 0.4,
+  efficiency: 0.2,
+  latency: 0.15,
+  rem: 0.125,
+  deep: 0.125,
+} as const;
+
+function interpolate(points: readonly [number, number][], x: number): number {
+  if (points.length === 0) return 0;
+  const head = points[0];
+  if (!head) return 0;
+  if (x <= head[0]) return head[1];
+  const last = points[points.length - 1];
+  if (last && x >= last[0]) return last[1];
+  for (let i = 0; i < points.length - 1; i++) {
+    const a = points[i];
+    const b = points[i + 1];
+    if (!a || !b) continue;
+    const [x0, y0] = a;
+    const [x1, y1] = b;
+    if (x >= x0 && x <= x1) {
+      const t = (x - x0) / (x1 - x0);
+      return y0 + t * (y1 - y0);
+    }
+  }
+  return last?.[1] ?? 0;
+}
+
+/** Duration minutes → [0,1] */
+export function normalizeSleepDurationMinutes(minutes: number): number {
+  if (minutes <= 240) return 0;
+  if (minutes >= 480) return 1;
+  const pts: [number, number][] = [
+    [240, 0],
+    [300, 0.35],
+    [360, 0.65],
+    [420, 0.9],
+    [480, 1],
+  ];
+  return interpolate(pts, minutes);
+}
+
+/** Efficiency 0–1 (or percent as >1); output [0,1] */
+export function normalizeSleepEfficiencyRatio(eff: number): number {
+  let r = eff;
+  if (r > 1 && r <= 100) r = r / 100;
+  if (r > 1) r = 1;
+  if (r < 0.7) return 0;
+  if (r > 0.95) return 1;
+  const pts: [number, number][] = [
+    [0.7, 0],
+    [0.8, 0.5],
+    [0.85, 0.75],
+    [0.9, 0.9],
+    [0.95, 1],
+  ];
+  return interpolate(pts, r);
+}
+
+/** Latency minutes; lower latency → higher score */
+export function normalizeSleepLatencyMinutes(latencyMin: number): number {
+  if (latencyMin <= 10) return 1;
+  if (latencyMin >= 60) return 0;
+  const pts: [number, number][] = [
+    [10, 1],
+    [20, 0.8],
+    [30, 0.6],
+    [45, 0.3],
+    [60, 0],
+  ];
+  return interpolate(pts, latencyMin);
+}
+
+/** REM minutes / duration */
+export function normalizeRemRatio(ratio: number): number {
+  const pts: [number, number][] = [
+    [0.1, 0.2],
+    [0.15, 0.6],
+    [0.2, 0.85],
+    [0.25, 1],
+    [0.3, 0.9],
+    [0.35, 0.75],
+  ];
+  const low = pts[0];
+  if (!low) return 0;
+  if (ratio <= low[0]) return low[1];
+  const last = pts[pts.length - 1];
+  if (last && ratio >= last[0]) return last[1];
+  return interpolate(pts, ratio);
+}
+
+export function normalizeDeepRatio(ratio: number): number {
+  const pts: [number, number][] = [
+    [0.08, 0.2],
+    [0.12, 0.65],
+    [0.18, 1],
+    [0.22, 0.9],
+    [0.28, 0.75],
+  ];
+  const low = pts[0];
+  if (!low) return 0;
+  if (ratio <= low[0]) return low[1];
+  const last = pts[pts.length - 1];
+  if (last && ratio >= last[0]) return last[1];
+  return interpolate(pts, ratio);
+}
+
+export type ComputeOliSleepScoreV1Input = {
+  sleep: DailySleepFacts | undefined;
+  /** Optional domain confidence for sleep (0–1), from enrichDailyFacts */
+  domainConfidenceSleep?: number;
+  computedAt: string;
+};
+
+/**
+ * Returns null when there is no sleep facts object; otherwise always returns a versioned document
+ * (value may be null per confidence / duration rules).
+ */
+export function computeOliSleepScoreV1(input: ComputeOliSleepScoreV1Input): OliSleepScoreV1 | null {
+  const { sleep, domainConfidenceSleep, computedAt } = input;
+  if (!sleep) return null;
+
+  const durationSource =
+    typeof sleep.mainSleepMinutes === "number" && sleep.mainSleepMinutes > 0
+      ? sleep.mainSleepMinutes
+      : typeof sleep.totalMinutes === "number" && sleep.totalMinutes > 0
+        ? sleep.totalMinutes
+        : undefined;
+
+  const reasons: string[] = [];
+
+  if (durationSource === undefined || durationSource <= 0) {
+    return {
+      value: null,
+      version: OLI_SLEEP_SCORE_VERSION,
+      computedAt,
+      confidence: 0,
+      components: {
+        duration: null,
+        efficiency: null,
+        latency: null,
+        rem: null,
+        deep: null,
+      },
+      weights: { ...BASE_WEIGHTS },
+      reasons: ["Stage data was incomplete, so no Oli score is shown."],
+    };
+  }
+
+  let confidence = 1;
+
+  const hasEff = typeof sleep.efficiency === "number" && Number.isFinite(sleep.efficiency);
+  const hasLat = typeof sleep.latencyMinutes === "number" && Number.isFinite(sleep.latencyMinutes);
+  const hasRem =
+    typeof sleep.remSleepMinutes === "number" &&
+    sleep.remSleepMinutes >= 0 &&
+    Number.isFinite(sleep.remSleepMinutes);
+  const hasDeep =
+    typeof sleep.deepSleepMinutes === "number" &&
+    sleep.deepSleepMinutes >= 0 &&
+    Number.isFinite(sleep.deepSleepMinutes);
+
+  if (!hasEff) confidence -= 0.2;
+  if (!hasLat) confidence -= 0.15;
+  if (!hasRem) confidence -= 0.15;
+  if (!hasDeep) confidence -= 0.15;
+
+  if (domainConfidenceSleep !== undefined && domainConfidenceSleep < 0.5) {
+    confidence -= 0.2;
+  }
+
+  confidence = Math.max(0, Math.min(1, confidence));
+
+  const cDur = normalizeSleepDurationMinutes(durationSource);
+  const cEff = hasEff ? normalizeSleepEfficiencyRatio(sleep.efficiency as number) : null;
+  const cLat = hasLat ? normalizeSleepLatencyMinutes(sleep.latencyMinutes as number) : null;
+  const remRatio = hasRem ? (sleep.remSleepMinutes as number) / durationSource : null;
+  const deepRatio = hasDeep ? (sleep.deepSleepMinutes as number) / durationSource : null;
+  const cRem = remRatio !== null ? normalizeRemRatio(remRatio) : null;
+  const cDeep = deepRatio !== null ? normalizeDeepRatio(deepRatio) : null;
+
+  const active: Partial<Record<keyof typeof BASE_WEIGHTS, number>> = {};
+  active.duration = BASE_WEIGHTS.duration;
+  if (cEff !== null) active.efficiency = BASE_WEIGHTS.efficiency;
+  if (cLat !== null) active.latency = BASE_WEIGHTS.latency;
+  if (cRem !== null) active.rem = BASE_WEIGHTS.rem;
+  if (cDeep !== null) active.deep = BASE_WEIGHTS.deep;
+
+  const weightSum = Object.values(active).reduce((s, w) => s + w, 0);
+  const normWeights = {
+    duration: (active.duration ?? 0) / weightSum,
+    efficiency: (active.efficiency ?? 0) / weightSum,
+    latency: (active.latency ?? 0) / weightSum,
+    rem: (active.rem ?? 0) / weightSum,
+    deep: (active.deep ?? 0) / weightSum,
+  };
+
+  let weighted =
+    normWeights.duration * cDur +
+    (cEff !== null ? normWeights.efficiency * cEff : 0) +
+    (cLat !== null ? normWeights.latency * cLat : 0) +
+    (cRem !== null ? normWeights.rem * cRem : 0) +
+    (cDeep !== null ? normWeights.deep * cDeep : 0);
+
+  if (!Number.isFinite(weighted)) weighted = 0;
+
+  let value: number | null = Math.round(weighted * 100);
+  if (confidence < 0.5) {
+    value = null;
+    reasons.length = 0;
+    reasons.push("Stage data was incomplete, so no Oli score is shown.");
+  } else {
+    if (cDur >= 0.85) reasons.push("Sleep duration was strong.");
+    if (cEff !== null && cEff < 0.5) reasons.push("Sleep efficiency was below target.");
+    if (cLat !== null && cLat < 0.5) reasons.push("Sleep latency was higher than ideal.");
+    if (cDeep !== null && cDeep < 0.45) reasons.push("Deep sleep contribution was low.");
+    if (reasons.length === 0) {
+      reasons.push("Based on your sleep duration and available stage metrics.");
+    }
+  }
+
+  return {
+    value,
+    version: OLI_SLEEP_SCORE_VERSION,
+    computedAt,
+    confidence,
+    components: {
+      duration: cDur,
+      efficiency: cEff,
+      latency: cLat,
+      rem: cRem,
+      deep: cDeep,
+    },
+    weights: normWeights,
+    reasons: reasons.slice(0, 3),
+  };
+}
+
+/** Merge score onto DailyFacts.sleep (mutates copy). */
+export function attachOliSleepScoreToSleepFacts(
+  sleep: DailySleepFacts,
+  input: Omit<ComputeOliSleepScoreV1Input, "sleep">,
+): DailySleepFacts {
+  const doc = computeOliSleepScoreV1({ ...input, sleep });
+  if (!doc) return sleep;
+  return { ...sleep, oliSleepScore: doc };
+}

--- a/services/functions/src/types/health.ts
+++ b/services/functions/src/types/health.ts
@@ -1,5 +1,7 @@
 // services/functions/src/types/health.ts
 
+import type { OliSleepScoreV1 } from "@oli/contracts";
+
 /**
  * Oli Health OS — Canonical Schema v1 (Sprint 2 + Sprint 5 extensions + Sprint 6)
  *
@@ -181,6 +183,12 @@ export interface SleepCanonicalEvent extends BaseCanonicalEvent {
 
   /** Whether this is the primary/main sleep for the day */
   isMainSleep: boolean;
+
+  /** REM duration for this episode (minutes), when source provides stages */
+  remSleepMinutes?: number | null;
+
+  /** Deep sleep duration for this episode (minutes), when source provides stages */
+  deepSleepMinutes?: number | null;
 }
 
 /**
@@ -343,9 +351,19 @@ export type CanonicalEvent =
 export interface DailySleepFacts {
   totalMinutes?: number;
   mainSleepMinutes?: number;
+  /** Mean efficiency across contributing sleep episodes (0–1), same as canonical */
   efficiency?: number;
   latencyMinutes?: number;
   awakenings?: number;
+  /** Sum of REM minutes from main-sleep episodes when present */
+  remSleepMinutes?: number;
+  /** Sum of deep sleep minutes from main-sleep episodes when present */
+  deepSleepMinutes?: number;
+  /** Strongest contributing raw/source id for main sleep (e.g. oura), not a vendor-specific schema field */
+  primarySourceId?: string;
+
+  /** Oli Sleep Score v1 (derived from this block; set by recompute pipeline) */
+  oliSleepScore?: OliSleepScoreV1;
 }
 
 export interface DailyActivityFacts {


### PR DESCRIPTION
…UI polish

- Fix Oura sleep ingestion to handle pagination (next_token)
- Extend pull window to include latest completed sleep
- Fix canonical sleep day assignment (wake-day logic for Oura)
- Ensure recompute updates correct DailyFacts day
- Add reprocessing support for moved sleep days
- Implement Sleep UI redesign:
  - Oura score display (validation mode)
  - Remove subtitles
  - Add rating pills per metric
  - Add semantic progress bar colors
  - Improve typography and spacing
  - Integrate calendar date picker
- Add tests for:
  - pagination
  - sleep day assignment
  - aggregation
  - UI display logic

Result:
Latest completed Oura sleep now ingests and displays correctly on the same day