### PR TITLE
feat(sleep): enforce vendor-only sleep score + fix latest-day refresh…

### DIFF
--- a/app/(app)/activity/__tests__/activity-overview.test.tsx
+++ b/app/(app)/activity/__tests__/activity-overview.test.tsx
@@ -67,6 +67,15 @@ const defaultOverviewData = {
       markerPosition01: 0.12,
     },
   },
+  yesterdayDetails: {
+    loading: false,
+    error: null,
+    model: {
+      title: "Sat 4/5",
+      compactStatsSummary: "9,876 steps",
+      markerPosition01: 0.42,
+    },
+  },
 };
 
 const mockUseActivityOverviewScreenData = jest.fn(() => defaultOverviewData);
@@ -164,8 +173,9 @@ describe("ActivityOverviewScreen", () => {
     expect(str).toContain("Step Ratings");
     expect(str).toContain("activity-step-ratings-toggle");
     expect(str.indexOf("Step Ratings")).toBeLessThan(str.indexOf("Today’s Steps"));
+    expect(str.indexOf("Today’s Steps")).toBeLessThan(str.indexOf("Yesterday’s Steps"));
     const overviewBarMarker = "activity-overview-steps-bar-day7";
-    expect(str.indexOf("Today’s Steps")).toBeLessThan(str.indexOf(overviewBarMarker));
+    expect(str.indexOf("Yesterday’s Steps")).toBeLessThan(str.indexOf(overviewBarMarker));
     expect(str).toContain(overviewBarMarker);
     expect(str).toContain("Today’s Steps");
     expect(str).toContain("7 Day");
@@ -177,11 +187,13 @@ describe("ActivityOverviewScreen", () => {
     expect(str).toContain("Not enough data");
     expect(str).toContain("4,000");
     expect(str).toContain("1,234");
+    expect(str).toContain("9,876");
     expect(str).not.toMatch(/1,234 steps/);
     expect(str).not.toMatch(/\d+ steps · \d/);
     expect(str).toContain("activity-overview-steps-bar-day7");
     expect(str).toContain("activity-overview-steps-bar-month12");
     expect(str).toContain("activity-daily-details-steps-bar");
+    expect(str).toContain("activity-yesterday-details-steps-bar");
   });
 
   it("tapping a weekly strip day pushes activity day detail with local YYYY-MM-DD param", async () => {

--- a/app/(app)/activity/index.tsx
+++ b/app/(app)/activity/index.tsx
@@ -85,6 +85,15 @@ export default function ActivityOverviewScreen() {
             model={data.dailyDetails.model}
           />
           <View style={styles.cardSpacer} />
+          <ActivityDailyDetailsCard
+            headingTitle="Yesterday’s Steps"
+            ratingTestID="activity-yesterday-details-rating"
+            stepsBarTestID="activity-yesterday-details-steps-bar"
+            loading={data.yesterdayDetails.loading}
+            error={data.yesterdayDetails.error}
+            model={data.yesterdayDetails.model}
+          />
+          <View style={styles.cardSpacer} />
           <ActivityOverviewCard
             loading={data.overview.loading}
             error={data.overview.error}

--- a/app/(app)/recovery/__tests__/sleep-screen.test.tsx
+++ b/app/(app)/recovery/__tests__/sleep-screen.test.tsx
@@ -43,6 +43,14 @@ jest.mock("@/lib/data/useSleepDayView", () => ({
   useSleepDayView: jest.fn(),
 }));
 
+const mockPullToRefreshSleep = jest.fn().mockResolvedValue({ didVendorSyncAndRecompute: false });
+
+jest.mock("@/lib/data/useSleepPullToRefresh", () => ({
+  useSleepPullToRefresh: jest.fn(() => ({
+    pullToRefreshSleep: mockPullToRefreshSleep,
+  })),
+}));
+
 jest.mock("@/lib/data/useSleepWeekDataPresence", () => ({
   useSleepWeekDataPresence: () => ({
     status: "ready" as const,
@@ -102,7 +110,8 @@ const defaultOuraFallbackState = {
     isFallback: false,
     day: "2026-04-06",
     score: 72,
-    contributors: {},
+    totalMinutes: 420,
+    contributors: { total_sleep: 420, efficiency: 88 },
   },
   refetch: jest.fn(),
 };
@@ -110,6 +119,7 @@ const defaultOuraFallbackState = {
 describe("SleepScreen", () => {
   beforeEach(() => {
     mockRouterPush.mockClear();
+    mockPullToRefreshSleep.mockClear();
     mockUseLocalSearchParams.mockReset();
     mockUseLocalSearchParams.mockReturnValue({});
     navigationOptions = {};
@@ -203,11 +213,63 @@ describe("SleepScreen", () => {
     expect(str).toContain("Sleep Score");
     expect(str).toContain("88");
     expect(str).not.toContain("81");
-    expect(str).not.toContain("Computed by Oli from your sleep facts");
-    expect(str).not.toContain("Oli sleep facts");
+    expect(str).toContain("Sleep score from your device snapshot");
   });
 
-  it("Oli branch falls back honestly when vendor and Oli scores are unavailable", async () => {
+  it("Oli branch: headline unavailable when vendor score missing even if Oli has a score", async () => {
+    jest.mocked(useSleepDayView).mockReturnValue({
+      status: "oli",
+      requestedDay: "2026-04-06",
+      resolvedDay: "2026-04-06",
+      facts: { schemaVersion: 1, userId: "u", date: "2026-04-06", computedAt: "2026-01-01T00:00:00.000Z" },
+      sleep: {
+        totalMinutes: 420,
+        mainSleepMinutes: 420,
+        oliSleepScore: {
+          value: 81,
+          version: "sleep-score-v1.0.0",
+          computedAt: "2026-01-01T00:00:00.000Z",
+          confidence: 0.85,
+          components: {
+            duration: 0.9,
+            efficiency: 0.8,
+            latency: 0.7,
+            rem: 0.6,
+            deep: 0.5,
+          },
+          weights: {
+            duration: 0.4,
+            efficiency: 0.2,
+            latency: 0.15,
+            rem: 0.125,
+            deep: 0.125,
+          },
+          reasons: [],
+        },
+      },
+      insights: null,
+      vendorSleepView: {
+        requestedDay: "2026-04-06",
+        resolvedDay: "2026-04-06",
+        isFallback: false,
+        day: "2026-04-06",
+        score: null,
+        contributors: {},
+      },
+      refetch: jest.fn(),
+    });
+    let tree!: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<SleepScreen />);
+      await Promise.resolve();
+    });
+    const str = JSON.stringify(tree!.toJSON());
+    expect(str).toContain("Score unavailable");
+    expect(str).toContain("No sleep score from your device snapshot");
+    expect(str).not.toContain("Oli sleep score");
+  });
+
+  it("Oli branch: vendor headline unavailable copy when no vendor snapshot score", async () => {
     jest.mocked(useSleepDayView).mockReturnValue({
       status: "oli",
       requestedDay: "2026-04-06",
@@ -247,8 +309,63 @@ describe("SleepScreen", () => {
       await Promise.resolve();
     });
     const str = JSON.stringify(tree!.toJSON());
-    expect(str).toContain("Stage data was incomplete");
+    expect(str).toContain("Score unavailable");
+    expect(str).toContain("No sleep score from your device snapshot");
     expect(str).not.toContain("We'll show a score when Oura provides one.");
+  });
+
+  it("Oli path: metrics card still renders when headline vendor score is missing", async () => {
+    jest.mocked(useSleepDayView).mockReturnValue({
+      status: "oli",
+      requestedDay: "2026-04-06",
+      resolvedDay: "2026-04-06",
+      facts: { schemaVersion: 1, userId: "u", date: "2026-04-06", computedAt: "2026-01-01T00:00:00.000Z" },
+      sleep: {
+        totalMinutes: 420,
+        mainSleepMinutes: 420,
+        efficiency: 0.88,
+        oliSleepScore: {
+          value: 80,
+          version: "sleep-score-v1.0.0",
+          computedAt: "2026-01-01T00:00:00.000Z",
+          confidence: 0.9,
+          components: {
+            duration: 0.9,
+            efficiency: 0.85,
+            latency: 0.8,
+            rem: 0.75,
+            deep: 0.7,
+          },
+          weights: {
+            duration: 0.4,
+            efficiency: 0.2,
+            latency: 0.15,
+            rem: 0.125,
+            deep: 0.125,
+          },
+          reasons: [],
+        },
+      },
+      insights: null,
+      vendorSleepView: {
+        requestedDay: "2026-04-06",
+        resolvedDay: "2026-04-06",
+        isFallback: false,
+        day: "2026-04-06",
+        score: null,
+        contributors: {},
+      },
+      refetch: jest.fn(),
+    });
+    let tree!: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<SleepScreen />);
+      await Promise.resolve();
+    });
+    const str = JSON.stringify(tree!.toJSON());
+    expect(str).toContain("Score unavailable");
+    expect(str).toContain("Last night's sleep");
+    expect(str).toContain("Sleep efficiency");
   });
 
   it("metrics card titles Last night's sleep, omits rollup copy and awakenings, renders metric bars", async () => {
@@ -383,7 +500,7 @@ describe("SleepScreen", () => {
     expect(str).toContain("Try again");
   });
 
-  it("Oura fallback branch uses Sleep Score title without legacy footnote", async () => {
+  it("Oura fallback branch shows Sleep Score with honest Oura source footnote", async () => {
     let tree!: renderer.ReactTestRenderer;
     await act(async () => {
       tree = renderer.create(<SleepScreen />);
@@ -391,7 +508,33 @@ describe("SleepScreen", () => {
     });
     const str = JSON.stringify(tree!.toJSON());
     expect(str).toContain("Sleep Score");
-    expect(str).not.toContain("Oura nightly score");
+    expect(str).toContain("Sleep score from your device snapshot");
     expect(str).not.toContain("Legacy Oura detail");
+    expect(str).toContain("Contributors");
   });
+
+  it("Oura cross-day fallback does not render contributors card", async () => {
+    jest.mocked(useSleepDayView).mockReturnValue({
+      status: "oura_fallback",
+      data: {
+        requestedDay: "2026-04-06",
+        resolvedDay: "2026-04-05",
+        isFallback: true,
+        day: "2026-04-05",
+        score: 80,
+        totalMinutes: 400,
+        contributors: { total_sleep: 400, efficiency: 90 },
+      },
+      refetch: jest.fn(),
+    });
+    let tree!: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<SleepScreen />);
+      await Promise.resolve();
+    });
+    const str = JSON.stringify(tree!.toJSON());
+    expect(str).toContain("Sleep Score");
+    expect(str).not.toContain("Contributors");
+  });
+
 });

--- a/app/(app)/recovery/sleep.tsx
+++ b/app/(app)/recovery/sleep.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useLayoutEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import {
   View,
   Text,
@@ -18,6 +18,7 @@ import {
 } from "@/lib/ui/headers/workoutsStackHeader";
 import { ModuleScreenShell } from "@/lib/ui/ModuleScreenShell";
 import { useSleepDayView } from "@/lib/data/useSleepDayView";
+import { useSleepPullToRefresh } from "@/lib/data/useSleepPullToRefresh";
 import { useOuraPresence } from "@/lib/data/useOuraPresence";
 import { useSleepWeekDataPresence } from "@/lib/data/useSleepWeekDataPresence";
 import { deriveOuraImportState } from "@/lib/integrations/oura/importState";
@@ -30,13 +31,18 @@ import { RecoveryOuraWeeklyStrip } from "@/lib/ui/recovery/RecoveryOuraWeeklyStr
 import { SleepOliMetricsCard } from "@/lib/ui/recovery/SleepOliMetricsCard";
 import { SleepInsightsCard } from "@/lib/ui/recovery/SleepInsightsCard";
 import {
-  scoreToRatingLabel,
   contributorValueToProgress,
   contributorValueToRatingLabel,
   formatContributorDisplayValue,
   formatSleepDurationMinutes,
   SLEEP_CONTRIBUTOR_KEYS,
 } from "@/lib/format/ouraScore";
+import { pickLatestSleepWeekDayWithPresence } from "@/lib/data/sleep/pickLatestSleepWeekDayWithPresence";
+import { sleepOuraContributorsCardShouldRender } from "@/lib/ui/recovery/sleepOuraContributorsVisibility";
+import {
+  buildSleepHeadlineScoreCardModelForOliPath,
+  buildSleepHeadlineScoreCardModelForOuraFallbackPath,
+} from "@/lib/data/sleep/sleepHeadlineScoreCardModel";
 import { getTodayDayKeyLocal, getWeekDaysForAnchor } from "@/lib/ui/calendar/dateUtils";
 import type { CalendarDay } from "@/lib/ui/calendar/types";
 
@@ -88,35 +94,75 @@ export default function SleepScreen() {
   const params = useLocalSearchParams<{ day?: string | string[] }>();
   const dayFromRoute = parseDayRouteParam(params.day);
   const [selectedDay, setSelectedDay] = useState(() => dayFromRoute ?? getTodayDayKeyLocal());
+  /** True after calendar route param or explicit strip tap — blocks auto “snap to latest” week day. */
+  const userPinnedSelectedDayRef = useRef(dayFromRoute != null);
 
   useEffect(() => {
     const d = parseDayRouteParam(params.day);
-    if (d != null) setSelectedDay(d);
+    if (d != null) {
+      userPinnedSelectedDayRef.current = true;
+      setSelectedDay(d);
+    }
   }, [params.day]);
+
   const weekDayKeys = useMemo(() => getWeekDaysForAnchor(selectedDay), [selectedDay]);
   const weekStripPresence = useSleepWeekDataPresence(weekDayKeys);
   const refetchWeekStrip = weekStripPresence.refetch;
   const { refetch: refetchSleep, ...sleepState } = useSleepDayView(selectedDay);
   const ouraPresence = useOuraPresence();
 
+  const oliHeadlineScoreModel = useMemo(() => {
+    if (sleepState.status !== "oli") return null;
+    const vendorRaw = sleepState.vendorSleepView?.score;
+    const vendorScore =
+      typeof vendorRaw === "number" && Number.isFinite(vendorRaw) ? vendorRaw : null;
+    return buildSleepHeadlineScoreCardModelForOliPath(vendorScore);
+  }, [sleepState]);
+
+  const ouraFallbackHeadlineScoreModel = useMemo(() => {
+    if (sleepState.status !== "oura_fallback") return null;
+    const raw = sleepState.data.score ?? null;
+    const ouraScore = typeof raw === "number" && Number.isFinite(raw) ? raw : null;
+    return buildSleepHeadlineScoreCardModelForOuraFallbackPath(ouraScore);
+  }, [sleepState]);
+
+  const weekPresenceFingerprint = useMemo(() => {
+    if (weekStripPresence.status !== "ready") return "";
+    return weekDayKeys.map((k) => `${k}:${weekStripPresence.hasSleepDataByDay[k] === true ? 1 : 0}`).join("|");
+  }, [weekDayKeys, weekStripPresence]);
+
+  useEffect(() => {
+    if (userPinnedSelectedDayRef.current) return;
+    if (weekStripPresence.status !== "ready" || weekPresenceFingerprint.length === 0) return;
+    const map = weekStripPresence.hasSleepDataByDay;
+    if (map[selectedDay] === true) return;
+    const pivot = pickLatestSleepWeekDayWithPresence(weekDayKeys, map);
+    if (pivot != null && pivot !== selectedDay) {
+      setSelectedDay(pivot);
+    }
+  }, [weekPresenceFingerprint, weekStripPresence, selectedDay, weekDayKeys]);
+
+  const onStripDayPress = useCallback((day: string) => {
+    userPinnedSelectedDayRef.current = true;
+    setSelectedDay(day);
+  }, []);
+
   const [refreshing, setRefreshing] = useState(false);
 
-  const runSleepRefresh = useCallback(async () => {
-    const bust = Date.now();
-    await Promise.all([
-      refetchSleep({ cacheBust: `sleep:pull:${bust}` }),
-      refetchWeekStrip(),
-    ]);
-  }, [refetchSleep, refetchWeekStrip]);
+  const { pullToRefreshSleep } = useSleepPullToRefresh({
+    selectedDay,
+    refetchSleep,
+    refetchWeekStrip,
+  });
 
   const onSleepRefresh = useCallback(async () => {
     setRefreshing(true);
     try {
-      await runSleepRefresh();
+      await pullToRefreshSleep();
     } finally {
       setRefreshing(false);
     }
-  }, [runSleepRefresh]);
+  }, [pullToRefreshSleep]);
 
   const sleepRefreshControl = useMemo(
     () => (
@@ -138,7 +184,7 @@ export default function SleepScreen() {
     <RecoveryOuraWeeklyStrip
       days={stripDays}
       selectedDay={selectedDay}
-      onDayPress={setSelectedDay}
+      onDayPress={onStripDayPress}
       categoryLabel="sleep"
       stripVariant="sleep"
       testIDPrefix="sleep-weekly"
@@ -228,7 +274,7 @@ export default function SleepScreen() {
           <Pressable
             accessibilityRole="button"
             accessibilityLabel="Retry loading sleep data"
-            onPress={() => void runSleepRefresh()}
+            onPress={() => void pullToRefreshSleep()}
             style={({ pressed }) => [styles.retryButton, pressed && styles.retryButtonPressed]}
           >
             <Text style={styles.retryLabel}>Try again</Text>
@@ -239,26 +285,7 @@ export default function SleepScreen() {
   }
 
   if (sleepState.status === "oli") {
-    const vendorRaw = sleepState.vendorSleepView?.score;
-    const vendorScore =
-      typeof vendorRaw === "number" && Number.isFinite(vendorRaw) ? vendorRaw : null;
-
-    const oliScore = sleepState.sleep.oliSleepScore;
-    const hasOliScoreDoc = oliScore != null;
-    const oliScoreValue =
-      oliScore?.value != null && typeof oliScore.value === "number" ? oliScore.value : null;
-
-    /** Vendor snapshot wins for side-by-side compare when the API returned a score. */
-    const displayScore = vendorScore ?? oliScoreValue;
-    const ratingLabel = displayScore != null ? scoreToRatingLabel(displayScore) : null;
-
-    const scoreUnavailableSubtitle =
-      displayScore == null
-        ? !hasOliScoreDoc
-          ? "Sleep score isn’t available for this day yet."
-          : (oliScore?.reasons?.[0] ??
-            "Score isn’t available — insufficient sleep data for this day.")
-        : null;
+    const headlineModel = oliHeadlineScoreModel!;
 
     const sleepInsightItems =
       sleepState.insights?.items.filter((i) => i.tags?.includes("sleep")) ?? [];
@@ -267,12 +294,12 @@ export default function SleepScreen() {
       <RecoveryShell title="Sleep" headerContent={headerStrip} refreshControl={sleepRefreshControl}>
         <View style={styles.content}>
           <RecoveryScoreCard
-            title="Sleep Score"
-            score={displayScore}
-            ratingLabel={ratingLabel}
+            title={headlineModel.title}
+            score={headlineModel.score}
+            ratingLabel={headlineModel.ratingLabel}
             fallbackMessage={null}
-            scoreFootnote={null}
-            scoreUnavailableSubtitle={scoreUnavailableSubtitle}
+            scoreFootnote={headlineModel.scoreFootnote}
+            scoreUnavailableSubtitle={headlineModel.scoreUnavailableSubtitle}
           />
           <SleepOliMetricsCard sleep={sleepState.sleep} />
           <SleepInsightsCard items={sleepInsightItems} />
@@ -293,6 +320,8 @@ export default function SleepScreen() {
 
   const view = sleepState.data;
   const score = view.score ?? null;
+  const headlineOuraModel = ouraFallbackHeadlineScoreModel!;
+
   const contributors =
     view.contributors && typeof view.contributors === "object"
       ? (view.contributors as Record<string, unknown>)
@@ -313,27 +342,27 @@ export default function SleepScreen() {
     ? `Showing latest available Oura sleep for ${formatResolvedDay(view.resolvedDay)}`
     : null;
 
+  const showContributorsCard = sleepOuraContributorsCardShouldRender(view, contributorRows);
+  const showOuraEmptyDetails =
+    !showContributorsCard && score == null && Object.keys(contributors).length === 0;
+
   return (
     <RecoveryShell title="Sleep" headerContent={headerStrip} refreshControl={sleepRefreshControl}>
       <View style={styles.content}>
         <RecoveryScoreCard
-          title="Sleep Score"
-          score={score}
-          ratingLabel={score != null ? scoreToRatingLabel(score) : null}
+          title={headlineOuraModel.title}
+          score={headlineOuraModel.score}
+          ratingLabel={headlineOuraModel.ratingLabel}
           fallbackMessage={fallbackMessage}
-          scoreFootnote={null}
-          scoreUnavailableSubtitle={
-            score == null
-              ? "No score in this Oura snapshot for this day. Try syncing or choose another day."
-              : null
-          }
+          scoreFootnote={headlineOuraModel.scoreFootnote}
+          scoreUnavailableSubtitle={headlineOuraModel.scoreUnavailableSubtitle}
         />
-        <RecoveryContributorsCard rows={contributorRows} />
-        {score == null && Object.keys(contributors).length === 0 && (
+        {showContributorsCard ? <RecoveryContributorsCard rows={contributorRows} /> : null}
+        {showOuraEmptyDetails ? (
           <View style={styles.messageCard}>
-            <Text style={styles.emptySubtitle}>No detailed metrics for this day.</Text>
+            <Text style={styles.emptySubtitle}>No detailed sleep metrics for this day.</Text>
           </View>
-        )}
+        ) : null}
       </View>
     </RecoveryShell>
   );

--- a/lib/api/ouraSleepDayRefresh.ts
+++ b/lib/api/ouraSleepDayRefresh.ts
@@ -1,0 +1,36 @@
+/**
+ * POST /integrations/oura/sleep-day-refresh — Oura sync + server recompute for a day (Sleep latest-day refresh).
+ */
+
+import type { ApiResult } from "@/lib/api/http";
+import type { PostOptions } from "@/lib/api/http";
+import { apiPostZodAuthed } from "@/lib/api/validate";
+import { z } from "zod";
+
+const ouraSleepDayRefreshResponseSchema = z.object({
+  ok: z.literal(true),
+  requestId: z.string(),
+  day: z.string(),
+  pullNowStatus: z.number(),
+});
+
+export type OuraSleepDayRefreshResponse = z.infer<typeof ouraSleepDayRefreshResponseSchema>;
+
+export async function postOuraSleepDayRefresh(
+  idToken: string,
+  body: { day: string },
+  opts?: PostOptions,
+): Promise<ApiResult<OuraSleepDayRefreshResponse>> {
+  return apiPostZodAuthed(
+    "/integrations/oura/sleep-day-refresh",
+    body,
+    idToken,
+    ouraSleepDayRefreshResponseSchema,
+    {
+      timeoutMs: 120_000,
+      noStore: true,
+      ...(opts?.cacheBust ? { cacheBust: opts.cacheBust } : {}),
+      ...(opts?.idempotencyKey ? { idempotencyKey: opts.idempotencyKey } : {}),
+    },
+  );
+}

--- a/lib/data/activity/__tests__/useActivityOverviewScreenData.test.tsx
+++ b/lib/data/activity/__tests__/useActivityOverviewScreenData.test.tsx
@@ -81,6 +81,7 @@ describe("useActivityOverviewScreenData", () => {
     const refetch = jest.fn();
     const rollupByDay: Record<string, { kind: string; steps?: number; message?: string; requestId?: string | null }> =
       {
+        "2026-04-13": { kind: "numeric", steps: 99 },
         "2026-04-14": { kind: "numeric", steps: 148 },
         "2026-04-01": { kind: "error", message: "fail", requestId: "r1" },
         "2026-04-02": { kind: "error", message: "fail", requestId: "r2" },
@@ -96,6 +97,7 @@ describe("useActivityOverviewScreenData", () => {
     expect(probe.current?.overview.error?.message).toMatch(/Couldn’t load steps for 3 days/);
     expect(probe.current?.dailyDetails.error).toBeNull();
     expect(probe.current?.dailyDetails.model?.compactStatsSummary).toBe("148 steps");
+    expect(probe.current?.yesterdayDetails.model?.compactStatsSummary).toBe("99 steps");
     expect(probe.current?.weeklyStripDays.find((d) => d.day === "2026-04-14")?.meta).toEqual(
       expect.objectContaining({ hasSteps: true, ringTierIndex: 0 }),
     );
@@ -117,6 +119,8 @@ describe("useActivityOverviewScreenData", () => {
     expect(probe.current?.overview.error?.message).toMatch(/Couldn’t load steps for one day/);
     expect(probe.current?.dailyDetails.error?.message).toBe("Today fetch failed");
     expect(probe.current?.dailyDetails.model).toBeNull();
+    expect(probe.current?.yesterdayDetails.error).toBeNull();
+    expect(probe.current?.yesterdayDetails.model?.compactStatsSummary).toBe("10 steps");
   });
 
   it("prefers live HealthKit steps for Today’s Steps when the hook reports ready", async () => {
@@ -126,7 +130,13 @@ describe("useActivityOverviewScreenData", () => {
     });
     const refetch = jest.fn();
     mockUseActivityStepsRollupMap.mockReturnValue(
-      mockStepsRollup({ "2026-04-14": { kind: "numeric" as const, steps: 148 } }, { refetch }),
+      mockStepsRollup(
+        {
+          "2026-04-13": { kind: "numeric" as const, steps: 4200 },
+          "2026-04-14": { kind: "numeric" as const, steps: 148 },
+        },
+        { refetch },
+      ),
     );
 
     const probe: { current: ReturnType<typeof useActivityOverviewScreenData> | null } = { current: null };
@@ -136,11 +146,13 @@ describe("useActivityOverviewScreenData", () => {
 
     expect(probe.current?.dailyDetails.model?.compactStatsSummary).toBe("5,313 steps");
     expect(probe.current?.dailyDetails.error).toBeNull();
+    expect(probe.current?.yesterdayDetails.model?.compactStatsSummary).toBe("4,200 steps");
   });
 
   it("Today’s Steps stays on live today when strip selection changes; overview uses yesterday anchor", async () => {
     const refetch = jest.fn();
     const rollupByDay = {
+      "2026-04-13": { kind: "numeric" as const, steps: 111 },
       "2026-04-14": { kind: "numeric" as const, steps: 5313 },
       "2026-04-05": { kind: "numeric" as const, steps: 148 },
     };
@@ -152,6 +164,7 @@ describe("useActivityOverviewScreenData", () => {
     });
 
     expect(probe.current?.dailyDetails.model?.compactStatsSummary).toBe("5,313 steps");
+    expect(probe.current?.yesterdayDetails.model?.compactStatsSummary).toBe("111 steps");
     expect(probe.current?.overview.model?.timeframes[0]?.label).toBe("7 Day");
 
     await act(async () => {
@@ -197,7 +210,13 @@ describe("useActivityOverviewScreenData", () => {
   it("uses neutral weekly strip ring tier when numeric rollup is zero steps", async () => {
     const refetch = jest.fn();
     mockUseActivityStepsRollupMap.mockReturnValue(
-      mockStepsRollup({ "2026-04-14": { kind: "numeric" as const, steps: 0 } }, { refetch }),
+      mockStepsRollup(
+        {
+          "2026-04-13": { kind: "numeric" as const, steps: 500 },
+          "2026-04-14": { kind: "numeric" as const, steps: 0 },
+        },
+        { refetch },
+      ),
     );
 
     const probe: { current: ReturnType<typeof useActivityOverviewScreenData> | null } = { current: null };
@@ -213,7 +232,13 @@ describe("useActivityOverviewScreenData", () => {
   it("has no overview or daily rollup errors when map has no failures", async () => {
     const refetch = jest.fn();
     mockUseActivityStepsRollupMap.mockReturnValue(
-      mockStepsRollup({ "2026-04-14": { kind: "numeric" as const, steps: 200 } }, { refetch }),
+      mockStepsRollup(
+        {
+          "2026-04-13": { kind: "numeric" as const, steps: 150 },
+          "2026-04-14": { kind: "numeric" as const, steps: 200 },
+        },
+        { refetch },
+      ),
     );
 
     const probe: { current: ReturnType<typeof useActivityOverviewScreenData> | null } = { current: null };
@@ -224,5 +249,33 @@ describe("useActivityOverviewScreenData", () => {
     expect(probe.current?.overview.error).toBeNull();
     expect(probe.current?.dailyDetails.error).toBeNull();
     expect(probe.current?.dailyDetails.model?.compactStatsSummary).toBe("200 steps");
+    expect(probe.current?.yesterdayDetails.error).toBeNull();
+    expect(probe.current?.yesterdayDetails.model?.compactStatsSummary).toBe("150 steps");
+  });
+
+  it("surfaces rollup failure for Yesterday’s Steps without affecting Today’s HK live row", async () => {
+    mockUseActivityHealthKitTodayStepsCard.mockReturnValue({
+      hkToday: { status: "ready", steps: 9999 },
+      refreshHealthKitToday: jest.fn(),
+    });
+    const refetch = jest.fn();
+    mockUseActivityStepsRollupMap.mockReturnValue(
+      mockStepsRollup(
+        {
+          "2026-04-13": { kind: "error" as const, message: "Yesterday fetch failed", requestId: "ry" },
+          "2026-04-14": { kind: "numeric" as const, steps: 100 },
+        },
+        { refetch },
+      ),
+    );
+
+    const probe: { current: ReturnType<typeof useActivityOverviewScreenData> | null } = { current: null };
+    await act(async () => {
+      renderer.create(<Harness probe={probe} />);
+    });
+
+    expect(probe.current?.dailyDetails.model?.compactStatsSummary).toBe("9,999 steps");
+    expect(probe.current?.yesterdayDetails.error?.message).toBe("Yesterday fetch failed");
+    expect(probe.current?.yesterdayDetails.model).toBeNull();
   });
 });

--- a/lib/data/activity/useActivityOverviewScreenData.ts
+++ b/lib/data/activity/useActivityOverviewScreenData.ts
@@ -82,6 +82,15 @@ export function useActivityOverviewScreenData() {
     );
   }, [todayDayKey, displayRollup, stepsRollup]);
 
+  /** Local calendar yesterday — same completed-day anchor as Overview ({@link getActivityOverviewAnchorEndDay}). */
+  const yesterdayDayKey = overviewAnchorEndDay;
+
+  const rollupYesterdayEntryError = useMemo(() => {
+    return buildActivitySelectedDayRollupError(yesterdayDayKey, displayRollup, () =>
+      void stepsRollup.refetch({ cacheBust: `activityRollupYesterdayRetry:${Date.now()}` }),
+    );
+  }, [yesterdayDayKey, displayRollup, stepsRollup]);
+
   const overviewCardModel = useMemo(() => {
     return buildActivityOverviewCardModel({
       overviewAnchorEndDay,
@@ -189,6 +198,31 @@ export function useActivityOverviewScreenData() {
     [dailyDetailsLoading, dailyDetailsModel, dailyDetailsTodayError],
   );
 
+  const yesterdayDetailsModel = useMemo(() => {
+    if (!user) return null;
+    const entry = displayRollup[yesterdayDayKey];
+    if (entry === undefined || entry.kind === "error") return null;
+    return buildActivityDailyDetailsCardModel({
+      detailDayKey: yesterdayDayKey,
+      todayDayKey,
+      rollupByDay: displayRollup,
+    });
+  }, [user, yesterdayDayKey, todayDayKey, displayRollup]);
+
+  const yesterdayDetailsLoading = useMemo(() => {
+    if (!user) return false;
+    return displayRollup[yesterdayDayKey] === undefined;
+  }, [user, displayRollup, yesterdayDayKey]);
+
+  const yesterdayDetails = useMemo(
+    () => ({
+      loading: yesterdayDetailsLoading,
+      error: rollupYesterdayEntryError,
+      model: yesterdayDetailsModel,
+    }),
+    [rollupYesterdayEntryError, yesterdayDetailsLoading, yesterdayDetailsModel],
+  );
+
   return {
     user,
     initializing,
@@ -198,5 +232,6 @@ export function useActivityOverviewScreenData() {
     stepsRollup,
     overview,
     dailyDetails,
+    yesterdayDetails,
   };
 }

--- a/lib/data/sleep/__tests__/pickLatestSleepWeekDayWithPresence.test.ts
+++ b/lib/data/sleep/__tests__/pickLatestSleepWeekDayWithPresence.test.ts
@@ -1,0 +1,13 @@
+import { pickLatestSleepWeekDayWithPresence } from "@/lib/data/sleep/pickLatestSleepWeekDayWithPresence";
+
+describe("pickLatestSleepWeekDayWithPresence", () => {
+  it("returns the latest ISO day key that has presence", () => {
+    const keys = ["2026-04-05", "2026-04-06", "2026-04-07"] as const;
+    const map = { "2026-04-05": false, "2026-04-06": true, "2026-04-07": true } as Record<string, boolean>;
+    expect(pickLatestSleepWeekDayWithPresence(keys, map)).toBe("2026-04-07");
+  });
+
+  it("returns null when no day has presence", () => {
+    expect(pickLatestSleepWeekDayWithPresence(["2026-04-05", "2026-04-06"], { "2026-04-05": false })).toBeNull();
+  });
+});

--- a/lib/data/sleep/__tests__/runSleepPullToRefresh.test.ts
+++ b/lib/data/sleep/__tests__/runSleepPullToRefresh.test.ts
@@ -1,0 +1,57 @@
+import { runSleepPullToRefresh } from "@/lib/data/sleep/runSleepPullToRefresh";
+
+const mockPostOuraSleepDayRefresh = jest.fn();
+
+jest.mock("@/lib/api/ouraSleepDayRefresh", () => ({
+  postOuraSleepDayRefresh: (...args: unknown[]) => mockPostOuraSleepDayRefresh(...args),
+}));
+
+describe("runSleepPullToRefresh", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPostOuraSleepDayRefresh.mockResolvedValue({
+      ok: true,
+      status: 200,
+      requestId: "r1",
+      json: { ok: true, requestId: "r1", day: "2026-04-06", pullNowStatus: 202 },
+    });
+  });
+
+  it("calls Oura sleep-day-refresh when selected day matches today", async () => {
+    const refetchSleep = jest.fn().mockResolvedValue(undefined);
+    const refetchWeekStrip = jest.fn().mockResolvedValue(undefined);
+    const getIdToken = jest.fn().mockResolvedValue("token");
+
+    const out = await runSleepPullToRefresh({
+      selectedDay: "2026-04-06",
+      todayDayKey: "2026-04-06",
+      getIdToken,
+      refetchSleep,
+      refetchWeekStrip,
+    });
+
+    expect(out.didVendorSyncAndRecompute).toBe(true);
+    expect(mockPostOuraSleepDayRefresh).toHaveBeenCalled();
+    expect(refetchSleep).toHaveBeenCalled();
+    expect(refetchWeekStrip).toHaveBeenCalled();
+  });
+
+  it("skips vendor sync for a historical day", async () => {
+    const refetchSleep = jest.fn().mockResolvedValue(undefined);
+    const refetchWeekStrip = jest.fn().mockResolvedValue(undefined);
+    const getIdToken = jest.fn().mockResolvedValue("token");
+
+    const out = await runSleepPullToRefresh({
+      selectedDay: "2026-04-05",
+      todayDayKey: "2026-04-06",
+      getIdToken,
+      refetchSleep,
+      refetchWeekStrip,
+    });
+
+    expect(out.didVendorSyncAndRecompute).toBe(false);
+    expect(mockPostOuraSleepDayRefresh).not.toHaveBeenCalled();
+    expect(refetchSleep).toHaveBeenCalled();
+    expect(refetchWeekStrip).toHaveBeenCalled();
+  });
+});

--- a/lib/data/sleep/__tests__/sleepHeadlineScoreCardModel.test.ts
+++ b/lib/data/sleep/__tests__/sleepHeadlineScoreCardModel.test.ts
@@ -1,0 +1,41 @@
+import {
+  buildSleepHeadlineScoreCardModelForOliPath,
+  buildSleepHeadlineScoreCardModelForOuraFallbackPath,
+} from "@/lib/data/sleep/sleepHeadlineScoreCardModel";
+import { SLEEP_HEADLINE_FOOTNOTE_VENDOR, SLEEP_HEADLINE_VENDOR_SCORE_UNAVAILABLE } from "@/lib/format/sleepDisplay";
+
+describe("buildSleepHeadlineScoreCardModelForOliPath", () => {
+  it("shows vendor score and rating when snapshot has a score", () => {
+    const m = buildSleepHeadlineScoreCardModelForOliPath(88);
+    expect(m.score).toBe(88);
+    expect(m.ratingLabel).toBe("Optimal");
+    expect(m.scoreFootnote).toBe(SLEEP_HEADLINE_FOOTNOTE_VENDOR);
+    expect(m.scoreUnavailableSubtitle).toBeNull();
+    expect(m.source).toBe("vendor");
+  });
+
+  it("never uses Oli when vendor score is missing", () => {
+    const m = buildSleepHeadlineScoreCardModelForOliPath(null);
+    expect(m.score).toBeNull();
+    expect(m.ratingLabel).toBeNull();
+    expect(m.scoreFootnote).toBeNull();
+    expect(m.scoreUnavailableSubtitle).toBe(SLEEP_HEADLINE_VENDOR_SCORE_UNAVAILABLE);
+    expect(m.source).toBe("none");
+  });
+});
+
+describe("buildSleepHeadlineScoreCardModelForOuraFallbackPath", () => {
+  it("shows vendor score when present", () => {
+    const m = buildSleepHeadlineScoreCardModelForOuraFallbackPath(72);
+    expect(m.score).toBe(72);
+    expect(m.source).toBe("vendor");
+    expect(m.scoreFootnote).toBe(SLEEP_HEADLINE_FOOTNOTE_VENDOR);
+  });
+
+  it("unavailable when vendor score missing", () => {
+    const m = buildSleepHeadlineScoreCardModelForOuraFallbackPath(null);
+    expect(m.score).toBeNull();
+    expect(m.scoreUnavailableSubtitle).toBe(SLEEP_HEADLINE_VENDOR_SCORE_UNAVAILABLE);
+    expect(m.source).toBe("none");
+  });
+});

--- a/lib/data/sleep/pickLatestSleepWeekDayWithPresence.ts
+++ b/lib/data/sleep/pickLatestSleepWeekDayWithPresence.ts
@@ -1,0 +1,16 @@
+/**
+ * Pick the chronologically latest day in the strip week that has sleep presence.
+ * Week keys are ISO day strings (lexicographic order matches calendar order).
+ */
+export function pickLatestSleepWeekDayWithPresence(
+  weekDayKeys: readonly string[],
+  hasSleepDataByDay: Record<string, boolean>,
+): string | null {
+  let best: string | null = null;
+  for (const k of weekDayKeys) {
+    if (hasSleepDataByDay[k] === true && (best == null || k > best)) {
+      best = k;
+    }
+  }
+  return best;
+}

--- a/lib/data/sleep/runSleepPullToRefresh.ts
+++ b/lib/data/sleep/runSleepPullToRefresh.ts
@@ -1,0 +1,44 @@
+import { postOuraSleepDayRefresh } from "@/lib/api/ouraSleepDayRefresh";
+import type { TruthGetOptions } from "@/lib/api/usersMe";
+import { getTodayDayKeyLocal } from "@/lib/ui/calendar/dateUtils";
+
+export type SleepPullToRefreshDeps = {
+  selectedDay: string;
+  /** Override for tests (defaults to local calendar “today”). */
+  todayDayKey?: string;
+  getIdToken: (forceRefresh: boolean) => Promise<string | null>;
+  refetchSleep: (opts?: TruthGetOptions) => void | Promise<void>;
+  refetchWeekStrip: () => void | Promise<void>;
+};
+
+/**
+ * Sleep pull-to-refresh: on the latest calendar day, run Oura sync + server recompute, then refetch UI.
+ * Historical days only refetch (no vendor sync / recompute).
+ */
+export async function runSleepPullToRefresh(deps: SleepPullToRefreshDeps): Promise<{
+  didVendorSyncAndRecompute: boolean;
+}> {
+  const today = deps.todayDayKey ?? getTodayDayKeyLocal();
+  const bust = Date.now();
+  let didVendorSyncAndRecompute = false;
+
+  if (deps.selectedDay === today) {
+    const token = await deps.getIdToken(false);
+    if (token) {
+      didVendorSyncAndRecompute = true;
+      const idem = `sleep-day-refresh:${deps.selectedDay}:${bust}`;
+      await postOuraSleepDayRefresh(
+        token,
+        { day: deps.selectedDay },
+        { idempotencyKey: idem, timeoutMs: 120_000, noStore: true },
+      );
+    }
+  }
+
+  await Promise.all([
+    deps.refetchSleep({ cacheBust: `sleep:pull:${bust}` }),
+    deps.refetchWeekStrip(),
+  ]);
+
+  return { didVendorSyncAndRecompute };
+}

--- a/lib/data/sleep/sleepHeadlineScoreCardModel.ts
+++ b/lib/data/sleep/sleepHeadlineScoreCardModel.ts
@@ -1,0 +1,72 @@
+/**
+ * Sleep headline score card — vendor snapshot score only (Phase 1: Oura vendor view).
+ * Never uses DailyFacts oliSleepScore for the headline number.
+ */
+
+import { scoreToRatingLabel } from "@/lib/format/ouraScore";
+import { SLEEP_HEADLINE_FOOTNOTE_VENDOR, SLEEP_HEADLINE_VENDOR_SCORE_UNAVAILABLE } from "@/lib/format/sleepDisplay";
+
+export type SleepHeadlineScoreSource = "vendor" | "none";
+
+export type SleepHeadlineScoreCardModel = {
+  title: "Sleep Score";
+  score: number | null;
+  ratingLabel: string | null;
+  scoreFootnote: string | null;
+  scoreUnavailableSubtitle: string | null;
+  source: SleepHeadlineScoreSource;
+};
+
+/**
+ * Oli read-model branch: vendor parallel view only for the headline score.
+ */
+export function buildSleepHeadlineScoreCardModelForOliPath(vendorScore: number | null): SleepHeadlineScoreCardModel {
+  const title = "Sleep Score" as const;
+
+  if (vendorScore != null) {
+    return {
+      title,
+      score: vendorScore,
+      ratingLabel: scoreToRatingLabel(vendorScore),
+      scoreFootnote: SLEEP_HEADLINE_FOOTNOTE_VENDOR,
+      scoreUnavailableSubtitle: null,
+      source: "vendor",
+    };
+  }
+
+  return {
+    title,
+    score: null,
+    ratingLabel: null,
+    scoreFootnote: null,
+    scoreUnavailableSubtitle: SLEEP_HEADLINE_VENDOR_SCORE_UNAVAILABLE,
+    source: "none",
+  };
+}
+
+/** Oura-fallback branch: primary read is vendor `SleepViewDto`. */
+export function buildSleepHeadlineScoreCardModelForOuraFallbackPath(
+  ouraScore: number | null,
+): SleepHeadlineScoreCardModel {
+  const title = "Sleep Score" as const;
+
+  if (ouraScore != null) {
+    return {
+      title,
+      score: ouraScore,
+      ratingLabel: scoreToRatingLabel(ouraScore),
+      scoreFootnote: SLEEP_HEADLINE_FOOTNOTE_VENDOR,
+      scoreUnavailableSubtitle: null,
+      source: "vendor",
+    };
+  }
+
+  return {
+    title,
+    score: null,
+    ratingLabel: null,
+    scoreFootnote: null,
+    scoreUnavailableSubtitle: SLEEP_HEADLINE_VENDOR_SCORE_UNAVAILABLE,
+    source: "none",
+  };
+}

--- a/lib/data/useSleepPullToRefresh.ts
+++ b/lib/data/useSleepPullToRefresh.ts
@@ -1,0 +1,25 @@
+import { useCallback } from "react";
+
+import { useAuth } from "@/lib/auth/AuthProvider";
+import type { TruthGetOptions } from "@/lib/api/usersMe";
+import { runSleepPullToRefresh } from "@/lib/data/sleep/runSleepPullToRefresh";
+
+export function useSleepPullToRefresh(args: {
+  selectedDay: string;
+  refetchSleep: (opts?: TruthGetOptions) => void | Promise<void>;
+  refetchWeekStrip: () => void | Promise<void>;
+}): { pullToRefreshSleep: () => Promise<{ didVendorSyncAndRecompute: boolean }> } {
+  const { getIdToken } = useAuth();
+  const { selectedDay, refetchSleep, refetchWeekStrip } = args;
+
+  const pullToRefreshSleep = useCallback(async () => {
+    return runSleepPullToRefresh({
+      selectedDay,
+      getIdToken,
+      refetchSleep,
+      refetchWeekStrip,
+    });
+  }, [selectedDay, getIdToken, refetchSleep, refetchWeekStrip]);
+
+  return { pullToRefreshSleep };
+}

--- a/lib/format/sleepDisplay.ts
+++ b/lib/format/sleepDisplay.ts
@@ -4,6 +4,14 @@
 
 import { formatSleepDurationMinutes } from "@/lib/format/ouraScore";
 
+/** Shown under the headline when a vendor sleep score is displayed (Phase 1: Oura snapshot). */
+export const SLEEP_HEADLINE_FOOTNOTE_VENDOR =
+  "Sleep score from your device snapshot (Oura) — same value we store from the vendor.";
+
+/** Headline only: no vendor sleep score for this day (Oli metrics below are unchanged). */
+export const SLEEP_HEADLINE_VENDOR_SCORE_UNAVAILABLE =
+  "No sleep score from your device snapshot for this day. Try syncing or choose another day.";
+
 /** Efficiency stored in DailyFacts as aggregate mean of canonical episodes (0–1). */
 export function formatEfficiencyRatio(ratio: number | undefined): string {
   if (ratio == null || typeof ratio !== "number" || !Number.isFinite(ratio)) return "—";

--- a/lib/ui/ModuleScreenShell.tsx
+++ b/lib/ui/ModuleScreenShell.tsx
@@ -41,6 +41,7 @@ export function ModuleScreenShell({
       <ScrollView
         style={styles.scroll}
         contentContainerStyle={styles.container}
+        alwaysBounceVertical={Boolean(refreshControl)}
         {...(refreshControl ? { refreshControl } : {})}
       >
         <View style={styles.content}>{children}</View>

--- a/lib/ui/__tests__/ModuleScreenShell.refresh.test.tsx
+++ b/lib/ui/__tests__/ModuleScreenShell.refresh.test.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import renderer, { act } from "react-test-renderer";
+import { RefreshControl, ScrollView, Text } from "react-native";
+
+import { ModuleScreenShell } from "@/lib/ui/ModuleScreenShell";
+
+describe("ModuleScreenShell refresh", () => {
+  it("enables vertical bounce when refreshControl is provided so pull-to-refresh can engage", async () => {
+    let tree!: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(
+        <ModuleScreenShell
+          title="Test"
+          refreshControl={<RefreshControl refreshing={false} onRefresh={jest.fn()} />}
+        >
+          <Text>Body</Text>
+        </ModuleScreenShell>,
+      );
+      await Promise.resolve();
+    });
+    const scroll = tree!.root.findByType(ScrollView);
+    expect(scroll.props.alwaysBounceVertical).toBe(true);
+  });
+});

--- a/lib/ui/activity/ActivityDailyDetailsCard.tsx
+++ b/lib/ui/activity/ActivityDailyDetailsCard.tsx
@@ -16,12 +16,21 @@ type ActivityDailyDetailsCardProps = {
   loading: boolean;
   error: { message: string; requestId: string | null; onRetry: () => void } | null;
   model: ActivityDailyDetailsCardModel | null;
+  /** Visible card heading (defaults to Today’s Steps). */
+  headingTitle?: string;
+  ratingTestID?: string;
+  stepsBarTestID?: string;
 };
 
 /** Parses `compactStatsSummary` for display only (e.g. `7,524 steps` → `7,524`). Hook output unchanged. */
 function primaryStepsFigureFromCompactSummary(compactStatsSummary: string): string | null {
   const m = compactStatsSummary.trim().match(/^([\d,]+)\s+steps$/i);
   return m?.[1] ?? null;
+}
+
+/** Header phrase for a11y (matches Today’s Steps → Today’s steps). */
+function headingSentenceLowerSteps(headingTitle: string): string {
+  return headingTitle.endsWith(" Steps") ? `${headingTitle.slice(0, -" Steps".length)} steps` : headingTitle;
 }
 
 function DetailsTierProgressTrack({ testID, tierIndex }: { testID: string; tierIndex: number | null }) {
@@ -38,17 +47,25 @@ function DetailsTierProgressTrack({ testID, tierIndex }: { testID: string; tierI
   );
 }
 
-export function ActivityDailyDetailsCard({ loading, error, model }: ActivityDailyDetailsCardProps) {
+export function ActivityDailyDetailsCard({
+  loading,
+  error,
+  model,
+  headingTitle = "Today’s Steps",
+  ratingTestID = "activity-daily-details-rating",
+  stepsBarTestID = "activity-daily-details-steps-bar",
+}: ActivityDailyDetailsCardProps) {
   const digits = model != null ? primaryStepsFigureFromCompactSummary(model.compactStatsSummary) : null;
   const rating = digits != null ? getStepRating(stepsFromLocaleDigitString(digits)) : null;
+  const headingA11y = headingSentenceLowerSteps(headingTitle);
   const titleRowA11y =
     loading || model == null
-      ? "Today’s Steps"
+      ? headingTitle
       : digits != null
         ? rating != null
-          ? `Today’s steps, ${rating.label}, ${digits}`
-          : `Today’s steps, ${digits}`
-        : `Today’s steps, ${model.compactStatsSummary}`;
+          ? `${headingA11y}, ${rating.label}, ${digits}`
+          : `${headingA11y}, ${digits}`
+        : `${headingA11y}, ${model.compactStatsSummary}`;
 
   return (
     <View style={styles.card}>
@@ -60,7 +77,7 @@ export function ActivityDailyDetailsCard({ loading, error, model }: ActivityDail
       >
         <View style={styles.labelPillCluster}>
           <Text style={styles.cardTitle} numberOfLines={1}>
-            Today’s Steps
+            {headingTitle}
           </Text>
           {!loading && model != null && rating != null ? (
             <ActivityRatingPill
@@ -68,7 +85,7 @@ export function ActivityDailyDetailsCard({ loading, error, model }: ActivityDail
               color={rating.color}
               backgroundColor={rating.backgroundColor}
               emphasis="subtle"
-              testID="activity-daily-details-rating"
+              testID={ratingTestID}
             />
           ) : null}
         </View>
@@ -95,7 +112,7 @@ export function ActivityDailyDetailsCard({ loading, error, model }: ActivityDail
       {!loading && model != null ? (
         <View style={moduleOverviewMetricLayoutStyles.metricBlock}>
           <DetailsTierProgressTrack
-            testID="activity-daily-details-steps-bar"
+            testID={stepsBarTestID}
             tierIndex={digits != null ? getStepRatingTierIndex(stepsFromLocaleDigitString(digits)) : null}
           />
         </View>

--- a/lib/ui/activity/__tests__/ActivityDailyDetailsCard.test.tsx
+++ b/lib/ui/activity/__tests__/ActivityDailyDetailsCard.test.tsx
@@ -60,4 +60,27 @@ describe("ActivityDailyDetailsCard", () => {
     });
     expect(JSON.stringify(tree.toJSON())).not.toContain("Other days may still show");
   });
+
+  it("supports custom heading title without changing numeric tier UI", () => {
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(
+        <ActivityDailyDetailsCard
+          headingTitle="Yesterday’s Steps"
+          loading={false}
+          error={null}
+          model={{
+            title: "Sat",
+            compactStatsSummary: "148 steps",
+            markerPosition01: 0.2,
+          }}
+        />,
+      );
+    });
+    const str = JSON.stringify(tree.toJSON());
+    expect(str).toContain("Yesterday’s Steps");
+    expect(str).not.toContain("Today’s Steps");
+    expect(str).toContain("148");
+    expect(str).toContain("Low");
+  });
 });

--- a/lib/ui/recovery/__tests__/sleepOuraContributorsVisibility.test.ts
+++ b/lib/ui/recovery/__tests__/sleepOuraContributorsVisibility.test.ts
@@ -1,0 +1,38 @@
+import type { SleepViewDto } from "@oli/contracts";
+
+import { sleepOuraContributorsCardShouldRender } from "@/lib/ui/recovery/sleepOuraContributorsVisibility";
+import type { ContributorRowProps } from "@/lib/ui/recovery/RecoveryContributorsCard";
+
+describe("sleepOuraContributorsCardShouldRender", () => {
+  const baseView: SleepViewDto = {
+    requestedDay: "2026-04-06",
+    resolvedDay: "2026-04-06",
+    isFallback: false,
+    day: "2026-04-06",
+    score: 70,
+    contributors: {},
+  };
+
+  it("returns false when API is in cross-day fallback", () => {
+    expect(
+      sleepOuraContributorsCardShouldRender(
+        { ...baseView, isFallback: true, resolvedDay: "2026-04-05", day: "2026-04-05" },
+        [],
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false when all rows are placeholders", () => {
+    const rows: ContributorRowProps[] = [
+      { label: "Total sleep", valueDisplay: "—", progress: 0, rating: "Pay attention" },
+    ];
+    expect(sleepOuraContributorsCardShouldRender(baseView, rows)).toBe(false);
+  });
+
+  it("returns true when at least one row has a real value", () => {
+    const rows: ContributorRowProps[] = [
+      { label: "Total sleep", valueDisplay: "420", progress: 0.5, rating: "Good" },
+    ];
+    expect(sleepOuraContributorsCardShouldRender(baseView, rows)).toBe(true);
+  });
+});

--- a/lib/ui/recovery/sleepOuraContributorsVisibility.ts
+++ b/lib/ui/recovery/sleepOuraContributorsVisibility.ts
@@ -1,0 +1,15 @@
+import type { SleepViewDto } from "@oli/contracts";
+
+import type { ContributorRowProps } from "@/lib/ui/recovery/RecoveryContributorsCard";
+
+/**
+ * Vendor contributor rows must not appear when the API fell back to another night,
+ * or when there is no non-placeholder contributor data for the resolved night.
+ */
+export function sleepOuraContributorsCardShouldRender(
+  view: SleepViewDto,
+  contributorRows: ContributorRowProps[],
+): boolean {
+  if (view.isFallback) return false;
+  return contributorRows.some((r) => r.valueDisplay !== "—");
+}

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -25,6 +25,10 @@ COPY . .
 WORKDIR /app/lib/contracts
 RUN npm run build && test -f dist/index.js && test -f dist/index.d.ts
 
+# Functions: shared recompute bundle consumed by oli-api (sleep-day-refresh)
+WORKDIR /app/services/functions
+RUN npm run build && test -f lib/index.js && test -f lib/recomputeForDayExport.js
+
 # Build the API and fail-closed if the entrypoint is missing
 WORKDIR /app/services/api
 RUN npm run build && test -f dist/src/server.js
@@ -38,6 +42,9 @@ ENV PORT=8080
 # API runtime artifacts
 COPY --from=build /app/services/api/dist ./services/api/dist
 COPY --from=build /app/services/api/package.json ./services/api/package.json
+
+# Shared recompute bundle (see loadRecomputeDerivedTruthForDay.ts path resolution)
+COPY --from=build /app/services/functions/lib/recomputeForDayExport.js ./services/functions/lib/recomputeForDayExport.js
 
 # Monorepo workspace runtime deps (prevents MODULE_NOT_FOUND for @oli/contracts)
 COPY --from=build /app/lib/contracts/dist ./lib/contracts/dist

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -14,6 +14,7 @@ import integrationsRoutes, { handleOuraCallback } from "./routes/integrations";
 import appleHealthStatusRouter from "./routes/integrations/appleHealthStatus";
 import ouraIngestRouter from "./routes/integrations/ouraIngest";
 import ouraPullNowRouter from "./routes/integrations/ouraPullNow";
+import ouraSleepDayRefreshRouter from "./routes/integrations/ouraSleepDayRefresh";
 import ouraPullRouter from "./routes/ouraPull";
 import { authMiddleware } from "./middleware/auth";
 import { requireInvokerAuth } from "./middleware/invokerAuth";
@@ -158,6 +159,7 @@ app.get("/integrations/oura/complete", (_req: Request, res: Response) => {
 app.use("/integrations/oura/ingest", authMiddleware, ouraIngestRouter);
 app.use("/integrations/oura/pull", requireInvokerAuth, ouraPullRouter);
 app.use("/integrations/oura/pull-now", authMiddleware, ouraPullNowRouter);
+app.use("/integrations/oura/sleep-day-refresh", authMiddleware, ouraSleepDayRefreshRouter);
 
 /**
  * Integrations (authenticated): connect, revoke.

--- a/services/api/src/lib/loadRecomputeDerivedTruthForDay.ts
+++ b/services/api/src/lib/loadRecomputeDerivedTruthForDay.ts
@@ -1,0 +1,45 @@
+/**
+ * Loads the bundled `recomputeDerivedTruthForDay` implementation from @oli/functions at runtime.
+ * Keeps the API TypeScript project boundary clean (no cross-package TS imports) while sharing one pipeline.
+ */
+
+import path from "node:path";
+import { createRequire } from "node:module";
+
+import type { Firestore } from "firebase-admin/firestore";
+
+export type RecomputeDerivedTruthForDayInput = {
+  db: Firestore;
+  userId: string;
+  dayKey: string;
+  canonicalAnchorDay?: string;
+  trigger:
+    | { type: "factOnly"; rawEventId: string }
+    | { type: "realtime"; eventId: string }
+    | { type: "admin"; source: string };
+};
+
+let cachedFn: ((input: RecomputeDerivedTruthForDayInput) => Promise<void>) | undefined;
+
+export function getRecomputeDerivedTruthForDay(): (input: RecomputeDerivedTruthForDayInput) => Promise<void> {
+  if (cachedFn) return cachedFn;
+
+  const requireFn = createRequire(__filename);
+  const upCount = __dirname.includes(`${path.sep}dist${path.sep}`) ? 4 : 3;
+  const ups = path.join(...Array.from({ length: upCount }, () => ".."));
+  const bundlePath = path.join(__dirname, ups, "functions", "lib", "recomputeForDayExport.js");
+
+  try {
+    const mod = requireFn(bundlePath) as {
+      recomputeDerivedTruthForDay: (input: RecomputeDerivedTruthForDayInput) => Promise<void>;
+    };
+    cachedFn = mod.recomputeDerivedTruthForDay;
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new Error(
+      `Failed to load recompute bundle at ${bundlePath} (from ${__dirname}). Build @oli/functions first. Underlying: ${msg}`,
+    );
+  }
+
+  return cachedFn!;
+}

--- a/services/api/src/routes/integrations/__tests__/ouraSleepDayRefresh.test.ts
+++ b/services/api/src/routes/integrations/__tests__/ouraSleepDayRefresh.test.ts
@@ -1,0 +1,92 @@
+/**
+ * POST /integrations/oura/sleep-day-refresh — Oura pull + derived-truth recompute for Sleep refresh.
+ */
+
+import express from "express";
+import request from "supertest";
+
+jest.mock("../../../db", () => ({
+  db: {},
+}));
+
+const mockPerformOuraPullNowCore = jest.fn();
+const mockRecompute = jest.fn().mockResolvedValue(undefined);
+
+jest.mock("../ouraPullNow", () => ({
+  performOuraPullNowCore: (...args: unknown[]) => mockPerformOuraPullNowCore(...args),
+}));
+
+jest.mock("../../../lib/loadRecomputeDerivedTruthForDay", () => ({
+  getRecomputeDerivedTruthForDay: () => mockRecompute,
+}));
+
+import ouraSleepDayRefreshRouter from "../ouraSleepDayRefresh";
+
+describe("POST /integrations/oura/sleep-day-refresh", () => {
+  let app: express.Express;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as unknown as { uid: string; rid: string }).uid = "user_sleep_refresh";
+      (req as unknown as { rid: string }).rid = "req-sleep-refresh";
+      next();
+    });
+    app.use("/integrations/oura/sleep-day-refresh", ouraSleepDayRefreshRouter);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPerformOuraPullNowCore.mockResolvedValue({
+      statusCode: 202,
+      body: { ok: true, requestId: "rid", windowDays: 30, eventsCreated: 1, eventsAlreadyExists: 0 },
+    });
+  });
+
+  it("returns 400 without Idempotency-Key", async () => {
+    const res = await request(app)
+      .post("/integrations/oura/sleep-day-refresh")
+      .set("Authorization", "Bearer test")
+      .send({ day: "2026-04-06" });
+
+    expect(res.status).toBe(400);
+    expect(mockPerformOuraPullNowCore).not.toHaveBeenCalled();
+    expect(mockRecompute).not.toHaveBeenCalled();
+  });
+
+  it("runs pull then recompute and returns 200", async () => {
+    const res = await request(app)
+      .post("/integrations/oura/sleep-day-refresh")
+      .set("Authorization", "Bearer test")
+      .set("Idempotency-Key", "idem-1")
+      .send({ day: "2026-04-06" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(mockPerformOuraPullNowCore).toHaveBeenCalledWith("user_sleep_refresh", "req-sleep-refresh");
+    expect(mockRecompute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "user_sleep_refresh",
+        dayKey: "2026-04-06",
+        trigger: { type: "admin", source: "oura_sleep_day_refresh" },
+      }),
+    );
+  });
+
+  it("does not run recompute when pull fails", async () => {
+    mockPerformOuraPullNowCore.mockResolvedValue({
+      statusCode: 502,
+      body: { ok: false, error: { code: "OURA_NOT_CONNECTED", message: "nope", requestId: "rid" } },
+    });
+
+    const res = await request(app)
+      .post("/integrations/oura/sleep-day-refresh")
+      .set("Authorization", "Bearer test")
+      .set("Idempotency-Key", "idem-2")
+      .send({ day: "2026-04-06" });
+
+    expect(res.status).toBe(502);
+    expect(mockRecompute).not.toHaveBeenCalled();
+  });
+});

--- a/services/api/src/routes/integrations/ouraSleepDayRefresh.ts
+++ b/services/api/src/routes/integrations/ouraSleepDayRefresh.ts
@@ -1,0 +1,116 @@
+/**
+ * POST /integrations/oura/sleep-day-refresh — authenticated: Oura pull-now core + recompute for one day.
+ * Used by Sleep pull-to-refresh on the latest calendar day so the client matches manual pull + recompute.
+ */
+
+import { Router, type Request, type Response } from "express";
+import { z } from "zod";
+
+import type { AuthedRequest } from "../../middleware/auth";
+import { db } from "../../db";
+import { getRecomputeDerivedTruthForDay } from "../../lib/loadRecomputeDerivedTruthForDay";
+import { logger } from "../../lib/logger";
+import { performOuraPullNowCore } from "./ouraPullNow";
+
+const router = Router();
+
+const bodySchema = z.object({
+  day: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+});
+
+function getRequestId(req: Request): string {
+  return (req as AuthedRequest).rid ?? (req.header("x-request-id") ?? "unknown").toString();
+}
+
+function getIdempotencyKey(req: Request): string | undefined {
+  const fromHeader =
+    (typeof req.header("Idempotency-Key") === "string" ? req.header("Idempotency-Key") : undefined) ??
+    (typeof req.header("X-Idempotency-Key") === "string" ? req.header("X-Idempotency-Key") : undefined);
+  return fromHeader?.trim() || undefined;
+}
+
+router.post("/", async (req: Request, res: Response): Promise<void> => {
+  const uid = (req as AuthedRequest).uid;
+  const rid = getRequestId(req);
+
+  if (!uid) {
+    res.status(401).json({
+      ok: false as const,
+      error: {
+        code: "UNAUTHORIZED" as const,
+        message: "Unauthorized",
+        requestId: rid,
+      },
+    });
+    return;
+  }
+
+  const idem = getIdempotencyKey(req);
+  if (!idem) {
+    res.status(400).json({
+      ok: false as const,
+      error: {
+        code: "IDEMPOTENCY_KEY_REQUIRED" as const,
+        message: "Idempotency-Key header is required",
+        requestId: rid,
+      },
+    });
+    return;
+  }
+
+  const parsed = bodySchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({
+      ok: false as const,
+      error: {
+        code: "INVALID_BODY" as const,
+        message: "Invalid request body",
+        requestId: rid,
+      },
+    });
+    return;
+  }
+
+  const { day } = parsed.data;
+
+  try {
+    const pull = await performOuraPullNowCore(uid, rid);
+    if (pull.statusCode < 200 || pull.statusCode >= 300) {
+      res.status(pull.statusCode).json(pull.body);
+      return;
+    }
+
+    await getRecomputeDerivedTruthForDay()({
+      db,
+      userId: uid,
+      dayKey: day,
+      trigger: { type: "admin", source: "oura_sleep_day_refresh" },
+    });
+
+    res.status(200).json({
+      ok: true as const,
+      requestId: rid,
+      day,
+      pullNowStatus: pull.statusCode,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error({
+      msg: "oura_sleep_day_refresh_failed",
+      rid,
+      uid,
+      day,
+      err: message,
+    });
+    res.status(500).json({
+      ok: false as const,
+      error: {
+        code: "SLEEP_DAY_REFRESH_FAILED" as const,
+        message,
+        requestId: rid,
+      },
+    });
+  }
+});
+
+export default router;

--- a/services/functions/scripts/build.mjs
+++ b/services/functions/scripts/build.mjs
@@ -40,3 +40,30 @@ await build({
 });
 
 console.log(`Built ${outFile}`);
+
+/** Standalone bundle for oli-api to run the same derived-truth recompute as Cloud Functions (shared logic). */
+const recomputeEntry = path.join(projectRoot, "src", "pipeline", "recomputeForDay.ts");
+const recomputeOut = path.join(projectRoot, "lib", "recomputeForDayExport.js");
+
+await build({
+  entryPoints: [recomputeEntry],
+  outfile: recomputeOut,
+  bundle: true,
+  platform: "node",
+  format: "cjs",
+  target: "node20",
+  sourcemap: true,
+  logLevel: "info",
+  alias: {
+    "@/lib": path.join(repoRoot, "lib"),
+    "@oli/contracts": path.join(repoRoot, "lib/contracts/index.ts"),
+  },
+  external: [
+    "firebase-functions",
+    "firebase-functions/*",
+    "firebase-admin",
+    "firebase-admin/*",
+  ],
+});
+
+console.log(`Built ${recomputeOut}`);


### PR DESCRIPTION
… behavior

- Remove oliSleepScore from Sleep headline card entirely
- Enforce vendor-only score display (Oura snapshot)
- Show honest unavailable state when vendor score missing
- Add sleep-day-refresh API endpoint (pull + recompute)
- Implement latest-day pull-to-refresh behavior (sync + recompute + refetch)
- Keep historical-day refresh as read-only refetch
- Fix contributors card visibility (no cross-day or empty render)
- Improve initial selected-day logic (latest valid day unless pinned)
- Add supporting helpers:
  - sleepHeadlineScoreCardModel
  - runSleepPullToRefresh
  - sleepOuraContributorsVisibility
- Add tests for:
  - refresh behavior
  - vendor-only score
  - contributors visibility
  - day selection logic

Result:
- Sleep page now shows exact vendor score users expect
- Pull-to-refresh matches manual sync behavior
- No misleading cross-day or fallback data shown