### PR TITLE
feat(strength): enable delete for Apple Health workouts + UI refactor

### DIFF
--- a/app/(app)/activity/__tests__/activity-overview.test.tsx
+++ b/app/(app)/activity/__tests__/activity-overview.test.tsx
@@ -186,7 +186,7 @@ describe("ActivityOverviewScreen", () => {
     expect(str.indexOf("Today’s Steps")).toBeLessThan(str.indexOf("Yesterday"));
     const overviewBarMarker = "activity-overview-steps-bar-day7";
     expect(str.indexOf("Yesterday")).toBeLessThan(str.indexOf(overviewBarMarker));
-    expect(str.indexOf("Your baseline is your average daily steps over the past 90 days")).toBeLessThan(
+    expect(str.indexOf("Your typical daily activity level based on the past 90 days")).toBeLessThan(
       str.indexOf("Today’s Steps"),
     );
     expect(str).toContain(overviewBarMarker);
@@ -202,7 +202,7 @@ describe("ActivityOverviewScreen", () => {
     expect(str).toContain("1,234");
     expect(str).toContain("9,876");
     expect(str).toContain("5,555");
-    expect(str).toContain("Your baseline is your average daily steps over the past 90 days");
+    expect(str).toContain("Your typical daily activity level based on the past 90 days");
     expect(str).toContain("activity-daily-details-delta-label");
     expect(str).toContain("steps below your baseline");
     expect(str).not.toContain("activity-baseline-tier-legend");
@@ -213,6 +213,8 @@ describe("ActivityOverviewScreen", () => {
     expect(str).toContain("activity-overview-steps-bar-day7");
     expect(str).toContain("activity-overview-steps-bar-month12");
     expect(str).toContain("activity-baseline-details-steps-bar");
+    expect(str).toContain("activity-baseline-threshold-markers");
+    expect(str).toContain("7.5k");
     expect(str).toContain("activity-daily-details-steps-bar");
     expect(str).toContain("activity-overview-steps-bar-yesterday");
   });

--- a/app/(app)/activity/index.tsx
+++ b/app/(app)/activity/index.tsx
@@ -85,6 +85,7 @@ export default function ActivityOverviewScreen() {
             error={data.baselineDetails.error}
             model={data.baselineDetails.model}
             footerCaption={ACTIVITY_BASELINE_DEFINITION_SENTENCE}
+            showBaselineStepThresholdMarkers
           />
           <View style={styles.cardSpacer} />
           <ActivityDailyDetailsCard

--- a/app/(app)/workouts/__tests__/overview-recent-after-backfill.test.tsx
+++ b/app/(app)/workouts/__tests__/overview-recent-after-backfill.test.tsx
@@ -323,7 +323,7 @@ it("renders formatted recent workout title and summary metadata", async () => {
   expect(json).not.toContain("Apple Health");
 });
 
-it("renders up to five recent workouts on the overview and supports fifth-row interactions", async () => {
+it("lists all in-week workouts on the overview (earliest first) and supports fifth-row interactions", async () => {
   mockUseWorkoutsCalendarRange.mockImplementation(() => ({
     status: "ready",
     durableTitlesByWorkoutId: {},
@@ -354,10 +354,10 @@ it("renders up to five recent workouts on the overview and supports fifth-row in
       typeof n.props?.accessibilityLabel === "string" &&
       n.props.accessibilityLabel.startsWith("Open workout details r"),
   );
-  expect(rows).toHaveLength(5);
+  expect(rows).toHaveLength(8);
 
   act(() => {
-    test.root.findByProps({ accessibilityLabel: "Open workout details r5" }).props.onPress();
+    test.root.findByProps({ accessibilityLabel: "Open workout details r4" }).props.onPress();
   });
   expect(mockPush).toHaveBeenCalledWith({
     pathname: "/(app)/workouts/day/[day]",
@@ -365,7 +365,7 @@ it("renders up to five recent workouts on the overview and supports fifth-row in
   });
 
   act(() => {
-    test.root.findByProps({ accessibilityLabel: "Workout actions r5" }).props.onPress();
+    test.root.findByProps({ accessibilityLabel: "Workout actions r4" }).props.onPress();
   });
   act(() => {
     test.root.findByProps({ accessibilityLabel: "View details" }).props.onPress();

--- a/app/(app)/workouts/__tests__/overview-strength-week-slice.test.tsx
+++ b/app/(app)/workouts/__tests__/overview-strength-week-slice.test.tsx
@@ -1,6 +1,6 @@
 /**
- * Strength overview main body: Baseline, This Week + Last Week combined week lists;
- * analytics detail charts stay off this screen.
+ * Regression: Strength combined week card lists only local-calendar-week sessions,
+ * earliest-first; hydrated days outside the week slice must not appear as rows.
  */
 import React from "react";
 import renderer, { act } from "react-test-renderer";
@@ -44,21 +44,44 @@ jest.mock("@/lib/preferences/PreferencesProvider", () => ({
   }),
 }));
 
-jest.mock("@/lib/data/workouts/useWorkoutsCalendar", () => ({
-  useWorkoutsCalendarRange: () => ({
-    status: "ready" as const,
-    durableTitlesByWorkoutId: {},
-    days: [
-      { day: "2026-03-09", workouts: [] },
-      { day: "2026-03-10", workouts: [] },
-      { day: "2026-03-11", workouts: [] },
-      { day: "2026-03-12", workouts: [] },
-      { day: "2026-03-13", workouts: [] },
-      { day: "2026-03-14", workouts: [] },
-      { day: "2026-03-15", workouts: [] },
-    ],
-  }),
-}));
+jest.mock("@/lib/data/workouts/useWorkoutsCalendar", () => {
+  const strengthW = (id: string, start: string) => ({
+    id,
+    observedAt: start,
+    sourceId: "manual",
+    title: "Lift",
+    workoutType: "strength" as const,
+    start,
+    end: null,
+    durationMinutes: 45,
+    calories: null,
+  });
+  return {
+    useWorkoutsCalendarRange: () => ({
+      status: "ready" as const,
+      durableTitlesByWorkoutId: {},
+      days: [
+        {
+          day: "2026-03-08",
+          workouts: [strengthW("prior-week-strength", "2026-03-08T18:00:00.000Z")],
+        },
+        { day: "2026-03-09", workouts: [] },
+        {
+          day: "2026-03-10",
+          workouts: [strengthW("early-week-strength", "2026-03-10T09:00:00.000Z")],
+        },
+        { day: "2026-03-11", workouts: [] },
+        {
+          day: "2026-03-12",
+          workouts: [strengthW("later-week-strength", "2026-03-12T16:00:00.000Z")],
+        },
+        { day: "2026-03-13", workouts: [] },
+        { day: "2026-03-14", workouts: [] },
+        { day: "2026-03-15", workouts: [] },
+      ],
+    }),
+  };
+});
 
 jest.mock("@/lib/ui/calendar/dateUtils", () => ({
   ...jest.requireActual("@/lib/ui/calendar/dateUtils"),
@@ -150,19 +173,10 @@ jest.mock("@react-navigation/native", () => ({
   useFocusEffect: jest.fn(),
 }));
 
-jest.mock("expo-router", () => {
-  const w = { push: jest.fn(), setOptions: jest.fn() };
-  (globalThis as unknown as { __oliWorkoutsOverviewExpo?: typeof w }).__oliWorkoutsOverviewExpo = w;
-  return {
-    useNavigation: () => ({ setOptions: w.setOptions, goBack: jest.fn() }),
-    useRouter: () => ({ push: w.push }),
-  };
-});
-
-function workoutsOverviewExpoMocks() {
-  return (globalThis as unknown as { __oliWorkoutsOverviewExpo: { push: jest.Mock; setOptions: jest.Mock } })
-    .__oliWorkoutsOverviewExpo;
-}
+jest.mock("expo-router", () => ({
+  useNavigation: () => ({ setOptions: jest.fn(), goBack: jest.fn() }),
+  useRouter: () => ({ push: jest.fn() }),
+}));
 
 jest.mock("react-native-safe-area-context", () => ({
   SafeAreaView: "SafeAreaView",
@@ -171,83 +185,30 @@ jest.mock("react-native-safe-area-context", () => ({
 
 import StrengthTrainingOverviewScreen from "../overview";
 
-describe("Strength overview main layout", () => {
-  beforeEach(() => {
-    workoutsOverviewExpoMocks().push.mockClear();
-    workoutsOverviewExpoMocks().setOptions.mockClear();
-  });
-
-  it("renders Strength Baseline, This Week + Last Week blocks and omits Weekly Insights / weekly/monthly analytics cards", async () => {
+describe("Strength overview week slice list", () => {
+  it("places prior-week sessions only on Last Week; This Week orders earliest-first", async () => {
     let tree!: renderer.ReactTestRenderer;
     await act(async () => {
       tree = renderer.create(<StrengthTrainingOverviewScreen />);
     });
     const json = JSON.stringify(tree.toJSON());
-    const iBaseline = json.indexOf('"Strength Baseline"');
-    const iThisWeek = json.indexOf('"This Week"');
-    const iLastWeek = json.indexOf('"Last Week"');
-    expect(iBaseline).toBeGreaterThan(-1);
-    expect(iThisWeek).toBeGreaterThan(-1);
-    expect(iLastWeek).toBeGreaterThan(-1);
-    expect(json).not.toContain("strength-this-week-frequency-bar");
-    expect(json).not.toContain('"Overview"');
-    expect(json).not.toContain('"Recent Workouts"');
-    expect(iBaseline).toBeLessThan(iThisWeek);
-    expect(iThisWeek).toBeLessThan(iLastWeek);
-    expect(json).not.toContain("Weekly Insights");
-    expect(json).not.toContain("Weekly Strength");
-    expect(json).not.toContain("Weekly Muscle Group");
-    expect(json).not.toContain("Monthly Workouts");
-    expect(json).not.toContain("Yearly Workouts");
-    expect(json).toContain("This Week");
-    expect(json).not.toContain("No workout logged today");
-    expect((json.match(/strength-baseline-frequency-markers/g) ?? []).length).toBe(1);
-  });
+    const iThisWeekHeading = json.indexOf('"This Week"');
+    const iLastWeekHeading = json.indexOf('"Last Week"');
+    expect(iThisWeekHeading).toBeGreaterThan(-1);
+    expect(iLastWeekHeading).toBeGreaterThan(-1);
 
-  it("overflow opens Strength settings route (dedicated settings, not in-popup menu)", async () => {
-    let tree!: renderer.ReactTestRenderer;
-    await act(async () => {
-      tree = renderer.create(<StrengthTrainingOverviewScreen />);
-    });
-    const { setOptions, push } = workoutsOverviewExpoMocks();
-    expect(setOptions.mock.calls.length).toBeGreaterThan(0);
-    const lastOpts = setOptions.mock.calls[setOptions.mock.calls.length - 1]![0] as {
-      headerRight?: () => React.ReactElement;
-    };
-    expect(lastOpts.headerRight).toBeDefined();
-    let header!: renderer.ReactTestRenderer;
-    await act(async () => {
-      header = renderer.create(lastOpts.headerRight!());
-    });
-    const overflow = header.root.findByProps({ accessibilityLabel: "Strength settings" });
-    await act(async () => {
-      overflow.props.onPress();
-    });
-    expect(push).toHaveBeenCalledWith("/(app)/workouts/settings");
-    void tree;
-  });
+    const thisWeekSegment = json.slice(iThisWeekHeading, iLastWeekHeading);
+    expect(thisWeekSegment).not.toContain("prior-week-strength");
+    expect(thisWeekSegment).toContain("early-week-strength");
+    expect(thisWeekSegment).toContain("later-week-strength");
 
-  it("pressing Strength Baseline navigates to Strength Analytics (analytics-detail)", async () => {
-    let tree!: renderer.ReactTestRenderer;
-    await act(async () => {
-      tree = renderer.create(<StrengthTrainingOverviewScreen />);
-    });
-    const baselineNav = tree.root.findByProps({ testID: "strength-baseline-card-nav" });
-    await act(async () => {
-      baselineNav.props.onPress();
-    });
-    expect(workoutsOverviewExpoMocks().push).toHaveBeenCalledWith("/(app)/workouts/analytics-detail");
-  });
+    expect(json.indexOf("prior-week-strength")).toBeGreaterThan(iLastWeekHeading);
 
-  it("combined card header View More navigates to All Strength Workouts", async () => {
-    let tree!: renderer.ReactTestRenderer;
-    await act(async () => {
-      tree = renderer.create(<StrengthTrainingOverviewScreen />);
-    });
-    const footer = tree.root.findByProps({ testID: "strength-recent-week-combined-view-more" });
-    await act(async () => {
-      footer.props.onPress();
-    });
-    expect(workoutsOverviewExpoMocks().push).toHaveBeenCalledWith("/(app)/workouts/recent-workouts-full");
+    const iEarly = json.indexOf("Open workout details early-week-strength");
+    const iLate = json.indexOf("Open workout details later-week-strength");
+    expect(iEarly).toBeGreaterThan(-1);
+    expect(iLate).toBeGreaterThan(-1);
+    expect(iEarly).toBeLessThan(iLate);
+    expect(iLate).toBeLessThan(iLastWeekHeading);
   });
 });

--- a/app/(app)/workouts/__tests__/overview-workout-actions.test.tsx
+++ b/app/(app)/workouts/__tests__/overview-workout-actions.test.tsx
@@ -1,10 +1,18 @@
 import React from "react";
 import renderer, { act } from "react-test-renderer";
+import { useWorkoutsCalendarRange } from "@/lib/data/workouts/useWorkoutsCalendar";
 import TrainingOverviewScreen from "../overview";
 
 const mockPush = jest.fn();
 const mockSetOptions = jest.fn();
 const mockSaveOverride = jest.fn(async () => undefined);
+const mockClearWorkoutOverride = jest.fn(async () => undefined);
+const mockDeleteIngestedRawEventAuthed = jest.fn(async () => ({
+  ok: true as const,
+  status: 200 as const,
+  data: { ok: true as const, rawEventId: "w1", requestId: "rid" },
+  requestId: "rid" as string | null,
+}));
 let mockOverridesState: Record<string, unknown> = {};
 
 jest.mock("@/lib/api/usersMe", () => ({
@@ -72,27 +80,117 @@ jest.mock("@/lib/workouts/gymRegistry", () => ({
 }));
 
 jest.mock("@/lib/data/workouts/useWorkoutsCalendar", () => ({
-  useWorkoutsCalendarRange: () => ({
-    status: "ready",
-    durableTitlesByWorkoutId: {},
-    days: [
-      { day: "2026-03-09", workouts: [] },
-      {
-        day: "2026-03-10",
-        workouts: [
-          { id: "w1", observedAt: "2026-03-10T10:00:00.000Z", sourceId: "manual", title: "Lift", workoutType: "strength", start: "2026-03-10T10:00:00.000Z", end: null, durationMinutes: 20, calories: 200 },
-          { id: "w2", observedAt: "2026-03-10T09:00:00.000Z", sourceId: "manual", title: "Lift", workoutType: "strength", start: "2026-03-10T09:00:00.000Z", end: null, durationMinutes: 20, calories: 200 },
-          { id: "w3", observedAt: "2026-03-10T08:00:00.000Z", sourceId: "manual", title: "Lift", workoutType: "strength", start: "2026-03-10T08:00:00.000Z", end: null, durationMinutes: 20, calories: 200 },
-          { id: "w4", observedAt: "2026-03-10T07:00:00.000Z", sourceId: "manual", title: "Lift", workoutType: "strength", start: "2026-03-10T07:00:00.000Z", end: null, durationMinutes: 20, calories: 200 },
-          { id: "w5", observedAt: "2026-03-10T06:00:00.000Z", sourceId: "manual", title: "Lift", workoutType: "strength", start: "2026-03-10T06:00:00.000Z", end: null, durationMinutes: 20, calories: 200 },
-          { id: "w6", observedAt: "2026-03-10T05:00:00.000Z", sourceId: "manual", title: "Lift", workoutType: "strength", start: "2026-03-10T05:00:00.000Z", end: null, durationMinutes: 20, calories: 200 },
-          { id: "w7", observedAt: "2026-03-10T04:00:00.000Z", sourceId: "manual", title: "Lift", workoutType: "strength", start: "2026-03-10T04:00:00.000Z", end: null, durationMinutes: 20, calories: 200 },
-          { id: "w8", observedAt: "2026-03-10T03:00:00.000Z", sourceId: "manual", title: "Lift", workoutType: "strength", start: "2026-03-10T03:00:00.000Z", end: null, durationMinutes: 20, calories: 200 },
-        ],
-      },
-    ],
-  }),
+  useWorkoutsCalendarRange: jest.fn(),
 }));
+
+const DEFAULT_WORKOUTS_CALENDAR_RANGE = {
+  status: "ready" as const,
+  durableTitlesByWorkoutId: {},
+  days: [
+    { day: "2026-03-09", workouts: [] },
+    {
+      day: "2026-03-10",
+      workouts: [
+        {
+          id: "w1",
+          provider: "manual",
+          observedAt: "2026-03-10T10:00:00.000Z",
+          sourceId: "manual",
+          title: "Lift",
+          workoutType: "strength",
+          start: "2026-03-10T10:00:00.000Z",
+          end: null,
+          durationMinutes: 20,
+          calories: 200,
+        },
+        {
+          id: "w2",
+          provider: "manual",
+          observedAt: "2026-03-10T09:00:00.000Z",
+          sourceId: "manual",
+          title: "Lift",
+          workoutType: "strength",
+          start: "2026-03-10T09:00:00.000Z",
+          end: null,
+          durationMinutes: 20,
+          calories: 200,
+        },
+        {
+          id: "w3",
+          provider: "manual",
+          observedAt: "2026-03-10T08:00:00.000Z",
+          sourceId: "manual",
+          title: "Lift",
+          workoutType: "strength",
+          start: "2026-03-10T08:00:00.000Z",
+          end: null,
+          durationMinutes: 20,
+          calories: 200,
+        },
+        {
+          id: "w4",
+          provider: "manual",
+          observedAt: "2026-03-10T07:00:00.000Z",
+          sourceId: "manual",
+          title: "Lift",
+          workoutType: "strength",
+          start: "2026-03-10T07:00:00.000Z",
+          end: null,
+          durationMinutes: 20,
+          calories: 200,
+        },
+        {
+          id: "w5",
+          provider: "manual",
+          observedAt: "2026-03-10T06:00:00.000Z",
+          sourceId: "manual",
+          title: "Lift",
+          workoutType: "strength",
+          start: "2026-03-10T06:00:00.000Z",
+          end: null,
+          durationMinutes: 20,
+          calories: 200,
+        },
+        {
+          id: "w6",
+          provider: "manual",
+          observedAt: "2026-03-10T05:00:00.000Z",
+          sourceId: "manual",
+          title: "Lift",
+          workoutType: "strength",
+          start: "2026-03-10T05:00:00.000Z",
+          end: null,
+          durationMinutes: 20,
+          calories: 200,
+        },
+        {
+          id: "w7",
+          provider: "manual",
+          observedAt: "2026-03-10T04:00:00.000Z",
+          sourceId: "manual",
+          title: "Lift",
+          workoutType: "strength",
+          start: "2026-03-10T04:00:00.000Z",
+          end: null,
+          durationMinutes: 20,
+          calories: 200,
+        },
+        {
+          id: "w8",
+          provider: "manual",
+          observedAt: "2026-03-10T03:00:00.000Z",
+          sourceId: "manual",
+          title: "Lift",
+          workoutType: "strength",
+          start: "2026-03-10T03:00:00.000Z",
+          end: null,
+          durationMinutes: 20,
+          calories: 200,
+        },
+      ],
+    },
+  ],
+};
 
 jest.mock("@/lib/ui/calendar/dateUtils", () => ({
   ...jest.requireActual("@/lib/ui/calendar/dateUtils"),
@@ -110,11 +208,12 @@ jest.mock("@/lib/ui/calendar/dateUtils", () => ({
 }));
 
 jest.mock("@/lib/data/workouts/workoutOverrides", () => ({
+  clearWorkoutOverride: (...args: unknown[]) => mockClearWorkoutOverride(...args),
   useWorkoutOverrides: () => ({
     loaded: true,
     overridesByWorkoutId: mockOverridesState,
     saveOverride: mockSaveOverride,
-    reload: jest.fn(),
+    reload: jest.fn(async () => undefined),
   }),
 }));
 
@@ -176,6 +275,7 @@ jest.mock("@/lib/integrations/appleHealth/storage", () => ({
 
 jest.mock("@/lib/api/ingest", () => ({
   ingestRawEvent: jest.fn(),
+  deleteIngestedRawEventAuthed: (...args: unknown[]) => mockDeleteIngestedRawEventAuthed(...args),
 }));
 
 jest.mock("react-native-safe-area-context", () => ({
@@ -211,6 +311,13 @@ describe("overview workout actions", () => {
   beforeEach(() => {
     mockOverridesState = {};
     jest.clearAllMocks();
+    jest.mocked(useWorkoutsCalendarRange).mockReturnValue(DEFAULT_WORKOUTS_CALENDAR_RANGE as never);
+    mockDeleteIngestedRawEventAuthed.mockResolvedValue({
+      ok: true as const,
+      status: 200 as const,
+      data: { ok: true as const, rawEventId: "w1", requestId: "rid" },
+      requestId: "rid" as string | null,
+    });
   });
 
   it("view details keeps day navigation", async () => {
@@ -250,6 +357,7 @@ describe("overview workout actions", () => {
     expect(test.root.findByProps({ accessibilityLabel: "Rename workout" })).toBeTruthy();
     expect(test.root.findByProps({ accessibilityLabel: "Edit duration" })).toBeTruthy();
     expect(test.root.findByProps({ accessibilityLabel: "Edit workout type" })).toBeTruthy();
+    expect(test.root.findByProps({ accessibilityLabel: "Delete workout" })).toBeTruthy();
     act(() => {
       test.root.findByProps({ accessibilityLabel: "Close workout menu" }).props.onPress();
     });
@@ -264,34 +372,34 @@ describe("overview workout actions", () => {
     expect(json).not.toContain("Manual");
   });
 
-  it("shows at most five recent strength sessions on the overview (newest first)", async () => {
+  it("lists all strength-tab sessions in the local calendar week on the overview (earliest first)", async () => {
     const test = await mountTrainingOverview();
     const rowButtons = test.root.findAll(
       (n) =>
         typeof n.props?.accessibilityLabel === "string" &&
         n.props.accessibilityLabel.startsWith("Open workout details "),
     );
-    expect(rowButtons).toHaveLength(5);
+    expect(rowButtons).toHaveLength(8);
   });
 
-  it("fifth visible row still supports row tap and action menu", async () => {
+  it("fifth visible row (earliest-first order) still supports row tap and action menu", async () => {
     const test = await mountTrainingOverview();
     act(() => {
-      test.root.findByProps({ accessibilityLabel: "Open workout details w5" }).props.onPress();
+      test.root.findByProps({ accessibilityLabel: "Open workout details w4" }).props.onPress();
     });
     expect(mockPush).toHaveBeenCalledWith({
       pathname: "/(app)/workouts/day/[day]",
       params: { day: "2026-03-10" },
     });
     act(() => {
-      test.root.findByProps({ accessibilityLabel: "Workout actions w5" }).props.onPress();
+      test.root.findByProps({ accessibilityLabel: "Workout actions w4" }).props.onPress();
     });
     act(() => {
       test.root.findByProps({ accessibilityLabel: "Edit workout type" }).props.onPress();
     });
     expect(mockPush).toHaveBeenCalledWith({
       pathname: "/(app)/workouts/edit/type",
-      params: expect.objectContaining({ workoutId: "w5" }),
+      params: expect.objectContaining({ workoutId: "w4" }),
     });
   });
 
@@ -333,5 +441,159 @@ describe("overview workout actions", () => {
       pathname: "/(app)/workouts/edit/type",
       params: expect.objectContaining({ workoutId: "w1" }),
     });
+  });
+
+  it("delete workout requires confirmation and calls delete with the selected workout id", async () => {
+    const test = await mountTrainingOverview();
+    act(() => {
+      test.root.findByProps({ accessibilityLabel: "Workout actions w4" }).props.onPress();
+    });
+    act(() => {
+      test.root.findByProps({ accessibilityLabel: "Delete workout" }).props.onPress();
+    });
+    expect(mockDeleteIngestedRawEventAuthed).not.toHaveBeenCalled();
+
+    expect(test.root.findByProps({ accessibilityLabel: "Confirm delete workout" })).toBeTruthy();
+
+    await act(async () => {
+      test.root.findByProps({ accessibilityLabel: "Confirm delete workout" }).props.onPress();
+      await Promise.resolve();
+    });
+
+    expect(mockDeleteIngestedRawEventAuthed).toHaveBeenCalledWith("w4", "token");
+    expect(mockClearWorkoutOverride).toHaveBeenCalledWith("w4");
+  });
+
+  it("cancel on delete confirmation does not call delete", async () => {
+    const test = await mountTrainingOverview();
+    act(() => {
+      test.root.findByProps({ accessibilityLabel: "Workout actions w1" }).props.onPress();
+    });
+    act(() => {
+      test.root.findByProps({ accessibilityLabel: "Delete workout" }).props.onPress();
+    });
+    act(() => {
+      test.root.findByProps({ accessibilityLabel: "Cancel delete workout" }).props.onPress();
+    });
+    expect(mockDeleteIngestedRawEventAuthed).not.toHaveBeenCalled();
+  });
+
+  it("shows Delete Workout for Apple Health imports when raw-events list omitted provider (sourceId healthkit only)", async () => {
+    jest.mocked(useWorkoutsCalendarRange).mockReturnValue({
+      status: "ready",
+      durableTitlesByWorkoutId: {},
+      days: [
+        {
+          day: "2026-03-09",
+          workouts: [],
+        },
+        {
+          day: "2026-03-10",
+          workouts: [
+            {
+              id: "hk1",
+              observedAt: "2026-03-10T10:00:00.000Z",
+              sourceId: "healthkit",
+              rawKind: "strength_workout",
+              title: "Strength",
+              workoutType: "strength",
+              start: "2026-03-10T10:00:00.000Z",
+              end: null,
+              durationMinutes: 45,
+              calories: null,
+            },
+          ],
+        },
+      ],
+    } as never);
+
+    const test = await mountTrainingOverview();
+    act(() => {
+      test.root.findByProps({ accessibilityLabel: "Workout actions hk1" }).props.onPress();
+    });
+    expect(test.root.findByProps({ accessibilityLabel: "Delete workout" })).toBeTruthy();
+  });
+
+  it("shows Delete Workout for manual rows when provider field omitted (sourceId manual only)", async () => {
+    jest.mocked(useWorkoutsCalendarRange).mockReturnValue({
+      status: "ready",
+      durableTitlesByWorkoutId: {},
+      days: [
+        { day: "2026-03-09", workouts: [] },
+        {
+          day: "2026-03-10",
+          workouts: [
+            {
+              id: "md1",
+              observedAt: "2026-03-10T11:00:00.000Z",
+              sourceId: "manual",
+              rawKind: "strength_workout",
+              title: "Lift",
+              workoutType: "strength",
+              start: "2026-03-10T11:00:00.000Z",
+              end: null,
+              durationMinutes: 30,
+              calories: null,
+            },
+          ],
+        },
+      ],
+    } as never);
+
+    const test = await mountTrainingOverview();
+    act(() => {
+      test.root.findByProps({ accessibilityLabel: "Workout actions md1" }).props.onPress();
+    });
+    expect(test.root.findByProps({ accessibilityLabel: "Delete workout" })).toBeTruthy();
+  });
+
+  it("hides Delete Workout for unsupported workout providers", async () => {
+    jest.mocked(useWorkoutsCalendarRange).mockReturnValue({
+      status: "ready",
+      durableTitlesByWorkoutId: {},
+      days: [
+        {
+          day: "2026-03-09",
+          workouts: [],
+        },
+        {
+          day: "2026-03-10",
+          workouts: [
+            {
+              id: "vx1",
+              provider: "vendor_xyz",
+              observedAt: "2026-03-10T10:00:00.000Z",
+              sourceId: "vendor_xyz",
+              rawKind: "strength_workout",
+              title: "Strength",
+              workoutType: "strength",
+              start: "2026-03-10T10:00:00.000Z",
+              end: null,
+              durationMinutes: 45,
+              calories: null,
+            },
+          ],
+        },
+      ],
+    } as never);
+
+    const test = await mountTrainingOverview();
+    act(() => {
+      test.root.findByProps({ accessibilityLabel: "Workout actions vx1" }).props.onPress();
+    });
+    expect(() => test.root.findByProps({ accessibilityLabel: "Delete workout" })).toThrow();
+  });
+
+  it("delete confirmation copy describes removing from Oli (not Apple Health source deletion)", async () => {
+    const test = await mountTrainingOverview();
+    act(() => {
+      test.root.findByProps({ accessibilityLabel: "Workout actions w1" }).props.onPress();
+    });
+    act(() => {
+      test.root.findByProps({ accessibilityLabel: "Delete workout" }).props.onPress();
+    });
+    const body = test.root.findByProps({ accessibilityLabel: "Delete workout confirmation body" });
+    expect(String(body.props.children)).toContain("from Oli");
+    expect(String(body.props.children)).not.toContain("Apple Health");
   });
 });

--- a/app/(app)/workouts/__tests__/strength-analytics-detail.test.tsx
+++ b/app/(app)/workouts/__tests__/strength-analytics-detail.test.tsx
@@ -1,8 +1,9 @@
 /**
- * Strength Analytics screen shows the full analytics card stack.
+ * Strength Analytics screen shows the yearly strength workouts chart (`WORKOUT_OVERVIEW_ANALYTICS_YEAR`).
  */
 import React from "react";
 import renderer, { act } from "react-test-renderer";
+import { WORKOUT_OVERVIEW_ANALYTICS_YEAR } from "@/lib/data/workouts/workoutsCalendarModel";
 import { buildStrengthAnalyticsCardModels } from "@/lib/data/workouts/strengthAnalyticsCardModels";
 
 const mockSetParams = jest.fn();
@@ -64,24 +65,32 @@ describe("StrengthAnalyticsDetailScreen", () => {
     }
   });
 
-  it("renders weekly, muscle, monthly, and yearly sections", async () => {
+  it("renders only the yearly strength workouts section with calendar-year title", async () => {
     await act(async () => {
       mounted = renderer.create(<StrengthAnalyticsDetailScreen />);
     });
     const json = JSON.stringify(mounted!.toJSON());
-    expect(json).toContain("Weekly Strength");
-    expect(json).toContain("Weekly Muscle Group");
-    expect(json).toContain("Monthly Workouts");
-    expect(json).toContain("Yearly Workouts");
+    expect(json).toContain(`${WORKOUT_OVERVIEW_ANALYTICS_YEAR} Strength Workouts`);
+    expect(json).not.toContain("Weekly Strength");
+    expect(json).not.toContain("Weekly Muscle Group");
+    expect(json).not.toContain("Monthly Workouts");
+    expect(json).not.toContain("Yearly Workouts");
+    expect(json).not.toContain("Total Workouts");
+    expect(json).not.toContain("Avg per Month");
+    expect(json).not.toContain("Avg per Week");
+    expect(json).not.toContain("Avg Duration");
+    expect(json).toContain("strength-analytics-yearly");
+    expect(json).toContain("strength-yearly-chart-baseline-line");
   });
 
-  it("exposes section test ids for Weekly Strength and Weekly Muscle Group", async () => {
+  it("does not resurrect removed weekly/monthly analytics UI if strings regress", async () => {
     await act(async () => {
       mounted = renderer.create(<StrengthAnalyticsDetailScreen />);
     });
     const json = JSON.stringify(mounted!.toJSON());
-    expect(json).toContain("strength-analytics-weekly-strength");
-    expect(json).toContain("strength-analytics-weekly-muscle");
+    expect(json).not.toContain("strength-analytics-weekly-strength");
+    expect(json).not.toContain("strength-analytics-weekly-muscle");
+    expect(json).not.toContain("strength-analytics-monthly");
   });
 
   it("clears focus route params after models are ready and focus is present", async () => {

--- a/app/(app)/workouts/analytics-detail.tsx
+++ b/app/(app)/workouts/analytics-detail.tsx
@@ -1,5 +1,5 @@
 /**
- * Strength Analytics — weekly strength, muscle groups, monthly and yearly workout charts.
+ * Strength Analytics — yearly strength workouts chart for the overview analytics calendar year (`WORKOUT_OVERVIEW_ANALYTICS_YEAR`).
  */
 
 import React, { useCallback, useEffect, useRef, useState } from "react";
@@ -23,6 +23,18 @@ import {
 
 const EMPHASIS_CLEAR_MS = 2400;
 
+/** Weekly Insights still serialize legacy sections; map removed UI targets to the yearly card. */
+function normalizeStrengthAnalyticsSection(section: StrengthAnalyticsSectionTarget): StrengthAnalyticsSectionTarget {
+  if (
+    section === "weekly_strength" ||
+    section === "weekly_muscle_group" ||
+    section === "monthly_workouts"
+  ) {
+    return "yearly_workouts";
+  }
+  return section;
+}
+
 export default function StrengthAnalyticsDetailScreen() {
   const navigation = useNavigation();
   const router = useRouter();
@@ -41,9 +53,6 @@ export default function StrengthAnalyticsDetailScreen() {
   const lastConsumedFocusKeyRef = useRef<string | null>(null);
 
   const [emphasizedSection, setEmphasizedSection] = useState<StrengthAnalyticsSectionTarget | null>(null);
-  const [muscleGroupInitialTab, setMuscleGroupInitialTab] = useState<"volume" | "sets" | undefined>(
-    undefined,
-  );
 
   const tryScrollToSection = useCallback((section: StrengthAnalyticsSectionTarget) => {
     const y = sectionYRef.current[section];
@@ -73,7 +82,16 @@ export default function StrengthAnalyticsDetailScreen() {
     navigation.setOptions({
       ...workoutsStackNavigationOptions("detail"),
       headerLeft: () => <HeaderBackButton onPress={() => navigation.goBack()} />,
-      title: "Strength Analytics",
+      title: "",
+      headerTitle: "",
+      headerStyle: {
+        backgroundColor: WORKOUTS_SCREEN_CONTENT_BG,
+        borderBottomWidth: 0,
+        elevation: 0,
+        shadowOpacity: 0,
+        shadowOffset: { width: 0, height: 0 },
+      },
+      headerShadowVisible: false,
     });
   }, [navigation]);
 
@@ -100,16 +118,11 @@ export default function StrengthAnalyticsDetailScreen() {
     if (lastConsumedFocusKeyRef.current === focusKey) return;
     lastConsumedFocusKeyRef.current = focusKey;
 
-    pendingScrollSectionRef.current = dest.section;
-    setEmphasizedSection(dest.section);
-    if (dest.section === "weekly_muscle_group") {
-      if (dest.emphasis === "sets") setMuscleGroupInitialTab("sets");
-      else setMuscleGroupInitialTab("volume");
-    } else {
-      setMuscleGroupInitialTab(undefined);
-    }
+    const canonicalSection = normalizeStrengthAnalyticsSection(dest.section);
+    pendingScrollSectionRef.current = canonicalSection;
+    setEmphasizedSection(canonicalSection);
 
-    tryScrollToSection(dest.section);
+    tryScrollToSection(canonicalSection);
     router.setParams(clearedStrengthAnalyticsFocusParams());
 
     const t = setTimeout(() => setEmphasizedSection(null), EMPHASIS_CLEAR_MS);
@@ -159,7 +172,6 @@ export default function StrengthAnalyticsDetailScreen() {
         models={models}
         emphasizedSection={emphasizedSection}
         onAnalyticsSectionLayout={onAnalyticsSectionLayout}
-        {...(muscleGroupInitialTab != null ? { muscleGroupInitialTab } : {})}
       />
     </ScrollView>
   );

--- a/app/(app)/workouts/overview.tsx
+++ b/app/(app)/workouts/overview.tsx
@@ -17,6 +17,8 @@ import {
   NativeModules,
   AppState,
   InteractionManager,
+  Modal,
+  Alert,
 } from "react-native";
 import { useNavigation, useRouter } from "expo-router";
 import { useFocusEffect } from "@react-navigation/native";
@@ -49,6 +51,7 @@ import {
 import {
   buildWorkoutOverviewAnalyticsFromCalendarDays,
   getRecentWorkoutSessionsFromCalendarDays,
+  getStrengthOverviewTabSessionsForCalendarDaysAscending,
   WORKOUT_OVERVIEW_RECENT_SESSION_CAP,
   WORKOUT_OVERVIEW_ANALYTICS_RANGE_END,
   WORKOUT_OVERVIEW_ANALYTICS_RANGE_START,
@@ -87,7 +90,7 @@ import {
   setAppleHealthWorkoutRangeBootstrapBuild,
   clearAppleHealthWorkoutRangeBootstrapBuild,
 } from "@/lib/integrations/appleHealth/storage";
-import { ingestRawEvent } from "@/lib/api/ingest";
+import { deleteIngestedRawEventAuthed, ingestRawEvent } from "@/lib/api/ingest";
 import { scheduleAppleHealthStepsRepair } from "@/lib/data/activity/appleHealthStepsRepairCoordinator";
 import { shouldRun, nowIso } from "@/lib/sync/throttle";
 import {
@@ -102,29 +105,28 @@ import {
   pickWorkoutForSessionActions,
   pickWorkoutOverrideForSession,
 } from "@/lib/data/workouts/workoutSessionSurface";
-import { useWorkoutOverrides } from "@/lib/data/workouts/workoutOverrides";
+import { clearWorkoutOverride, useWorkoutOverrides } from "@/lib/data/workouts/workoutOverrides";
 import { WorkoutActionSheet } from "@/lib/ui/WorkoutActionSheet";
 import type { WorkoutActionAnchor } from "@/lib/ui/WorkoutActionSheet";
 import type { ReconciledWorkoutSession } from "@/lib/data/workouts/workoutSessionReconciliation";
+import { resolveWorkoutIngestProvider, type WorkoutHistoryItem } from "@/lib/data/workouts/parseWorkoutFromRawEvent";
 import {
   listManualWorkoutDaySummaries,
   type ManualWorkoutDaySummary,
 } from "@/lib/workouts/journal/manualWorkoutSummary";
-import {
-  listCustomExercises,
-  type CustomExerciseRecord,
-} from "@/lib/workouts/exercises/customExerciseStore";
-import { buildWeeklyStrengthCardModel } from "@/lib/data/workouts/weeklyStrengthCardModel";
-import { buildWeeklyInsightsCardModel } from "@/lib/data/workouts/weeklyInsightsCardModel";
 import { WorkoutAnalyticsChart } from "@/lib/ui/workouts/WorkoutAnalyticsChart";
 import { workoutOverviewInCardHeaderStyles } from "@/lib/ui/workouts/workoutOverviewInCardHeaderStyles";
 import { WorkoutsOverviewBottomNav } from "@/lib/ui/workouts/WorkoutsOverviewBottomNav";
-import { buildStrengthOverviewCardModel } from "@/lib/data/workouts/strengthOverviewCardModel";
-import { StrengthOverviewCard } from "@/lib/ui/workouts/StrengthOverviewCard";
-import { WeeklyInsightsCard } from "@/lib/ui/workouts/WeeklyInsightsCard";
+import { buildStrengthBaselineCardModel } from "@/lib/data/workouts/strengthBaselineCardModel";
+import {
+  buildStrengthLastWeekCardModel,
+  buildStrengthThisWeekCardModel,
+  formatStrengthLastWeekSessionsMicroCaption,
+  formatStrengthThisWeekSessionsMicroCaption,
+} from "@/lib/data/workouts/strengthThisWeekCardModel";
+import { StrengthBaselineCard } from "@/lib/ui/workouts/StrengthBaselineCard";
+import { StrengthFrequencyMetricCard } from "@/lib/ui/workouts/StrengthFrequencyMetricCard";
 import { elevatedCardSurfaceStyle } from "@/lib/ui/theme/elevatedCardSurface";
-import { serializeStrengthAnalyticsFocusParams } from "@/lib/workouts/navigation/strengthAnalyticsNavigationIntent";
-
 type ConnectionStatus = "loading" | "not_available" | "not_connected" | "connected";
 
 type MaybeIsAvailable = { isAvailable?: unknown };
@@ -142,9 +144,6 @@ const WORKOUT_DEEP_BACKFILL_VERSION = "v13m";
 const WORKOUT_DEEP_BACKFILL_IN_PROGRESS = "v13m:in_progress";
 const CARD_BG = "#FFFFFF";
 const RADIUS = 12;
-
-/** Strength overview “Recent Workouts” list: max visible rows (newest-first; source list still uses WORKOUT_OVERVIEW_RECENT_SESSION_CAP). */
-const STRENGTH_OVERVIEW_RECENT_DISPLAY_COUNT = 5;
 
 const WEEKDAY_SHORT = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
@@ -175,6 +174,16 @@ function formatWorkoutDayLabel(dayKey: string): string {
   const month = d.getUTCMonth() + 1;
   const day = d.getUTCDate();
   return `${wd} ${month}/${day}`;
+}
+
+/** Matches DELETE /ingest allowlist via {@link resolveWorkoutIngestProvider} (handles list hydrate rows that omit raw `provider`). */
+function strengthWorkoutEligibleForDeleteFromOli(workout: WorkoutHistoryItem | null | undefined): boolean {
+  if (!workout) return false;
+  const p = resolveWorkoutIngestProvider(workout);
+  if (p !== "manual" && p !== "apple_health") return false;
+  const k = workout.rawKind;
+  if (k === undefined) return true;
+  return k === "strength_workout" || k === "workout";
 }
 
 function countJournalSetsForDisplay(summary: ManualWorkoutDaySummary | null): number {
@@ -238,10 +247,9 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
     session: ReconciledWorkoutSession;
   } | null>(null);
   const [workoutMenuAnchor, setWorkoutMenuAnchor] = useState<WorkoutActionAnchor | null>(null);
+  const [pendingDeleteWorkoutId, setPendingDeleteWorkoutId] = useState<string | null>(null);
+  const [deleteWorkoutSubmitting, setDeleteWorkoutSubmitting] = useState(false);
   const [manualWorkoutSummaries, setManualWorkoutSummaries] = useState<ManualWorkoutDaySummary[]>([]);
-  const [customExerciseById, setCustomExerciseById] = useState<ReadonlyMap<string, CustomExerciseRecord>>(
-    () => new Map(),
-  );
   const today = getTodayDayKeyLocal();
   const anchorDay = today;
   const [workoutsCalendarRefreshEpoch, setWorkoutsCalendarRefreshEpoch] = useState(0);
@@ -298,6 +306,10 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
   const weekDaysSlice = useMemo(
     () => filterWorkoutCalendarDaysInclusive(domainSharedDays, weekStart, weekEnd),
     [domainSharedDays, weekStart, weekEnd],
+  );
+  const lastWeekDaysSlice = useMemo(
+    () => filterWorkoutCalendarDaysInclusive(domainSharedDays, prevWeekStart, prevWeekEnd),
+    [domainSharedDays, prevWeekStart, prevWeekEnd],
   );
   const recentDaysSlice = useMemo(
     () => filterWorkoutCalendarDaysInclusive(domainSharedDays, recentRangeStart, recentRangeEnd),
@@ -425,10 +437,20 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
     return getRecentWorkoutSessionsFromCalendarDays(recentDaysSlice, WORKOUT_OVERVIEW_RECENT_SESSION_CAP);
   }, [overviewSharedRange.status, recentDaysSlice]);
 
-  const recentSessionsShownOnOverview = useMemo(() => {
-    if (domain !== "strength") return recentWorkouts;
-    return recentWorkouts.slice(0, STRENGTH_OVERVIEW_RECENT_DISPLAY_COUNT);
+  const recentSessionsShownOnOverview = useMemo((): typeof recentWorkouts => {
+    if (domain === "strength") return [];
+    return recentWorkouts;
   }, [domain, recentWorkouts]);
+
+  const strengthWeekSessionsAscending = useMemo(() => {
+    if (overviewSharedRange.status !== "ready" || domain !== "strength") return [];
+    return getStrengthOverviewTabSessionsForCalendarDaysAscending(weekDaysSlice);
+  }, [overviewSharedRange.status, domain, weekDaysSlice]);
+
+  const strengthLastWeekSessionsAscending = useMemo(() => {
+    if (overviewSharedRange.status !== "ready" || domain !== "strength") return [];
+    return getStrengthOverviewTabSessionsForCalendarDaysAscending(lastWeekDaysSlice);
+  }, [overviewSharedRange.status, domain, lastWeekDaysSlice]);
 
   const weekWorkoutIds = useMemo(
     () =>
@@ -438,17 +460,29 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
     [weekDaysSlice],
   );
 
+  const lastWeekWorkoutIds = useMemo(
+    () =>
+      lastWeekDaysSlice.flatMap((d) =>
+        reconcileWorkoutSessionsForDay(d.day, d.workouts).flatMap((s) => s.workouts.map((w) => w.id)),
+      ),
+    [lastWeekDaysSlice],
+  );
+
   const recentWorkoutIds = useMemo(
-    () => recentSessionsShownOnOverview.flatMap((entry) => entry.session.workouts.map((w) => w.id)),
-    [recentSessionsShownOnOverview],
+    () =>
+      domain === "strength"
+        ? strengthWeekSessionsAscending.flatMap((entry) => entry.session.workouts.map((w) => w.id))
+        : recentSessionsShownOnOverview.flatMap((entry) => entry.session.workouts.map((w) => w.id)),
+    [domain, strengthWeekSessionsAscending, recentSessionsShownOnOverview],
   );
 
   const workoutIdsForOverrides = useMemo(() => {
     const uniq = new Set<string>();
     for (const id of recentWorkoutIds) uniq.add(id);
     for (const id of weekWorkoutIds) uniq.add(id);
+    for (const id of lastWeekWorkoutIds) uniq.add(id);
     return [...uniq];
-  }, [recentWorkoutIds, weekWorkoutIds]);
+  }, [recentWorkoutIds, weekWorkoutIds, lastWeekWorkoutIds]);
 
   const { overridesByWorkoutId, reload } = useWorkoutOverrides(workoutIdsForOverrides);
 
@@ -469,50 +503,39 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
     };
   }, [overviewSharedRange.status, analyticsDaysSlice, today]);
 
-  const weeklyInsightsCardModel = useMemo(() => {
-    if (domain !== "strength") return null;
-    const analyticsCtx = { customExerciseById };
-    const currentWeek = buildWeeklyStrengthCardModel(manualWorkoutSummaries, {
-      weekStartDay: weekStart,
-      weekEndDay: weekEnd,
-      weekKey: `${weekStart}..${weekEnd}`,
-      sessionDisplayHints: [],
-      analyticsContext: analyticsCtx,
-    });
-    const previousWeek = buildWeeklyStrengthCardModel(manualWorkoutSummaries, {
-      weekStartDay: prevWeekStart,
-      weekEndDay: prevWeekEnd,
-      weekKey: `${prevWeekStart}..${prevWeekEnd}`,
-      sessionDisplayHints: [],
-      analyticsContext: analyticsCtx,
-    });
-    return buildWeeklyInsightsCardModel(currentWeek, previousWeek);
-  }, [domain, manualWorkoutSummaries, weekStart, weekEnd, prevWeekStart, prevWeekEnd, customExerciseById]);
-
   const overviewAnalytics =
     domain === "strength" ? workoutOverviewAnalyticsBundle.strength : workoutOverviewAnalyticsBundle.cardio;
 
-  const strengthOverviewModel = useMemo(() => {
+  const strengthBaselineModel = useMemo(() => {
     if (domain !== "strength") return null;
     if (overviewSharedRange.status !== "ready") return null;
-    return buildStrengthOverviewCardModel({
+    return buildStrengthBaselineCardModel({
       strengthCalendarDays: domainSharedDays,
-      analyticsDaysSlice,
+      todayDayKey: today,
+    });
+  }, [domain, overviewSharedRange.status, domainSharedDays, today]);
+
+  const strengthThisWeekModel = useMemo(() => {
+    if (domain !== "strength") return null;
+    if (overviewSharedRange.status !== "ready") return null;
+    return buildStrengthThisWeekCardModel({
+      strengthCalendarDays: domainSharedDays,
       todayDayKey: today,
       weekStartDay: weekStart,
       weekEndDay: weekEnd,
-      manualWorkoutSummaries,
     });
-  }, [
-    domain,
-    overviewSharedRange.status,
-    domainSharedDays,
-    analyticsDaysSlice,
-    today,
-    weekStart,
-    weekEnd,
-    manualWorkoutSummaries,
-  ]);
+  }, [domain, overviewSharedRange.status, domainSharedDays, today, weekStart, weekEnd]);
+
+  const strengthLastWeekModel = useMemo(() => {
+    if (domain !== "strength") return null;
+    if (overviewSharedRange.status !== "ready") return null;
+    return buildStrengthLastWeekCardModel({
+      strengthCalendarDays: domainSharedDays,
+      todayDayKey: today,
+      lastWeekStartDay: prevWeekStart,
+      lastWeekEndDay: prevWeekEnd,
+    });
+  }, [domain, overviewSharedRange.status, domainSharedDays, today, prevWeekStart, prevWeekEnd]);
 
   useEffect(() => {
     if (!__DEV__ || process.env.JEST_WORKER_ID) return;
@@ -563,29 +586,24 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
     if (process.env.JEST_WORKER_ID) return;
     if (domain !== "strength") {
       setManualWorkoutSummaries([]);
-      setCustomExerciseById(new Map());
       return;
     }
     if (overviewSharedRange.status !== "ready") return;
     if (!user?.uid) {
       setManualWorkoutSummaries([]);
-      setCustomExerciseById(new Map());
       return;
     }
     const task = runAfterInteractionsSafe(() => {
-      void Promise.all([listManualWorkoutDaySummaries(user.uid), listCustomExercises(user.uid)]).then(
-        ([rows, customRows]) => {
-          if (cancelled) return;
-          setManualWorkoutSummaries(rows);
-          setCustomExerciseById(new Map(customRows.map((r) => [r.exerciseId, r])));
-        },
-      );
+      void listManualWorkoutDaySummaries(user.uid).then((rows) => {
+        if (cancelled) return;
+        setManualWorkoutSummaries(rows);
+      });
     });
     return () => {
       cancelled = true;
       task.cancel();
     };
-  }, [domain, overviewSharedRange.status, user?.uid]);
+  }, [domain, overviewSharedRange.status, user?.uid, workoutsCalendarRefreshEpoch]);
 
   useEffect(() => {
     navigation.setOptions({
@@ -832,6 +850,50 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
     setWorkoutMenuAnchor(null);
   }, []);
 
+  const beginDeleteStrengthWorkoutFromMenu = useCallback(() => {
+    if (!selectedWorkoutForMenu || domain !== "strength") return;
+    const workout = pickWorkoutForSessionActions(selectedWorkoutForMenu.session);
+    if (!strengthWorkoutEligibleForDeleteFromOli(workout)) return;
+    closeWorkoutMenu();
+    setPendingDeleteWorkoutId(workout!.id);
+  }, [selectedWorkoutForMenu, domain, closeWorkoutMenu]);
+
+  const confirmDeleteStrengthWorkout = useCallback(async () => {
+    if (!pendingDeleteWorkoutId) return;
+    const id = pendingDeleteWorkoutId;
+    const token = await getIdToken(false);
+    if (!token) {
+      setPendingDeleteWorkoutId(null);
+      Alert.alert("Couldn't delete workout", "Sign in again and try once more.");
+      return;
+    }
+    setDeleteWorkoutSubmitting(true);
+    const res = await deleteIngestedRawEventAuthed(id, token);
+    setDeleteWorkoutSubmitting(false);
+
+    if (res.ok) {
+      await clearWorkoutOverride(id);
+      await reload();
+      setPendingDeleteWorkoutId(null);
+      setWorkoutsCalendarRefreshEpoch((n) => n + 1);
+      return;
+    }
+
+    setPendingDeleteWorkoutId(null);
+
+    let message = "Something went wrong. Your workouts were not changed.";
+    if (res.status === 403) {
+      message = "This workout can't be removed from Oli.";
+    } else if (res.status === 404) {
+      message = "That workout is no longer available.";
+    } else if (res.kind === "http" && typeof res.error === "string" && res.error.trim().length > 0) {
+      const short = res.error.trim();
+      if (short.length <= 140) message = short;
+    }
+
+    Alert.alert("Couldn't delete workout", message);
+  }, [pendingDeleteWorkoutId, getIdToken, reload]);
+
   const openEditRoute = useCallback(
     (mode: "rename" | "duration" | "type") => {
       if (!selectedWorkoutForMenu) return;
@@ -884,12 +946,266 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
     ],
   );
 
-  const recentCard = (
+  const strengthRecentWeekCombinedCard =
+    domain === "strength" ? (
+      <View style={styles.strengthRecentCombinedCard}>
+        <StrengthFrequencyMetricCard
+          variant="embedded"
+          headingTitle="This Week"
+          loading={overviewSharedRange.status !== "ready"}
+          model={
+            strengthThisWeekModel != null
+              ? {
+                  compactValuePrimary: strengthThisWeekModel.compactValuePrimary,
+                  ratingLabel: strengthThisWeekModel.ratingLabel,
+                  activityTierIndexForBar: strengthThisWeekModel.activityTierIndexForBar,
+                  fillWidth01Override: strengthThisWeekModel.fillWidth01Override,
+                }
+              : null
+          }
+          footerCaption=""
+          showFrequencyTrack={false}
+          showFrequencyMarkers={false}
+          showFooterCaption={false}
+          compactTitlePillSpacing
+          mutedMicroCaption={
+            strengthThisWeekModel != null
+              ? formatStrengthThisWeekSessionsMicroCaption(strengthThisWeekModel.totalWorkoutsThisWeek)
+              : null
+          }
+          titleRowTrailing={
+            <Pressable
+              onPress={() => router.push(`${basePath}/recent-workouts-full`)}
+              accessibilityRole="button"
+              accessibilityLabel="View all"
+              hitSlop={8}
+              style={({ pressed }) => [
+                workoutOverviewInCardHeaderStyles.linkHit,
+                pressed && workoutOverviewInCardHeaderStyles.linkPressed,
+              ]}
+              testID="strength-recent-week-combined-view-more"
+            >
+              <Text style={workoutOverviewInCardHeaderStyles.link}>View All →</Text>
+            </Pressable>
+          }
+          ratingPillTestID="strength-this-week-rating-pill"
+          frequencyBarTestID="strength-this-week-frequency-bar"
+          instrumentClusterTestID="strength-this-week-instrument-cluster"
+        />
+        <View style={styles.strengthRecentSectionDivider} />
+        {overviewSharedRange.status !== "ready" ? null : strengthWeekSessionsAscending.length === 0 ? (
+          <Text style={styles.placeholder}>No strength workouts this week yet</Text>
+        ) : (
+          strengthWeekSessionsAscending.map(({ day, session }, rowIndex) => {
+            const representative = session.workouts[0];
+            if (!representative) return null;
+            const journalSummary = pickJournalSummaryForStrengthSession(day, session, manualWorkoutSummaries);
+            const surface = buildWorkoutSessionSurfaceModel(
+              session,
+              overridesByWorkoutId,
+              "strength",
+              journalSummary,
+              durableTitlesByWorkoutId,
+            );
+            const sessionOverride = pickWorkoutOverrideForSession(session, overridesByWorkoutId);
+            const resolvedMetrics = resolveWorkoutDisplay(
+              surface.metricsWorkout,
+              sessionOverride ?? overridesByWorkoutId[surface.metricsWorkout.id] ?? null,
+            );
+            const durationLabel = formatWorkoutDurationLabel(
+              resolveWorkoutDisplayDurationMinutes({
+                overrideDurationMinutes: resolvedMetrics.displayDurationMinutes,
+                sessionDurationMinutes: null,
+                fallbackWorkoutDurationMinutes:
+                  surface.metricsWorkout.durationMinutes ?? session.durationMinutes,
+              }),
+            );
+            const metaLine = formatRecentWorkoutMetaLine("strength", durationLabel, journalSummary);
+            return (
+              <Pressable
+                key={session.id}
+                style={({ pressed }) => [
+                  styles.recentRow,
+                  rowIndex === 0 && styles.recentRowFirst,
+                  pressed && styles.recentRowPressed,
+                ]}
+                onPress={() => {
+                  router.push({
+                    pathname: "/(app)/workouts/day/[day]",
+                    params: { day },
+                  });
+                }}
+                accessibilityRole="button"
+                accessibilityLabel={`Open workout details ${surface.actionWorkout.id}`}
+              >
+                <View style={styles.recentRowTextCol}>
+                  <Text style={styles.recentDate}>{formatWorkoutDayLabel(day)}</Text>
+                  <Text style={styles.recentTitle} numberOfLines={2} ellipsizeMode="tail">
+                    {surface.displayTitle}
+                  </Text>
+                  <Text style={styles.recentMeta} numberOfLines={1} ellipsizeMode="tail">
+                    {metaLine}
+                  </Text>
+                </View>
+                <Pressable
+                  onPress={(e) => {
+                    e?.stopPropagation?.();
+                    const native = e?.nativeEvent;
+                    setWorkoutMenuAnchor({
+                      x: typeof native?.pageX === "number" ? native.pageX : 320,
+                      y: typeof native?.pageY === "number" ? native.pageY : 220,
+                      width: 24,
+                      height: 24,
+                    });
+                    setSelectedWorkoutForMenu({ day, session });
+                    setWorkoutMenuOpen(true);
+                  }}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Workout actions ${surface.actionWorkout.id}`}
+                  hitSlop={10}
+                  style={styles.rowMenuBtn}
+                >
+                  <Text style={styles.rowMenuText}>•••</Text>
+                </Pressable>
+              </Pressable>
+            );
+          })
+        )}
+      </View>
+    ) : null;
+
+  const strengthLastWeekCombinedCard =
+    domain === "strength" ? (
+      <View style={styles.strengthRecentCombinedCard}>
+        <StrengthFrequencyMetricCard
+          variant="embedded"
+          headingTitle="Last Week"
+          loading={overviewSharedRange.status !== "ready"}
+          model={
+            strengthLastWeekModel != null
+              ? {
+                  compactValuePrimary: strengthLastWeekModel.compactValuePrimary,
+                  ratingLabel: strengthLastWeekModel.ratingLabel,
+                  activityTierIndexForBar: strengthLastWeekModel.activityTierIndexForBar,
+                  fillWidth01Override: strengthLastWeekModel.fillWidth01Override,
+                }
+              : null
+          }
+          footerCaption=""
+          showFrequencyTrack={false}
+          showFrequencyMarkers={false}
+          showFooterCaption={false}
+          compactTitlePillSpacing
+          mutedMicroCaption={
+            strengthLastWeekModel != null
+              ? formatStrengthLastWeekSessionsMicroCaption(strengthLastWeekModel.totalWorkoutsThisWeek)
+              : null
+          }
+          titleRowTrailing={
+            <Pressable
+              onPress={() => router.push(`${basePath}/recent-workouts-full`)}
+              accessibilityRole="button"
+              accessibilityLabel="View all"
+              hitSlop={8}
+              style={({ pressed }) => [
+                workoutOverviewInCardHeaderStyles.linkHit,
+                pressed && workoutOverviewInCardHeaderStyles.linkPressed,
+              ]}
+              testID="strength-recent-last-week-combined-view-more"
+            >
+              <Text style={workoutOverviewInCardHeaderStyles.link}>View All →</Text>
+            </Pressable>
+          }
+          ratingPillTestID="strength-last-week-rating-pill"
+          frequencyBarTestID="strength-last-week-frequency-bar"
+          instrumentClusterTestID="strength-last-week-instrument-cluster"
+        />
+        <View style={styles.strengthRecentSectionDivider} />
+        {overviewSharedRange.status !== "ready" ? null : strengthLastWeekSessionsAscending.length === 0 ? (
+          <Text style={styles.placeholder}>No strength workouts last week yet</Text>
+        ) : (
+          strengthLastWeekSessionsAscending.map(({ day, session }, rowIndex) => {
+            const representative = session.workouts[0];
+            if (!representative) return null;
+            const journalSummary = pickJournalSummaryForStrengthSession(day, session, manualWorkoutSummaries);
+            const surface = buildWorkoutSessionSurfaceModel(
+              session,
+              overridesByWorkoutId,
+              "strength",
+              journalSummary,
+              durableTitlesByWorkoutId,
+            );
+            const sessionOverride = pickWorkoutOverrideForSession(session, overridesByWorkoutId);
+            const resolvedMetrics = resolveWorkoutDisplay(
+              surface.metricsWorkout,
+              sessionOverride ?? overridesByWorkoutId[surface.metricsWorkout.id] ?? null,
+            );
+            const durationLabel = formatWorkoutDurationLabel(
+              resolveWorkoutDisplayDurationMinutes({
+                overrideDurationMinutes: resolvedMetrics.displayDurationMinutes,
+                sessionDurationMinutes: null,
+                fallbackWorkoutDurationMinutes:
+                  surface.metricsWorkout.durationMinutes ?? session.durationMinutes,
+              }),
+            );
+            const metaLine = formatRecentWorkoutMetaLine("strength", durationLabel, journalSummary);
+            return (
+              <Pressable
+                key={`last-${session.id}`}
+                style={({ pressed }) => [
+                  styles.recentRow,
+                  rowIndex === 0 && styles.recentRowFirst,
+                  pressed && styles.recentRowPressed,
+                ]}
+                onPress={() => {
+                  router.push({
+                    pathname: "/(app)/workouts/day/[day]",
+                    params: { day },
+                  });
+                }}
+                accessibilityRole="button"
+                accessibilityLabel={`Open workout details ${surface.actionWorkout.id}`}
+              >
+                <View style={styles.recentRowTextCol}>
+                  <Text style={styles.recentDate}>{formatWorkoutDayLabel(day)}</Text>
+                  <Text style={styles.recentTitle} numberOfLines={2} ellipsizeMode="tail">
+                    {surface.displayTitle}
+                  </Text>
+                  <Text style={styles.recentMeta} numberOfLines={1} ellipsizeMode="tail">
+                    {metaLine}
+                  </Text>
+                </View>
+                <Pressable
+                  onPress={(e) => {
+                    e?.stopPropagation?.();
+                    const native = e?.nativeEvent;
+                    setWorkoutMenuAnchor({
+                      x: typeof native?.pageX === "number" ? native.pageX : 320,
+                      y: typeof native?.pageY === "number" ? native.pageY : 220,
+                      width: 24,
+                      height: 24,
+                    });
+                    setSelectedWorkoutForMenu({ day, session });
+                    setWorkoutMenuOpen(true);
+                  }}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Workout actions ${surface.actionWorkout.id}`}
+                  hitSlop={10}
+                  style={styles.rowMenuBtn}
+                >
+                  <Text style={styles.rowMenuText}>•••</Text>
+                </Pressable>
+              </Pressable>
+            );
+          })
+        )}
+      </View>
+    ) : null;
+
+  const cardioRecentCard = (
     <View style={styles.card}>
       <View style={workoutOverviewInCardHeaderStyles.row}>
-        <Text style={workoutOverviewInCardHeaderStyles.title}>
-          {domain === "strength" ? "Recent Workouts" : "Recent cardio sessions"}
-        </Text>
+        <Text style={workoutOverviewInCardHeaderStyles.title}>Recent cardio sessions</Text>
         <Pressable
           onPress={() => router.push(`${basePath}/recent-workouts-full`)}
           accessibilityRole="button"
@@ -904,17 +1220,12 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
         </Pressable>
       </View>
       {recentWorkouts.length === 0 ? (
-        <Text style={styles.placeholder}>
-          {domain === "strength" ? "No strength workouts yet" : "No cardio sessions yet"}
-        </Text>
+        <Text style={styles.placeholder}>No cardio sessions yet</Text>
       ) : (
         recentSessionsShownOnOverview.map(({ day, session }, rowIndex) => {
           const representative = session.workouts[0];
           if (!representative) return null;
-          const journalSummary =
-            domain === "strength"
-              ? pickJournalSummaryForStrengthSession(day, session, manualWorkoutSummaries)
-              : null;
+          const journalSummary = null;
           const surface = buildWorkoutSessionSurfaceModel(
             session,
             overridesByWorkoutId,
@@ -946,10 +1257,7 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
               ]}
               onPress={() => {
                 router.push({
-                  pathname:
-                    domain === "strength"
-                      ? "/(app)/workouts/day/[day]"
-                      : "/(app)/cardio/day/[day]",
+                  pathname: "/(app)/cardio/day/[day]",
                   params: { day },
                 });
               }}
@@ -996,23 +1304,20 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
     <View style={styles.pageBody}>
       {domain === "strength" ? (
         <>
-          <StrengthOverviewCard
-            loading={overviewSharedRange.status !== "ready"}
-            model={strengthOverviewModel}
-            onViewMore={() => router.push(`${basePath}/analytics-detail`)}
-          />
-          {recentCard}
-          {weeklyInsightsCardModel != null ? (
-            <WeeklyInsightsCard
-              model={weeklyInsightsCardModel}
-              onInsightPress={(insight) =>
-                router.push({
-                  pathname: "/(app)/workouts/analytics-detail",
-                  params: serializeStrengthAnalyticsFocusParams(insight.destination),
-                })
-              }
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Open strength analytics"
+            onPress={() => router.push(`${basePath}/analytics-detail`)}
+            style={({ pressed }) => [styles.strengthBaselineCardPressable, pressed && styles.strengthBaselineCardPressed]}
+            testID="strength-baseline-card-nav"
+          >
+            <StrengthBaselineCard
+              loading={overviewSharedRange.status !== "ready"}
+              model={strengthBaselineModel}
             />
-          ) : null}
+          </Pressable>
+          {strengthRecentWeekCombinedCard}
+          {strengthLastWeekCombinedCard}
         </>
       ) : (
         <>
@@ -1024,7 +1329,7 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
             chartPoints={overviewAnalytics.chartPoints}
             metrics={overviewAnalytics.metrics}
           />
-          {recentCard}
+          {cardioRecentCard}
         </>
       )}
 
@@ -1049,7 +1354,58 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
         onRename={() => openEditRoute("rename")}
         onEditDuration={() => openEditRoute("duration")}
         onEditType={() => openEditRoute("type")}
+        {...(domain === "strength" &&
+        selectedWorkoutForMenu &&
+        strengthWorkoutEligibleForDeleteFromOli(pickWorkoutForSessionActions(selectedWorkoutForMenu.session))
+          ? { onDeleteWorkout: beginDeleteStrengthWorkoutFromMenu }
+          : {})}
       />
+
+      <Modal
+        visible={pendingDeleteWorkoutId != null}
+        transparent
+        animationType="fade"
+        onRequestClose={() => {
+          if (!deleteWorkoutSubmitting) setPendingDeleteWorkoutId(null);
+        }}
+        presentationStyle="overFullScreen"
+      >
+        <Pressable
+          style={styles.deleteConfirmBackdrop}
+          onPress={() => {
+            if (!deleteWorkoutSubmitting) setPendingDeleteWorkoutId(null);
+          }}
+          accessibilityLabel="Close delete workout confirmation"
+        >
+          <Pressable style={styles.deleteConfirmCard} onPress={(e) => e.stopPropagation()}>
+            <Text style={styles.deleteConfirmTitle}>Delete workout?</Text>
+            <Text style={styles.deleteConfirmBody} accessibilityLabel="Delete workout confirmation body">
+              This will remove this workout from Oli and update your strength history.
+            </Text>
+            <View style={styles.deleteConfirmActions}>
+              <Pressable
+                onPress={() => {
+                  if (!deleteWorkoutSubmitting) setPendingDeleteWorkoutId(null);
+                }}
+                style={styles.deleteConfirmCancelBtn}
+                accessibilityRole="button"
+                accessibilityLabel="Cancel delete workout"
+              >
+                <Text style={styles.deleteConfirmCancelLabel}>Cancel</Text>
+              </Pressable>
+              <Pressable
+                onPress={() => void confirmDeleteStrengthWorkout()}
+                disabled={deleteWorkoutSubmitting}
+                style={[styles.deleteConfirmDangerBtn, deleteWorkoutSubmitting && styles.deleteConfirmDangerBtnDisabled]}
+                accessibilityRole="button"
+                accessibilityLabel="Confirm delete workout"
+              >
+                <Text style={styles.deleteConfirmDangerLabel}>Delete</Text>
+              </Pressable>
+            </View>
+          </Pressable>
+        </Pressable>
+      </Modal>
     </View>
   );
 
@@ -1108,6 +1464,13 @@ const styles = StyleSheet.create({
   overviewRoot: {
     flex: 1,
   },
+  strengthBaselineCardPressable: {
+    alignSelf: "stretch",
+    borderRadius: RADIUS,
+  },
+  strengthBaselineCardPressed: {
+    opacity: 0.88,
+  },
   pageBody: {
     backgroundColor: WORKOUTS_SCREEN_CONTENT_BG,
     marginHorizontal: -16,
@@ -1124,6 +1487,24 @@ const styles = StyleSheet.create({
     gap: 10,
     ...elevatedCardSurfaceStyle,
   },
+  /** Combined Strength “This Week” header (summary + inline View More) + in-week list — see StrengthFrequencyMetricCard `embedded`. */
+  strengthRecentCombinedCard: {
+    backgroundColor: CARD_BG,
+    borderRadius: RADIUS,
+    paddingHorizontal: 16,
+    paddingTop: 15,
+    paddingBottom: 14,
+    /** Symmetric rhythm: header block | divider | list rows (same gap summary→divider as divider→first row). */
+    gap: 7,
+    ...elevatedCardSurfaceStyle,
+  },
+  strengthRecentSectionDivider: {
+    height: StyleSheet.hairlineWidth,
+    backgroundColor: "rgba(60, 60, 67, 0.06)",
+    marginTop: 0,
+    marginBottom: 0,
+    alignSelf: "stretch",
+  },
   placeholder: { fontSize: 15, fontWeight: "400", color: "#8E8E93", letterSpacing: -0.1 },
   metricRow: { flexDirection: "row", justifyContent: "space-between", alignItems: "center" },
   metricLabel: { fontSize: 15, color: "#3C3C43" },
@@ -1131,9 +1512,9 @@ const styles = StyleSheet.create({
   recentRow: {
     flexDirection: "row",
     alignItems: "center",
-    paddingVertical: 11,
+    paddingVertical: 8,
     borderTopWidth: 1,
-    borderTopColor: "rgba(60, 60, 67, 0.055)",
+    borderTopColor: "rgba(60, 60, 67, 0.045)",
     gap: 2,
   },
   /** Most recent session: no rule above so the list reads as one block from the header. */
@@ -1146,7 +1527,7 @@ const styles = StyleSheet.create({
   recentRowTextCol: {
     flex: 1,
     minWidth: 0,
-    gap: 3,
+    gap: 4,
   },
   recentDate: {
     fontSize: 12,
@@ -1163,9 +1544,9 @@ const styles = StyleSheet.create({
   },
   recentMeta: {
     fontSize: 13,
-    fontWeight: "500",
-    color: "#6E6E73",
-    letterSpacing: -0.1,
+    fontWeight: "400",
+    color: "#8E8E93",
+    letterSpacing: -0.08,
   },
   rowMenuBtn: {
     paddingHorizontal: 6,
@@ -1198,4 +1579,42 @@ const styles = StyleSheet.create({
     fontWeight: "600",
     color: "#1C1C1E",
   },
+  deleteConfirmBackdrop: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.4)",
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 24,
+  },
+  deleteConfirmCard: {
+    backgroundColor: "#FFFFFF",
+    borderRadius: 16,
+    padding: 20,
+    width: "100%",
+    maxWidth: 320,
+  },
+  deleteConfirmTitle: { fontSize: 18, fontWeight: "800", color: "#1C1C1E", marginBottom: 8 },
+  deleteConfirmBody: { fontSize: 14, color: "#6E6E73", lineHeight: 20 },
+  deleteConfirmActions: { flexDirection: "row", gap: 12, marginTop: 16 },
+  deleteConfirmCancelBtn: {
+    flex: 1,
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderRadius: 10,
+    backgroundColor: "#F2F2F7",
+    alignItems: "center",
+  },
+  deleteConfirmCancelLabel: { fontSize: 15, fontWeight: "700", color: "#1C1C1E" },
+  deleteConfirmDangerBtn: {
+    flex: 1,
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderRadius: 10,
+    backgroundColor: "#FFF5F5",
+    borderWidth: 1,
+    borderColor: "#FFD6D6",
+    alignItems: "center",
+  },
+  deleteConfirmDangerBtnDisabled: { opacity: 0.55 },
+  deleteConfirmDangerLabel: { fontSize: 15, fontWeight: "700", color: "#FF3B30" },
 });

--- a/lib/api/http.ts
+++ b/lib/api/http.ts
@@ -40,6 +40,12 @@ export type PutOptions = {
   noStore?: boolean;
 };
 
+export type DeleteOptions = {
+  cacheBust?: string;
+  timeoutMs?: number;
+  noStore?: boolean;
+};
+
 function isJsonValue(v: unknown): v is JsonValue {
   if (v === null) return true;
   const t = typeof v;
@@ -432,4 +438,47 @@ export async function apiPutJsonAuthed<T>(
   const bodyStr = JSON.stringify(body);
 
   return apiFetchJson<T>(url, { method: "PUT", headers, body: bodyStr }, opts?.timeoutMs);
+}
+
+export async function apiDeleteJsonAuthed<T>(
+  path: string,
+  idToken: string,
+  opts?: DeleteOptions,
+): Promise<ApiResult<T>> {
+  const baseRaw = process.env.EXPO_PUBLIC_BACKEND_BASE_URL;
+  if (__DEV__ && !process.env.JEST_WORKER_ID) console.log("DEBUG_BACKEND_BASE_URL", baseRaw);
+  if (!baseRaw) {
+    return {
+      ok: false,
+      status: 0,
+      kind: "unknown",
+      error: "Missing EXPO_PUBLIC_BACKEND_BASE_URL",
+      requestId: null,
+    };
+  }
+
+  const base = normalizeBaseUrl(baseRaw);
+  let url = appendCacheBust(`${base}${path}`, opts?.cacheBust);
+
+  if (isGatewayBaseUrl(base)) {
+    const apiKey = requireGatewayApiKey();
+    if (!apiKey) {
+      return {
+        ok: false,
+        status: 0,
+        kind: "unknown",
+        error: "Missing EXPO_PUBLIC_GATEWAY_API_KEY (required for API Gateway)",
+        requestId: null,
+      };
+    }
+    url = appendQueryParam(url, "key", apiKey);
+  }
+
+  const headerOpts: HeaderOptions = {};
+  if (opts?.noStore) headerOpts.noStore = true;
+
+  const headers = buildHeaders(headerOpts);
+  headers.Authorization = `Bearer ${idToken}`;
+
+  return apiFetchJson<T>(url, { method: "DELETE", headers }, opts?.timeoutMs);
 }

--- a/lib/api/ingest.ts
+++ b/lib/api/ingest.ts
@@ -1,7 +1,12 @@
 // lib/api/ingest.ts
 import type { ApiFailure } from "./http";
-import { apiPostZodAuthed } from "./validate";
-import { ingestAcceptedResponseDtoSchema, type IngestAcceptedResponseDto } from "@oli/contracts";
+import { apiDeleteZodAuthed, apiPostZodAuthed } from "./validate";
+import {
+  deleteRawEventResponseDtoSchema,
+  ingestAcceptedResponseDtoSchema,
+  type DeleteRawEventResponseDto,
+  type IngestAcceptedResponseDto,
+} from "@oli/contracts";
 
 export type IngestAccepted = IngestAcceptedResponseDto;
 
@@ -56,6 +61,49 @@ export async function ingestRawEventAuthed(
 
   if (res.ok) {
     return { ok: true, status: 202, data: res.json, requestId: res.requestId };
+  }
+
+  return {
+    ok: false,
+    status: res.status,
+    requestId: res.requestId,
+    kind: res.kind,
+    error: res.error,
+    ...(res.json !== undefined ? { json: res.json } : {}),
+  };
+}
+
+export type DeleteIngestedRawEventOk = {
+  ok: true;
+  status: 200;
+  data: DeleteRawEventResponseDto;
+  requestId: string | null;
+};
+
+export type DeleteIngestedRawEventFail = {
+  ok: false;
+  status: number;
+  requestId: string | null;
+  kind: ApiFailure["kind"];
+  error: string;
+  json?: ApiFailure["json"];
+};
+
+/**
+ * Delete a user-ingested workout RawEvent via DELETE /ingest/:rawEventId (server allows manual provider only).
+ */
+export async function deleteIngestedRawEventAuthed(
+  rawEventId: string,
+  idToken: string,
+  opts?: { timeoutMs?: number },
+): Promise<DeleteIngestedRawEventOk | DeleteIngestedRawEventFail> {
+  const path = `/ingest/${encodeURIComponent(rawEventId)}`;
+  const res = await apiDeleteZodAuthed(path, idToken, deleteRawEventResponseDtoSchema, {
+    ...(typeof opts?.timeoutMs === "number" ? { timeoutMs: opts.timeoutMs } : {}),
+  });
+
+  if (res.ok) {
+    return { ok: true, status: 200, data: res.json, requestId: res.requestId };
   }
 
   return {

--- a/lib/api/validate.ts
+++ b/lib/api/validate.ts
@@ -9,8 +9,8 @@
  *   - failure: return ApiFailure kind="contract" (fail-closed, never cast)
  */
 import type { ApiFailure, ApiResult, JsonValue } from "@/lib/api/http";
-import { apiGetJsonAuthed, apiPostJsonAuthed, apiPutJsonAuthed } from "@/lib/api/http";
-import type { GetOptions, PostOptions, PutOptions } from "@/lib/api/http";
+import { apiDeleteJsonAuthed, apiGetJsonAuthed, apiPostJsonAuthed, apiPutJsonAuthed } from "@/lib/api/http";
+import type { DeleteOptions, GetOptions, PostOptions, PutOptions } from "@/lib/api/http";
 import type { z } from "zod";
 
 function makeContractFailure(
@@ -127,6 +127,29 @@ export async function apiPutZodAuthed<T>(
   opts?: PutOptions,
 ): Promise<ApiResult<T>> {
   const res = await apiPutJsonAuthed<unknown>(path, body, idToken, opts);
+
+  if (!res.ok) return res as ApiResult<T>;
+
+  const parsed = schema.safeParse(res.json);
+  if (!parsed.success) {
+    return makeContractFailure(res.status, res.requestId, "Invalid response shape", parsed) as ApiResult<T>;
+  }
+
+  return {
+    ok: true,
+    status: res.status,
+    requestId: res.requestId,
+    json: parsed.data,
+  };
+}
+
+export async function apiDeleteZodAuthed<T>(
+  path: string,
+  idToken: string,
+  schema: z.ZodType<T>,
+  opts?: DeleteOptions,
+): Promise<ApiResult<T>> {
+  const res = await apiDeleteJsonAuthed<unknown>(path, idToken, opts);
 
   if (!res.ok) return res as ApiResult<T>;
 

--- a/lib/contracts/rawEvent.ts
+++ b/lib/contracts/rawEvent.ts
@@ -97,6 +97,19 @@ export const ingestAcceptedResponseDtoSchema = z
 
 export type IngestAcceptedResponseDto = z.infer<typeof ingestAcceptedResponseDtoSchema>;
 
+/**
+ * DELETE /ingest/:rawEventId — successful removal of an ingested RawEvent (manual workouts only; server-enforced).
+ */
+export const deleteRawEventResponseDtoSchema = z
+  .object({
+    ok: z.literal(true),
+    rawEventId: z.string().min(1),
+    requestId: z.string().min(1),
+  })
+  .strip();
+
+export type DeleteRawEventResponseDto = z.infer<typeof deleteRawEventResponseDtoSchema>;
+
 // -----------------------------
 // Payloads
 // -----------------------------

--- a/lib/data/workouts/__tests__/parseWorkoutFromRawEvent.test.ts
+++ b/lib/data/workouts/__tests__/parseWorkoutFromRawEvent.test.ts
@@ -1,5 +1,5 @@
 import type { RawEventDoc } from "@oli/contracts";
-import { parseWorkoutHistoryItem } from "../parseWorkoutFromRawEvent";
+import { parseWorkoutHistoryItem, resolveWorkoutIngestProvider } from "../parseWorkoutFromRawEvent";
 
 function minimalRaw(overrides: Partial<{ id: string; observedAt: string; receivedAt: string; sourceId: string; payload: unknown }>): RawEventDoc {
   return {
@@ -21,8 +21,9 @@ describe("parseWorkoutHistoryItem", () => {
   it("full payload workout parses expected fields including hk", () => {
     const raw = minimalRaw({
       id: "ev-1",
+      provider: "apple_health",
       observedAt: "2024-06-01T10:00:00Z",
-      sourceId: "apple_health",
+      sourceId: "healthkit",
       payload: {
         start: "2024-06-01T10:00:00Z",
         end: "2024-06-01T11:30:00Z",
@@ -34,14 +35,30 @@ describe("parseWorkoutHistoryItem", () => {
     });
     const item = parseWorkoutHistoryItem(raw);
     expect(item.id).toBe("ev-1");
+    expect(item.provider).toBe("apple_health");
     expect(item.observedAt).toBe("2024-06-01T10:00:00Z");
-    expect(item.sourceId).toBe("apple_health");
+    expect(item.sourceId).toBe("healthkit");
     expect(item.title).toBe("Running");
     expect(item.start).toBe("2024-06-01T10:00:00Z");
     expect(item.end).toBe("2024-06-01T11:30:00Z");
     expect(item.durationMinutes).toBe(90);
     expect(item.calories).toBe(450);
     expect(item.hk).toEqual({ sourceId: "HK", activityId: 12345 });
+  });
+
+  it("infers apple_health when GET /raw-events list omitted provider but sourceId is healthkit", () => {
+    const raw = minimalRaw({
+      provider: "",
+      sourceId: "healthkit",
+      payload: {
+        start: "2024-06-01T10:00:00Z",
+        end: "2024-06-01T11:30:00Z",
+        sport: "Traditional Strength Training",
+        durationMinutes: 30,
+      },
+    }) as RawEventDoc;
+    expect(resolveWorkoutIngestProvider(raw)).toBe("apple_health");
+    expect(parseWorkoutHistoryItem(raw).provider).toBe("apple_health");
   });
 
   it("payload.name wins over sport for display title", () => {

--- a/lib/data/workouts/__tests__/strengthBaselineCardModel.test.ts
+++ b/lib/data/workouts/__tests__/strengthBaselineCardModel.test.ts
@@ -1,0 +1,77 @@
+import { buildStrengthBaselineCardModel } from "../strengthBaselineCardModel";
+
+/** Minimal calendar row matching existing Strength overview tests (resolves to strength sessions). */
+function strengthDay(day: string, id: string) {
+  return {
+    day: day as `${string}-${string}-${string}`,
+    workouts: [
+      {
+        id,
+        observedAt: `${day}T10:00:00.000Z`,
+        sourceId: "apple_health",
+        title: "Lift",
+        workoutType: "strength" as const,
+        start: `${day}T10:00:00.000Z`,
+        end: `${day}T10:30:00.000Z`,
+        durationMinutes: 30,
+        calories: null,
+      },
+    ],
+  };
+}
+
+describe("buildStrengthBaselineCardModel", () => {
+  const today = "2026-06-15" as const;
+
+  it("uses 90 completed local days ending yesterday (not today)", () => {
+    const yesterday = "2026-06-14";
+    const onlyToday = strengthDay(today, "t1");
+    const onlyYesterday = strengthDay(yesterday, "y1");
+
+    const baselineTodayOnly = buildStrengthBaselineCardModel({
+      strengthCalendarDays: [onlyToday],
+      todayDayKey: today,
+    });
+    expect(baselineTodayOnly.avgWorkoutsPerWeek).toBe(0);
+
+    const baselineYesterday = buildStrengthBaselineCardModel({
+      strengthCalendarDays: [onlyYesterday],
+      todayDayKey: today,
+    });
+    expect(baselineYesterday.avgWorkoutsPerWeek).toBeCloseTo(7 / 90, 10);
+
+    const regressionMerged = buildStrengthBaselineCardModel({
+      strengthCalendarDays: [onlyYesterday, onlyToday],
+      todayDayKey: today,
+    });
+    expect(regressionMerged.avgWorkoutsPerWeek).toBeCloseTo(7 / 90, 10);
+  });
+
+  it("regresses if today’s strength sessions affected the numerator: extra workouts on today do not move baseline", () => {
+    const yesterday = "2026-06-14";
+    const yesterdaySession = strengthDay(yesterday, "y1");
+    const oneTodayWorkout = strengthDay(today, "t1");
+    const twoTodayWorkouts = {
+      ...oneTodayWorkout,
+      workouts: [
+        oneTodayWorkout.workouts[0]!,
+        {
+          ...oneTodayWorkout.workouts[0]!,
+          id: "t2",
+        },
+      ],
+    };
+
+    const oneToday = buildStrengthBaselineCardModel({
+      strengthCalendarDays: [yesterdaySession, oneTodayWorkout],
+      todayDayKey: today,
+    });
+    const twoToday = buildStrengthBaselineCardModel({
+      strengthCalendarDays: [yesterdaySession, twoTodayWorkouts],
+      todayDayKey: today,
+    });
+
+    expect(oneToday.avgWorkoutsPerWeek).toBe(twoToday.avgWorkoutsPerWeek);
+    expect(oneToday.avgWorkoutsPerWeek).toBeCloseTo(7 / 90, 10);
+  });
+});

--- a/lib/data/workouts/__tests__/strengthOverviewCardModel.test.ts
+++ b/lib/data/workouts/__tests__/strengthOverviewCardModel.test.ts
@@ -2,6 +2,7 @@ import { addCalendarDaysToDayKey } from "@/lib/ui/calendar/dateUtils";
 import { reconcileWorkoutSessionsForDay } from "@/lib/data/workouts/workoutSessionReconciliation";
 import {
   buildStrengthOverviewCardModel,
+  computeStrengthThisWeekWindowMetrics,
   formatStrengthOverviewCompactStatsLine,
   STRENGTH_OVERVIEW_THREE_MONTH_ROLLING_DAYS,
 } from "../strengthOverviewCardModel";
@@ -187,6 +188,38 @@ describe("buildStrengthOverviewCardModel", () => {
     }
   });
 
+  it("computeStrengthThisWeekWindowMetrics matches Overview This Week row (single source of truth)", () => {
+    const days = [
+      {
+        day: weekStart,
+        workouts: [
+          {
+            id: "w",
+            observedAt: "2026-03-30T10:00:00.000Z",
+            sourceId: "apple_health",
+            title: "Lift",
+            workoutType: "strength" as const,
+            start: "2026-03-30T10:00:00.000Z",
+            end: "2026-03-30T10:30:00.000Z",
+            durationMinutes: 30,
+            calories: null,
+          },
+        ],
+      },
+    ];
+    const input = baseInput({ strengthCalendarDays: days, analyticsDaysSlice: days });
+    const m = buildStrengthOverviewCardModel(input);
+    const w = m.timeframes.find((t) => t.key === "thisWeek")!;
+    const c = computeStrengthThisWeekWindowMetrics({
+      strengthCalendarDays: input.strengthCalendarDays,
+      todayDayKey: input.todayDayKey,
+      weekStartDay: input.weekStartDay,
+      weekEndDay: input.weekEndDay,
+    });
+    expect(c.totalWorkouts).toBe(w.totalWorkouts);
+    expect(c.avgWorkoutsPerWeek).toBe(w.avgWorkoutsPerWeek);
+  });
+
   it("This Week counts only strength sessions in the calendar week slice", () => {
     const days = [
       {
@@ -226,6 +259,35 @@ describe("buildStrengthOverviewCardModel", () => {
 
   it("documents 3-month rolling span constant", () => {
     expect(STRENGTH_OVERVIEW_THREE_MONTH_ROLLING_DAYS).toBe(90);
+  });
+
+  it("regresses if today were excluded from the weekly slice: strength session only on today still counts", () => {
+    const days = [
+      {
+        day: today,
+        workouts: [
+          {
+            id: "today-only",
+            observedAt: "2026-04-04T10:00:00.000Z",
+            sourceId: "apple_health",
+            title: "Lift",
+            workoutType: "strength" as const,
+            start: "2026-04-04T10:00:00.000Z",
+            end: "2026-04-04T10:30:00.000Z",
+            durationMinutes: 30,
+            calories: null,
+          },
+        ],
+      },
+    ];
+    const input = baseInput({ strengthCalendarDays: days, analyticsDaysSlice: days });
+    const c = computeStrengthThisWeekWindowMetrics({
+      strengthCalendarDays: input.strengthCalendarDays,
+      todayDayKey: input.todayDayKey,
+      weekStartDay: input.weekStartDay,
+      weekEndDay: input.weekEndDay,
+    });
+    expect(c.totalWorkouts).toBe(1);
   });
 });
 

--- a/lib/data/workouts/__tests__/strengthThisWeekCardModel.test.ts
+++ b/lib/data/workouts/__tests__/strengthThisWeekCardModel.test.ts
@@ -1,0 +1,188 @@
+import {
+  STRENGTH_THIS_WEEK_FOOTER_NO_TODAY,
+  STRENGTH_THIS_WEEK_FOOTER_WITH_TODAY,
+  buildStrengthLastWeekCardModel,
+  buildStrengthThisWeekCardModel,
+  formatStrengthLastWeekSessionsMicroCaption,
+  formatStrengthThisWeekSessionsMicroCaption,
+  formatStrengthThisWeekWorkoutCountLine,
+} from "../strengthThisWeekCardModel";
+import { strengthWeeklyFrequencyRatingLabelFromBucket } from "@/lib/utils/strengthWeeklyFrequencyRating";
+
+describe("formatStrengthThisWeekWorkoutCountLine", () => {
+  it("uses singular for 1 and plural otherwise", () => {
+    expect(formatStrengthThisWeekWorkoutCountLine(0)).toBe("0 workouts");
+    expect(formatStrengthThisWeekWorkoutCountLine(1)).toBe("1 workout");
+    expect(formatStrengthThisWeekWorkoutCountLine(2)).toBe("2 workouts");
+    expect(formatStrengthThisWeekWorkoutCountLine(11)).toBe("11 workouts");
+  });
+});
+
+describe("formatStrengthThisWeekSessionsMicroCaption", () => {
+  it("matches session totals with conversational copy", () => {
+    expect(formatStrengthThisWeekSessionsMicroCaption(0)).toBe("0 sessions this week");
+    expect(formatStrengthThisWeekSessionsMicroCaption(1)).toBe("1 session this week");
+    expect(formatStrengthThisWeekSessionsMicroCaption(2)).toBe("2 sessions this week");
+  });
+});
+
+describe("formatStrengthLastWeekSessionsMicroCaption", () => {
+  it("matches session totals with last-week copy", () => {
+    expect(formatStrengthLastWeekSessionsMicroCaption(0)).toBe("0 sessions last week");
+    expect(formatStrengthLastWeekSessionsMicroCaption(1)).toBe("1 session last week");
+    expect(formatStrengthLastWeekSessionsMicroCaption(2)).toBe("2 sessions last week");
+  });
+});
+
+describe("buildStrengthLastWeekCardModel", () => {
+  const today = "2026-03-12" as const;
+  /** Prior Sun–Sat when current week anchor is `2026-03-09` … `2026-03-15`. */
+  const lastWeekStart = "2026-03-02" as const;
+  const lastWeekEnd = "2026-03-08" as const;
+
+  function strengthWorkout(id: string, day: string) {
+    return {
+      day: day as `${string}-${string}-${string}`,
+      workouts: [
+        {
+          id,
+          observedAt: `${day}T10:00:00.000Z`,
+          sourceId: "apple_health",
+          title: "Lift",
+          workoutType: "strength" as const,
+          start: `${day}T10:00:00.000Z`,
+          end: `${day}T10:30:00.000Z`,
+          durationMinutes: 30,
+          calories: null,
+        },
+      ],
+    };
+  }
+
+  it("counts only strength-tab sessions in the prior calendar week window", () => {
+    const days = [
+      strengthWorkout("p1", lastWeekStart),
+      strengthWorkout("p2", "2026-03-05"),
+      strengthWorkout("cur", "2026-03-12"),
+    ];
+    const m = buildStrengthLastWeekCardModel({
+      strengthCalendarDays: days,
+      todayDayKey: today,
+      lastWeekStartDay: lastWeekStart,
+      lastWeekEndDay: lastWeekEnd,
+    });
+    expect(m.totalWorkoutsThisWeek).toBe(2);
+    expect(m.compactValuePrimary).toBe("2 workouts");
+  });
+
+  it("matches This Week ladder for weekly session totals", () => {
+    const days = [
+      strengthWorkout("a", lastWeekStart),
+      strengthWorkout("b", "2026-03-04"),
+      strengthWorkout("c", "2026-03-06"),
+    ];
+    const m = buildStrengthLastWeekCardModel({
+      strengthCalendarDays: days,
+      todayDayKey: today,
+      lastWeekStartDay: lastWeekStart,
+      lastWeekEndDay: lastWeekEnd,
+    });
+    expect(m.totalWorkoutsThisWeek).toBe(3);
+    expect(m.ratingLabel).toBe(strengthWeeklyFrequencyRatingLabelFromBucket(3));
+  });
+});
+
+describe("buildStrengthThisWeekCardModel", () => {
+  const today = "2026-04-04" as const;
+  const weekStart = "2026-03-30" as const;
+  const weekEnd = "2026-04-05" as const;
+
+  function strengthWorkout(id: string, day: string) {
+    return {
+      day: day as `${string}-${string}-${string}`,
+      workouts: [
+        {
+          id,
+          observedAt: `${day}T10:00:00.000Z`,
+          sourceId: "apple_health",
+          title: "Lift",
+          workoutType: "strength" as const,
+          start: `${day}T10:00:00.000Z`,
+          end: `${day}T10:30:00.000Z`,
+          durationMinutes: 30,
+          calories: null,
+        },
+      ],
+    };
+  }
+
+  it("shows total workouts for the week, not average/week format", () => {
+    const days = [strengthWorkout("a", weekStart)];
+    const m = buildStrengthThisWeekCardModel({
+      strengthCalendarDays: days,
+      todayDayKey: today,
+      weekStartDay: weekStart,
+      weekEndDay: weekEnd,
+    });
+    expect(m.compactValuePrimary).toBe("1 workout");
+    expect(m.totalWorkoutsThisWeek).toBe(1);
+    expect(m.compactValuePrimary).not.toMatch(/\/wk$/);
+    expect(m.compactValuePrimary).not.toContain(".");
+  });
+
+  it("regresses if average/week formatting returned: model must not contain /wk", () => {
+    const days = [
+      strengthWorkout("a", weekStart),
+      strengthWorkout("b", "2026-04-01"),
+    ];
+    const m = buildStrengthThisWeekCardModel({
+      strengthCalendarDays: days,
+      todayDayKey: today,
+      weekStartDay: weekStart,
+      weekEndDay: weekEnd,
+    });
+    expect(JSON.stringify(m)).not.toContain("/wk");
+    expect(m.compactValuePrimary).toBe("2 workouts");
+  });
+
+  it("maps weekly total to frequency pill and bar fill on 0–7 scale", () => {
+    const days = [
+      strengthWorkout("id0", weekStart),
+      strengthWorkout("id1", "2026-04-01"),
+      strengthWorkout("id2", "2026-04-02"),
+    ];
+    const m = buildStrengthThisWeekCardModel({
+      strengthCalendarDays: days,
+      todayDayKey: today,
+      weekStartDay: weekStart,
+      weekEndDay: weekEnd,
+    });
+    expect(m.totalWorkoutsThisWeek).toBe(3);
+    expect(m.ratingLabel).toBe(strengthWeeklyFrequencyRatingLabelFromBucket(3));
+    expect(m.fillWidth01Override).toBeCloseTo(3 / 7, 10);
+  });
+
+  it("includes today’s strength session in total when present in hydrate", () => {
+    const days = [strengthWorkout("t", today)];
+    const m = buildStrengthThisWeekCardModel({
+      strengthCalendarDays: days,
+      todayDayKey: today,
+      weekStartDay: weekStart,
+      weekEndDay: weekEnd,
+    });
+    expect(m.totalWorkoutsThisWeek).toBe(1);
+    expect(m.compactValuePrimary).toBe("1 workout");
+    expect(m.footerSupportCaption).toBe(STRENGTH_THIS_WEEK_FOOTER_WITH_TODAY);
+  });
+
+  it("footer when no workout on today", () => {
+    const days = [strengthWorkout("a", weekStart)];
+    const m = buildStrengthThisWeekCardModel({
+      strengthCalendarDays: days,
+      todayDayKey: today,
+      weekStartDay: weekStart,
+      weekEndDay: weekEnd,
+    });
+    expect(m.footerSupportCaption).toBe(STRENGTH_THIS_WEEK_FOOTER_NO_TODAY);
+  });
+});

--- a/lib/data/workouts/__tests__/strengthYearlyChartBaseline.test.ts
+++ b/lib/data/workouts/__tests__/strengthYearlyChartBaseline.test.ts
@@ -1,0 +1,50 @@
+import { averageExpectedMonthlyWorkloadFromWeeklyBaseline } from "@/lib/data/workouts/strengthYearlyChartBaseline";
+
+describe("averageExpectedMonthlyWorkloadFromWeeklyBaseline", () => {
+  it("returns 0 for non-finite or negative weekly rates", () => {
+    expect(averageExpectedMonthlyWorkloadFromWeeklyBaseline(Number.NaN, 2026)).toBe(0);
+    expect(averageExpectedMonthlyWorkloadFromWeeklyBaseline(-1, 2026)).toBe(0);
+  });
+
+  it("equates weekly rate to calendar-month totals via avg(d_i/7 × w); 2026 non-leap February shortens yearly average", () => {
+    const w = 7;
+    const expected2026 =
+      [
+        w * (31 / 7),
+        w * (28 / 7),
+        w * (31 / 7),
+        w * (30 / 7),
+        w * (31 / 7),
+        w * (30 / 7),
+        w * (31 / 7),
+        w * (31 / 7),
+        w * (30 / 7),
+        w * (31 / 7),
+        w * (30 / 7),
+        w * (31 / 7),
+      ].reduce((a, b) => a + b, 0) / 12;
+
+    expect(averageExpectedMonthlyWorkloadFromWeeklyBaseline(w, 2026)).toBeCloseTo(expected2026, 10);
+  });
+
+  it("uses actual days per month for leap years (Feb 29)", () => {
+    const w = 7;
+    const expected2024 =
+      [
+        w * (31 / 7),
+        w * (29 / 7),
+        w * (31 / 7),
+        w * (30 / 7),
+        w * (31 / 7),
+        w * (30 / 7),
+        w * (31 / 7),
+        w * (31 / 7),
+        w * (30 / 7),
+        w * (31 / 7),
+        w * (30 / 7),
+        w * (31 / 7),
+      ].reduce((a, b) => a + b, 0) / 12;
+
+    expect(averageExpectedMonthlyWorkloadFromWeeklyBaseline(w, 2024)).toBeCloseTo(expected2024, 10);
+  });
+});

--- a/lib/data/workouts/__tests__/strengthYearlyChartLabelVisibility.test.ts
+++ b/lib/data/workouts/__tests__/strengthYearlyChartLabelVisibility.test.ts
@@ -1,0 +1,28 @@
+import { shouldShowStrengthYearlyMonthValueLabel } from "@/lib/data/workouts/strengthYearlyChartLabelVisibility";
+
+describe("shouldShowStrengthYearlyMonthValueLabel", () => {
+  it("hides labels for months strictly after todayMonthKey", () => {
+    expect(shouldShowStrengthYearlyMonthValueLabel("2026-06", "2026-03", 0)).toBe(false);
+    expect(shouldShowStrengthYearlyMonthValueLabel("2026-06", "2026-03", 5)).toBe(false);
+  });
+
+  it("shows labels for past months only when workoutCount > 0", () => {
+    expect(shouldShowStrengthYearlyMonthValueLabel("2026-01", "2026-03", 0)).toBe(false);
+    expect(shouldShowStrengthYearlyMonthValueLabel("2026-01", "2026-03", 4)).toBe(true);
+  });
+
+  it("shows labels for current month only when workoutCount > 0", () => {
+    expect(shouldShowStrengthYearlyMonthValueLabel("2026-03", "2026-03", 0)).toBe(false);
+    expect(shouldShowStrengthYearlyMonthValueLabel("2026-03", "2026-03", 2)).toBe(true);
+  });
+
+  it("uses lexicographic order consistent with chronological order across years", () => {
+    expect(shouldShowStrengthYearlyMonthValueLabel("2026-08", "2027-05", 3)).toBe(true);
+    expect(shouldShowStrengthYearlyMonthValueLabel("2028-01", "2027-05", 0)).toBe(false);
+  });
+
+  it("falls back to workoutCount > 0 when keys are non-canonical length", () => {
+    expect(shouldShowStrengthYearlyMonthValueLabel("bad", "2026-03", 0)).toBe(false);
+    expect(shouldShowStrengthYearlyMonthValueLabel("bad", "2026-03", 2)).toBe(true);
+  });
+});

--- a/lib/data/workouts/__tests__/workoutsCalendarModel.test.ts
+++ b/lib/data/workouts/__tests__/workoutsCalendarModel.test.ts
@@ -8,6 +8,7 @@ import {
   deriveOverviewTabSessionCounts,
   getRecentWorkoutsFromCalendarDays,
   getRecentWorkoutSessionsFromCalendarDays,
+  getStrengthOverviewTabSessionsForCalendarDaysAscending,
   sortWorkoutsChronologicalAsc,
   WORKOUT_OVERVIEW_ANALYTICS_RANGE_END,
   WORKOUT_OVERVIEW_ANALYTICS_RANGE_START,
@@ -615,5 +616,46 @@ describe("workoutsCalendarModel", () => {
         cardioSessionCount: 1,
       });
     });
+  });
+
+  it("getStrengthOverviewTabSessionsForCalendarDaysAscending is earliest-first for strength-tab sessions", () => {
+    const days = [
+      {
+        day: "2026-03-10",
+        workouts: [
+          {
+            id: "later",
+            observedAt: "2026-03-10T20:00:00.000Z",
+            sourceId: "apple_health",
+            title: "Lift",
+            workoutType: "strength" as const,
+            start: "2026-03-10T20:00:00.000Z",
+            end: "2026-03-10T21:00:00.000Z",
+            durationMinutes: 60,
+            calories: null,
+          },
+        ],
+      },
+      {
+        day: "2026-03-09",
+        workouts: [
+          {
+            id: "earlier",
+            observedAt: "2026-03-09T08:00:00.000Z",
+            sourceId: "apple_health",
+            title: "Lift",
+            workoutType: "strength" as const,
+            start: "2026-03-09T08:00:00.000Z",
+            end: "2026-03-09T09:00:00.000Z",
+            durationMinutes: 60,
+            calories: null,
+          },
+        ],
+      },
+    ];
+    const asc = getStrengthOverviewTabSessionsForCalendarDaysAscending(days);
+    expect(asc.map((x) => x.session.workouts[0]?.id)).toEqual(["earlier", "later"]);
+    const newestFirst = getRecentWorkoutSessionsFromCalendarDays(days, 10);
+    expect(newestFirst[0]?.session.workouts[0]?.id).toBe("later");
   });
 });

--- a/lib/data/workouts/overviewCalendarRangeSlices.ts
+++ b/lib/data/workouts/overviewCalendarRangeSlices.ts
@@ -27,7 +27,7 @@ export function overviewSharedRangeBounds(args: {
 }
 
 /**
- * Calendar hydrate bounds for the Strength **main tab** (Today, Recent, Weekly Insights only).
+ * Calendar hydrate bounds for the Strength **main tab** (combined week cards + workout list slice).
  * Omits the year-wide analytics window so the first open does not fetch Jan–Dec solely for charts
  * that live on Strength Analytics.
  */

--- a/lib/data/workouts/parseWorkoutFromRawEvent.ts
+++ b/lib/data/workouts/parseWorkoutFromRawEvent.ts
@@ -7,10 +7,27 @@ import type { ManualWorkoutExerciseSummary } from "@/lib/workouts/journal/manual
 /** Best-effort minutes per zone (1–5) when present on raw payload; not part of strict ingest schema. */
 export type HeartRateZoneMinutes5 = readonly [number, number, number, number, number];
 
+/**
+ * Resolves ingestion `provider` for UI and delete eligibility.
+ * GET /users/me/raw-events list rows omit `provider`; calendar hydrate synthesizes docs with empty provider — infer from `sourceId`
+ * (HealthKit imports use `sourceId` "healthkit" with Firestore `provider` "apple_health"; manual uses `sourceId` "manual").
+ */
+export function resolveWorkoutIngestProvider(raw: { provider?: string; sourceId?: string }): string | undefined {
+  const trimmed = typeof raw.provider === "string" ? raw.provider.trim() : "";
+  if (trimmed === "manual" || trimmed === "apple_health") return trimmed;
+  if (trimmed.length > 0) return trimmed;
+  const sid = typeof raw.sourceId === "string" ? raw.sourceId : "";
+  if (sid === "manual") return "manual";
+  if (sid === "healthkit" || sid === "apple_health") return "apple_health";
+  return undefined;
+}
+
 export type WorkoutHistoryItem = {
   id: string;
   observedAt: string;
   sourceId: string;
+  /** RawEvent ingestion provider (e.g. `manual`, `apple_health`); aligns with DELETE /ingest eligibility. */
+  provider?: string;
   /** Original RawEvent kind (e.g. `strength_workout`, `workout`) for domain routing. */
   rawKind?: string;
   title: string;
@@ -133,6 +150,7 @@ export function parseWorkoutHistoryItem(raw: RawEventDoc): WorkoutHistoryItem {
   const id = raw.id;
   const observedAt = raw.observedAt ?? raw.receivedAt;
   const sourceId = raw.sourceId ?? "unknown";
+  const resolvedProvider = resolveWorkoutIngestProvider(raw);
 
   const rawPayload: unknown = raw.payload;
   const payload = isRecord(rawPayload) ? rawPayload : null;
@@ -216,6 +234,7 @@ export function parseWorkoutHistoryItem(raw: RawEventDoc): WorkoutHistoryItem {
     id,
     observedAt,
     sourceId,
+    ...(resolvedProvider !== undefined ? { provider: resolvedProvider } : {}),
     rawKind: raw.kind,
     title,
     ...(workoutType != null ? { workoutType } : {}),

--- a/lib/data/workouts/strengthAnalyticsCardModels.ts
+++ b/lib/data/workouts/strengthAnalyticsCardModels.ts
@@ -14,6 +14,7 @@ import {
   type StrengthMonthChartBar,
   type StrengthMonthScopedMetrics,
 } from "@/lib/data/workouts/strengthOverviewMonthAnalytics";
+import { buildStrengthBaselineCardModel } from "@/lib/data/workouts/strengthBaselineCardModel";
 import {
   buildWorkoutOverviewAnalyticsFromCalendarDays,
   monthKeyFromDay,
@@ -21,7 +22,7 @@ import {
   type WorkoutAnalyticsMonthPoint,
   type WorkoutCalendarDayLike,
 } from "@/lib/data/workouts/workoutsCalendarModel";
-import type { WorkoutProductDomain } from "@/lib/data/workouts/workoutDomain";
+import { mapWorkoutCalendarDaysForDomain, type WorkoutProductDomain } from "@/lib/data/workouts/workoutDomain";
 import type { DayKey } from "@/lib/ui/calendar/types";
 import type { ManualWorkoutDaySummary } from "@/lib/workouts/journal/manualWorkoutSummary";
 
@@ -46,6 +47,8 @@ export type StrengthAnalyticsCardModels = {
   yearChartPoints: WorkoutAnalyticsMonthPoint[];
   yearMetrics: WorkoutAnalyticsMetrics;
   focusStrengthMonthKey: string;
+  /** Same Strength Baseline rate as the overview card — for yearly chart reference only. */
+  strengthBaselineAvgWorkoutsPerWeek: number;
 };
 
 export function buildStrengthAnalyticsCardModels(
@@ -73,11 +76,17 @@ export function buildStrengthAnalyticsCardModels(
     analyticsContext: { customExerciseById: input.customExerciseById },
   });
 
+  const strengthBaselineModel = buildStrengthBaselineCardModel({
+    strengthCalendarDays: mapWorkoutCalendarDaysForDomain(input.analyticsDaysSlice, "strength"),
+    todayDayKey: input.todayDayKey,
+  });
+
   return {
     weeklyStrengthModel,
     strengthMonthOverview,
     yearChartPoints: bundle.chartPointsByTab.strength,
     yearMetrics: bundle.metricsByTab.strength,
     focusStrengthMonthKey,
+    strengthBaselineAvgWorkoutsPerWeek: strengthBaselineModel.avgWorkoutsPerWeek,
   };
 }

--- a/lib/data/workouts/strengthBaselineCardModel.ts
+++ b/lib/data/workouts/strengthBaselineCardModel.ts
@@ -1,0 +1,62 @@
+import {
+  ACTIVITY_BASELINE_TRAILING_DAY_COUNT,
+  activityTrailingNDaysInclusive,
+  getActivityOverviewAnchorEndDay,
+} from "@/lib/data/activity/activityOverviewRanges";
+import {
+  strengthWeeklyFrequencyActivityTierIndexForBar,
+  strengthWeeklyFrequencyDisplayScaleFill01,
+  strengthWeeklyFrequencyRatingBucketFromAvg,
+  strengthWeeklyFrequencyRatingLabelFromBucket,
+  type StrengthWeeklyFrequencyRatingBucket,
+} from "@/lib/utils/strengthWeeklyFrequencyRating";
+import { collectStrengthOverviewTabSessions } from "@/lib/data/workouts/strengthOverviewCardModel";
+import { filterWorkoutCalendarDaysInclusive } from "@/lib/data/workouts/overviewCalendarRangeSlices";
+import type { WorkoutCalendarDayLike } from "@/lib/data/workouts/workoutsCalendarModel";
+import type { DayKey } from "@/lib/ui/calendar/types";
+import { enumerateDaysInclusive } from "@/lib/ui/calendar/dateUtils";
+
+export type StrengthBaselineCardModel = {
+  /** Average strength sessions per week over the trailing completed-day window (see builder). */
+  avgWorkoutsPerWeek: number;
+  /** Primary figure for the header row (display: `X.X/wk`). */
+  compactValuePrimary: string;
+  ratingBucket: StrengthWeeklyFrequencyRatingBucket;
+  ratingLabel: string;
+  /** Pass to {@link ActivityTierProgressTrack} tier coloring. */
+  activityTierIndexForBar: number;
+  fillWidth01Override: number;
+};
+
+/**
+ * Strength Baseline: average strength-tab sessions per week over {@link ACTIVITY_BASELINE_TRAILING_DAY_COUNT}
+ * completed local days ending {@link getActivityOverviewAnchorEndDay}`(todayDayKey)` (local yesterday).
+ * Matches Activity Baseline completed-day semantics; today is excluded by construction.
+ *
+ * Uses the same strength-session rules as {@link buildStrengthOverviewCardModel} / Overview “3 Month”.
+ */
+export function buildStrengthBaselineCardModel(input: {
+  strengthCalendarDays: readonly WorkoutCalendarDayLike[];
+  todayDayKey: DayKey;
+}): StrengthBaselineCardModel {
+  const { strengthCalendarDays, todayDayKey } = input;
+  const anchorEnd = getActivityOverviewAnchorEndDay(todayDayKey);
+  const windowKeys = activityTrailingNDaysInclusive(anchorEnd, ACTIVITY_BASELINE_TRAILING_DAY_COUNT);
+  const windowStart = windowKeys[0]!;
+  const elapsedDays = enumerateDaysInclusive(windowStart, anchorEnd).length;
+  const sortedDays = [...strengthCalendarDays].sort((a, b) => (a.day < b.day ? -1 : a.day > b.day ? 1 : 0));
+  const slice = filterWorkoutCalendarDaysInclusive(sortedDays, windowStart, anchorEnd);
+  const sessions = collectStrengthOverviewTabSessions(slice);
+  const total = sessions.length;
+  const avgWorkoutsPerWeek = elapsedDays > 0 ? (total * 7) / elapsedDays : 0;
+  const compactValuePrimary = `${avgWorkoutsPerWeek.toFixed(1)}/wk`;
+  const ratingBucket = strengthWeeklyFrequencyRatingBucketFromAvg(avgWorkoutsPerWeek);
+  return {
+    avgWorkoutsPerWeek,
+    compactValuePrimary,
+    ratingBucket,
+    ratingLabel: strengthWeeklyFrequencyRatingLabelFromBucket(ratingBucket),
+    activityTierIndexForBar: strengthWeeklyFrequencyActivityTierIndexForBar(ratingBucket),
+    fillWidth01Override: strengthWeeklyFrequencyDisplayScaleFill01(avgWorkoutsPerWeek),
+  };
+}

--- a/lib/data/workouts/strengthOverviewCardModel.ts
+++ b/lib/data/workouts/strengthOverviewCardModel.ts
@@ -69,7 +69,8 @@ function monthYearFromMonthKey(monthKey: string): MonthYear | null {
   return { year, month };
 }
 
-function collectStrengthTabSessions(days: readonly WorkoutCalendarDayLike[]): ReconciledWorkoutSession[] {
+/** Strength Overview + Baseline: sessions that count toward Strength tabs (`sessionType === "strength"` only). */
+export function collectStrengthOverviewTabSessions(days: readonly WorkoutCalendarDayLike[]): ReconciledWorkoutSession[] {
   const out: ReconciledWorkoutSession[] = [];
   for (const d of days) {
     for (const s of reconcileWorkoutSessionsForDay(d.day, d.workouts)) {
@@ -77,6 +78,49 @@ function collectStrengthTabSessions(days: readonly WorkoutCalendarDayLike[]): Re
     }
   }
   return out;
+}
+
+/**
+ * Single source for Overview “This Week” + Strength This Week card: local calendar week slice through
+ * `weekCoverageEnd = max(weekStart, min(today, weekEnd))`, same strength-tab session rules.
+ */
+export function computeStrengthThisWeekWindowMetrics(input: {
+  strengthCalendarDays: readonly WorkoutCalendarDayLike[];
+  todayDayKey: DayKey;
+  weekStartDay: DayKey;
+  weekEndDay: DayKey;
+}): {
+  totalWorkouts: number;
+  avgWorkoutsPerWeek: number | null;
+  /** Denominator used for avg (≥1 when week slice is valid). */
+  elapsedCalendarDaysForAvg: number;
+} {
+  const sortedDays = [...input.strengthCalendarDays].sort((a, b) =>
+    a.day < b.day ? -1 : a.day > b.day ? 1 : 0,
+  );
+  const weekDays = filterWorkoutCalendarDaysInclusive(sortedDays, input.weekStartDay, input.weekEndDay);
+  const weekSessions = collectStrengthOverviewTabSessions(weekDays);
+  const weekCoverageEnd = maxDayKey(input.weekStartDay, minDayKey(input.todayDayKey, input.weekEndDay));
+  const weekElapsedDays =
+    weekCoverageEnd < input.weekStartDay ? 0 : enumerateDaysInclusive(input.weekStartDay, weekCoverageEnd).length;
+  const weekElapsedForMetrics = Math.max(weekElapsedDays, 1);
+  const weekMetrics = metricsForSessions(weekSessions, weekElapsedForMetrics);
+  return {
+    totalWorkouts: weekMetrics.totalWorkouts,
+    avgWorkoutsPerWeek: weekMetrics.avgWorkoutsPerWeek,
+    elapsedCalendarDaysForAvg: weekElapsedForMetrics,
+  };
+}
+
+/** Repo-truth: whether local `todayDayKey` has at least one strength-tab session in the hydrated calendar. */
+export function hasStrengthWorkoutLoggedToday(
+  strengthCalendarDays: readonly WorkoutCalendarDayLike[],
+  todayDayKey: DayKey,
+): boolean {
+  const sortedDays = [...strengthCalendarDays].sort((a, b) => (a.day < b.day ? -1 : a.day > b.day ? 1 : 0));
+  const row = sortedDays.find((d) => d.day === todayDayKey);
+  if (row == null) return false;
+  return collectStrengthOverviewTabSessions([row]).length > 0;
 }
 
 function computeAvgPerWeekFromTotals(totalWorkouts: number, elapsedCalendarDays: number): number | null {
@@ -145,21 +189,21 @@ export function buildStrengthOverviewCardModel(input: {
     threeStart,
     todayDayKey,
   );
-  const threeSessions = collectStrengthTabSessions(threeDays);
+  const threeSessions = collectStrengthOverviewTabSessions(threeDays);
   const threeElapsed = enumerateDaysInclusive(threeStart, todayDayKey).length;
   const threeMetrics = metricsForSessions(threeSessions, threeElapsed);
 
-  const weekDays = filterWorkoutCalendarDaysInclusive(
-    [...input.strengthCalendarDays],
+  const weekMetricsBundle = computeStrengthThisWeekWindowMetrics({
+    strengthCalendarDays: input.strengthCalendarDays,
+    todayDayKey,
     weekStartDay,
     weekEndDay,
-  );
-  const weekSessions = collectStrengthTabSessions(weekDays);
-  const weekCoverageEnd = maxDayKey(weekStartDay, minDayKey(todayDayKey, weekEndDay));
-  const weekElapsedDays =
-    weekCoverageEnd < weekStartDay ? 0 : enumerateDaysInclusive(weekStartDay, weekCoverageEnd).length;
-  const weekElapsedForMetrics = Math.max(weekElapsedDays, 1);
-  const weekMetrics = metricsForSessions(weekSessions, weekElapsedForMetrics);
+  });
+  const weekMetrics = {
+    totalWorkouts: weekMetricsBundle.totalWorkouts,
+    avgWorkoutsPerWeek: weekMetricsBundle.avgWorkoutsPerWeek,
+  };
+  const weekElapsedForMetrics = weekMetricsBundle.elapsedCalendarDaysForAvg;
 
   const ytdRating = strengthOverviewTimeframeConsistencyRating({
     timeframe: "ytd",

--- a/lib/data/workouts/strengthThisWeekCardModel.ts
+++ b/lib/data/workouts/strengthThisWeekCardModel.ts
@@ -1,0 +1,108 @@
+import {
+  computeStrengthThisWeekWindowMetrics,
+  hasStrengthWorkoutLoggedToday,
+} from "@/lib/data/workouts/strengthOverviewCardModel";
+import type { WorkoutCalendarDayLike } from "@/lib/data/workouts/workoutsCalendarModel";
+import type { StrengthWeeklyFrequencyCardDisplayModel } from "@/lib/ui/workouts/strengthWeeklyFrequencyCardTypes";
+import type { DayKey } from "@/lib/ui/calendar/types";
+import {
+  strengthWeeklyFrequencyActivityTierIndexForBar,
+  strengthWeeklyFrequencyDisplayScaleFill01,
+  strengthWeeklyFrequencyRatingBucketFromAvg,
+  strengthWeeklyFrequencyRatingLabelFromBucket,
+  type StrengthWeeklyFrequencyRatingBucket,
+} from "@/lib/utils/strengthWeeklyFrequencyRating";
+
+export type StrengthThisWeekCardModel = StrengthWeeklyFrequencyCardDisplayModel & {
+  /** Strength-tab session count in the current local week window (same as Overview “This Week” total). */
+  totalWorkoutsThisWeek: number;
+  ratingBucket: StrengthWeeklyFrequencyRatingBucket;
+  footerSupportCaption: string;
+};
+
+/** Support line under the bar — only states grounded in hydrated calendar truth. */
+export const STRENGTH_THIS_WEEK_FOOTER_WITH_TODAY = "Includes today's workout";
+export const STRENGTH_THIS_WEEK_FOOTER_NO_TODAY = "No workout logged today";
+
+/**
+ * Display-only line for the This Week card header (actual count, not average/week).
+ */
+export function formatStrengthThisWeekWorkoutCountLine(totalWorkouts: number): string {
+  const n = Math.max(0, Math.round(Number.isFinite(totalWorkouts) ? totalWorkouts : 0));
+  if (n === 1) return "1 workout";
+  return `${n} workouts`;
+}
+
+/** Muted subtitle for This Week embedded header (`N sessions this week`). Display-only; uses the same session count basis as {@link formatStrengthThisWeekWorkoutCountLine}. */
+export function formatStrengthThisWeekSessionsMicroCaption(totalWorkouts: number): string {
+  const n = Math.max(0, Math.round(Number.isFinite(totalWorkouts) ? totalWorkouts : 0));
+  if (n === 1) return "1 session this week";
+  return `${n} sessions this week`;
+}
+
+/** Muted subtitle for Last Week embedded header (`N sessions last week`). Same session-count basis as {@link formatStrengthThisWeekSessionsMicroCaption}. */
+export function formatStrengthLastWeekSessionsMicroCaption(totalWorkouts: number): string {
+  const n = Math.max(0, Math.round(Number.isFinite(totalWorkouts) ? totalWorkouts : 0));
+  if (n === 1) return "1 session last week";
+  return `${n} sessions last week`;
+}
+
+/**
+ * Last Week card: previous **completed** local calendar week (`lastWeekStartDay`…`lastWeekEndDay`), same strength-tab rules as {@link computeStrengthThisWeekWindowMetrics}.
+ * Uses the same rating ladder as This Week / Baseline ({@link strengthWeeklyFrequencyRatingBucketFromAvg}).
+ */
+export function buildStrengthLastWeekCardModel(input: {
+  strengthCalendarDays: readonly WorkoutCalendarDayLike[];
+  todayDayKey: DayKey;
+  lastWeekStartDay: DayKey;
+  lastWeekEndDay: DayKey;
+}): StrengthThisWeekCardModel {
+  const week = computeStrengthThisWeekWindowMetrics({
+    strengthCalendarDays: input.strengthCalendarDays,
+    todayDayKey: input.todayDayKey,
+    weekStartDay: input.lastWeekStartDay,
+    weekEndDay: input.lastWeekEndDay,
+  });
+  const totalWorkoutsLastWeek = Math.max(0, week.totalWorkouts);
+  const compactValuePrimary = formatStrengthThisWeekWorkoutCountLine(totalWorkoutsLastWeek);
+  const ratingBucket = strengthWeeklyFrequencyRatingBucketFromAvg(totalWorkoutsLastWeek);
+
+  return {
+    totalWorkoutsThisWeek: totalWorkoutsLastWeek,
+    compactValuePrimary,
+    ratingBucket,
+    ratingLabel: strengthWeeklyFrequencyRatingLabelFromBucket(ratingBucket),
+    activityTierIndexForBar: strengthWeeklyFrequencyActivityTierIndexForBar(ratingBucket),
+    fillWidth01Override: strengthWeeklyFrequencyDisplayScaleFill01(totalWorkoutsLastWeek),
+    footerSupportCaption: "",
+  };
+}
+
+/**
+ * This Week card: same weekly window + strength session rules as Overview “This Week”
+ * ({@link computeStrengthThisWeekWindowMetrics}). Value is **total** sessions this week; pill + 0–7 bar use
+ * that count on the same frequency ladder as Strength Baseline ({@link strengthWeeklyFrequencyRatingBucketFromAvg}).
+ */
+export function buildStrengthThisWeekCardModel(input: {
+  strengthCalendarDays: readonly WorkoutCalendarDayLike[];
+  todayDayKey: DayKey;
+  weekStartDay: DayKey;
+  weekEndDay: DayKey;
+}): StrengthThisWeekCardModel {
+  const week = computeStrengthThisWeekWindowMetrics(input);
+  const totalWorkoutsThisWeek = Math.max(0, week.totalWorkouts);
+  const compactValuePrimary = formatStrengthThisWeekWorkoutCountLine(totalWorkoutsThisWeek);
+  /** Same 0–7 bucket + fill scale as Baseline; input is weekly session count (not average). */
+  const ratingBucket = strengthWeeklyFrequencyRatingBucketFromAvg(totalWorkoutsThisWeek);
+  const hasToday = hasStrengthWorkoutLoggedToday(input.strengthCalendarDays, input.todayDayKey);
+
+  return {
+    totalWorkoutsThisWeek,
+    compactValuePrimary,
+    ratingBucket,
+    ratingLabel: strengthWeeklyFrequencyRatingLabelFromBucket(ratingBucket),
+    activityTierIndexForBar: strengthWeeklyFrequencyActivityTierIndexForBar(ratingBucket),
+    fillWidth01Override: strengthWeeklyFrequencyDisplayScaleFill01(totalWorkoutsThisWeek),
+    footerSupportCaption: hasToday ? STRENGTH_THIS_WEEK_FOOTER_WITH_TODAY : STRENGTH_THIS_WEEK_FOOTER_NO_TODAY,
+  };
+}

--- a/lib/data/workouts/strengthYearlyChartBaseline.ts
+++ b/lib/data/workouts/strengthYearlyChartBaseline.ts
@@ -1,0 +1,21 @@
+/**
+ * Presentation-only conversion from Strength Baseline {@link StrengthBaselineCardModel.avgWorkoutsPerWeek}
+ * to a single vertical scale value comparable to calendar-month workout totals on the yearly chart.
+ *
+ * Semantics: Baseline is sessions/week over elapsed days; expected sessions in a calendar month with `D`
+ * days at rate `w`/week is `w × (D / 7)` (same dimensionality as monthly bar totals).
+ * The reference line uses the **average** of those 12 monthly expectations for `analyticsCalendarYear`
+ * (handles Feb/leap years via actual month lengths).
+ */
+export function averageExpectedMonthlyWorkloadFromWeeklyBaseline(
+  avgWorkoutsPerWeek: number,
+  analyticsCalendarYear: number,
+): number {
+  if (!Number.isFinite(avgWorkoutsPerWeek) || avgWorkoutsPerWeek < 0) return 0;
+  let sum = 0;
+  for (let monthIndex = 0; monthIndex < 12; monthIndex += 1) {
+    const daysInMonth = new Date(analyticsCalendarYear, monthIndex + 1, 0).getDate();
+    sum += avgWorkoutsPerWeek * (daysInMonth / 7);
+  }
+  return sum / 12;
+}

--- a/lib/data/workouts/strengthYearlyChartLabelVisibility.ts
+++ b/lib/data/workouts/strengthYearlyChartLabelVisibility.ts
@@ -1,0 +1,21 @@
+/**
+ * Presentation-only rules for Strength Analytics yearly chart value labels.
+ *
+ * Chart points use ISO month keys (`YYYY-MM`) from {@link buildTwelveMonthSkeleton}; `todayMonthKey`
+ * is {@link monthKeyFromDay} for the builder's `todayDayKey`. Lexicographic order on `YYYY-MM`
+ * matches chronological order across calendar years.
+ *
+ * - Future months (month key strictly after today): no numeric label (including zero-filled future).
+ * - Past and current months: show a label only when {@link workoutCount} &gt; 0 (hide redundant zeros).
+ */
+export function shouldShowStrengthYearlyMonthValueLabel(
+  monthKey: string,
+  todayMonthKey: string,
+  workoutCount: number,
+): boolean {
+  if (monthKey.length !== 7 || todayMonthKey.length !== 7) {
+    return workoutCount > 0;
+  }
+  if (monthKey > todayMonthKey) return false;
+  return workoutCount > 0;
+}

--- a/lib/data/workouts/useWorkoutsCalendar.ts
+++ b/lib/data/workouts/useWorkoutsCalendar.ts
@@ -7,7 +7,7 @@ import {
   postWorkoutDaySummariesRebuild,
 } from "@/lib/api/usersMe";
 import type { WorkoutHistoryItem } from "@/lib/data/workouts/parseWorkoutFromRawEvent";
-import { parseWorkoutHistoryItem } from "@/lib/data/workouts/parseWorkoutFromRawEvent";
+import { parseWorkoutHistoryItem, resolveWorkoutIngestProvider } from "@/lib/data/workouts/parseWorkoutFromRawEvent";
 import type { DayKey } from "@/lib/ui/calendar/types";
 import { isValidDayKey } from "@/lib/ui/calendar/types";
 import { addCalendarDaysToDayKey, enumerateDaysInclusive } from "@/lib/ui/calendar/dateUtils";
@@ -269,12 +269,13 @@ function rawListItemIncludesPayload(
 
 /** Enough for {@link parseWorkoutHistoryItem} + {@link deriveWorkoutDayKey} on this path. */
 function rawListItemToParseableDoc(item: RawEventListItem & { payload: unknown }): RawEventDoc {
+  const resolvedProvider = resolveWorkoutIngestProvider({ provider: "", sourceId: item.sourceId }) ?? "";
   return {
     schemaVersion: 1,
     id: item.id,
     userId: item.userId,
     sourceId: item.sourceId,
-    provider: "",
+    provider: resolvedProvider,
     sourceType: "",
     kind: item.kind,
     observedAt: item.observedAt,

--- a/lib/data/workouts/workoutSessionSurface.ts
+++ b/lib/data/workouts/workoutSessionSurface.ts
@@ -1,4 +1,7 @@
-import type { WorkoutHistoryItem } from "@/lib/data/workouts/parseWorkoutFromRawEvent";
+import {
+  resolveWorkoutIngestProvider,
+  type WorkoutHistoryItem,
+} from "@/lib/data/workouts/parseWorkoutFromRawEvent";
 import type { WorkoutOverride } from "@/lib/data/workouts/workoutOverrides";
 import { formatWorkoutTitle } from "@/lib/data/workouts/workoutDisplay";
 import type { ReconciledWorkoutSession } from "@/lib/data/workouts/workoutSessionReconciliation";
@@ -16,7 +19,7 @@ import type { DayKey } from "@/lib/ui/calendar/types";
  * sorts first in {@link reconcileWorkoutSessionsForDay}).
  */
 export function pickWorkoutForSessionActions(session: ReconciledWorkoutSession): WorkoutHistoryItem | null {
-  const manual = session.workouts.find((w) => w.sourceId === "manual");
+  const manual = session.workouts.find((w) => resolveWorkoutIngestProvider(w) === "manual");
   return manual ?? session.workouts[0] ?? null;
 }
 
@@ -39,7 +42,7 @@ export function pickWorkoutOverrideForSession(
   for (const w of session.workouts) {
     const o = overridesByWorkoutId[w.id];
     if (!o || !overrideHasPatch(o)) continue;
-    if (w.sourceId === "manual") return o;
+    if (resolveWorkoutIngestProvider(w) === "manual") return o;
     if (!fallback) fallback = o;
   }
   return fallback;
@@ -51,7 +54,7 @@ export function pickDurableTitleForSession(
   durableTitlesByWorkoutId: Record<string, string | undefined> | undefined,
 ): string | null {
   if (!durableTitlesByWorkoutId) return null;
-  const manual = session.workouts.find((w) => w.sourceId === "manual");
+  const manual = session.workouts.find((w) => resolveWorkoutIngestProvider(w) === "manual");
   if (manual) {
     const t = durableTitlesByWorkoutId[manual.id]?.trim();
     if (t) return t;
@@ -109,7 +112,7 @@ export function pickJournalSummaryForStrengthSession(
 ): ManualWorkoutDaySummary | null {
   const sameDay = summaries.filter((s) => s.day === day);
   if (sameDay.length === 0) return null;
-  const manualMember = session.workouts.find((w) => w.sourceId === "manual");
+  const manualMember = session.workouts.find((w) => resolveWorkoutIngestProvider(w) === "manual");
   if (!manualMember) return null;
   const anchor = workoutAnchorMs(manualMember);
   if (anchor == null) return sameDay[0] ?? null;
@@ -131,7 +134,7 @@ export function pickJournalSummaryForStrengthSession(
 
 /** Apple / HealthKit row for duration, calories, distance, zones when present in a merged session. */
 export function pickMetricsWorkoutForSession(session: ReconciledWorkoutSession): WorkoutHistoryItem | null {
-  const apple = session.workouts.find((w) => w.sourceId === "apple_health");
+  const apple = session.workouts.find((w) => resolveWorkoutIngestProvider(w) === "apple_health");
   if (apple) return apple;
   const hk = session.workouts.find((w) => w.hk != null);
   return hk ?? null;

--- a/lib/data/workouts/workoutsCalendarModel.ts
+++ b/lib/data/workouts/workoutsCalendarModel.ts
@@ -420,6 +420,34 @@ export function getRecentWorkoutSessionsFromCalendarDays(
   return entries.slice(0, maxCount);
 }
 
+/**
+ * Strength overview tab sessions only ({@link sessionMatchesOverviewStrengthTab}), ordered **earliest first**
+ * (reverse of {@link getRecentWorkoutSessionsFromCalendarDays}). Use with domain-filtered days for the local week slice.
+ */
+export function getStrengthOverviewTabSessionsForCalendarDaysAscending(
+  days: readonly WorkoutCalendarDayLike[],
+): RecentWorkoutSessionEntry[] {
+  const entries: RecentWorkoutSessionEntry[] = [];
+  for (const d of days) {
+    for (const session of reconcileWorkoutSessionsForDay(d.day, d.workouts)) {
+      if (sessionMatchesOverviewStrengthTab(session)) {
+        entries.push({ day: d.day, session });
+      }
+    }
+  }
+  entries.sort((a, b) => {
+    const ka = a.session.start ?? a.session.workouts[0]?.observedAt ?? "";
+    const kb = b.session.start ?? b.session.workouts[0]?.observedAt ?? "";
+    if (!ka && !kb) return a.session.id.localeCompare(b.session.id);
+    if (!ka) return -1;
+    if (!kb) return 1;
+    const t = ka.localeCompare(kb);
+    if (t !== 0) return t;
+    return a.session.id.localeCompare(b.session.id);
+  });
+  return entries;
+}
+
 function sessionMatchesTab(session: ReconciledWorkoutSession, tab: WorkoutAnalyticsTab): boolean {
   if (tab === "all") return true;
   if (tab === "strength") return session.sessionType === "strength" || session.sessionType === "mixed";

--- a/lib/ui/WorkoutActionSheet.tsx
+++ b/lib/ui/WorkoutActionSheet.tsx
@@ -21,6 +21,8 @@ type WorkoutActionSheetProps = {
   onRename: () => void;
   onEditDuration: () => void;
   onEditType: () => void;
+  /** When set, shows a destructive row (manual-ingest workouts only; caller decides eligibility). */
+  onDeleteWorkout?: () => void;
 };
 
 function Row({
@@ -29,13 +31,17 @@ function Row({
   onPress,
   showDivider = true,
   accessibilityLabel,
+  destructive,
 }: {
   label: string;
   icon: React.ComponentProps<typeof Ionicons>["name"];
   onPress: () => void;
   showDivider?: boolean;
   accessibilityLabel: string;
+  destructive?: boolean;
 }) {
+  const labelColor = destructive ? "#FF3B30" : "#1C1C1E";
+  const iconColor = destructive ? "#FF3B30" : "#1C1C1E";
   return (
     <Pressable
       onPress={onPress}
@@ -44,8 +50,8 @@ function Row({
       style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
     >
       <View style={styles.rowLeft}>
-        <Ionicons name={icon} size={18} color="#1C1C1E" />
-        <Text style={styles.rowLabel}>{label}</Text>
+        <Ionicons name={icon} size={18} color={iconColor} />
+        <Text style={[styles.rowLabel, { color: labelColor }]}>{label}</Text>
       </View>
       {showDivider ? <View style={styles.rowDivider} /> : null}
     </Pressable>
@@ -62,6 +68,7 @@ export function WorkoutActionSheet({
   onRename,
   onEditDuration,
   onEditType,
+  onDeleteWorkout,
 }: WorkoutActionSheetProps) {
   if (!visible) return null;
   const screenWidth = 390;
@@ -119,10 +126,22 @@ export function WorkoutActionSheet({
               label="Edit workout type"
               icon="barbell-outline"
               onPress={onEditType}
-              showDivider={false}
+              showDivider={onDeleteWorkout != null}
               accessibilityLabel="Edit workout type"
             />
           </View>
+          {onDeleteWorkout != null ? (
+            <View style={styles.section}>
+              <Row
+                label="Delete Workout"
+                icon="trash-outline"
+                onPress={onDeleteWorkout}
+                showDivider={false}
+                destructive
+                accessibilityLabel="Delete workout"
+              />
+            </View>
+          ) : null}
           <Pressable
             onPress={onClose}
             accessibilityRole="button"

--- a/lib/ui/__tests__/WorkoutAnalyticsCards.test.tsx
+++ b/lib/ui/__tests__/WorkoutAnalyticsCards.test.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 import renderer, { act } from "react-test-renderer";
-import { buildWorkoutOverviewAnalyticsFromCalendarDays } from "@/lib/data/workouts/workoutsCalendarModel";
+import {
+  WORKOUT_OVERVIEW_ANALYTICS_YEAR,
+  buildWorkoutOverviewAnalyticsFromCalendarDays,
+} from "@/lib/data/workouts/workoutsCalendarModel";
 import { buildStrengthMonthOverviewFromCalendarDays } from "@/lib/data/workouts/strengthOverviewMonthAnalytics";
 import { WorkoutAnalyticsChart } from "@/lib/ui/workouts/WorkoutAnalyticsChart";
 
@@ -73,5 +76,39 @@ describe("Workout analytics cards", () => {
     const jsonMonth = JSON.stringify(tree.toJSON());
     expect(jsonMonth).toContain("Typical Volume");
     expect(jsonMonth).not.toContain("Avg per Month");
+  });
+
+  it("strengthYearly + fixed year omits summary metrics and keeps title + chart only", () => {
+    const bundle = buildWorkoutOverviewAnalyticsFromCalendarDays([]);
+    const monthBundle = buildStrengthMonthOverviewFromCalendarDays([], "2026-03", {
+      todayDayKey: "2026-03-15",
+    });
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(
+        <WorkoutAnalyticsChart
+          layout="singleStrengthPeriod"
+          layoutVariant="strengthYearly"
+          fixedPeriod="year"
+          headerTitle={`${WORKOUT_OVERVIEW_ANALYTICS_YEAR} Strength Workouts`}
+          yearTabLabel="2026"
+          monthTabLabel="Mar"
+          yearlyStrengthVisualization={{
+            avgWorkoutsPerWeek: 3,
+            analyticsCalendarYear: WORKOUT_OVERVIEW_ANALYTICS_YEAR,
+            todayMonthKey: "2026-03",
+          }}
+          yearChartPoints={bundle.chartPointsByTab.strength}
+          yearMetrics={sampleMetrics.strength}
+          monthChartBars={monthBundle.chartBars}
+          monthMetrics={monthBundle.metrics}
+        />,
+      );
+    });
+    const json = JSON.stringify(tree.toJSON());
+    expect(json).toContain("Strength Workouts");
+    expect(json).not.toContain("Total Workouts");
+    expect(json).not.toContain("Avg per Month");
+    expect(json).toContain("strength-yearly-chart-baseline-line");
   });
 });

--- a/lib/ui/activity/ActivityBaselineThresholdMarkers.tsx
+++ b/lib/ui/activity/ActivityBaselineThresholdMarkers.tsx
@@ -1,0 +1,136 @@
+import { Fragment, useCallback, useEffect, useRef, useState } from "react";
+import { LayoutChangeEvent, StyleSheet, Text, View } from "react-native";
+
+import {
+  activityBaselineThresholdLabelLeftPx,
+  activityBaselineThresholdTickLeftPx,
+} from "@/lib/ui/activity/activityBaselineMarkerLayout";
+import { ACTIVITY_BASELINE_MARKER_DISPLAY_STEP_STEPS } from "@/lib/utils/activityStepRating";
+
+/** Parallel to {@link ACTIVITY_BASELINE_MARKER_DISPLAY_STEP_STEPS} (same order, same length). */
+const MARKER_LABELS = ["0", "2.5k", "5k", "7.5k", "10k", "12.5k", "15k"] as const;
+
+/** At least 1px so ticks stay visible on high-DPI; aligns to scale with track rim hairline. */
+const TICK_WIDTH_PX = Math.max(1, StyleSheet.hairlineWidth * 2);
+const TICK_HEIGHT_PX = 5;
+/** One visual unit: tick + label; `top` places label under the tick. */
+const LABEL_TOP_PX = TICK_HEIGHT_PX + 1;
+
+/**
+ * Baseline-only ruler: ticks + labels on {@link ACTIVITY_BASELINE_MARKER_DISPLAY_STEP_STEPS}, same 0→15k
+ * linear scale as {@link ActivityTierProgressTrack} bounded fill (rim inset matches track).
+ */
+export function ActivityBaselineThresholdMarkers() {
+  const [outerW, setOuterW] = useState(0);
+  const [labelWidths, setLabelWidths] = useState<(number | null)[]>(() =>
+    Array.from({ length: MARKER_LABELS.length }, () => null),
+  );
+
+  const prevOuterW = useRef(0);
+  useEffect(() => {
+    if (outerW <= 0) return;
+    if (prevOuterW.current > 0 && prevOuterW.current !== outerW) {
+      setLabelWidths(Array.from({ length: MARKER_LABELS.length }, () => null));
+    }
+    prevOuterW.current = outerW;
+  }, [outerW]);
+
+  const onRowLayout = useCallback((e: LayoutChangeEvent) => {
+    setOuterW(e.nativeEvent.layout.width);
+  }, []);
+
+  const onLabelTextLayout = useCallback((index: number, width: number) => {
+    setLabelWidths((prev) => {
+      if (prev[index] === width) return prev;
+      const next = [...prev];
+      next[index] = width;
+      return next;
+    });
+  }, []);
+
+  const allMeasured =
+    outerW > 0 && labelWidths.every((w) => w != null && Number.isFinite(w) && (w as number) > 0);
+
+  return (
+    <View style={styles.wrap} testID="activity-baseline-threshold-markers" onLayout={onRowLayout}>
+      {!allMeasured ? (
+        <View style={styles.measureRow} pointerEvents="none">
+          {MARKER_LABELS.map((lab, i) => (
+            <Text
+              key={`measure-${i}`}
+              style={styles.label}
+              onTextLayout={(e) => {
+                const lines = e.nativeEvent.lines;
+                const w = lines.reduce((max, line) => Math.max(max, line.width), 0);
+                onLabelTextLayout(i, w);
+              }}
+            >
+              {lab}
+            </Text>
+          ))}
+        </View>
+      ) : (
+        ACTIVITY_BASELINE_MARKER_DISPLAY_STEP_STEPS.map((thresholdSteps, i) => (
+          <Fragment key={thresholdSteps}>
+            <View
+              style={[
+                styles.tick,
+                {
+                  left: activityBaselineThresholdTickLeftPx(outerW, thresholdSteps, TICK_WIDTH_PX),
+                  width: TICK_WIDTH_PX,
+                },
+              ]}
+              accessibilityElementsHidden
+              importantForAccessibility="no"
+            />
+            <Text
+              style={[
+                styles.label,
+                styles.labelPositioned,
+                {
+                  left: activityBaselineThresholdLabelLeftPx(outerW, thresholdSteps, labelWidths[i]!),
+                },
+              ]}
+              numberOfLines={1}
+              testID={`activity-baseline-marker-label-${i}`}
+            >
+              {MARKER_LABELS[i]!}
+            </Text>
+          </Fragment>
+        ))
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: {
+    position: "relative",
+    width: "100%",
+    minHeight: LABEL_TOP_PX + 11,
+    marginTop: 0,
+  },
+  measureRow: {
+    flexDirection: "row",
+    opacity: 0,
+    height: LABEL_TOP_PX + 11,
+    overflow: "hidden",
+    gap: 8,
+  },
+  tick: {
+    position: "absolute",
+    top: 0,
+    height: TICK_HEIGHT_PX,
+    backgroundColor: "rgba(60, 60, 67, 0.14)",
+  },
+  label: {
+    fontSize: 10,
+    fontWeight: "500",
+    color: "#636366",
+    letterSpacing: -0.08,
+  },
+  labelPositioned: {
+    position: "absolute",
+    top: LABEL_TOP_PX,
+  },
+});

--- a/lib/ui/activity/ActivityDailyDetailsCard.tsx
+++ b/lib/ui/activity/ActivityDailyDetailsCard.tsx
@@ -3,6 +3,7 @@ import { StyleSheet, Text, View } from "react-native";
 
 import type { ActivityDailyDetailsCardModel } from "@/lib/data/activity/activityOverviewCardModel";
 import { ActivityRatingPill } from "@/lib/ui/activity/ActivityRatingPill";
+import { ActivityBaselineThresholdMarkers } from "@/lib/ui/activity/ActivityBaselineThresholdMarkers";
 import {
   ActivityTierProgressTrack,
   activityTierProgressAccessibilityPercent,
@@ -12,6 +13,7 @@ import { moduleOverviewMetricLayoutStyles } from "@/lib/ui/overview/moduleOvervi
 import { ErrorState, LoadingState } from "@/lib/ui/ScreenStates";
 import { elevatedCardSurfaceStyle } from "@/lib/ui/theme/elevatedCardSurface";
 import {
+  activityStepsDisplayScaleFill01,
   getStepRatingActivityDescriptorPill,
   getStepRatingTierIndex,
   stepsFromLocaleDigitString,
@@ -29,6 +31,8 @@ type ActivityDailyDetailsCardProps = {
   footerCaption?: string;
   /** Today’s Steps vs baseline insight (precomputed in data layer). */
   deltaLabel?: string | null;
+  /** Activity Baseline only: subtle tier threshold ticks under the bar. */
+  showBaselineStepThresholdMarkers?: boolean;
 };
 
 /** Parses `compactStatsSummary` for display only (e.g. `7,524 steps` → `7,524`). Hook output unchanged. */
@@ -42,12 +46,25 @@ function headingSentenceLowerSteps(headingTitle: string): string {
   return headingTitle.endsWith(" Steps") ? `${headingTitle.slice(0, -" Steps".length)} steps` : headingTitle;
 }
 
-function DetailsTierProgressTrack({ testID, tierIndex }: { testID: string; tierIndex: number | null }) {
-  const pct = activityTierProgressAccessibilityPercent(tierIndex);
+function DetailsTierProgressTrack({
+  testID,
+  tierIndex,
+  fillWidth01Override,
+}: {
+  testID: string;
+  tierIndex: number | null;
+  /** Bounded 0 → 15k display fill when steps are numeric (`null` → empty bar). */
+  fillWidth01Override: number | null;
+}) {
+  const pct = activityTierProgressAccessibilityPercent(
+    tierIndex,
+    fillWidth01Override != null ? { fillWidth01Override } : undefined,
+  );
   return (
     <ActivityTierProgressTrack
       testID={testID}
       tierIndex={tierIndex}
+      fillWidth01Override={fillWidth01Override}
       wrapperProps={{
         accessibilityRole: "progressbar",
         accessibilityValue: { now: pct, min: 0, max: 100 },
@@ -65,11 +82,17 @@ export function ActivityDailyDetailsCard({
   stepsBarTestID = "activity-daily-details-steps-bar",
   footerCaption,
   deltaLabel,
+  showBaselineStepThresholdMarkers = false,
 }: ActivityDailyDetailsCardProps) {
   const digits = model != null ? primaryStepsFigureFromCompactSummary(model.compactStatsSummary) : null;
   const hasFooterCaption = footerCaption != null && footerCaption.length > 0;
   const hasDeltaLabel = deltaLabel != null && deltaLabel.length > 0;
+  const hasBaselineMarkers = showBaselineStepThresholdMarkers;
   const rating = digits != null ? getStepRatingActivityDescriptorPill(stepsFromLocaleDigitString(digits)) : null;
+  const stepsTierIndex =
+    digits != null ? getStepRatingTierIndex(stepsFromLocaleDigitString(digits)) : null;
+  const activityDisplayScaleFill01: number | null =
+    digits != null ? activityStepsDisplayScaleFill01(stepsFromLocaleDigitString(digits)) : null;
   const headingA11y = headingSentenceLowerSteps(headingTitle);
   const titleRowA11y =
     loading || model == null
@@ -130,17 +153,31 @@ export function ActivityDailyDetailsCard({
             moduleOverviewMetricLayoutStyles.metricBlock,
             styles.activityDetailsMetricBlock,
             styles.metricFooterStack,
-            hasFooterCaption
-              ? styles.metricFooterStackWithCaption
-              : hasDeltaLabel
-                ? styles.metricFooterStackWithDelta
-                : null,
+            hasFooterCaption && hasBaselineMarkers
+              ? styles.metricFooterStackBaselineWithMarkers
+              : hasFooterCaption
+                ? styles.metricFooterStackWithCaption
+                : hasDeltaLabel
+                  ? styles.metricFooterStackWithDelta
+                  : null,
           ]}
         >
-          <DetailsTierProgressTrack
-            testID={stepsBarTestID}
-            tierIndex={digits != null ? getStepRatingTierIndex(stepsFromLocaleDigitString(digits)) : null}
-          />
+          {hasBaselineMarkers ? (
+            <View style={styles.baselineInstrumentCluster} testID="activity-baseline-instrument-cluster">
+              <DetailsTierProgressTrack
+                testID={stepsBarTestID}
+                tierIndex={stepsTierIndex}
+                fillWidth01Override={activityDisplayScaleFill01}
+              />
+              <ActivityBaselineThresholdMarkers />
+            </View>
+          ) : (
+            <DetailsTierProgressTrack
+              testID={stepsBarTestID}
+              tierIndex={stepsTierIndex}
+              fillWidth01Override={activityDisplayScaleFill01}
+            />
+          )}
           {hasDeltaLabel ? (
             <Text style={styles.deltaInsight} testID="activity-daily-details-delta-label">
               {deltaLabel}
@@ -169,6 +206,13 @@ const styles = StyleSheet.create({
   },
   metricFooterStackWithCaption: {
     gap: 14,
+  },
+  /** Bar + markers live in `baselineInstrumentCluster`; this gap separates that unit from delta / explainer. */
+  metricFooterStackBaselineWithMarkers: {
+    gap: 12,
+  },
+  baselineInstrumentCluster: {
+    gap: 3,
   },
   metricFooterStackWithDelta: {
     gap: 11,

--- a/lib/ui/activity/ActivityOverviewCard.tsx
+++ b/lib/ui/activity/ActivityOverviewCard.tsx
@@ -13,6 +13,7 @@ import { ActivityRatingPill } from "@/lib/ui/activity/ActivityRatingPill";
 import { ErrorState, LoadingState } from "@/lib/ui/ScreenStates";
 import { elevatedCardSurfaceStyle } from "@/lib/ui/theme/elevatedCardSurface";
 import {
+  activityStepsDisplayScaleFill01,
   getStepRatingActivityDescriptorPill,
   getStepRatingTierIndex,
   stepsFromLocaleDigitString,
@@ -40,12 +41,26 @@ function overviewRowFigureDisplay(compactStatsSummary: string): { numeric: true;
   return { numeric: false, text: s };
 }
 
-function ActivityOverviewTierProgressTrack({ testID, tierIndex }: { testID: string; tierIndex: number | null }) {
-  const pct = activityTierProgressAccessibilityPercent(tierIndex);
+function ActivityOverviewTierProgressTrack({
+  testID,
+  tierIndex,
+  rowSteps,
+}: {
+  testID: string;
+  tierIndex: number | null;
+  /** Parsed steps for bounded display fill; `null` when row is non-numeric. */
+  rowSteps: number | null;
+}) {
+  const boundedFill = rowSteps != null ? activityStepsDisplayScaleFill01(rowSteps) : null;
+  const pct = activityTierProgressAccessibilityPercent(
+    tierIndex,
+    boundedFill != null ? { fillWidth01Override: boundedFill } : undefined,
+  );
   return (
     <ActivityTierProgressTrack
       testID={testID}
       tierIndex={tierIndex}
+      fillWidth01Override={boundedFill}
       wrapperProps={{
         accessibilityRole: "progressbar",
         accessibilityValue: { now: pct, min: 0, max: 100 },
@@ -147,7 +162,11 @@ export function ActivityOverviewCard({
                     </Text>
                   )}
                 </View>
-                <ActivityOverviewTierProgressTrack testID={`activity-overview-steps-bar-${tf.key}`} tierIndex={tierIndex} />
+                <ActivityOverviewTierProgressTrack
+                  testID={`activity-overview-steps-bar-${tf.key}`}
+                  tierIndex={tierIndex}
+                  rowSteps={rowSteps}
+                />
               </View>
             );
           })}

--- a/lib/ui/activity/ActivityTierProgressTrack.tsx
+++ b/lib/ui/activity/ActivityTierProgressTrack.tsx
@@ -20,6 +20,11 @@ export type ActivityTierProgressTrackProps = {
   testID?: string;
   /** Tier 0–5 from {@link getStepRatingTierIndex}; `null` → empty bar (non-numeric / insufficient row). */
   tierIndex: number | null;
+  /**
+   * When set (Activity Baseline card only), bar width follows this 0–1 value instead of fixed tier-segment
+   * widths; tier still controls fill color.
+   */
+  fillWidth01Override?: number | null;
   barHeight?: number;
   trackRadius?: number;
   wrapperProps?: Omit<ViewProps, "children" | "onLayout" | "testID" | "style"> & {
@@ -34,13 +39,19 @@ export type ActivityTierProgressTrackProps = {
 export function ActivityTierProgressTrack({
   testID,
   tierIndex,
+  fillWidth01Override,
   barHeight = DEFAULT_BAR_HEIGHT,
   trackRadius = DEFAULT_TRACK_RADIUS,
   wrapperProps,
 }: ActivityTierProgressTrackProps) {
   const reduceMotion = useActivityReduceMotion();
   const visual = activityStepTierBarVisual(tierIndex);
-  const targetFill01 = visual?.fill01 ?? 0;
+  const targetFill01 =
+    visual != null &&
+    fillWidth01Override != null &&
+    Number.isFinite(fillWidth01Override)
+      ? Math.min(1, Math.max(0, fillWidth01Override))
+      : (visual?.fill01 ?? 0);
   const targetColor = visual?.fillColor ?? "rgba(0,0,0,0)";
 
   const fill01Anim = useRef(new Animated.Value(targetFill01)).current;
@@ -108,7 +119,7 @@ export function ActivityTierProgressTrack({
     return () => {
       anim.stop();
     };
-  }, [tierIndex, targetFill01, targetColor, reduceMotion, fill01Anim, colorBlend]);
+  }, [tierIndex, fillWidth01Override, targetFill01, targetColor, reduceMotion, fill01Anim, colorBlend]);
 
   const fillWidthStyle = useMemo(
     () => ({
@@ -198,9 +209,16 @@ export function ActivityTierProgressTrack({
 }
 
 /** Re-export for callers that set `accessibilityValue` on the wrapper (progressbar). */
-export function activityTierProgressAccessibilityPercent(tierIndex: number | null): number {
-  const v = activityStepTierBarVisual(tierIndex);
-  return v != null ? Math.round(v.fill01 * 100) : 0;
+export function activityTierProgressAccessibilityPercent(
+  tierIndex: number | null,
+  opts?: { fillWidth01Override?: number | null },
+): number {
+  const visual = activityStepTierBarVisual(tierIndex);
+  const o = opts?.fillWidth01Override;
+  if (visual != null && o != null && Number.isFinite(o)) {
+    return Math.round(Math.min(1, Math.max(0, o)) * 100);
+  }
+  return visual != null ? Math.round(visual.fill01 * 100) : 0;
 }
 
 const styles = StyleSheet.create({

--- a/lib/ui/activity/__tests__/ActivityBaselineThresholdMarkers.test.tsx
+++ b/lib/ui/activity/__tests__/ActivityBaselineThresholdMarkers.test.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import renderer, { act } from "react-test-renderer";
+
+import { ActivityBaselineThresholdMarkers } from "@/lib/ui/activity/ActivityBaselineThresholdMarkers";
+
+describe("ActivityBaselineThresholdMarkers", () => {
+  it("renders bounded-scale labels including 0, 2.5k, and canonical tier thresholds", () => {
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<ActivityBaselineThresholdMarkers />);
+    });
+    const str = JSON.stringify(tree.toJSON());
+    expect(str).toContain("activity-baseline-threshold-markers");
+    expect(str).toContain('["0"]');
+    expect(str).toContain("2.5k");
+    expect(str).toContain("5k");
+    expect(str).toContain("7.5k");
+    expect(str).toContain("10k");
+    expect(str).toContain("12.5k");
+    expect(str).toContain("15k");
+  });
+});

--- a/lib/ui/activity/__tests__/ActivityDailyDetailsCard.test.tsx
+++ b/lib/ui/activity/__tests__/ActivityDailyDetailsCard.test.tsx
@@ -29,6 +29,7 @@ describe("ActivityDailyDetailsCard", () => {
     expect(str).not.toMatch(/148 steps/);
     expect(str).not.toContain("Couldn’t load steps for");
     expect(str).toContain("activity-daily-details-steps-bar");
+    expect(str).not.toContain("activity-baseline-threshold-markers");
   });
 
   it("shows selected-day inline error when that day failed and model is absent", () => {
@@ -80,6 +81,31 @@ describe("ActivityDailyDetailsCard", () => {
       );
     });
     expect(JSON.stringify(tree.toJSON())).not.toContain("Other days may still show");
+  });
+
+  it("wraps the progress track and baseline threshold markers in a single cluster for the Activity Baseline card", () => {
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(
+        <ActivityDailyDetailsCard
+          loading={false}
+          error={null}
+          model={{
+            title: "Baseline",
+            compactStatsSummary: "10,000 steps",
+            markerPosition01: 0.5,
+          }}
+          footerCaption="Explainer below."
+          showBaselineStepThresholdMarkers
+        />,
+      );
+    });
+    const str = JSON.stringify(tree.toJSON());
+    expect(str).toContain("activity-baseline-instrument-cluster");
+    expect(str).toContain("activity-baseline-threshold-markers");
+    expect(str).toContain("2.5k");
+    expect(str).toContain("5k");
+    expect(str).toContain("Explainer below.");
   });
 
   it("supports custom heading title without changing numeric tier UI", () => {

--- a/lib/ui/activity/__tests__/ActivityOverviewCard.test.tsx
+++ b/lib/ui/activity/__tests__/ActivityOverviewCard.test.tsx
@@ -85,6 +85,7 @@ describe("ActivityOverviewCard", () => {
     expect(str).toContain("Sedentary");
     expect(str).not.toContain("Optimal");
     expect(str).not.toContain("Overview");
+    expect(str).not.toContain("activity-baseline-threshold-markers");
   });
 
   it("renders Not enough data copy when model supplies it", () => {

--- a/lib/ui/activity/__tests__/activityBaselineMarkerLayout.test.ts
+++ b/lib/ui/activity/__tests__/activityBaselineMarkerLayout.test.ts
@@ -1,0 +1,56 @@
+import {
+  ACTIVITY_BASELINE_PROGRESS_RIM_INSET_PX,
+  activityBaselineProgressInnerWidthPx,
+  activityBaselineThresholdCenterXInOuterPx,
+  activityBaselineThresholdLabelLeftPx,
+  activityBaselineThresholdTickLeftPx,
+} from "@/lib/ui/activity/activityBaselineMarkerLayout";
+import { ACTIVITY_BASELINE_THRESHOLD_MARKER_TRACK_MAX_STEPS } from "@/lib/utils/activityStepRating";
+
+describe("activityBaselineMarkerLayout", () => {
+  const outer = 360;
+  const inner = activityBaselineProgressInnerWidthPx(outer);
+  const rim = ACTIVITY_BASELINE_PROGRESS_RIM_INSET_PX;
+
+  it("inner width subtracts two rim insets from outer width", () => {
+    expect(inner).toBeCloseTo(outer - 2 * rim, 5);
+  });
+
+  it("places 0 at the inner-track left edge on the bounded scale", () => {
+    const cx0 = activityBaselineThresholdCenterXInOuterPx(outer, 0);
+    expect(cx0).toBeCloseTo(rim, 5);
+  });
+
+  it("places 2.5k at one-sixth of the inner span", () => {
+    const cx = activityBaselineThresholdCenterXInOuterPx(outer, 2500);
+    const expected = rim + (2500 / ACTIVITY_BASELINE_THRESHOLD_MARKER_TRACK_MAX_STEPS) * inner;
+    expect(cx).toBeCloseTo(expected, 5);
+  });
+
+  it("centers 5k at the linear threshold on the inner track (in outer coords)", () => {
+    const cx = activityBaselineThresholdCenterXInOuterPx(outer, 5000);
+    const expected = rim + (5000 / ACTIVITY_BASELINE_THRESHOLD_MARKER_TRACK_MAX_STEPS) * inner;
+    expect(cx).toBeCloseTo(expected, 5);
+  });
+
+  it("centers 15k at the inner-track right edge on the bounded 0→15k scale", () => {
+    const cx = activityBaselineThresholdCenterXInOuterPx(outer, 15000);
+    expect(cx).toBeCloseTo(rim + inner, 5);
+    const expected = rim + (15000 / ACTIVITY_BASELINE_THRESHOLD_MARKER_TRACK_MAX_STEPS) * inner;
+    expect(cx).toBeCloseTo(expected, 5);
+  });
+
+  it("label left clamps so the label stays inside the outer track", () => {
+    const w = 40;
+    const left = activityBaselineThresholdLabelLeftPx(outer, 5000, w);
+    expect(left).toBeGreaterThanOrEqual(0);
+    expect(left + w).toBeLessThanOrEqual(outer);
+  });
+
+  it("tick left centers the tick on the same x as the label math", () => {
+    const tickW = 2;
+    const cx = activityBaselineThresholdCenterXInOuterPx(outer, 10000);
+    const tickLeft = activityBaselineThresholdTickLeftPx(outer, 10000, tickW);
+    expect(tickLeft + tickW / 2).toBeCloseTo(cx, 5);
+  });
+});

--- a/lib/ui/activity/activityBaselineCopy.ts
+++ b/lib/ui/activity/activityBaselineCopy.ts
@@ -1,3 +1,3 @@
 /** Fixed definition line on the Activity Baseline card (display-only copy). */
 export const ACTIVITY_BASELINE_DEFINITION_SENTENCE =
-  "Your baseline is your average daily steps over the past 90 days";
+  "Your typical daily activity level based on the past 90 days";

--- a/lib/ui/activity/activityBaselineMarkerLayout.ts
+++ b/lib/ui/activity/activityBaselineMarkerLayout.ts
@@ -1,0 +1,52 @@
+import { StyleSheet } from "react-native";
+
+import { ACTIVITY_BASELINE_THRESHOLD_MARKER_TRACK_MAX_STEPS } from "@/lib/utils/activityStepRating";
+
+/** Matches {@link ActivityTierProgressTrack} rim (`trackRim` `borderWidth`) so markers align to inner track. */
+export const ACTIVITY_BASELINE_PROGRESS_RIM_INSET_PX = StyleSheet.hairlineWidth;
+
+/** Inner drawable width of the bar for a measured outer track width (same box model as progress rim). */
+export function activityBaselineProgressInnerWidthPx(outerTrackWidthPx: number): number {
+  const rim = ACTIVITY_BASELINE_PROGRESS_RIM_INSET_PX;
+  return Math.max(0, outerTrackWidthPx - 2 * rim);
+}
+
+/**
+ * Horizontal center of a step threshold on the **outer** track coordinate system (0 = left edge of
+ * `trackWrap`), linear on the bounded **0 → {@link ACTIVITY_BASELINE_THRESHOLD_MARKER_TRACK_MAX_STEPS}**
+ * inner segment — matches Activity bounded bar fill (`activityStepsDisplayScaleFill01` scale).
+ */
+export function activityBaselineThresholdCenterXInOuterPx(
+  outerTrackWidthPx: number,
+  thresholdSteps: number,
+): number {
+  const max = ACTIVITY_BASELINE_THRESHOLD_MARKER_TRACK_MAX_STEPS;
+  const rim = ACTIVITY_BASELINE_PROGRESS_RIM_INSET_PX;
+  const inner = activityBaselineProgressInnerWidthPx(outerTrackWidthPx);
+  const center01 = Math.min(1, Math.max(0, thresholdSteps / max));
+  return rim + center01 * inner;
+}
+
+/** Left edge for a label centered on `thresholdSteps`, clamped to the outer track. */
+export function activityBaselineThresholdLabelLeftPx(
+  outerTrackWidthPx: number,
+  thresholdSteps: number,
+  labelWidthPx: number,
+): number {
+  const cx = activityBaselineThresholdCenterXInOuterPx(outerTrackWidthPx, thresholdSteps);
+  const raw = cx - labelWidthPx / 2;
+  const maxLeft = Math.max(0, outerTrackWidthPx - labelWidthPx);
+  return Math.max(0, Math.min(maxLeft, raw));
+}
+
+/** Left edge for a tick centered on `thresholdSteps`, clamped to the outer track. */
+export function activityBaselineThresholdTickLeftPx(
+  outerTrackWidthPx: number,
+  thresholdSteps: number,
+  tickWidthPx: number,
+): number {
+  const cx = activityBaselineThresholdCenterXInOuterPx(outerTrackWidthPx, thresholdSteps);
+  const raw = cx - tickWidthPx / 2;
+  const maxLeft = Math.max(0, outerTrackWidthPx - tickWidthPx);
+  return Math.max(0, Math.min(maxLeft, raw));
+}

--- a/lib/ui/workouts/StrengthBaselineCard.tsx
+++ b/lib/ui/workouts/StrengthBaselineCard.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+
+import type { StrengthBaselineCardModel } from "@/lib/data/workouts/strengthBaselineCardModel";
+import { STRENGTH_BASELINE_CARD_DEFINITION_SENTENCE } from "@/lib/ui/workouts/strengthBaselineCopy";
+import { StrengthFrequencyMetricCard } from "@/lib/ui/workouts/StrengthFrequencyMetricCard";
+
+type StrengthBaselineCardProps = {
+  loading: boolean;
+  model: StrengthBaselineCardModel | null;
+};
+
+export function StrengthBaselineCard({ loading, model }: StrengthBaselineCardProps) {
+  const display =
+    model != null
+      ? {
+          compactValuePrimary: model.compactValuePrimary,
+          ratingLabel: model.ratingLabel,
+          activityTierIndexForBar: model.activityTierIndexForBar,
+          fillWidth01Override: model.fillWidth01Override,
+        }
+      : null;
+
+  return (
+    <StrengthFrequencyMetricCard
+      headingTitle="Strength Baseline"
+      loading={loading}
+      model={display}
+      footerCaption={STRENGTH_BASELINE_CARD_DEFINITION_SENTENCE}
+      ratingPillTestID="strength-baseline-rating-pill"
+      frequencyBarTestID="strength-baseline-frequency-bar"
+      instrumentClusterTestID="strength-baseline-instrument-cluster"
+    />
+  );
+}

--- a/lib/ui/workouts/StrengthBaselineFrequencyMarkers.tsx
+++ b/lib/ui/workouts/StrengthBaselineFrequencyMarkers.tsx
@@ -1,0 +1,141 @@
+import { Fragment, useCallback, useEffect, useRef, useState } from "react";
+import { LayoutChangeEvent, StyleSheet, Text, View } from "react-native";
+
+import {
+  STRENGTH_BASELINE_WEEKLY_FREQUENCY_DISPLAY_MAX,
+} from "@/lib/utils/strengthWeeklyFrequencyRating";
+import {
+  strengthBaselineFrequencyThresholdLabelLeftPx,
+  strengthBaselineFrequencyThresholdTickLeftPx,
+} from "@/lib/ui/workouts/strengthBaselineMarkerLayout";
+
+/** Integer markers on 0 → {@link STRENGTH_BASELINE_WEEKLY_FREQUENCY_DISPLAY_MAX} inclusive. */
+const FREQUENCY_MARKER_VALUES = Array.from({ length: STRENGTH_BASELINE_WEEKLY_FREQUENCY_DISPLAY_MAX + 1 }, (_, i) => i);
+
+const MARKER_LABELS = FREQUENCY_MARKER_VALUES.map(String) as readonly string[];
+
+const TICK_WIDTH_PX = Math.max(1, StyleSheet.hairlineWidth * 2);
+const TICK_HEIGHT_PX = 5;
+const LABEL_TOP_PX = TICK_HEIGHT_PX + 1;
+
+/**
+ * Baseline ruler for weekly frequency (matches {@link ActivityBaselineThresholdMarkers} geometry; linear 0→7 scale).
+ */
+export function StrengthBaselineFrequencyMarkers() {
+  const [outerW, setOuterW] = useState(0);
+  const [labelWidths, setLabelWidths] = useState<(number | null)[]>(() =>
+    Array.from({ length: MARKER_LABELS.length }, () => null),
+  );
+
+  const prevOuterW = useRef(0);
+  useEffect(() => {
+    if (outerW <= 0) return;
+    if (prevOuterW.current > 0 && prevOuterW.current !== outerW) {
+      setLabelWidths(Array.from({ length: MARKER_LABELS.length }, () => null));
+    }
+    prevOuterW.current = outerW;
+  }, [outerW]);
+
+  const onRowLayout = useCallback((e: LayoutChangeEvent) => {
+    setOuterW(e.nativeEvent.layout.width);
+  }, []);
+
+  const onLabelTextLayout = useCallback((index: number, width: number) => {
+    setLabelWidths((prev) => {
+      if (prev[index] === width) return prev;
+      const next = [...prev];
+      next[index] = width;
+      return next;
+    });
+  }, []);
+
+  const allMeasured =
+    outerW > 0 && labelWidths.every((w) => w != null && Number.isFinite(w) && (w as number) > 0);
+
+  return (
+    <View style={styles.wrap} testID="strength-baseline-frequency-markers" onLayout={onRowLayout}>
+      {!allMeasured ? (
+        <View style={styles.measureRow} pointerEvents="none">
+          {MARKER_LABELS.map((lab, i) => (
+            <Text
+              key={`measure-${i}`}
+              style={styles.label}
+              onTextLayout={(e) => {
+                const lines = e.nativeEvent.lines;
+                const w = lines.reduce((max, line) => Math.max(max, line.width), 0);
+                onLabelTextLayout(i, w);
+              }}
+            >
+              {lab}
+            </Text>
+          ))}
+        </View>
+      ) : (
+        FREQUENCY_MARKER_VALUES.map((frequency, i) => (
+          <Fragment key={frequency}>
+            <View
+              style={[
+                styles.tick,
+                {
+                  left: strengthBaselineFrequencyThresholdTickLeftPx(outerW, frequency, TICK_WIDTH_PX),
+                  width: TICK_WIDTH_PX,
+                },
+              ]}
+              accessibilityElementsHidden
+              importantForAccessibility="no"
+            />
+            <Text
+              style={[
+                styles.label,
+                styles.labelPositioned,
+                {
+                  left: strengthBaselineFrequencyThresholdLabelLeftPx(
+                    outerW,
+                    frequency,
+                    labelWidths[i]!,
+                  ),
+                },
+              ]}
+              numberOfLines={1}
+              testID={`strength-baseline-marker-label-${frequency}`}
+            >
+              {MARKER_LABELS[i]}
+            </Text>
+          </Fragment>
+        ))
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: {
+    position: "relative",
+    width: "100%",
+    minHeight: LABEL_TOP_PX + 11,
+    marginTop: 0,
+  },
+  measureRow: {
+    flexDirection: "row",
+    opacity: 0,
+    height: LABEL_TOP_PX + 11,
+    overflow: "hidden",
+    gap: 8,
+  },
+  tick: {
+    position: "absolute",
+    top: 0,
+    height: TICK_HEIGHT_PX,
+    backgroundColor: "rgba(60, 60, 67, 0.14)",
+  },
+  label: {
+    fontSize: 10,
+    fontWeight: "500",
+    color: "#636366",
+    letterSpacing: -0.08,
+  },
+  labelPositioned: {
+    position: "absolute",
+    top: LABEL_TOP_PX,
+  },
+});

--- a/lib/ui/workouts/StrengthBaselineFrequencyTrack.tsx
+++ b/lib/ui/workouts/StrengthBaselineFrequencyTrack.tsx
@@ -1,0 +1,131 @@
+import React from "react";
+import { Platform, StyleSheet, View, type ViewProps } from "react-native";
+
+import { MODULE_OVERVIEW_SEGMENTED_TRACK } from "@/lib/ui/overview/moduleOverviewSegmentedTrackMetrics";
+import {
+  activityStepTierBarVisual,
+  STEP_TIER_TRACK_INNER_BACKGROUND,
+  STEP_TIER_TRACK_RIM_BORDER,
+} from "@/lib/utils/activityStepTierVisual";
+
+const DEFAULT_BAR_HEIGHT = MODULE_OVERVIEW_SEGMENTED_TRACK.barHeight;
+const DEFAULT_TRACK_RADIUS = MODULE_OVERVIEW_SEGMENTED_TRACK.trackRadius;
+
+export type StrengthBaselineFrequencyTrackProps = {
+  testID?: string;
+  tierIndex: number;
+  /** Bounded 0 → 1 along the weekly frequency ruler (typically avg/7). */
+  fillWidth01: number;
+  wrapperProps?: Omit<ViewProps, "children" | "onLayout" | "testID" | "style"> & {
+    style?: ViewProps["style"];
+  };
+};
+
+/** Static Activity-baseline-style bar (no Animated / Easing) — matches {@link ActivityTierProgressTrack} shell. */
+export function StrengthBaselineFrequencyTrack({
+  testID,
+  tierIndex,
+  fillWidth01,
+  wrapperProps,
+}: StrengthBaselineFrequencyTrackProps) {
+  const visual = activityStepTierBarVisual(tierIndex);
+  const w01 = Math.min(1, Math.max(0, Number.isFinite(fillWidth01) ? fillWidth01 : 0));
+  const pct = Math.round(w01 * 100);
+  const fillColor = visual?.fillColor ?? "rgba(0,0,0,0)";
+
+  const os = typeof Platform !== "undefined" && Platform.OS != null ? Platform.OS : "ios";
+  const rimShadow =
+    os === "ios"
+      ? {
+          shadowColor: "#000000",
+          shadowOffset: { width: 0, height: 1 },
+          shadowOpacity: 0.05,
+          shadowRadius: 2,
+        }
+      : os === "android"
+        ? { elevation: 1 }
+        : {};
+
+  const { style: wrapperStyle, ...wrapperRest } = wrapperProps ?? {};
+
+  return (
+    <View
+      {...wrapperRest}
+      {...(testID != null ? { testID } : {})}
+      style={[styles.trackWrap, { height: DEFAULT_BAR_HEIGHT }, wrapperStyle]}
+    >
+      <View
+        style={[
+          styles.trackRim,
+          {
+            height: DEFAULT_BAR_HEIGHT,
+            borderRadius: DEFAULT_TRACK_RADIUS,
+            borderColor: STEP_TIER_TRACK_RIM_BORDER,
+            ...rimShadow,
+          },
+        ]}
+        importantForAccessibility="no"
+      >
+        <View
+          style={[
+            styles.trackInner,
+            {
+              borderRadius: DEFAULT_TRACK_RADIUS,
+              height: DEFAULT_BAR_HEIGHT,
+              backgroundColor: STEP_TIER_TRACK_INNER_BACKGROUND,
+            },
+          ]}
+          importantForAccessibility="no"
+        >
+          {visual != null ? (
+            <View
+              style={[
+                styles.fill,
+                {
+                  width: `${pct}%`,
+                  height: DEFAULT_BAR_HEIGHT,
+                  backgroundColor: fillColor,
+                  borderTopLeftRadius: DEFAULT_TRACK_RADIUS,
+                  borderBottomLeftRadius: DEFAULT_TRACK_RADIUS,
+                  borderTopRightRadius: DEFAULT_TRACK_RADIUS,
+                  borderBottomRightRadius: DEFAULT_TRACK_RADIUS,
+                },
+              ]}
+              importantForAccessibility="no"
+            />
+          ) : null}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+export function strengthBaselineFrequencyTrackAccessibilityPercent(tierIndex: number, fillWidth01: number): number {
+  const visual = activityStepTierBarVisual(tierIndex);
+  const w01 = Math.min(1, Math.max(0, Number.isFinite(fillWidth01) ? fillWidth01 : 0));
+  if (visual != null && Number.isFinite(fillWidth01)) {
+    return Math.round(w01 * 100);
+  }
+  return visual != null ? Math.round(visual.fill01 * 100) : 0;
+}
+
+const styles = StyleSheet.create({
+  trackWrap: {
+    width: "100%",
+    position: "relative",
+    justifyContent: "center",
+  },
+  trackRim: {
+    borderWidth: StyleSheet.hairlineWidth,
+    backgroundColor: "#FFFFFF",
+  },
+  trackInner: {
+    position: "relative",
+    overflow: "hidden",
+  },
+  fill: {
+    position: "absolute",
+    left: 0,
+    top: 0,
+  },
+});

--- a/lib/ui/workouts/StrengthFrequencyMetricCard.tsx
+++ b/lib/ui/workouts/StrengthFrequencyMetricCard.tsx
@@ -1,0 +1,271 @@
+import React from "react";
+import { StyleSheet, Text, View, type StyleProp, type ViewStyle } from "react-native";
+
+import { ACTIVITY_DETAILS_SUBTLE_PILL_LABEL_TYPOGRAPHY } from "@/lib/ui/activity/activityUiTypography";
+import { ActivityRatingPill } from "@/lib/ui/activity/ActivityRatingPill";
+import {
+  StrengthBaselineFrequencyTrack,
+  strengthBaselineFrequencyTrackAccessibilityPercent,
+} from "@/lib/ui/workouts/StrengthBaselineFrequencyTrack";
+import { StrengthBaselineFrequencyMarkers } from "@/lib/ui/workouts/StrengthBaselineFrequencyMarkers";
+import type { StrengthWeeklyFrequencyCardDisplayModel } from "@/lib/ui/workouts/strengthWeeklyFrequencyCardTypes";
+import { moduleOverviewMetricLayoutStyles } from "@/lib/ui/overview/moduleOverviewMetricLayout";
+import { LoadingState } from "@/lib/ui/ScreenStates";
+import { elevatedCardSurfaceStyle } from "@/lib/ui/theme/elevatedCardSurface";
+import { UI_TEXT_TERTIARY_LABEL } from "@/lib/ui/theme/uiTokens";
+import { strengthMetricCardTitleTextStyle } from "@/lib/ui/workouts/strengthMetricCardTitleStyle";
+import { ACTIVITY_STEP_RATING_TIERS } from "@/lib/utils/activityStepRating";
+
+type StrengthFrequencyMetricCardProps = {
+  headingTitle: string;
+  loading: boolean;
+  model: StrengthWeeklyFrequencyCardDisplayModel | null;
+  footerCaption: string;
+  ratingPillTestID: string;
+  frequencyBarTestID: string;
+  instrumentClusterTestID: string;
+  /** `embedded`: no outer card chrome — parent supplies the elevated surface (see combined Recent Workouts card). */
+  variant?: "standalone" | "embedded";
+  /** When false, hides the 0–7 marker row below the bar (Strength Baseline keeps default `true`). */
+  showFrequencyMarkers?: boolean;
+  /** When false, hides the footer support/definition line (Strength Baseline keeps default `true`). */
+  showFooterCaption?: boolean;
+  /** When false, hides the frequency track + markers cluster (This Week summary-only header). */
+  showFrequencyTrack?: boolean;
+  /** Replaces the large primary figure on the title row (e.g. inline View More link). */
+  titleRowTrailing?: React.ReactNode;
+  /** Optional muted subtitle below the title row (e.g. “N sessions this week”). */
+  mutedMicroCaption?: string | null;
+  /** Tighter horizontal gap between heading and rating pill (embedded This Week). */
+  compactTitlePillSpacing?: boolean;
+};
+
+function FrequencyTrackRow({
+  testID,
+  tierIndex,
+  fillWidth01,
+}: {
+  testID: string;
+  tierIndex: number;
+  fillWidth01: number;
+}) {
+  const pct = strengthBaselineFrequencyTrackAccessibilityPercent(tierIndex, fillWidth01);
+  return (
+    <StrengthBaselineFrequencyTrack
+      testID={testID}
+      tierIndex={tierIndex}
+      fillWidth01={fillWidth01}
+      wrapperProps={{
+        accessibilityRole: "progressbar",
+        accessibilityValue: { now: pct, min: 0, max: 100 },
+      }}
+    />
+  );
+}
+
+/**
+ * Shared shell for Strength Baseline + This Week: activity-grade row, optional 0–7 frequency track,
+ * optional markers/caption. This Week embed mode can omit the track and show summary + trailing link only.
+ */
+export function StrengthFrequencyMetricCard({
+  headingTitle,
+  loading,
+  model,
+  footerCaption,
+  ratingPillTestID,
+  frequencyBarTestID,
+  instrumentClusterTestID,
+  variant = "standalone",
+  showFrequencyMarkers = true,
+  showFooterCaption = true,
+  showFrequencyTrack = true,
+  titleRowTrailing,
+  mutedMicroCaption = null,
+  compactTitlePillSpacing = false,
+}: StrengthFrequencyMetricCardProps) {
+  const primary = model?.compactValuePrimary ?? null;
+  const tierIdx = model != null ? Math.min(model.activityTierIndexForBar, ACTIVITY_STEP_RATING_TIERS.length - 1) : 0;
+  const tierPill = ACTIVITY_STEP_RATING_TIERS[tierIdx]!;
+  const microTrimmed = mutedMicroCaption?.trim() ?? "";
+  const showMutedMicro = microTrimmed.length > 0;
+  const titleRowA11y =
+    loading || model == null
+      ? headingTitle
+      : showMutedMicro
+        ? `${headingTitle}. ${model.ratingLabel}. ${microTrimmed}. View all.`
+        : `${model.ratingLabel}, ${primary ?? ""}`;
+  const rootStyle: StyleProp<ViewStyle> =
+    variant === "embedded"
+      ? [styles.embeddedRoot, !showFrequencyTrack && styles.embeddedRootCompactHeaderOnly]
+      : styles.card;
+  const embeddedCompact =
+    variant === "embedded" &&
+    (!showFrequencyMarkers || !showFooterCaption || !showFrequencyTrack);
+  const metricFooterGapStyle =
+    showFrequencyMarkers && showFooterCaption
+      ? styles.metricFooterStackBaselineWithMarkers
+      : embeddedCompact
+        ? styles.metricFooterStackEmbeddedCompact
+        : styles.metricFooterStack;
+
+  const titleRowEl = (
+    <View
+      style={[
+        moduleOverviewMetricLayoutStyles.topRow,
+        styles.activityRowTop,
+        styles.titleNumberRow,
+        embeddedCompact && styles.titleNumberRowEmbeddedCompact,
+      ]}
+      accessible={!showMutedMicro}
+      accessibilityRole={showMutedMicro ? undefined : "header"}
+      accessibilityLabel={showMutedMicro ? undefined : titleRowA11y}
+    >
+      <View style={[styles.titlePillLeftGroup, compactTitlePillSpacing && styles.titlePillLeftGroupTight]}>
+        <Text style={styles.cardTitle} numberOfLines={1}>
+          {headingTitle}
+        </Text>
+        {!loading && model != null ? (
+          <ActivityRatingPill
+            label={model.ratingLabel}
+            color={tierPill.color}
+            backgroundColor={tierPill.backgroundColor}
+            emphasis="subtle"
+            compactChrome
+            labelTypography={ACTIVITY_DETAILS_SUBTLE_PILL_LABEL_TYPOGRAPHY}
+            testID={ratingPillTestID}
+          />
+        ) : null}
+      </View>
+      {titleRowTrailing != null ? (
+        titleRowTrailing
+      ) : !loading && model != null && primary != null ? (
+        <Text style={styles.primaryValueFigure} numberOfLines={1}>
+          {primary}
+        </Text>
+      ) : null}
+    </View>
+  );
+
+  const headingSection =
+    showMutedMicro ? (
+      <View style={styles.headingSummaryStack} accessible accessibilityRole="header" accessibilityLabel={titleRowA11y}>
+        {titleRowEl}
+        {!loading ? <Text style={styles.mutedMicroCaption}>{microTrimmed}</Text> : null}
+      </View>
+    ) : (
+      titleRowEl
+    );
+
+  return (
+    <View style={rootStyle}>
+      {headingSection}
+
+      {loading ? <LoadingState variant="inline" message="Loading workouts…" /> : null}
+
+      {!loading && model != null && showFrequencyTrack ? (
+        <View
+          style={[
+            moduleOverviewMetricLayoutStyles.metricBlock,
+            styles.activityDetailsMetricBlock,
+            styles.metricFooterStack,
+            metricFooterGapStyle,
+          ]}
+        >
+          <View style={styles.baselineInstrumentCluster} testID={instrumentClusterTestID}>
+            <FrequencyTrackRow
+              testID={frequencyBarTestID}
+              tierIndex={model.activityTierIndexForBar}
+              fillWidth01={model.fillWidth01Override}
+            />
+            {showFrequencyMarkers ? <StrengthBaselineFrequencyMarkers /> : null}
+          </View>
+          {showFooterCaption ? <Text style={styles.footerCaption}>{footerCaption}</Text> : null}
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: "#FFFFFF",
+    borderRadius: 12,
+    padding: 15,
+    gap: 11,
+    ...elevatedCardSurfaceStyle,
+  },
+  embeddedRoot: {
+    gap: 10,
+    width: "100%",
+  },
+  embeddedRootCompactHeaderOnly: {
+    gap: 0,
+  },
+  headingSummaryStack: {
+    width: "100%",
+    gap: 5,
+  },
+  mutedMicroCaption: {
+    fontSize: 12,
+    lineHeight: 16,
+    fontWeight: "400",
+    color: UI_TEXT_TERTIARY_LABEL,
+    letterSpacing: -0.06,
+    alignSelf: "flex-start",
+  },
+  activityDetailsMetricBlock: {
+    gap: 10,
+  },
+  metricFooterStack: {
+    gap: 10,
+  },
+  metricFooterStackEmbeddedCompact: {
+    gap: 8,
+  },
+  metricFooterStackBaselineWithMarkers: {
+    gap: 12,
+  },
+  baselineInstrumentCluster: {
+    gap: 3,
+  },
+  activityRowTop: {
+    alignItems: "baseline",
+  },
+  titleNumberRow: {
+    paddingBottom: 2,
+  },
+  /** Tighter title → bar rhythm when embedded This Week omits markers + footer line. */
+  titleNumberRowEmbeddedCompact: {
+    paddingBottom: 0,
+  },
+  titlePillLeftGroup: {
+    flex: 1,
+    minWidth: 0,
+    flexDirection: "row",
+    alignItems: "baseline",
+    gap: 7,
+  },
+  titlePillLeftGroupTight: {
+    gap: 5,
+  },
+  cardTitle: {
+    ...strengthMetricCardTitleTextStyle,
+  },
+  primaryValueFigure: {
+    fontSize: 23,
+    lineHeight: 28,
+    fontWeight: "600",
+    fontVariant: ["tabular-nums"],
+    color: "#1C1C1E",
+    letterSpacing: -0.44,
+    flexShrink: 0,
+  },
+  footerCaption: {
+    fontSize: 14,
+    lineHeight: 22,
+    fontWeight: "400",
+    color: "#8E8E93",
+    letterSpacing: -0.2,
+    marginBottom: 6,
+  },
+});

--- a/lib/ui/workouts/StrengthTrainingAnalyticsCards.tsx
+++ b/lib/ui/workouts/StrengthTrainingAnalyticsCards.tsx
@@ -5,8 +5,6 @@ import { WORKOUT_OVERVIEW_ANALYTICS_YEAR } from "@/lib/data/workouts/workoutsCal
 import { monthShortLabelFromMonthKey } from "@/lib/data/workouts/strengthOverviewMonthAnalytics";
 import type { StrengthAnalyticsSectionTarget } from "@/lib/workouts/navigation/strengthAnalyticsNavigationIntent";
 import { WorkoutAnalyticsChart } from "@/lib/ui/workouts/WorkoutAnalyticsChart";
-import { WeeklyMuscleGroupCard } from "@/lib/ui/workouts/WeeklyMuscleGroupCard";
-import { WeeklyStrengthCard } from "@/lib/ui/workouts/WeeklyStrengthCard";
 
 export type StrengthTrainingAnalyticsCardsProps = {
   models: StrengthAnalyticsCardModels;
@@ -16,100 +14,58 @@ export type StrengthTrainingAnalyticsCardsProps = {
   emphasizedSection?: StrengthAnalyticsSectionTarget | null;
   /** Y offset within this stack (for ScrollView scrollTo). */
   onAnalyticsSectionLayout?: (section: StrengthAnalyticsSectionTarget, y: number) => void;
-  /** Initial muscle card tab when opening from a volume/sets-specific insight (future). */
-  muscleGroupInitialTab?: "volume" | "sets";
 };
 
-const SECTION_TEST_ID: Record<StrengthAnalyticsSectionTarget, string> = {
-  weekly_strength: "strength-analytics-weekly-strength",
-  weekly_muscle_group: "strength-analytics-weekly-muscle",
-  monthly_workouts: "strength-analytics-monthly",
-  yearly_workouts: "strength-analytics-yearly",
-};
+const YEARLY_SECTION_TEST_ID = "strength-analytics-yearly";
 
 function AnalyticsSectionFrame({
-  section,
   emphasized,
   onLayoutY,
   children,
 }: {
-  section: StrengthAnalyticsSectionTarget;
   emphasized: boolean;
   onLayoutY?: (section: StrengthAnalyticsSectionTarget, y: number) => void;
   children: React.ReactNode;
 }) {
   const onLayout = (e: LayoutChangeEvent) => {
-    onLayoutY?.(section, e.nativeEvent.layout.y);
+    onLayoutY?.("yearly_workouts", e.nativeEvent.layout.y);
   };
   return (
-    <View
-      testID={SECTION_TEST_ID[section]}
-      style={[styles.sectionFrame, emphasized && styles.sectionFrameEmphasized]}
-      onLayout={onLayout}
-    >
+    <View testID={YEARLY_SECTION_TEST_ID} style={[styles.sectionFrame, emphasized && styles.sectionFrameEmphasized]} onLayout={onLayout}>
       {children}
     </View>
   );
 }
 
 /**
- * Strength-only analytics stack: weekly volume, weekly muscle, monthly + yearly workout charts.
+ * Strength analytics: yearly workout chart + metrics ({@link WORKOUT_OVERVIEW_ANALYTICS_YEAR} slice).
  */
 export function StrengthTrainingAnalyticsCards({
   models,
   chartOnViewMore,
   emphasizedSection = null,
   onAnalyticsSectionLayout,
-  muscleGroupInitialTab,
 }: StrengthTrainingAnalyticsCardsProps) {
+  const yearlyTitle = `${WORKOUT_OVERVIEW_ANALYTICS_YEAR} Strength Workouts`;
+
   return (
     <View style={styles.stack}>
       <AnalyticsSectionFrame
-        section="weekly_strength"
-        emphasized={emphasizedSection === "weekly_strength"}
-        {...(onAnalyticsSectionLayout != null ? { onLayoutY: onAnalyticsSectionLayout } : {})}
-      >
-        <WeeklyStrengthCard model={models.weeklyStrengthModel} />
-      </AnalyticsSectionFrame>
-      <AnalyticsSectionFrame
-        section="weekly_muscle_group"
-        emphasized={emphasizedSection === "weekly_muscle_group"}
-        {...(onAnalyticsSectionLayout != null ? { onLayoutY: onAnalyticsSectionLayout } : {})}
-      >
-        <WeeklyMuscleGroupCard
-          model={models.weeklyStrengthModel}
-          {...(muscleGroupInitialTab != null ? { initialTab: muscleGroupInitialTab } : {})}
-        />
-      </AnalyticsSectionFrame>
-      <AnalyticsSectionFrame
-        section="monthly_workouts"
-        emphasized={emphasizedSection === "monthly_workouts"}
-        {...(onAnalyticsSectionLayout != null ? { onLayoutY: onAnalyticsSectionLayout } : {})}
-      >
-        <WorkoutAnalyticsChart
-          layout="singleStrengthPeriod"
-          fixedPeriod="month"
-          headerTitle="Monthly Workouts"
-          yearTabLabel={String(WORKOUT_OVERVIEW_ANALYTICS_YEAR)}
-          monthTabLabel={monthShortLabelFromMonthKey(models.focusStrengthMonthKey)}
-          {...(chartOnViewMore != null ? { onViewMore: chartOnViewMore } : {})}
-          yearChartPoints={models.yearChartPoints}
-          yearMetrics={models.yearMetrics}
-          monthChartBars={models.strengthMonthOverview.chartBars}
-          monthMetrics={models.strengthMonthOverview.metrics}
-        />
-      </AnalyticsSectionFrame>
-      <AnalyticsSectionFrame
-        section="yearly_workouts"
         emphasized={emphasizedSection === "yearly_workouts"}
         {...(onAnalyticsSectionLayout != null ? { onLayoutY: onAnalyticsSectionLayout } : {})}
       >
         <WorkoutAnalyticsChart
           layout="singleStrengthPeriod"
+          layoutVariant="strengthYearly"
           fixedPeriod="year"
-          headerTitle="Yearly Workouts"
+          headerTitle={yearlyTitle}
           yearTabLabel={String(WORKOUT_OVERVIEW_ANALYTICS_YEAR)}
           monthTabLabel={monthShortLabelFromMonthKey(models.focusStrengthMonthKey)}
+          yearlyStrengthVisualization={{
+            avgWorkoutsPerWeek: models.strengthBaselineAvgWorkoutsPerWeek,
+            analyticsCalendarYear: WORKOUT_OVERVIEW_ANALYTICS_YEAR,
+            todayMonthKey: models.focusStrengthMonthKey,
+          }}
           {...(chartOnViewMore != null ? { onViewMore: chartOnViewMore } : {})}
           yearChartPoints={models.yearChartPoints}
           yearMetrics={models.yearMetrics}

--- a/lib/ui/workouts/StrengthYearlyWorkloadBars.tsx
+++ b/lib/ui/workouts/StrengthYearlyWorkloadBars.tsx
@@ -1,0 +1,223 @@
+import React, { useEffect, useMemo, useRef } from "react";
+import { Animated, Easing, StyleSheet, Text, View } from "react-native";
+
+import { shouldShowStrengthYearlyMonthValueLabel } from "@/lib/data/workouts/strengthYearlyChartLabelVisibility";
+import { UI_TEXT_TERTIARY_LABEL } from "@/lib/ui/theme/uiTokens";
+import { STEP_TIER_COLORS, STEP_TIER_TRACK_RIM_BORDER } from "@/lib/utils/activityStepTierVisual";
+
+export type YearWorkloadPoint = { monthKey: string; displayLabel: string; value: number };
+
+const BAR_TOP_RADIUS = 6;
+
+type StrengthYearlyWorkloadBarsProps = {
+  points: YearWorkloadPoint[];
+  barTrackHeight: number;
+  /** Primary bar fill ({@link STEP_TIER_COLORS.good}). */
+  fillColorGood: string;
+  /** Vertical scale maximum (aligned with Y-axis ticks). */
+  maxScale: number;
+  /** Expected monthly workload at baseline rate (same units as bar values). */
+  baselineMonthlyAvg: number;
+  /** Month key `YYYY-MM` for today in the analytics calendar year. */
+  todayMonthKey: string;
+};
+
+/** Multiplier on non-current-month bars (current month stays at full emphasis). */
+const BAR_DIM_OPACITY_NON_CURRENT = 0.74;
+
+function barTierOpacity(
+  monthKey: string,
+  todayMonthKey: string,
+  value: number,
+  maxScale: number,
+): number {
+  if (monthKey > todayMonthKey) {
+    return value <= 0 ? 0.22 : 0.38;
+  }
+  if (value <= 0) return 0.3;
+  const threshold = Math.max(maxScale * 0.06, 0.5);
+  return value < threshold ? 0.46 : 1;
+}
+
+const ANIM_MS = 260;
+
+export function StrengthYearlyWorkloadBars({
+  points,
+  barTrackHeight,
+  fillColorGood,
+  maxScale,
+  baselineMonthlyAvg,
+  todayMonthKey,
+}: StrengthYearlyWorkloadBarsProps) {
+  const baselineYPxFromBottom = Math.min(
+    barTrackHeight,
+    Math.max(0, (baselineMonthlyAvg / maxScale) * barTrackHeight),
+  );
+
+  const targetHeights = useMemo(
+    () => points.map((p) => Math.max(6, Math.round((p.value / maxScale) * barTrackHeight))),
+    [points, maxScale, barTrackHeight],
+  );
+
+  const skipAnim = typeof process.env.JEST_WORKER_ID !== "undefined";
+
+  const animsRef = useRef<Animated.Value[]>([]);
+
+  if (animsRef.current.length !== targetHeights.length) {
+    animsRef.current = targetHeights.map((t) => new Animated.Value(skipAnim ? t : 0));
+  }
+
+  const heightSig = targetHeights.join(",");
+
+  useEffect(() => {
+    targetHeights.forEach((target, i) => {
+      const v = animsRef.current[i];
+      if (!v) return;
+      if (skipAnim) {
+        v.setValue(target);
+        return;
+      }
+      v.setValue(0);
+      Animated.timing(v, {
+        toValue: target,
+        duration: ANIM_MS,
+        easing: Easing.out(Easing.quad),
+        useNativeDriver: false,
+      }).start();
+    });
+  }, [heightSig, skipAnim]);
+
+  function pointKey(p: YearWorkloadPoint): string {
+    return p.monthKey;
+  }
+
+  return (
+    <View style={styles.outer}>
+      <View style={styles.valueLabelsRow}>
+        {points.map((p) => {
+          const showLabel = shouldShowStrengthYearlyMonthValueLabel(p.monthKey, todayMonthKey, p.value);
+          return (
+            <View key={`lab-${pointKey(p)}`} style={styles.valueLabelCell}>
+              {showLabel ? <Text style={styles.valueLabelAbove}>{p.value}</Text> : null}
+            </View>
+          );
+        })}
+      </View>
+
+      <View style={[styles.trackWrap, { height: barTrackHeight }]}>
+        <View
+          pointerEvents="none"
+          style={[styles.baselineHairline, { bottom: baselineYPxFromBottom }]}
+          accessibilityElementsHidden
+          importantForAccessibility="no-hide-descendants"
+          testID="strength-yearly-chart-baseline-line"
+        />
+        <View
+          pointerEvents="none"
+          style={[styles.baselineLabelWrap, { bottom: baselineYPxFromBottom + StyleSheet.hairlineWidth + 2 }]}
+          accessibilityElementsHidden
+          importantForAccessibility="no-hide-descendants"
+        >
+          <Text style={styles.baselineLabel}>Baseline</Text>
+        </View>
+
+        <View style={styles.barsRowInner}>
+          {points.map((p, idx) => {
+            const isTodayMonth = p.monthKey === todayMonthKey;
+            const baseColor = isTodayMonth ? STEP_TIER_COLORS.great : fillColorGood;
+            const stackOpacity =
+              (isTodayMonth ? 1 : BAR_DIM_OPACITY_NON_CURRENT) *
+              barTierOpacity(p.monthKey, todayMonthKey, p.value, maxScale);
+
+            return (
+              <View key={pointKey(p)} style={styles.barCol}>
+                <Animated.View
+                  style={[
+                    styles.barFill,
+                    {
+                      borderTopLeftRadius: BAR_TOP_RADIUS,
+                      borderTopRightRadius: BAR_TOP_RADIUS,
+                      height: animsRef.current[idx] ?? new Animated.Value(0),
+                      opacity: stackOpacity,
+                      backgroundColor: baseColor,
+                    },
+                  ]}
+                />
+              </View>
+            );
+          })}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  outer: {
+    width: "100%",
+  },
+  valueLabelsRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    paddingHorizontal: 8,
+    marginBottom: 3,
+    minHeight: 14,
+  },
+  valueLabelCell: {
+    width: 20,
+    alignItems: "center",
+  },
+  valueLabelAbove: {
+    fontSize: 10,
+    fontWeight: "400",
+    color: UI_TEXT_TERTIARY_LABEL,
+    textAlign: "center",
+    letterSpacing: -0.08,
+  },
+  trackWrap: {
+    position: "relative",
+    width: "100%",
+    justifyContent: "flex-end",
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: STEP_TIER_TRACK_RIM_BORDER,
+  },
+  baselineHairline: {
+    position: "absolute",
+    left: 8,
+    right: 8,
+    height: StyleSheet.hairlineWidth,
+    borderRadius: StyleSheet.hairlineWidth / 2,
+    backgroundColor: "rgba(60, 60, 67, 0.28)",
+    zIndex: 1,
+  },
+  baselineLabelWrap: {
+    position: "absolute",
+    left: 10,
+    zIndex: 2,
+  },
+  baselineLabel: {
+    fontSize: 9,
+    fontWeight: "400",
+    color: UI_TEXT_TERTIARY_LABEL,
+    letterSpacing: 0.05,
+    opacity: 0.92,
+  },
+  barsRowInner: {
+    flexDirection: "row",
+    alignItems: "flex-end",
+    justifyContent: "space-between",
+    height: "100%",
+    paddingHorizontal: 8,
+    width: "100%",
+  },
+  barCol: {
+    width: 20,
+    alignItems: "center",
+    justifyContent: "flex-end",
+    height: "100%",
+  },
+  barFill: {
+    width: "100%",
+    minHeight: 6,
+  },
+});

--- a/lib/ui/workouts/WorkoutAnalyticsChart.tsx
+++ b/lib/ui/workouts/WorkoutAnalyticsChart.tsx
@@ -14,6 +14,16 @@ import {
   formatWorkoutDurationLabel,
 } from "@/lib/data/workouts/workoutDisplay";
 import { overviewAccentForTab } from "@/lib/ui/workouts/workoutOverviewAnalyticsTheme";
+import {
+  STEP_TIER_COLORS,
+  STEP_TIER_TRACK_RIM_BORDER,
+} from "@/lib/utils/activityStepTierVisual";
+import { averageExpectedMonthlyWorkloadFromWeeklyBaseline } from "@/lib/data/workouts/strengthYearlyChartBaseline";
+import {
+  strengthMetricCardTitleTextStyle,
+  strengthYearlyAnalyticsCardShellStyle,
+} from "@/lib/ui/workouts/strengthMetricCardTitleStyle";
+import { StrengthYearlyWorkloadBars } from "@/lib/ui/workouts/StrengthYearlyWorkloadBars";
 import { workoutOverviewInCardHeaderStyles } from "@/lib/ui/workouts/workoutOverviewInCardHeaderStyles";
 import {
   WorkoutAnalyticsMonthBarChart,
@@ -26,6 +36,8 @@ export type WorkoutAnalyticsChartProps = {
   headerTitle: string;
   /** Omit to hide the header "View More" action (e.g. on the analytics destination screen). */
   onViewMore?: () => void;
+  /** When `"strengthYearly"`, card shell + title typography match Strength Baseline / metric cards. */
+  layoutVariant?: "default" | "strengthYearly";
 } & (
   | {
       layout: "dual";
@@ -47,6 +59,12 @@ export type WorkoutAnalyticsChartProps = {
       monthChartBars: StrengthMonthChartBar[];
       monthMetrics: StrengthMonthScopedMetrics;
       fixedPeriod?: StrengthPeriodTab;
+      /** Strength Analytics yearly card: baseline rate + scale + month highlight (presentation-only). */
+      yearlyStrengthVisualization?: {
+        avgWorkoutsPerWeek: number;
+        analyticsCalendarYear: number;
+        todayMonthKey: string;
+      };
     }
 );
 
@@ -54,6 +72,8 @@ export type WorkoutAnalyticsChartProps = {
 const CHART_MONTH_LETTERS = ["J", "F", "M", "A", "M", "J", "J", "A", "S", "O", "N", "D"] as const;
 
 const BAR_TRACK_HEIGHT = 120;
+/** Taller plot for Strength Analytics yearly card — chart-forward layout (presentation-only). */
+const BAR_TRACK_HEIGHT_STRENGTH_YEARLY = 176;
 /** Symmetric horizontal inset so Jan/Dec balance inside the plot. */
 const CHART_PLOT_INSET_H = 8;
 /** Matches monthLabelsRow marginTop + single-line label height for column alignment. */
@@ -80,7 +100,7 @@ type MonthChartPoint = { key: string; displayLabel: string; value: number };
  * Training overview: dual-tab (legacy) or single-domain (Strength-only / Cardio-only product flows).
  */
 export function WorkoutAnalyticsChart(props: WorkoutAnalyticsChartProps) {
-  const { headerTitle, onViewMore } = props;
+  const { headerTitle, onViewMore, layoutVariant = "default" } = props;
   const [dualTab, setDualTab] = useState<WorkoutOverviewMetricsTab>("strength");
   const [strengthPeriodTab, setStrengthPeriodTab] = useState<StrengthPeriodTab>("year");
 
@@ -171,7 +191,27 @@ export function WorkoutAnalyticsChart(props: WorkoutAnalyticsChartProps) {
     resolved.monthChartPoints != null &&
     chartPoints.length > 0;
 
-  const max = Math.max(1, ...chartPoints.map((p) => p.value));
+  const isStrengthYearlyYearView =
+    layoutVariant === "strengthYearly" &&
+    resolved.kind === "singleStrengthPeriod" &&
+    resolved.strengthPeriodTab === "year";
+
+  const yearlyStrengthVisualization =
+    props.layout === "singleStrengthPeriod" ? props.yearlyStrengthVisualization : undefined;
+
+  const yearlyBaselineMonthly =
+    isStrengthYearlyYearView && yearlyStrengthVisualization != null
+      ? averageExpectedMonthlyWorkloadFromWeeklyBaseline(
+          yearlyStrengthVisualization.avgWorkoutsPerWeek,
+          yearlyStrengthVisualization.analyticsCalendarYear,
+        )
+      : null;
+
+  const max = Math.max(
+    1,
+    yearlyBaselineMonthly ?? 0,
+    ...chartPoints.map((p) => p.value),
+  );
   const axisMid = Math.round(max / 2);
 
   const pointKey = (p: YearChartPoint | MonthChartPoint): string =>
@@ -185,10 +225,29 @@ export function WorkoutAnalyticsChart(props: WorkoutAnalyticsChartProps) {
       }))
     : [];
 
+  const barTrackHeight = isStrengthYearlyYearView ? BAR_TRACK_HEIGHT_STRENGTH_YEARLY : BAR_TRACK_HEIGHT;
+  /** Good-band tier green — same palette as Strength Baseline / tier fills ({@link STEP_TIER_COLORS}). */
+  const chartBarFillColor =
+    layoutVariant === "strengthYearly" && resolved.kind === "singleStrengthPeriod"
+      ? STEP_TIER_COLORS.good
+      : resolved.accent.barColor;
+
+  /** Strength Analytics yearly card is title + chart only ({@link layoutVariant} `"strengthYearly"`). */
+  const omitStrengthYearlySummaries =
+    layoutVariant === "strengthYearly" && resolved.kind === "singleStrengthPeriod";
+
   return (
-    <View style={styles.card}>
-      <View style={[workoutOverviewInCardHeaderStyles.row, styles.inCardHeaderRowSpacing]}>
-        <Text style={workoutOverviewInCardHeaderStyles.title}>{headerTitle}</Text>
+    <View style={[styles.card, layoutVariant === "strengthYearly" ? strengthYearlyAnalyticsCardShellStyle : null]}>
+      <View
+        style={[
+          workoutOverviewInCardHeaderStyles.row,
+          styles.inCardHeaderRowSpacing,
+          layoutVariant === "strengthYearly" && styles.inCardHeaderRowSpacingBaselineFamily,
+        ]}
+      >
+        <Text style={layoutVariant === "strengthYearly" ? strengthMetricCardTitleTextStyle : workoutOverviewInCardHeaderStyles.title}>
+          {headerTitle}
+        </Text>
         {onViewMore != null ? (
           <Pressable
             onPress={onViewMore}
@@ -303,10 +362,16 @@ export function WorkoutAnalyticsChart(props: WorkoutAnalyticsChartProps) {
           </Pressable>
         </View>
       ) : (
-        <View style={styles.singleDomainChartSpacer} />
+        <View
+          style={
+            layoutVariant === "strengthYearly" ? styles.singleDomainChartSpacerBaselineFamilyTight : styles.singleDomainChartSpacer
+          }
+        />
       )}
       {chartPoints.length === 0 ? (
-        <Text style={styles.placeholder}>{resolved.chartEmptyMessage}</Text>
+        <Text style={[styles.placeholder, omitStrengthYearlySummaries && styles.placeholderStrengthYearly]}>
+          {resolved.chartEmptyMessage}
+        </Text>
       ) : useMonthFixedScaleBars ? (
         <View style={styles.chartPlotRow}>
           <View style={styles.yAxisColumn}>
@@ -321,14 +386,45 @@ export function WorkoutAnalyticsChart(props: WorkoutAnalyticsChartProps) {
           </View>
           <View style={styles.chartBarsBlock}>
             <View style={[styles.chartBarsInner, styles.chartBarsInnerMonth]}>
-              <WorkoutAnalyticsMonthBarChart points={monthBarPoints} barColor={resolved.accent.barColor} />
+              <WorkoutAnalyticsMonthBarChart points={monthBarPoints} barColor={chartBarFillColor} />
+            </View>
+          </View>
+        </View>
+      ) : isStrengthYearlyYearView && yearlyStrengthVisualization != null ? (
+        <View style={[styles.chartPlotRowYearlyFill, { minHeight: barTrackHeight + MONTH_LABEL_STACK_HEIGHT + 26 + 12 }]}>
+          <View style={styles.chartBarsBlock}>
+            <View style={[styles.chartBarsInner, styles.chartBarsInnerStrengthYearly]}>
+              <StrengthYearlyWorkloadBars
+                points={resolved.yearPoints}
+                barTrackHeight={barTrackHeight}
+                fillColorGood={STEP_TIER_COLORS.good}
+                maxScale={max}
+                baselineMonthlyAvg={yearlyBaselineMonthly ?? 0}
+                todayMonthKey={yearlyStrengthVisualization.todayMonthKey}
+              />
+              <View style={styles.monthLabelsRow}>
+                {chartPoints.map((p) => (
+                  <View key={pointKey(p)} style={styles.monthLabelCol}>
+                    <Text
+                      style={styles.barLabel}
+                      accessibilityLabel={
+                        "monthKey" in p ? `Month ${p.monthKey}` : `Week ${p.displayLabel}`
+                      }
+                    >
+                      {p.displayLabel}
+                    </Text>
+                  </View>
+                ))}
+              </View>
             </View>
           </View>
         </View>
       ) : (
-        <View style={styles.chartPlotRow}>
+        <View
+          style={[styles.chartPlotRow, isStrengthYearlyYearView && { minHeight: barTrackHeight + MONTH_LABEL_STACK_HEIGHT + 12 }]}
+        >
           <View style={styles.yAxisColumn}>
-            <View style={styles.yAxisTrack}>
+            <View style={[styles.yAxisTrack, { height: barTrackHeight }]}>
               <Text style={styles.yAxisTick}>{max}</Text>
               <Text style={styles.yAxisTick}>{axisMid}</Text>
               <Text style={styles.yAxisTick}>0</Text>
@@ -337,15 +433,23 @@ export function WorkoutAnalyticsChart(props: WorkoutAnalyticsChartProps) {
           </View>
           <View style={styles.chartBarsBlock}>
             <View style={styles.chartBarsInner}>
-              <View style={styles.barsRow}>
+              <View
+                style={[
+                  styles.barsRow,
+                  { height: barTrackHeight },
+                  isStrengthYearlyYearView && {
+                    borderBottomColor: STEP_TIER_TRACK_RIM_BORDER,
+                  },
+                ]}
+              >
                 {chartPoints.map((p) => (
                   <View key={pointKey(p)} style={styles.barCol}>
                     <View
                       style={[
                         styles.bar,
                         {
-                          height: Math.max(6, Math.round((p.value / max) * BAR_TRACK_HEIGHT)),
-                          backgroundColor: resolved.accent.barColor,
+                          height: Math.max(6, Math.round((p.value / max) * barTrackHeight)),
+                          backgroundColor: chartBarFillColor,
                         },
                       ]}
                     />
@@ -371,7 +475,10 @@ export function WorkoutAnalyticsChart(props: WorkoutAnalyticsChartProps) {
         </View>
       )}
 
-      {resolved.kind === "singleStrengthPeriod" && resolved.strengthPeriodTab === "month" && resolved.monthMetrics ? (
+      {resolved.kind === "singleStrengthPeriod" &&
+      resolved.strengthPeriodTab === "month" &&
+      resolved.monthMetrics &&
+      !omitStrengthYearlySummaries ? (
         <View style={styles.metricsGrid}>
           <View style={styles.metricsRow}>
             <View style={[styles.metricCell, { backgroundColor: resolved.accent.metricTileBg }]}>
@@ -398,7 +505,7 @@ export function WorkoutAnalyticsChart(props: WorkoutAnalyticsChartProps) {
             </View>
           </View>
         </View>
-      ) : resolved.metrics != null ? (
+      ) : resolved.metrics != null && !omitStrengthYearlySummaries ? (
         <View style={styles.metricsGrid}>
           <View style={styles.metricsRow}>
             <View style={[styles.metricCell, { backgroundColor: resolved.accent.metricTileBg }]}>
@@ -435,7 +542,11 @@ const styles = StyleSheet.create({
     padding: 16,
   },
   inCardHeaderRowSpacing: { marginBottom: 12 },
+  inCardHeaderRowSpacingBaselineFamily: { marginBottom: 14 },
   singleDomainChartSpacer: { height: 12 },
+  singleDomainChartSpacerBaselineFamily: { height: 8 },
+  /** Title → chart breathing room on Strength Analytics yearly card (fixed-period, no tabs). */
+  singleDomainChartSpacerBaselineFamilyTight: { height: 12 },
   tabBar: {
     flexDirection: "row",
     backgroundColor: "#EBEBEF",
@@ -458,10 +569,18 @@ const styles = StyleSheet.create({
   tabText: { fontSize: 15, fontWeight: "500", color: "#8E8E93" },
   tabTextActive: { fontWeight: "700" },
   placeholder: { fontSize: 15, fontWeight: "400", color: "#8E8E93", paddingVertical: 16 },
+  placeholderStrengthYearly: { paddingVertical: 12 },
   chartPlotRow: {
     flexDirection: "row",
     alignItems: "flex-start",
     gap: 8,
+    minHeight: 150,
+  },
+  /** Yearly Strength chart without left Y-axis ticks — single full-width plot column. */
+  chartPlotRowYearlyFill: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    width: "100%",
     minHeight: 150,
   },
   yAxisColumn: {
@@ -502,6 +621,10 @@ const styles = StyleSheet.create({
   chartBarsInnerMonth: {
     paddingLeft: 4,
     paddingRight: 4,
+  },
+  chartBarsInnerStrengthYearly: {
+    paddingLeft: 12,
+    paddingRight: 12,
   },
   barsRow: {
     flexDirection: "row",

--- a/lib/ui/workouts/__tests__/StrengthBaselineCard.test.tsx
+++ b/lib/ui/workouts/__tests__/StrengthBaselineCard.test.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import renderer, { act } from "react-test-renderer";
+
+import { StrengthBaselineCard } from "../StrengthBaselineCard";
+import type { StrengthBaselineCardModel } from "@/lib/data/workouts/strengthBaselineCardModel";
+import { buildStrengthBaselineCardModel } from "@/lib/data/workouts/strengthBaselineCardModel";
+import { STRENGTH_BASELINE_CARD_DEFINITION_SENTENCE } from "../strengthBaselineCopy";
+
+const model: StrengthBaselineCardModel = buildStrengthBaselineCardModel({
+  strengthCalendarDays: [
+    {
+      day: "2026-04-20" as const,
+      workouts: [
+        {
+          id: "a",
+          observedAt: "2026-04-20T10:00:00.000Z",
+          sourceId: "apple_health",
+          title: "Lift",
+          workoutType: "strength" as const,
+          start: "2026-04-20T10:00:00.000Z",
+          end: "2026-04-20T10:30:00.000Z",
+          durationMinutes: 30,
+          calories: null,
+        },
+      ],
+    },
+  ],
+  todayDayKey: "2026-04-21" as const,
+});
+
+describe("StrengthBaselineCard", () => {
+  it("renders title, bar, 0–7 marker row, and the fixed definition sentence", async () => {
+    let tree!: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<StrengthBaselineCard loading={false} model={model} />);
+    });
+    const json = JSON.stringify(tree!.toJSON());
+    expect(json).toContain("Strength Baseline");
+    expect(json).toContain("strength-baseline-frequency-bar");
+    expect(json).toContain("strength-baseline-frequency-markers");
+    for (const d of [0, 1, 2, 3, 4, 5, 6, 7] as const) {
+      expect(json).toContain(`"children":["${d}"]`);
+    }
+    expect(json).toContain(STRENGTH_BASELINE_CARD_DEFINITION_SENTENCE);
+    expect(json).toContain("/wk");
+    expect(json).not.toContain("workouts / week");
+  });
+});

--- a/lib/ui/workouts/__tests__/StrengthFrequencyMetricCard.test.tsx
+++ b/lib/ui/workouts/__tests__/StrengthFrequencyMetricCard.test.tsx
@@ -1,0 +1,107 @@
+import React from "react";
+import renderer, { act } from "react-test-renderer";
+
+import { StrengthFrequencyMetricCard } from "@/lib/ui/workouts/StrengthFrequencyMetricCard";
+
+const minimalModel = {
+  compactValuePrimary: "2 workouts",
+  ratingLabel: "Fair",
+  activityTierIndexForBar: 2,
+  fillWidth01Override: 0.4,
+};
+
+describe("StrengthFrequencyMetricCard", () => {
+  it("omits the 0–7 marker row when showFrequencyMarkers is false", async () => {
+    let tree!: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(
+        <StrengthFrequencyMetricCard
+          variant="embedded"
+          headingTitle="This Week"
+          loading={false}
+          model={minimalModel}
+          footerCaption="ignored"
+          showFrequencyMarkers={false}
+          showFooterCaption={false}
+          ratingPillTestID="strength-this-week-rating-pill"
+          frequencyBarTestID="strength-this-week-frequency-bar"
+          instrumentClusterTestID="strength-this-week-instrument-cluster"
+        />,
+      );
+    });
+    const json = JSON.stringify(tree!.toJSON());
+    expect(json).not.toContain("strength-baseline-frequency-markers");
+    expect(json).toContain("strength-this-week-frequency-bar");
+  });
+
+  it("omits the frequency track when showFrequencyTrack is false", async () => {
+    let tree!: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(
+        <StrengthFrequencyMetricCard
+          variant="embedded"
+          headingTitle="This Week"
+          loading={false}
+          model={minimalModel}
+          footerCaption="ignored"
+          showFrequencyTrack={false}
+          showFrequencyMarkers={false}
+          showFooterCaption={false}
+          compactTitlePillSpacing
+          mutedMicroCaption="2 sessions this week"
+          titleRowTrailing={<></>}
+          ratingPillTestID="strength-this-week-rating-pill"
+          frequencyBarTestID="strength-this-week-frequency-bar"
+          instrumentClusterTestID="strength-this-week-instrument-cluster"
+        />,
+      );
+    });
+    const json = JSON.stringify(tree!.toJSON());
+    expect(json).not.toContain("strength-this-week-frequency-bar");
+    expect(json).not.toContain("strength-this-week-instrument-cluster");
+    expect(json).toContain("2 sessions this week");
+    expect(json).not.toContain("2 workouts");
+  });
+
+  it("omits footer support text when showFooterCaption is false", async () => {
+    let tree!: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(
+        <StrengthFrequencyMetricCard
+          variant="embedded"
+          headingTitle="This Week"
+          loading={false}
+          model={minimalModel}
+          footerCaption="No workout logged today"
+          showFrequencyMarkers={false}
+          showFooterCaption={false}
+          ratingPillTestID="strength-this-week-rating-pill"
+          frequencyBarTestID="strength-this-week-frequency-bar"
+          instrumentClusterTestID="strength-this-week-instrument-cluster"
+        />,
+      );
+    });
+    const json = JSON.stringify(tree!.toJSON());
+    expect(json).not.toContain("No workout logged today");
+  });
+
+  it("still renders markers by default for Strength Baseline parity", async () => {
+    let tree!: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(
+        <StrengthFrequencyMetricCard
+          headingTitle="Strength Baseline"
+          loading={false}
+          model={minimalModel}
+          footerCaption="Definition line."
+          ratingPillTestID="strength-baseline-rating-pill"
+          frequencyBarTestID="strength-baseline-frequency-bar"
+          instrumentClusterTestID="strength-baseline-instrument-cluster"
+        />,
+      );
+    });
+    const json = JSON.stringify(tree!.toJSON());
+    expect(json).toContain("strength-baseline-frequency-markers");
+    expect(json).toContain("Definition line.");
+  });
+});

--- a/lib/ui/workouts/__tests__/StrengthYearlyWorkloadBars.test.tsx
+++ b/lib/ui/workouts/__tests__/StrengthYearlyWorkloadBars.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * Presentation-only checks for Strength Analytics yearly workload bars (labels + baseline hairline).
+ */
+import React from "react";
+import renderer, { act } from "react-test-renderer";
+
+import { StrengthYearlyWorkloadBars } from "@/lib/ui/workouts/StrengthYearlyWorkloadBars";
+
+describe("StrengthYearlyWorkloadBars", () => {
+  const base = {
+    barTrackHeight: 120,
+    fillColorGood: "#00AA00",
+    maxScale: 10,
+    baselineMonthlyAvg: 5,
+    todayMonthKey: "2026-03",
+  };
+
+  it("renders baseline reference line test id", async () => {
+    let tree!: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(
+        <StrengthYearlyWorkloadBars
+          {...base}
+          points={[
+            { monthKey: "2026-01", displayLabel: "J", value: 3 },
+            { monthKey: "2026-02", displayLabel: "F", value: 0 },
+          ]}
+        />,
+      );
+    });
+    expect(tree.root.findByProps({ testID: "strength-yearly-chart-baseline-line" })).toBeTruthy();
+  });
+
+  it("shows value labels only for past/current months with workouts > 0", async () => {
+    let tree!: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(
+        <StrengthYearlyWorkloadBars
+          {...base}
+          points={[
+            { monthKey: "2026-01", displayLabel: "J", value: 4 },
+            { monthKey: "2026-02", displayLabel: "F", value: 0 },
+            { monthKey: "2026-03", displayLabel: "M", value: 0 },
+            { monthKey: "2026-04", displayLabel: "A", value: 9 },
+          ]}
+        />,
+      );
+    });
+    const json = JSON.stringify(tree.toJSON());
+    expect(json).toContain('"4"');
+    expect(json).not.toContain('"9"');
+    expect(json).not.toContain('"0"');
+  });
+});

--- a/lib/ui/workouts/strengthBaselineCopy.ts
+++ b/lib/ui/workouts/strengthBaselineCopy.ts
@@ -1,0 +1,3 @@
+/** Strength Baseline card footer (fixed product copy). */
+export const STRENGTH_BASELINE_CARD_DEFINITION_SENTENCE =
+  "Your typical weekly strength training frequency based on the past 90 days";

--- a/lib/ui/workouts/strengthBaselineMarkerLayout.ts
+++ b/lib/ui/workouts/strengthBaselineMarkerLayout.ts
@@ -1,0 +1,45 @@
+import { StyleSheet } from "react-native";
+
+import { STRENGTH_BASELINE_WEEKLY_FREQUENCY_DISPLAY_MAX } from "@/lib/utils/strengthWeeklyFrequencyRating";
+
+/** Matches {@link ActivityTierProgressTrack} rim (`trackRim` `borderWidth`) — same inset as Activity Baseline markers. */
+export const STRENGTH_BASELINE_PROGRESS_RIM_INSET_PX = StyleSheet.hairlineWidth;
+
+export function strengthBaselineProgressInnerWidthPx(outerTrackWidthPx: number): number {
+  const rim = STRENGTH_BASELINE_PROGRESS_RIM_INSET_PX;
+  return Math.max(0, outerTrackWidthPx - 2 * rim);
+}
+
+/** Linear 0 → {@link STRENGTH_BASELINE_WEEKLY_FREQUENCY_DISPLAY_MAX}; matches bounded bar fill scale. */
+export function strengthBaselineFrequencyThresholdCenterXInOuterPx(
+  outerTrackWidthPx: number,
+  frequency: number,
+): number {
+  const max = STRENGTH_BASELINE_WEEKLY_FREQUENCY_DISPLAY_MAX;
+  const rim = STRENGTH_BASELINE_PROGRESS_RIM_INSET_PX;
+  const inner = strengthBaselineProgressInnerWidthPx(outerTrackWidthPx);
+  const center01 = Math.min(1, Math.max(0, frequency / max));
+  return rim + center01 * inner;
+}
+
+export function strengthBaselineFrequencyThresholdLabelLeftPx(
+  outerTrackWidthPx: number,
+  frequency: number,
+  labelWidthPx: number,
+): number {
+  const cx = strengthBaselineFrequencyThresholdCenterXInOuterPx(outerTrackWidthPx, frequency);
+  const raw = cx - labelWidthPx / 2;
+  const maxLeft = Math.max(0, outerTrackWidthPx - labelWidthPx);
+  return Math.max(0, Math.min(maxLeft, raw));
+}
+
+export function strengthBaselineFrequencyThresholdTickLeftPx(
+  outerTrackWidthPx: number,
+  frequency: number,
+  tickWidthPx: number,
+): number {
+  const cx = strengthBaselineFrequencyThresholdCenterXInOuterPx(outerTrackWidthPx, frequency);
+  const raw = cx - tickWidthPx / 2;
+  const maxLeft = Math.max(0, outerTrackWidthPx - tickWidthPx);
+  return Math.max(0, Math.min(maxLeft, raw));
+}

--- a/lib/ui/workouts/strengthMetricCardTitleStyle.ts
+++ b/lib/ui/workouts/strengthMetricCardTitleStyle.ts
@@ -1,0 +1,25 @@
+import type { TextStyle, ViewStyle } from "react-native";
+
+import { elevatedCardSurfaceStyle } from "@/lib/ui/theme/elevatedCardSurface";
+
+/**
+ * Primary title typography for Strength metric cards ({@link StrengthFrequencyMetricCard}).
+ * Shared so Strength Analytics yearly chart can align with Strength Baseline without duplicating literals.
+ */
+export const strengthMetricCardTitleTextStyle: TextStyle = {
+  flexShrink: 1,
+  minWidth: 0,
+  fontSize: 19,
+  lineHeight: 24,
+  fontWeight: "600",
+  color: "#1C1C1E",
+  letterSpacing: -0.34,
+};
+
+/** Elevated shell aligned with Strength Baseline card (radius, padding, hairline border, shadow). Use where inner sections already manage vertical spacing. */
+export const strengthYearlyAnalyticsCardShellStyle: ViewStyle = {
+  backgroundColor: "#FFFFFF",
+  borderRadius: 12,
+  padding: 15,
+  ...elevatedCardSurfaceStyle,
+};

--- a/lib/ui/workouts/strengthWeeklyFrequencyCardTypes.ts
+++ b/lib/ui/workouts/strengthWeeklyFrequencyCardTypes.ts
@@ -1,0 +1,9 @@
+/**
+ * Shared presentation fields for Strength Baseline + This Week frequency cards (0–7 scale, X.X/wk).
+ */
+export type StrengthWeeklyFrequencyCardDisplayModel = {
+  compactValuePrimary: string;
+  ratingLabel: string;
+  activityTierIndexForBar: number;
+  fillWidth01Override: number;
+};

--- a/lib/utils/__tests__/activityStepRating.test.ts
+++ b/lib/utils/__tests__/activityStepRating.test.ts
@@ -1,10 +1,14 @@
 import {
+  ACTIVITY_BASELINE_MARKER_DISPLAY_STEP_STEPS,
+  ACTIVITY_BASELINE_THRESHOLD_MARKER_TRACK_MAX_STEPS,
   ACTIVITY_STEP_DESCRIPTOR_PILL_LABELS,
   ACTIVITY_STEP_DESCRIPTOR_RANGE_LINES,
   ACTIVITY_STEP_RATING_TIERS,
+  ACTIVITY_STEP_RATING_TIER_THRESHOLD_STEPS,
   getActivityStepDescriptorLabelForTierIndex,
   getStepRating,
   getStepRatingActivityDescriptorPill,
+  activityStepsDisplayScaleFill01,
   getStepRatingTierIndex,
   stepRatingTierMarkerPosition01,
   stepsFromLocaleDigitString,
@@ -74,6 +78,37 @@ describe("ACTIVITY_STEP_DESCRIPTOR_RANGE_LINES", () => {
     for (let i = 1; i <= 5; i += 1) {
       expect(ACTIVITY_STEP_DESCRIPTOR_RANGE_LINES[i]).toBe(ACTIVITY_STEP_RATING_TIERS[i]!.rangeDisplay);
     }
+  });
+});
+
+describe("ACTIVITY_STEP_RATING_TIER_THRESHOLD_STEPS", () => {
+  it("lists five ascending bounds consistent with getStepRatingTierIndex bands", () => {
+    expect(ACTIVITY_STEP_RATING_TIER_THRESHOLD_STEPS).toEqual([5000, 7500, 10000, 12500, 15000]);
+    expect(getStepRatingTierIndex(4999)).toBe(0);
+    expect(getStepRatingTierIndex(5000)).toBe(1);
+    expect(getStepRatingTierIndex(14999)).toBe(4);
+    expect(getStepRatingTierIndex(15000)).toBe(5);
+    expect(ACTIVITY_BASELINE_THRESHOLD_MARKER_TRACK_MAX_STEPS).toBe(
+      ACTIVITY_STEP_RATING_TIER_THRESHOLD_STEPS[ACTIVITY_STEP_RATING_TIER_THRESHOLD_STEPS.length - 1]!,
+    );
+  });
+});
+
+describe("activityStepsDisplayScaleFill01", () => {
+  it("scales linearly below the bounded max and clamps at 1 for steps ≥ max", () => {
+    expect(activityStepsDisplayScaleFill01(0)).toBe(0);
+    expect(activityStepsDisplayScaleFill01(7500)).toBe(0.5);
+    expect(activityStepsDisplayScaleFill01(15000)).toBe(1);
+    expect(activityStepsDisplayScaleFill01(20000)).toBe(1);
+  });
+});
+
+describe("ACTIVITY_BASELINE_MARKER_DISPLAY_STEP_STEPS", () => {
+  it("extends canonical thresholds with 0 and 2.5k anchors", () => {
+    expect(ACTIVITY_BASELINE_MARKER_DISPLAY_STEP_STEPS).toEqual([0, 2500, 5000, 7500, 10000, 12500, 15000]);
+    expect(ACTIVITY_BASELINE_MARKER_DISPLAY_STEP_STEPS.length).toBe(
+      2 + ACTIVITY_STEP_RATING_TIER_THRESHOLD_STEPS.length,
+    );
   });
 });
 

--- a/lib/utils/__tests__/strengthWeeklyFrequencyRating.test.ts
+++ b/lib/utils/__tests__/strengthWeeklyFrequencyRating.test.ts
@@ -1,0 +1,24 @@
+import {
+  strengthWeeklyFrequencyRatingBucketFromAvg,
+  strengthWeeklyFrequencyRatingLabelFromBucket,
+} from "../strengthWeeklyFrequencyRating";
+
+describe("strengthWeeklyFrequencyRating", () => {
+  it("maps buckets to required frequency labels (no subjective Strength/Optimal vocabulary)", () => {
+    expect(strengthWeeklyFrequencyRatingLabelFromBucket(0)).toBe("None");
+    expect(strengthWeeklyFrequencyRatingLabelFromBucket(1)).toBe("Very Low");
+    expect(strengthWeeklyFrequencyRatingLabelFromBucket(2)).toBe("Low");
+    expect(strengthWeeklyFrequencyRatingLabelFromBucket(3)).toBe("Moderate");
+    expect(strengthWeeklyFrequencyRatingLabelFromBucket(4)).toBe("High");
+    expect(strengthWeeklyFrequencyRatingLabelFromBucket(5)).toBe("Very High");
+    expect(strengthWeeklyFrequencyRatingLabelFromBucket(6)).toBe("Very High");
+    expect(strengthWeeklyFrequencyRatingLabelFromBucket(7)).toBe("Max Frequency");
+  });
+
+  it("rounds averages into 0–7 buckets", () => {
+    expect(strengthWeeklyFrequencyRatingBucketFromAvg(3.4)).toBe(3);
+    expect(strengthWeeklyFrequencyRatingBucketFromAvg(3.5)).toBe(4);
+    expect(strengthWeeklyFrequencyRatingBucketFromAvg(8.9)).toBe(7);
+    expect(strengthWeeklyFrequencyRatingBucketFromAvg(-1)).toBe(0);
+  });
+});

--- a/lib/utils/activityStepRating.ts
+++ b/lib/utils/activityStepRating.ts
@@ -79,16 +79,49 @@ export type ActivityStepRating = {
 };
 
 /**
+ * Step lower bounds for tiers 1–5 (exclusive upper bound per band).
+ * {@link getStepRatingTierIndex} returns `i` when `floor(steps)` is in `[THRESHOLDS[i-1], THRESHOLDS[i])`
+ * for `i < THRESHOLDS.length`, else tier 5.
+ */
+export const ACTIVITY_STEP_RATING_TIER_THRESHOLD_STEPS = [5000, 7500, 10000, 12500, 15000] as const;
+
+/**
+ * Display ruler end for Activity progress bars + baseline markers: bounded **0 → top tier threshold**
+ * (15k). Rating thresholds unchanged.
+ */
+export const ACTIVITY_BASELINE_THRESHOLD_MARKER_TRACK_MAX_STEPS =
+  ACTIVITY_STEP_RATING_TIER_THRESHOLD_STEPS[ACTIVITY_STEP_RATING_TIER_THRESHOLD_STEPS.length - 1]!;
+
+/**
+ * Baseline-only ruler ticks (steps): scale anchor at 0, mid-low anchor at 2.5k, then each canonical rating
+ * threshold. Display-only.
+ */
+export const ACTIVITY_BASELINE_MARKER_DISPLAY_STEP_STEPS = [
+  0,
+  2500,
+  ...ACTIVITY_STEP_RATING_TIER_THRESHOLD_STEPS,
+] as const;
+
+/**
+ * Bounded 0 → {@link ACTIVITY_BASELINE_THRESHOLD_MARKER_TRACK_MAX_STEPS} fill for **all** Activity progress
+ * tracks (Today, Yesterday, overview windows, baseline). Clamps at 100% when steps ≥ max.
+ * Does not affect {@link getStepRatingTierIndex}.
+ */
+export function activityStepsDisplayScaleFill01(steps: number): number {
+  const max = ACTIVITY_BASELINE_THRESHOLD_MARKER_TRACK_MAX_STEPS;
+  const n = Number.isFinite(steps) ? Math.max(0, steps) : 0;
+  return Math.min(1, n / max);
+}
+
+/**
  * Tier index 0–5 for `steps` (Low → Elite).
  */
 export function getStepRatingTierIndex(steps: number): number {
   const n = Number.isFinite(steps) ? Math.max(0, Math.floor(steps)) : 0;
-  if (n < 5000) return 0;
-  if (n < 7500) return 1;
-  if (n < 10000) return 2;
-  if (n < 12500) return 3;
-  if (n < 15000) return 4;
-  return 5;
+  for (let i = 0; i < ACTIVITY_STEP_RATING_TIER_THRESHOLD_STEPS.length; i++) {
+    if (n < ACTIVITY_STEP_RATING_TIER_THRESHOLD_STEPS[i]!) return i;
+  }
+  return ACTIVITY_STEP_RATING_TIER_THRESHOLD_STEPS.length;
 }
 
 /** Marker position along the 6-band ladder (center of the active band), 0–1. */

--- a/lib/utils/strengthWeeklyFrequencyRating.ts
+++ b/lib/utils/strengthWeeklyFrequencyRating.ts
@@ -1,0 +1,65 @@
+/** Upper bound for Strength Baseline progress-track display (workouts/week). */
+export const STRENGTH_BASELINE_WEEKLY_FREQUENCY_DISPLAY_MAX = 7;
+
+export type StrengthWeeklyFrequencyRatingBucket = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7;
+
+/**
+ * Maps measurable average weekly frequency to the product copy ladder (pill label only).
+ */
+export function strengthWeeklyFrequencyRatingLabelFromBucket(
+  bucket: StrengthWeeklyFrequencyRatingBucket,
+): string {
+  switch (bucket) {
+    case 0:
+      return "None";
+    case 1:
+      return "Very Low";
+    case 2:
+      return "Low";
+    case 3:
+      return "Moderate";
+    case 4:
+      return "High";
+    case 5:
+    case 6:
+      return "Very High";
+    case 7:
+      return "Max Frequency";
+    default:
+      return "None";
+  }
+}
+
+/**
+ * Buckets `avgWorkoutsPerWeek` with half-up rounding, clamped to 0–7 (same ladder as marker scale).
+ */
+export function strengthWeeklyFrequencyRatingBucketFromAvg(
+  avgWorkoutsPerWeek: number,
+): StrengthWeeklyFrequencyRatingBucket {
+  const n = Number.isFinite(avgWorkoutsPerWeek) ? avgWorkoutsPerWeek : 0;
+  const r = Math.round(n);
+  const clamped = Math.min(STRENGTH_BASELINE_WEEKLY_FREQUENCY_DISPLAY_MAX, Math.max(0, r));
+  return clamped as StrengthWeeklyFrequencyRatingBucket;
+}
+
+/**
+ * Bounded 0 → {@link STRENGTH_BASELINE_WEEKLY_FREQUENCY_DISPLAY_MAX} fill for the Strength Baseline bar.
+ */
+export function strengthWeeklyFrequencyDisplayScaleFill01(avgWorkoutsPerWeek: number): number {
+  const n = Number.isFinite(avgWorkoutsPerWeek) ? Math.max(0, avgWorkoutsPerWeek) : 0;
+  const max = STRENGTH_BASELINE_WEEKLY_FREQUENCY_DISPLAY_MAX;
+  return Math.min(1, n / max);
+}
+
+/**
+ * Maps bucket → Activity tier palette index (0–5) so {@link ActivityTierProgressTrack} fill colors align
+ * with the frequency ladder without changing Activity step thresholds.
+ */
+export function strengthWeeklyFrequencyActivityTierIndexForBar(bucket: StrengthWeeklyFrequencyRatingBucket): number {
+  if (bucket <= 1) return 0;
+  if (bucket === 2) return 1;
+  if (bucket === 3) return 2;
+  if (bucket === 4) return 3;
+  if (bucket <= 6) return 4;
+  return 5;
+}

--- a/services/api/src/routes/__tests__/events.delete.test.ts
+++ b/services/api/src/routes/__tests__/events.delete.test.ts
@@ -1,0 +1,158 @@
+// services/api/src/routes/__tests__/events.delete.test.ts
+import express from "express";
+import type http from "http";
+import { AddressInfo } from "net";
+
+import eventsRoutes from "../events";
+import { userCollection } from "../../db";
+
+jest.mock("../../db", () => ({
+  userCollection: jest.fn(),
+}));
+
+describe("DELETE /ingest/:rawEventId", () => {
+  let server: http.Server;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    const app = express();
+
+    app.use((req, _res, next) => {
+      (req as unknown as { uid: string }).uid = "user_123";
+      next();
+    });
+
+    app.use("/ingest", eventsRoutes);
+
+    server = app.listen(0);
+    const addr = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${addr.port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test("deletes a manual strength_workout raw event", async () => {
+    const rawEventId = "manual_key_1";
+    const rawEvent = {
+      schemaVersion: 1,
+      id: rawEventId,
+      userId: "user_123",
+      sourceId: "manual",
+      provider: "manual",
+      sourceType: "manual",
+      kind: "strength_workout",
+      receivedAt: "2025-01-02T00:00:00.000Z",
+      observedAt: "2025-01-02T00:00:00.000Z",
+      payload: {
+        startedAt: "2025-01-02T00:00:00.000Z",
+        timeZone: "America/New_York",
+        exercises: [{ name: "Bench", sets: [{ reps: 5, load: 60, unit: "kg" as const }] }],
+      },
+    };
+
+    const deleteMock = jest.fn(async () => undefined);
+
+    (userCollection as jest.Mock).mockReturnValue({
+      doc: () => ({
+        get: async () =>
+          ({
+            exists: true,
+            data: () => rawEvent,
+          }) as const,
+        delete: deleteMock,
+      }),
+    });
+
+    const res = await fetch(`${baseUrl}/ingest/${rawEventId}`, { method: "DELETE" });
+
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { ok: boolean; rawEventId: string };
+    expect(json.ok).toBe(true);
+    expect(json.rawEventId).toBe(rawEventId);
+    expect(deleteMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("deletes an apple_health strength_workout raw event (removes Oli record only)", async () => {
+    const rawEventId = "apple_hk_str_1";
+    const rawEvent = {
+      schemaVersion: 1,
+      id: rawEventId,
+      userId: "user_123",
+      sourceId: "healthkit",
+      provider: "apple_health",
+      sourceType: "apple_health",
+      kind: "strength_workout",
+      receivedAt: "2025-01-02T00:00:00.000Z",
+      observedAt: "2025-01-02T00:00:00.000Z",
+      payload: {
+        startedAt: "2025-01-02T00:00:00.000Z",
+        timeZone: "America/New_York",
+        exercises: [{ name: "Squat", sets: [{ reps: 5, load: 60, unit: "kg" as const }] }],
+      },
+    };
+
+    const deleteMock = jest.fn(async () => undefined);
+
+    (userCollection as jest.Mock).mockReturnValue({
+      doc: () => ({
+        get: async () =>
+          ({
+            exists: true,
+            data: () => rawEvent,
+          }) as const,
+        delete: deleteMock,
+      }),
+    });
+
+    const res = await fetch(`${baseUrl}/ingest/${rawEventId}`, { method: "DELETE" });
+
+    expect(res.status).toBe(200);
+    expect(deleteMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("rejects delete for unsupported workout provider", async () => {
+    const rawEventId = "vendor_xyz_1";
+    const rawEvent = {
+      schemaVersion: 1,
+      id: rawEventId,
+      userId: "user_123",
+      sourceId: "vendor_xyz",
+      provider: "vendor_xyz",
+      sourceType: "vendor_xyz",
+      kind: "workout",
+      receivedAt: "2025-01-02T00:00:00.000Z",
+      observedAt: "2025-01-02T00:00:00.000Z",
+      payload: {
+        start: "2025-01-02T00:00:00.000Z",
+        end: "2025-01-02T01:00:00.000Z",
+        timezone: "America/New_York",
+        sport: "running",
+        durationMinutes: 30,
+      },
+    };
+
+    const deleteMock = jest.fn(async () => undefined);
+
+    (userCollection as jest.Mock).mockReturnValue({
+      doc: () => ({
+        get: async () =>
+          ({
+            exists: true,
+            data: () => rawEvent,
+          }) as const,
+        delete: deleteMock,
+      }),
+    });
+
+    const res = await fetch(`${baseUrl}/ingest/${rawEventId}`, { method: "DELETE" });
+
+    expect(res.status).toBe(403);
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+});

--- a/services/api/src/routes/events.ts
+++ b/services/api/src/routes/events.ts
@@ -1,5 +1,6 @@
 // services/api/src/routes/events.ts
 import { Router, type Response } from "express";
+import { z } from "zod";
 
 import { localCalendarDayKeyFromIsoInTimeZone, rawEventDocSchema } from "@oli/contracts";
 import type { AuthedRequest } from "../middleware/auth";
@@ -499,6 +500,174 @@ router.post("/", async (req: AuthedRequest, res: Response) => {
       requestId,
     });
   }
+});
+
+const rawEventDeleteParamsSchema = z
+  .object({
+    rawEventId: z.string().min(1),
+  })
+  .strip();
+
+/** Providers whose workout raw events users may remove from Oli only (Firestore doc delete; does not mutate Apple Health). Mirrors supported ingest providers for workouts. */
+const DELETABLE_WORKOUT_EVENT_PROVIDERS = new Set(["manual", "apple_health"]);
+
+/**
+ * DELETE /ingest/:rawEventId
+ *
+ * Removes a user-owned RawEvent document (Admin SDK). Clients cannot delete via Firestore rules.
+ * Allowed only for kinds `workout` / `strength_workout` whose `provider` is accepted for deletion (manual + apple_health ingest).
+ */
+router.delete("/:rawEventId", async (req: AuthedRequest, res: Response) => {
+  const requestId = getRid(req);
+  const uid = req.uid;
+
+  if (!uid) {
+    return res.status(401).json({
+      ok: false as const,
+      error: "Unauthorized",
+      requestId,
+    });
+  }
+
+  const parsedParams = rawEventDeleteParamsSchema.safeParse(req.params);
+  if (!parsedParams.success) {
+    return res.status(400).json({
+      ok: false as const,
+      error: {
+        code: "INVALID_PARAMS" as const,
+        message: "Invalid route params",
+        details: parsedParams.error.flatten(),
+      },
+      requestId,
+    });
+  }
+
+  const { rawEventId } = parsedParams.data;
+  const ref = userCollection(uid, "rawEvents").doc(rawEventId);
+
+  let snap;
+  try {
+    snap = await ref.get();
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    try {
+      await writeFailure({
+        userId: uid,
+        source: "ingestion",
+        stage: "ingest_delete",
+        reasonCode: "RAW_EVENT_READ_FAILED",
+        message: "Failed to read RawEvent before delete",
+        day: dayUtcNow(),
+        requestId,
+        details: { rawEventId, err: message },
+      });
+    } catch {
+      // do not throw
+    }
+    return res.status(500).json({
+      ok: false as const,
+      error: {
+        code: "INTERNAL" as const,
+        message: "Failed to read workout record",
+      },
+      requestId,
+    });
+  }
+
+  if (!snap.exists) {
+    return res.status(404).json({
+      ok: false as const,
+      error: {
+        code: "NOT_FOUND" as const,
+        message: "Workout record not found",
+      },
+      requestId,
+    });
+  }
+
+  const data = snap.data();
+  const parsedDoc = rawEventDocSchema.safeParse(data);
+  if (!parsedDoc.success) {
+    try {
+      await writeFailure({
+        userId: uid,
+        source: "ingestion",
+        stage: "ingest_delete",
+        reasonCode: "INVALID_RAW_EVENT_CONTRACT",
+        message: "Stored RawEvent failed contract validation",
+        day: dayUtcNow(),
+        requestId,
+        details: { rawEventId, validation: parsedDoc.error.flatten() },
+      });
+    } catch {
+      // do not throw
+    }
+    return res.status(500).json({
+      ok: false as const,
+      error: {
+        code: "INVALID_STORED_RECORD" as const,
+        message: "Stored workout record is invalid",
+      },
+      requestId,
+    });
+  }
+
+  const doc = parsedDoc.data;
+  if (doc.kind !== "workout" && doc.kind !== "strength_workout") {
+    return res.status(400).json({
+      ok: false as const,
+      error: {
+        code: "NOT_DELETABLE_KIND" as const,
+        message: "Only workout entries can be removed with this action",
+      },
+      requestId,
+    });
+  }
+
+  if (!DELETABLE_WORKOUT_EVENT_PROVIDERS.has(doc.provider)) {
+    return res.status(403).json({
+      ok: false as const,
+      error: {
+        code: "DELETE_NOT_ALLOWED" as const,
+        message: "This workout can't be removed from Oli.",
+      },
+      requestId,
+    });
+  }
+
+  try {
+    await ref.delete();
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    try {
+      await writeFailure({
+        userId: uid,
+        source: "ingestion",
+        stage: "ingest_delete",
+        reasonCode: "RAW_EVENT_DELETE_FAILED",
+        message: "Failed to delete RawEvent",
+        day: dayUtcNow(),
+        requestId,
+        details: { rawEventId, err: message },
+      });
+    } catch {
+      // do not throw
+    }
+    return res.status(500).json({
+      ok: false as const,
+      error: {
+        code: "DELETE_FAILED" as const,
+        message: "Could not remove workout record",
+      },
+      requestId,
+    });
+  }
+
+  return res.status(200).json({
+    ok: true as const,
+    rawEventId,
+    requestId,
+  });
 });
 
 export default router;


### PR DESCRIPTION
- allow deletion for provider=apple_health in API (DELETE /ingest/:rawEventId)
- align UI eligibility with provider-based logic (manual + apple_health)
- add confirmation modal with 'remove from Oli' copy
- ensure downstream recompute + UI refresh via existing pipeline

Strength UI improvements:
- remove Overview card
- introduce This Week + Last Week cards with clean layout
- refactor workout list grouping and spacing
- unify typography with baseline system
- redesign analytics screen (yearly chart only)

Activity refinements:
- baseline markers + layout polish
- tier color + rating improvements

Tests:
- cover delete eligibility (manual + apple_health)
- verify confirmation flow and correct id usage
- ensure UI refresh after delete
- maintain 100% pass rate

All checks passing:
- typecheck ✅
- lint ✅
- tests (1672) ✅
- invariants ✅