### PR TITLE
fix(workouts): authoritative delete + Apple Health suppression to pre…

### DIFF
--- a/app/(app)/workouts/__tests__/overview-workout-actions.test.tsx
+++ b/app/(app)/workouts/__tests__/overview-workout-actions.test.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import renderer, { act } from "react-test-renderer";
-import { useWorkoutsCalendarRange } from "@/lib/data/workouts/useWorkoutsCalendar";
-import TrainingOverviewScreen from "../overview";
+import { Alert } from "react-native";
 
 const mockPush = jest.fn();
 const mockSetOptions = jest.fn();
@@ -79,9 +78,27 @@ jest.mock("@/lib/workouts/gymRegistry", () => ({
   getGymMenuOptions: () => [],
 }));
 
-jest.mock("@/lib/data/workouts/useWorkoutsCalendar", () => ({
-  useWorkoutsCalendarRange: jest.fn(),
-}));
+jest.mock("@/lib/data/workouts/useWorkoutsCalendar", () => {
+  const actual = jest.requireActual<typeof import("@/lib/data/workouts/useWorkoutsCalendar")>(
+    "@/lib/data/workouts/useWorkoutsCalendar",
+  );
+  const applyAuthoritativeWorkoutDeletionLocal = jest.fn();
+  return {
+    ...actual,
+    useWorkoutsCalendarRange: jest.fn(),
+    applyAuthoritativeWorkoutDeletionLocal,
+  };
+});
+
+const mockedWorkoutCal = jest.requireMock<typeof import("@/lib/data/workouts/useWorkoutsCalendar")>(
+  "@/lib/data/workouts/useWorkoutsCalendar",
+);
+const useWorkoutsCalendarRange = jest.mocked(mockedWorkoutCal.useWorkoutsCalendarRange);
+const applyDeletionMock = jest.mocked(mockedWorkoutCal.applyAuthoritativeWorkoutDeletionLocal);
+
+// `require` after mocks so the screen binds to the mocked `applyAuthoritativeWorkoutDeletionLocal`.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const TrainingOverviewScreen: typeof import("../overview").default = require("../overview").default;
 
 const DEFAULT_WORKOUTS_CALENDAR_RANGE = {
   status: "ready" as const,
@@ -102,6 +119,8 @@ const DEFAULT_WORKOUTS_CALENDAR_RANGE = {
           end: null,
           durationMinutes: 20,
           calories: 200,
+          rawKind: "strength_workout",
+          isDeletableRawEvent: true,
         },
         {
           id: "w2",
@@ -114,6 +133,8 @@ const DEFAULT_WORKOUTS_CALENDAR_RANGE = {
           end: null,
           durationMinutes: 20,
           calories: 200,
+          rawKind: "strength_workout",
+          isDeletableRawEvent: true,
         },
         {
           id: "w3",
@@ -126,6 +147,8 @@ const DEFAULT_WORKOUTS_CALENDAR_RANGE = {
           end: null,
           durationMinutes: 20,
           calories: 200,
+          rawKind: "strength_workout",
+          isDeletableRawEvent: true,
         },
         {
           id: "w4",
@@ -138,6 +161,8 @@ const DEFAULT_WORKOUTS_CALENDAR_RANGE = {
           end: null,
           durationMinutes: 20,
           calories: 200,
+          rawKind: "strength_workout",
+          isDeletableRawEvent: true,
         },
         {
           id: "w5",
@@ -150,6 +175,8 @@ const DEFAULT_WORKOUTS_CALENDAR_RANGE = {
           end: null,
           durationMinutes: 20,
           calories: 200,
+          rawKind: "strength_workout",
+          isDeletableRawEvent: true,
         },
         {
           id: "w6",
@@ -162,6 +189,8 @@ const DEFAULT_WORKOUTS_CALENDAR_RANGE = {
           end: null,
           durationMinutes: 20,
           calories: 200,
+          rawKind: "strength_workout",
+          isDeletableRawEvent: true,
         },
         {
           id: "w7",
@@ -174,6 +203,8 @@ const DEFAULT_WORKOUTS_CALENDAR_RANGE = {
           end: null,
           durationMinutes: 20,
           calories: 200,
+          rawKind: "strength_workout",
+          isDeletableRawEvent: true,
         },
         {
           id: "w8",
@@ -186,6 +217,8 @@ const DEFAULT_WORKOUTS_CALENDAR_RANGE = {
           end: null,
           durationMinutes: 20,
           calories: 200,
+          rawKind: "strength_workout",
+          isDeletableRawEvent: true,
         },
       ],
     },
@@ -311,6 +344,7 @@ describe("overview workout actions", () => {
   beforeEach(() => {
     mockOverridesState = {};
     jest.clearAllMocks();
+    applyDeletionMock.mockImplementation(() => undefined);
     jest.mocked(useWorkoutsCalendarRange).mockReturnValue(DEFAULT_WORKOUTS_CALENDAR_RANGE as never);
     mockDeleteIngestedRawEventAuthed.mockResolvedValue({
       ok: true as const,
@@ -462,6 +496,76 @@ describe("overview workout actions", () => {
 
     expect(mockDeleteIngestedRawEventAuthed).toHaveBeenCalledWith("w4", "token");
     expect(mockClearWorkoutOverride).toHaveBeenCalledWith("w4");
+    expect(applyDeletionMock).toHaveBeenCalledWith("u1", "w4");
+  });
+
+  it("delete 404 still evicts locally and does not show a blocking failure alert", async () => {
+    mockDeleteIngestedRawEventAuthed.mockResolvedValue({
+      ok: false as const,
+      status: 404,
+      requestId: "rid-404",
+      kind: "http",
+      error: "Not found",
+    });
+    const test = await mountTrainingOverview();
+    act(() => {
+      test.root.findByProps({ accessibilityLabel: "Workout actions w2" }).props.onPress();
+    });
+    act(() => {
+      test.root.findByProps({ accessibilityLabel: "Delete workout" }).props.onPress();
+    });
+    await act(async () => {
+      test.root.findByProps({ accessibilityLabel: "Confirm delete workout" }).props.onPress();
+      await Promise.resolve();
+    });
+    expect(applyDeletionMock).toHaveBeenCalledWith("u1", "w2");
+    expect(jest.mocked(Alert.alert)).not.toHaveBeenCalled();
+  });
+
+  it("delete 403 does not evict locally and shows an error alert", async () => {
+    mockDeleteIngestedRawEventAuthed.mockResolvedValue({
+      ok: false as const,
+      status: 403,
+      requestId: "rid-403",
+      kind: "http",
+      error: "Forbidden",
+    });
+    const test = await mountTrainingOverview();
+    act(() => {
+      test.root.findByProps({ accessibilityLabel: "Workout actions w3" }).props.onPress();
+    });
+    act(() => {
+      test.root.findByProps({ accessibilityLabel: "Delete workout" }).props.onPress();
+    });
+    await act(async () => {
+      test.root.findByProps({ accessibilityLabel: "Confirm delete workout" }).props.onPress();
+      await Promise.resolve();
+    });
+    expect(applyDeletionMock).not.toHaveBeenCalled();
+    expect(jest.mocked(Alert.alert)).toHaveBeenCalled();
+  });
+
+  it("delete network failure does not evict locally", async () => {
+    mockDeleteIngestedRawEventAuthed.mockResolvedValue({
+      ok: false as const,
+      status: 0,
+      requestId: null,
+      kind: "network",
+      error: "offline",
+    });
+    const test = await mountTrainingOverview();
+    act(() => {
+      test.root.findByProps({ accessibilityLabel: "Workout actions w5" }).props.onPress();
+    });
+    act(() => {
+      test.root.findByProps({ accessibilityLabel: "Delete workout" }).props.onPress();
+    });
+    await act(async () => {
+      test.root.findByProps({ accessibilityLabel: "Confirm delete workout" }).props.onPress();
+      await Promise.resolve();
+    });
+    expect(applyDeletionMock).not.toHaveBeenCalled();
+    expect(jest.mocked(Alert.alert)).toHaveBeenCalled();
   });
 
   it("cancel on delete confirmation does not call delete", async () => {
@@ -495,6 +599,7 @@ describe("overview workout actions", () => {
               observedAt: "2026-03-10T10:00:00.000Z",
               sourceId: "healthkit",
               rawKind: "strength_workout",
+              isDeletableRawEvent: true,
               title: "Strength",
               workoutType: "strength",
               start: "2026-03-10T10:00:00.000Z",
@@ -528,6 +633,7 @@ describe("overview workout actions", () => {
               observedAt: "2026-03-10T11:00:00.000Z",
               sourceId: "manual",
               rawKind: "strength_workout",
+              isDeletableRawEvent: true,
               title: "Lift",
               workoutType: "strength",
               start: "2026-03-10T11:00:00.000Z",
@@ -545,6 +651,40 @@ describe("overview workout actions", () => {
       test.root.findByProps({ accessibilityLabel: "Workout actions md1" }).props.onPress();
     });
     expect(test.root.findByProps({ accessibilityLabel: "Delete workout" })).toBeTruthy();
+  });
+
+  it("hides Delete Workout when row is not hydrate-backed (isDeletableRawEvent unset)", async () => {
+    jest.mocked(useWorkoutsCalendarRange).mockReturnValue({
+      status: "ready",
+      durableTitlesByWorkoutId: {},
+      days: [
+        { day: "2026-03-09", workouts: [] },
+        {
+          day: "2026-03-10",
+          workouts: [
+            {
+              id: "ghost",
+              provider: "manual",
+              observedAt: "2026-03-10T12:00:00.000Z",
+              sourceId: "manual",
+              rawKind: "strength_workout",
+              title: "Synthetic",
+              workoutType: "strength",
+              start: "2026-03-10T12:00:00.000Z",
+              end: null,
+              durationMinutes: 30,
+              calories: null,
+            },
+          ],
+        },
+      ],
+    } as never);
+
+    const test = await mountTrainingOverview();
+    act(() => {
+      test.root.findByProps({ accessibilityLabel: "Workout actions ghost" }).props.onPress();
+    });
+    expect(() => test.root.findByProps({ accessibilityLabel: "Delete workout" })).toThrow();
   });
 
   it("hides Delete Workout for unsupported workout providers", async () => {

--- a/app/(app)/workouts/overview.tsx
+++ b/app/(app)/workouts/overview.tsx
@@ -33,8 +33,9 @@ import {
 } from "@/lib/ui/headers/workoutsStackHeader";
 import { WeeklyStrip } from "@/lib/ui/calendar/WeeklyStrip";
 import { addCalendarDaysToDayKey, getTodayDayKeyLocal, getWeekDaysForAnchor } from "@/lib/ui/calendar/dateUtils";
-import type { CalendarDay, WorkoutDayMarker } from "@/lib/ui/calendar/types";
+import type { CalendarDay, DayKey, WorkoutDayMarker } from "@/lib/ui/calendar/types";
 import {
+  applyAuthoritativeWorkoutDeletionLocal,
   DEFAULT_WORKOUT_CALENDAR_RAW_EVENT_KINDS,
   useWorkoutsCalendarRange,
 } from "@/lib/data/workouts/useWorkoutsCalendar";
@@ -98,10 +99,15 @@ import {
   resolveWorkoutDisplay,
   resolveWorkoutDisplayDurationMinutes,
 } from "@/lib/data/workouts/workoutDisplay";
-import { deriveSessionTypeFlags, reconcileWorkoutSessionsForDay } from "@/lib/data/workouts/workoutSessionReconciliation";
+import {
+  deriveSessionTypeFlags,
+  reconcileWorkoutSessionsForDay,
+  resolveReconciledSessionWithLatestCalendarDays,
+} from "@/lib/data/workouts/workoutSessionReconciliation";
 import {
   buildWorkoutSessionSurfaceModel,
   pickJournalSummaryForStrengthSession,
+  pickStrengthDeleteTargetWorkout,
   pickWorkoutForSessionActions,
   pickWorkoutOverrideForSession,
 } from "@/lib/data/workouts/workoutSessionSurface";
@@ -109,7 +115,6 @@ import { clearWorkoutOverride, useWorkoutOverrides } from "@/lib/data/workouts/w
 import { WorkoutActionSheet } from "@/lib/ui/WorkoutActionSheet";
 import type { WorkoutActionAnchor } from "@/lib/ui/WorkoutActionSheet";
 import type { ReconciledWorkoutSession } from "@/lib/data/workouts/workoutSessionReconciliation";
-import { resolveWorkoutIngestProvider, type WorkoutHistoryItem } from "@/lib/data/workouts/parseWorkoutFromRawEvent";
 import {
   listManualWorkoutDaySummaries,
   type ManualWorkoutDaySummary,
@@ -174,16 +179,6 @@ function formatWorkoutDayLabel(dayKey: string): string {
   const month = d.getUTCMonth() + 1;
   const day = d.getUTCDate();
   return `${wd} ${month}/${day}`;
-}
-
-/** Matches DELETE /ingest allowlist via {@link resolveWorkoutIngestProvider} (handles list hydrate rows that omit raw `provider`). */
-function strengthWorkoutEligibleForDeleteFromOli(workout: WorkoutHistoryItem | null | undefined): boolean {
-  if (!workout) return false;
-  const p = resolveWorkoutIngestProvider(workout);
-  if (p !== "manual" && p !== "apple_health") return false;
-  const k = workout.rawKind;
-  if (k === undefined) return true;
-  return k === "strength_workout" || k === "workout";
 }
 
 function countJournalSetsForDisplay(summary: ManualWorkoutDaySummary | null): number {
@@ -302,6 +297,19 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
     () => mapWorkoutCalendarDaysForDomain(sharedDays, domain),
     [sharedDays, domain],
   );
+
+  /** Re-resolve menu session against latest hydrate so delete/edit ids stay valid after refresh while menu is open. */
+  const overviewMenuSessionResolved = useMemo(() => {
+    if (!selectedWorkoutForMenu) return null;
+    if (overviewSharedRange.status !== "ready") return selectedWorkoutForMenu.session;
+    return resolveReconciledSessionWithLatestCalendarDays(domainSharedDays, {
+      day: selectedWorkoutForMenu.day as DayKey,
+      session: selectedWorkoutForMenu.session,
+    });
+  }, [selectedWorkoutForMenu, domainSharedDays, overviewSharedRange.status]);
+
+  const overviewMenuSessionRef = useRef(overviewMenuSessionResolved);
+  overviewMenuSessionRef.current = overviewMenuSessionResolved;
 
   const weekDaysSlice = useMemo(
     () => filterWorkoutCalendarDaysInclusive(domainSharedDays, weekStart, weekEnd),
@@ -852,10 +860,13 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
 
   const beginDeleteStrengthWorkoutFromMenu = useCallback(() => {
     if (!selectedWorkoutForMenu || domain !== "strength") return;
-    const workout = pickWorkoutForSessionActions(selectedWorkoutForMenu.session);
-    if (!strengthWorkoutEligibleForDeleteFromOli(workout)) return;
+    const session = overviewMenuSessionRef.current ?? selectedWorkoutForMenu.session;
+    const workout = pickStrengthDeleteTargetWorkout(session);
+    if (!workout) return;
+    const rawEventId = (workout.id ?? "").trim();
+    if (!rawEventId) return;
     closeWorkoutMenu();
-    setPendingDeleteWorkoutId(workout!.id);
+    setPendingDeleteWorkoutId(rawEventId);
   }, [selectedWorkoutForMenu, domain, closeWorkoutMenu]);
 
   const confirmDeleteStrengthWorkout = useCallback(async () => {
@@ -872,6 +883,20 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
     setDeleteWorkoutSubmitting(false);
 
     if (res.ok) {
+      if (user?.uid) {
+        applyAuthoritativeWorkoutDeletionLocal(user.uid, id);
+      }
+      await clearWorkoutOverride(id);
+      await reload();
+      setPendingDeleteWorkoutId(null);
+      setWorkoutsCalendarRefreshEpoch((n) => n + 1);
+      return;
+    }
+
+    if (res.status === 404) {
+      if (user?.uid) {
+        applyAuthoritativeWorkoutDeletionLocal(user.uid, id);
+      }
       await clearWorkoutOverride(id);
       await reload();
       setPendingDeleteWorkoutId(null);
@@ -884,20 +909,19 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
     let message = "Something went wrong. Your workouts were not changed.";
     if (res.status === 403) {
       message = "This workout can't be removed from Oli.";
-    } else if (res.status === 404) {
-      message = "That workout is no longer available.";
     } else if (res.kind === "http" && typeof res.error === "string" && res.error.trim().length > 0) {
       const short = res.error.trim();
       if (short.length <= 140) message = short;
     }
 
     Alert.alert("Couldn't delete workout", message);
-  }, [pendingDeleteWorkoutId, getIdToken, reload]);
+  }, [pendingDeleteWorkoutId, getIdToken, reload, user?.uid]);
 
   const openEditRoute = useCallback(
     (mode: "rename" | "duration" | "type") => {
       if (!selectedWorkoutForMenu) return;
-      const { day: sessionDay, session } = selectedWorkoutForMenu;
+      const { day: sessionDay, session: staleSession } = selectedWorkoutForMenu;
+      const session = overviewMenuSessionResolved ?? staleSession;
       const workout = pickWorkoutForSessionActions(session);
       if (!workout) return;
       const journalSummary =
@@ -943,6 +967,7 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
       domain,
       manualWorkoutSummaries,
       durableTitlesByWorkoutId,
+      overviewMenuSessionResolved,
     ],
   );
 
@@ -1355,8 +1380,8 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
         onEditDuration={() => openEditRoute("duration")}
         onEditType={() => openEditRoute("type")}
         {...(domain === "strength" &&
-        selectedWorkoutForMenu &&
-        strengthWorkoutEligibleForDeleteFromOli(pickWorkoutForSessionActions(selectedWorkoutForMenu.session))
+        overviewMenuSessionResolved &&
+        pickStrengthDeleteTargetWorkout(overviewMenuSessionResolved) != null
           ? { onDeleteWorkout: beginDeleteStrengthWorkoutFromMenu }
           : {})}
       />

--- a/lib/contracts/rawEvent.ts
+++ b/lib/contracts/rawEvent.ts
@@ -92,6 +92,11 @@ export const ingestAcceptedResponseDtoSchema = z
     idempotentReplay: z.literal(true).optional(),
     /** Set when an existing apple_health workout doc had distanceMeters added without creating a duplicate. */
     payloadEnriched: z.literal(true).optional(),
+    /**
+     * Apple Health workout was not written because this idempotency key was suppressed after the user
+     * removed the workout from Oli (DELETE /ingest), blocking HealthKit re-sync from resurrecting it.
+     */
+    ingestSuppressed: z.literal(true).optional(),
   })
   .strip();
 

--- a/lib/data/useWorkoutsHistory.ts
+++ b/lib/data/useWorkoutsHistory.ts
@@ -37,7 +37,9 @@ async function hydrateInOrder(
   for (let i = 0; i < ids.length; i += concurrency) {
     const chunk = ids.slice(i, i + concurrency);
     const results = await Promise.all(chunk.map((id) => getRawEvent(id, idToken)));
-    for (const res of results) {
+    for (let j = 0; j < chunk.length; j += 1) {
+      const listId = chunk[j]!;
+      const res = results[j];
       if (!res) continue;
       if (!res.ok) {
         return {
@@ -46,7 +48,9 @@ async function hydrateInOrder(
           requestId: res.requestId,
         };
       }
-      items.push(parseWorkoutHistoryItem(res.json));
+      items.push(
+        parseWorkoutHistoryItem(res.json, { authoritativeRawEventId: listId, isDeletableRawEvent: true }),
+      );
     }
   }
   return { items };

--- a/lib/data/workouts/__tests__/parseWorkoutFromRawEvent.test.ts
+++ b/lib/data/workouts/__tests__/parseWorkoutFromRawEvent.test.ts
@@ -1,5 +1,9 @@
 import type { RawEventDoc } from "@oli/contracts";
-import { parseWorkoutHistoryItem, resolveWorkoutIngestProvider } from "../parseWorkoutFromRawEvent";
+import {
+  parseWorkoutHistoryItem,
+  resolveWorkoutIngestProvider,
+  strengthWorkoutRowEligibleForDeleteFromOli,
+} from "../parseWorkoutFromRawEvent";
 
 function minimalRaw(overrides: Partial<{ id: string; observedAt: string; receivedAt: string; sourceId: string; payload: unknown }>): RawEventDoc {
   return {
@@ -18,6 +22,54 @@ function minimalRaw(overrides: Partial<{ id: string; observedAt: string; receive
 }
 
 describe("parseWorkoutHistoryItem", () => {
+  it("sets isDeletableRawEvent when hydrate opts in", () => {
+    const raw = minimalRaw({
+      id: "ev-1",
+      provider: "manual",
+      payload: {
+        start: "2024-06-01T10:00:00Z",
+        end: "2024-06-01T11:00:00Z",
+        sport: "Run",
+        durationMinutes: 60,
+      },
+    });
+    const item = parseWorkoutHistoryItem(raw, { isDeletableRawEvent: true });
+    expect(item.isDeletableRawEvent).toBe(true);
+    expect(strengthWorkoutRowEligibleForDeleteFromOli(item)).toBe(true);
+  });
+
+  it("strength delete eligibility is false without isDeletableRawEvent even for manual provider", () => {
+    const raw = minimalRaw({
+      id: "ev-1",
+      provider: "manual",
+      payload: {
+        start: "2024-06-01T10:00:00Z",
+        end: "2024-06-01T11:00:00Z",
+        sport: "Run",
+        durationMinutes: 60,
+      },
+    });
+    const item = parseWorkoutHistoryItem(raw);
+    expect(item.isDeletableRawEvent).toBeUndefined();
+    expect(strengthWorkoutRowEligibleForDeleteFromOli(item)).toBe(false);
+  });
+
+  it("uses authoritativeRawEventId when stored body id disagrees with Firestore doc ref (DELETE /ingest target)", () => {
+    const raw = minimalRaw({
+      id: "wrong-embedded-id",
+      provider: "apple_health",
+      sourceId: "healthkit",
+      payload: {
+        start: "2024-06-01T10:00:00Z",
+        end: "2024-06-01T11:00:00Z",
+        sport: "Running",
+        durationMinutes: 60,
+      },
+    });
+    const item = parseWorkoutHistoryItem(raw, { authoritativeRawEventId: "appleHealth:v2:workout:abc" });
+    expect(item.id).toBe("appleHealth:v2:workout:abc");
+  });
+
   it("full payload workout parses expected fields including hk", () => {
     const raw = minimalRaw({
       id: "ev-1",

--- a/lib/data/workouts/__tests__/workoutDeletionAuthoritative.test.ts
+++ b/lib/data/workouts/__tests__/workoutDeletionAuthoritative.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it, beforeEach, jest } from "@jest/globals";
+
+jest.mock("@/lib/auth/AuthProvider", () => ({
+  useAuth: () => ({
+    user: { uid: "del-test-uid" },
+    initializing: false,
+    getIdToken: jest.fn(),
+  }),
+}));
+
+import type { DayKey } from "@/lib/ui/calendar/types";
+import { enumerateDaysInclusive } from "@/lib/ui/calendar/dateUtils";
+import type { WorkoutHistoryItem } from "@/lib/data/workouts/parseWorkoutFromRawEvent";
+import { mapWorkoutCalendarDaysForDomain } from "@/lib/data/workouts/workoutDomain";
+import {
+  buildStrengthLastWeekCardModel,
+  buildStrengthThisWeekCardModel,
+} from "@/lib/data/workouts/strengthThisWeekCardModel";
+import {
+  applyAuthoritativeWorkoutDeletionLocal,
+  getCachedWorkoutsForDay,
+  getLastGoodWorkoutCalendarRangeForTests,
+  mergeWorkoutsIntoDayCacheForTests,
+  resetWorkoutsCalendarCachesForTests,
+  seedDayWorkoutsCacheForTests,
+  seedLastGoodWorkoutCalendarRangeForTests,
+} from "@/lib/data/workouts/useWorkoutsCalendar";
+import { invalidateWorkoutCalendarHydrate } from "@/lib/data/workouts/workoutCalendarHydrateInvalidate";
+
+jest.mock("@/lib/data/workouts/workoutCalendarHydrateInvalidate", () => {
+  const actual = jest.requireActual<typeof import("@/lib/data/workouts/workoutCalendarHydrateInvalidate")>(
+    "@/lib/data/workouts/workoutCalendarHydrateInvalidate",
+  );
+  return {
+    ...actual,
+    invalidateWorkoutCalendarHydrate: jest.fn(actual.invalidateWorkoutCalendarHydrate),
+  };
+});
+
+const uid = "del-test-uid";
+const kindsSig = "workout";
+
+function strengthItem(id: string, day: DayKey): WorkoutHistoryItem {
+  return {
+    id,
+    observedAt: `${day}T12:00:00.000Z`,
+    sourceId: "manual",
+    title: "Lift",
+    start: `${day}T12:00:00.000Z`,
+    end: null,
+    durationMinutes: 30,
+    calories: null,
+    rawKind: "strength_workout",
+    workoutType: "strength",
+    isDeletableRawEvent: true,
+  };
+}
+
+describe("authoritative workout deletion (cache + merge trust)", () => {
+  beforeEach(() => {
+    resetWorkoutsCalendarCachesForTests();
+    jest.mocked(invalidateWorkoutCalendarHydrate).mockClear();
+  });
+
+  it("merge: empty incoming preserves per-day cache when the day was not delete-touched", () => {
+    const dayA: DayKey = "2026-03-10";
+    const dayB: DayKey = "2026-03-11";
+    seedDayWorkoutsCacheForTests(uid, dayA, [strengthItem("ghost-a", dayA)]);
+    seedDayWorkoutsCacheForTests(uid, dayB, [strengthItem("keep-b", dayB)]);
+    mergeWorkoutsIntoDayCacheForTests(uid, [
+      { day: dayA, workouts: [] },
+      { day: dayB, workouts: [] },
+    ]);
+    expect(getCachedWorkoutsForDay(uid, dayA).map((w) => w.id)).toEqual(["ghost-a"]);
+    expect(getCachedWorkoutsForDay(uid, dayB).map((w) => w.id)).toEqual(["keep-b"]);
+  });
+
+  it("merge: empty incoming clears delete-touched day cache (no ghost after authoritative empty)", () => {
+    const day: DayKey = "2026-03-10";
+    seedDayWorkoutsCacheForTests(uid, day, [strengthItem("gone", day)]);
+    applyAuthoritativeWorkoutDeletionLocal(uid, "gone");
+    mergeWorkoutsIntoDayCacheForTests(uid, [{ day, workouts: [] }]);
+    expect(getCachedWorkoutsForDay(uid, day)).toEqual([]);
+  });
+
+  it("merge: delete trust only affects touched days; other days still preserve on empty incoming", () => {
+    const touched: DayKey = "2026-03-10";
+    const other: DayKey = "2026-03-11";
+    seedDayWorkoutsCacheForTests(uid, touched, [strengthItem("gone", touched)]);
+    seedDayWorkoutsCacheForTests(uid, other, [strengthItem("stays", other)]);
+    applyAuthoritativeWorkoutDeletionLocal(uid, "gone");
+    mergeWorkoutsIntoDayCacheForTests(uid, [
+      { day: touched, workouts: [] },
+      { day: other, workouts: [] },
+    ]);
+    expect(getCachedWorkoutsForDay(uid, touched)).toEqual([]);
+    expect(getCachedWorkoutsForDay(uid, other).map((w) => w.id)).toEqual(["stays"]);
+  });
+
+  it("apply removes rawEventId from per-day cache across days", () => {
+    const d1: DayKey = "2026-03-09";
+    const d2: DayKey = "2026-03-10";
+    seedDayWorkoutsCacheForTests(uid, d1, [strengthItem("x", d1), strengthItem("dup", d1)]);
+    seedDayWorkoutsCacheForTests(uid, d2, [strengthItem("dup", d2)]);
+    applyAuthoritativeWorkoutDeletionLocal(uid, "dup");
+    expect(getCachedWorkoutsForDay(uid, d1).map((w) => w.id)).toEqual(["x"]);
+    expect(getCachedWorkoutsForDay(uid, d2)).toEqual([]);
+  });
+
+  it("apply strips workout from lastGood range shapes and durable title map", () => {
+    const start: DayKey = "2026-03-08";
+    const end: DayKey = "2026-03-14";
+    const day: DayKey = "2026-03-10";
+    const w = strengthItem("raw-1", day);
+    seedLastGoodWorkoutCalendarRangeForTests(uid, start, end, kindsSig, {
+      days: [
+        { day: start, workouts: [] },
+        { day: "2026-03-09", workouts: [] },
+        { day, workouts: [w] },
+        { day: "2026-03-11", workouts: [] },
+        { day: "2026-03-12", workouts: [] },
+        { day: "2026-03-13", workouts: [] },
+        { day: end, workouts: [] },
+      ],
+      durableTitlesByWorkoutId: { "raw-1": "Bench" },
+    });
+    applyAuthoritativeWorkoutDeletionLocal(uid, "raw-1");
+    const cached = getLastGoodWorkoutCalendarRangeForTests(uid, start, end, kindsSig);
+    expect(cached?.days.find((d) => d.day === day)?.workouts ?? []).toEqual([]);
+    expect(cached?.durableTitlesByWorkoutId.raw_1).toBeUndefined();
+    expect(jest.mocked(invalidateWorkoutCalendarHydrate)).toHaveBeenCalled();
+  });
+
+  it("This Week session count drops after apply strips lastGood strength row", () => {
+    const start: DayKey = "2026-03-08";
+    const end: DayKey = "2026-03-14";
+    const day: DayKey = "2026-03-10";
+    const w = strengthItem("week-del", day);
+    seedLastGoodWorkoutCalendarRangeForTests(uid, start, end, kindsSig, {
+      days: enumerateDaysInclusive(start, end).map((d) =>
+        d === day ? { day: d, workouts: [w] } : { day: d, workouts: [] },
+      ),
+      durableTitlesByWorkoutId: {},
+    });
+    applyAuthoritativeWorkoutDeletionLocal(uid, "week-del");
+    const cached = getLastGoodWorkoutCalendarRangeForTests(uid, start, end, kindsSig)!;
+    const strengthDays = mapWorkoutCalendarDaysForDomain(cached.days, "strength");
+    const model = buildStrengthThisWeekCardModel({
+      strengthCalendarDays: strengthDays,
+      todayDayKey: day,
+      weekStartDay: start,
+      weekEndDay: end,
+    });
+    expect(model.totalWorkoutsThisWeek).toBe(0);
+  });
+
+  it("Last Week session count drops when deleted workout was in last week window", () => {
+    const rangeStart: DayKey = "2026-03-01";
+    const rangeEnd: DayKey = "2026-03-14";
+    const lastWeekDay: DayKey = "2026-03-05";
+    const w = strengthItem("last-week-del", lastWeekDay);
+    seedLastGoodWorkoutCalendarRangeForTests(uid, rangeStart, rangeEnd, kindsSig, {
+      days: enumerateDaysInclusive(rangeStart, rangeEnd).map((d) =>
+        d === lastWeekDay ? { day: d, workouts: [w] } : { day: d, workouts: [] },
+      ),
+      durableTitlesByWorkoutId: {},
+    });
+    applyAuthoritativeWorkoutDeletionLocal(uid, "last-week-del");
+    const cached = getLastGoodWorkoutCalendarRangeForTests(uid, rangeStart, rangeEnd, kindsSig)!;
+    const strengthDays = mapWorkoutCalendarDaysForDomain(cached.days, "strength");
+    const lastWeekModel = buildStrengthLastWeekCardModel({
+      strengthCalendarDays: strengthDays,
+      todayDayKey: "2026-03-10",
+      lastWeekStartDay: "2026-03-01",
+      lastWeekEndDay: "2026-03-07",
+    });
+    expect(lastWeekModel.totalWorkoutsThisWeek).toBe(0);
+  });
+});

--- a/lib/data/workouts/__tests__/workoutSessionReconciliation.test.ts
+++ b/lib/data/workouts/__tests__/workoutSessionReconciliation.test.ts
@@ -1,7 +1,9 @@
 import type { WorkoutHistoryItem } from "@/lib/data/workouts/parseWorkoutFromRawEvent";
 import {
   deriveSessionTypeFlags,
+  matchReconciledWorkoutSessionToLatestDayWorkouts,
   reconcileWorkoutSessionsForDay,
+  resolveReconciledSessionWithLatestCalendarDays,
 } from "@/lib/data/workouts/workoutSessionReconciliation";
 
 function w(overrides: Partial<WorkoutHistoryItem>): WorkoutHistoryItem {
@@ -145,5 +147,35 @@ describe("workoutSessionReconciliation", () => {
       w({ id: "a1", sourceId: "apple_health", workoutType: "strength", durationMinutes: 200, start: "2026-03-20T10:20:00.000Z" }),
     ]);
     expect(sessions[0]?.durationMinutes).toBe(50);
+  });
+
+  it("matchReconciledWorkoutSessionToLatestDayWorkouts rebinds when merged session loses a member (session id changes)", () => {
+    const day = "2026-03-20";
+    const both = [
+      w({ id: "manual-1", sourceId: "manual", workoutType: "strength", start: "2026-03-20T17:00:00.000Z", durationMinutes: 60 }),
+      w({
+        id: "apple-1",
+        sourceId: "apple_health",
+        title: "TraditionalStrengthTraining",
+        workoutType: "strength",
+        start: "2026-03-20T17:20:00.000Z",
+        durationMinutes: 50,
+      }),
+    ];
+    const stale = reconcileWorkoutSessionsForDay(day, both)[0]!;
+    const onlyApple = both.filter((x) => x.id === "apple-1");
+    const matched = matchReconciledWorkoutSessionToLatestDayWorkouts(day, stale, onlyApple);
+    expect(matched).not.toBeNull();
+    expect(matched!.id).not.toBe(stale.id);
+    expect(matched!.workouts.map((x) => x.id)).toEqual(["apple-1"]);
+  });
+
+  it("resolveReconciledSessionWithLatestCalendarDays returns same session when day bucket unchanged", () => {
+    const day = "2026-03-20";
+    const workouts = [w({ id: "solo", sourceId: "manual", workoutType: "strength", start: "2026-03-20T08:00:00.000Z", durationMinutes: 40 })];
+    const stale = reconcileWorkoutSessionsForDay(day, workouts)[0]!;
+    const out = resolveReconciledSessionWithLatestCalendarDays([{ day, workouts }], { day, session: stale });
+    expect(out.id).toBe(stale.id);
+    expect(out.workouts.map((x) => x.id)).toEqual(["solo"]);
   });
 });

--- a/lib/data/workouts/__tests__/workoutSessionSurface.test.ts
+++ b/lib/data/workouts/__tests__/workoutSessionSurface.test.ts
@@ -6,6 +6,7 @@ import {
   buildWorkoutSessionSurfaceModel,
   pickJournalSummaryForStrengthSession,
   pickMetricsWorkoutForSession,
+  pickStrengthDeleteTargetWorkout,
   pickWorkoutForSessionActions,
   pickWorkoutOverrideForSession,
   resolveStrengthSessionExerciseDisplay,
@@ -433,5 +434,74 @@ describe("workoutSessionSurface", () => {
     expect(out.exercises[0]!.name).toBe("Squat");
     expect(out.totalVolume).toBe(100);
     expect(out.avgIntensity).toBe(7);
+  });
+});
+
+describe("pickStrengthDeleteTargetWorkout", () => {
+  it("prefers hydrate-backed manual over hydrate-backed apple", () => {
+    const day = "2026-03-11";
+    const workouts = [
+      item({
+        id: "apple1",
+        sourceId: "apple_health",
+        rawKind: "workout",
+        isDeletableRawEvent: true,
+        title: "Traditional Strength Training",
+        start: "2026-03-11T14:00:00.000Z",
+        workoutType: "strength",
+      }),
+      item({
+        id: "man1",
+        sourceId: "manual",
+        rawKind: "strength_workout",
+        isDeletableRawEvent: true,
+        title: "Bench Press",
+        start: "2026-03-11T14:05:00.000Z",
+        workoutType: "strength",
+      }),
+    ];
+    const [session] = reconcileWorkoutSessionsForDay(day, workouts);
+    expect(pickStrengthDeleteTargetWorkout(session!)?.id).toBe("man1");
+  });
+
+  it("skips manual without hydrate flag and picks apple when only apple is deletable", () => {
+    const day = "2026-03-11";
+    const workouts = [
+      item({
+        id: "apple1",
+        sourceId: "apple_health",
+        rawKind: "workout",
+        isDeletableRawEvent: true,
+        title: "Traditional Strength Training",
+        start: "2026-03-11T14:00:00.000Z",
+        workoutType: "strength",
+      }),
+      item({
+        id: "man1",
+        sourceId: "manual",
+        rawKind: "strength_workout",
+        title: "Bench Press",
+        start: "2026-03-11T14:05:00.000Z",
+        workoutType: "strength",
+      }),
+    ];
+    const [session] = reconcileWorkoutSessionsForDay(day, workouts);
+    expect(pickStrengthDeleteTargetWorkout(session!)?.id).toBe("apple1");
+  });
+
+  it("returns null when no session member is hydrate-backed deletable", () => {
+    const day = "2026-03-11";
+    const workouts = [
+      item({
+        id: "man1",
+        sourceId: "manual",
+        rawKind: "strength_workout",
+        title: "Bench Press",
+        start: "2026-03-11T14:05:00.000Z",
+        workoutType: "strength",
+      }),
+    ];
+    const [session] = reconcileWorkoutSessionsForDay(day, workouts);
+    expect(pickStrengthDeleteTargetWorkout(session!)).toBeNull();
   });
 });

--- a/lib/data/workouts/parseWorkoutFromRawEvent.ts
+++ b/lib/data/workouts/parseWorkoutFromRawEvent.ts
@@ -22,7 +22,35 @@ export function resolveWorkoutIngestProvider(raw: { provider?: string; sourceId?
   return undefined;
 }
 
+/**
+ * Strength overview DELETE /ingest eligibility: deletable raw row (hydrate-backed) + provider allowlist + workout kinds.
+ */
+export function strengthWorkoutRowEligibleForDeleteFromOli(workout: WorkoutHistoryItem | null | undefined): boolean {
+  if (!workout) return false;
+  if (workout.isDeletableRawEvent !== true) return false;
+  const p = resolveWorkoutIngestProvider(workout);
+  if (p !== "manual" && p !== "apple_health") return false;
+  const k = workout.rawKind;
+  if (k === undefined) return true;
+  return k === "strength_workout" || k === "workout";
+}
+
+export type ParseWorkoutHistoryItemOptions = {
+  /**
+   * Firestore document id from the listing query (path `rawEvents/{id}`).
+   * When the stored document body's `id` field can diverge from the doc ref (legacy / partial writes),
+   * this must be the id used for DELETE /ingest/:rawEventId and other raw-targeted APIs.
+   */
+  authoritativeRawEventId?: string;
+  /**
+   * When true, this item was produced from GET /users/me/raw-events hydration (listed doc id in `id`).
+   * Omit for summary-only or synthetic parses so Strength Delete stays hidden.
+   */
+  isDeletableRawEvent?: boolean;
+};
+
 export type WorkoutHistoryItem = {
+  /** Firestore `users/{uid}/rawEvents/{id}` document id (authoritative for DELETE /ingest). */
   id: string;
   observedAt: string;
   sourceId: string;
@@ -52,6 +80,11 @@ export type WorkoutHistoryItem = {
   strengthIngestExercises?: ManualWorkoutExerciseSummary[];
   /** Present only when `strength_workout` payload included `displayName` (title resolution vs exercise-derived title). */
   strengthIngestDisplayName?: string;
+  /**
+   * Set only for rows produced from raw-events calendar hydrate (listed doc existed at fetch time).
+   * Strength Delete requires this to be true alongside provider allowlist.
+   */
+  isDeletableRawEvent?: boolean;
 };
 
 function isRecord(v: unknown): v is Record<string, unknown> {
@@ -146,8 +179,10 @@ function parseHeartRateZoneMinutesFromPayload(payload: Record<string, unknown> |
  * Never throws. If payload is missing/unexpected, returns minimal item.
  * Treats payload as unknown record to support multiple sources (manual, HK, etc.).
  */
-export function parseWorkoutHistoryItem(raw: RawEventDoc): WorkoutHistoryItem {
-  const id = raw.id;
+export function parseWorkoutHistoryItem(raw: RawEventDoc, options?: ParseWorkoutHistoryItemOptions): WorkoutHistoryItem {
+  const auth =
+    typeof options?.authoritativeRawEventId === "string" ? options.authoritativeRawEventId.trim() : "";
+  const id = auth.length > 0 ? auth : raw.id;
   const observedAt = raw.observedAt ?? raw.receivedAt;
   const sourceId = raw.sourceId ?? "unknown";
   const resolvedProvider = resolveWorkoutIngestProvider(raw);
@@ -254,5 +289,6 @@ export function parseWorkoutHistoryItem(raw: RawEventDoc): WorkoutHistoryItem {
     ...(strengthIngestDisplayName != null && strengthIngestDisplayName.length > 0
       ? { strengthIngestDisplayName }
       : {}),
+    ...(options?.isDeletableRawEvent === true ? { isDeletableRawEvent: true as const } : {}),
   };
 }

--- a/lib/data/workouts/useWorkoutsCalendar.ts
+++ b/lib/data/workouts/useWorkoutsCalendar.ts
@@ -38,7 +38,10 @@ import {
 import { clearAllWorkoutCalendarMarkerCaches } from "@/lib/data/workouts/workoutsCalendarMarkerCache";
 import { WORKOUT_DAY_SUMMARY_EXPECTED } from "@oli/contracts";
 import type { WorkoutMarkerFlags } from "@/lib/data/workouts/workoutMarkerFlags";
-import { subscribeWorkoutCalendarHydrateInvalidate } from "@/lib/data/workouts/workoutCalendarHydrateInvalidate";
+import {
+  invalidateWorkoutCalendarHydrate,
+  subscribeWorkoutCalendarHydrateInvalidate,
+} from "@/lib/data/workouts/workoutCalendarHydrateInvalidate";
 import {
   durableTitleOverrideMapToRecord,
   mergeWorkoutTitleOverrideListRow,
@@ -101,7 +104,7 @@ export type WorkoutCalendarRangeState =
     }
   | { status: "error"; error: string; requestId: string | null };
 
-type CachedWorkoutCalendarRange = {
+export type CachedWorkoutCalendarRange = {
   days: WorkoutCalendarDay[];
   markerFlagsByDay?: Record<DayKey, WorkoutMarkerFlags>;
   durableTitlesByWorkoutId: Record<string, string>;
@@ -121,12 +124,98 @@ function clearRangeCachesForUidPrefix(uid: string): void {
   for (const k of lastGoodRangeByShape.keys()) {
     if (k.startsWith(p)) lastGoodRangeByShape.delete(k);
   }
+  deleteMergeTrustDaysByUid.delete(uid);
+}
+
+/**
+ * Calendar days explicitly affected by a successful or 404-equivalent raw-event delete.
+ * For these days only, an incoming hydrate bucket with `workouts.length === 0` replaces the
+ * per-day cache instead of preserving it (see `mergeWorkoutsIntoDayCache`).
+ */
+const deleteMergeTrustDaysByUid = new Map<string, Set<DayKey>>();
+
+function registerDeleteMergeTrustDays(uid: string, days: Iterable<DayKey>): void {
+  let set = deleteMergeTrustDaysByUid.get(uid);
+  if (!set) {
+    set = new Set();
+    deleteMergeTrustDaysByUid.set(uid, set);
+  }
+  for (const d of days) {
+    set.add(d);
+  }
+  if (set.size === 0) {
+    deleteMergeTrustDaysByUid.delete(uid);
+  }
+}
+
+/**
+ * After DELETE /ingest/:rawEventId returns 200 or 404, evict the id from per-day cache and from
+ * every cached range shape for this uid, register merge-trust for affected days, and fan out
+ * hydrate invalidation so mounted ranges refetch against server truth.
+ */
+export function applyAuthoritativeWorkoutDeletionLocal(uid: string, rawEventId: string): DayKey[] {
+  const id = rawEventId.trim();
+  if (!uid || !id) return [];
+
+  const affectedFromDayMap = evictRawEventIdFromWorkoutDayMap(uid, id);
+  const affectedFromRanges = optimisticallyRemoveWorkoutFromLastGoodRanges(uid, id);
+  const affected = [...new Set<DayKey>([...affectedFromDayMap, ...affectedFromRanges])];
+  if (affected.length > 0) {
+    registerDeleteMergeTrustDays(uid, affected);
+  }
+  invalidateWorkoutCalendarHydrate();
+  return affected;
+}
+
+function evictRawEventIdFromWorkoutDayMap(uid: string, rawEventId: string): DayKey[] {
+  const prefix = `${uid}|`;
+  const affected: DayKey[] = [];
+  for (const [key, workouts] of [...dayWorkoutsByUidDay.entries()]) {
+    if (!key.startsWith(prefix)) continue;
+    const day = key.slice(prefix.length) as DayKey;
+    const filtered = workouts.filter((w) => w.id !== rawEventId);
+    if (filtered.length === workouts.length) continue;
+    affected.push(day);
+    if (filtered.length === 0) {
+      dayWorkoutsByUidDay.delete(key);
+    } else {
+      dayWorkoutsByUidDay.set(key, sortWorkoutsChronologicalAsc(filtered));
+    }
+  }
+  return affected;
+}
+
+function optimisticallyRemoveWorkoutFromLastGoodRanges(uid: string, rawEventId: string): DayKey[] {
+  const p = `${uid}|`;
+  const affected: DayKey[] = [];
+  for (const [key, entry] of [...lastGoodRangeByShape.entries()]) {
+    if (!key.startsWith(p)) continue;
+    let changed = false;
+    const nextDays = entry.days.map((d) => {
+      const filtered = d.workouts.filter((w) => w.id !== rawEventId);
+      if (filtered.length !== d.workouts.length) {
+        changed = true;
+        affected.push(d.day);
+      }
+      return { day: d.day, workouts: filtered };
+    });
+    if (!changed) continue;
+    const durableTitlesByWorkoutId = { ...entry.durableTitlesByWorkoutId };
+    delete durableTitlesByWorkoutId[rawEventId];
+    lastGoodRangeByShape.set(key, {
+      ...entry,
+      days: nextDays,
+      durableTitlesByWorkoutId,
+    });
+  }
+  return affected;
 }
 
 /** Clears in-memory range/day caches (Jest tests only; avoids cross-test leakage). */
 export function resetWorkoutsCalendarCachesForTests(): void {
   lastGoodRangeByShape.clear();
   dayWorkoutsByUidDay.clear();
+  deleteMergeTrustDaysByUid.clear();
   void clearAllWorkoutCalendarMarkerCaches();
 }
 
@@ -151,22 +240,35 @@ export function getCachedWorkoutsForDay(uid: string, day: DayKey): WorkoutHistor
 function mergeWorkoutsIntoDayCache(uid: string, days: WorkoutCalendarDay[]): void {
   for (const d of days) {
     const k = dayCacheKey(uid, d.day);
+    const deleteTrust = deleteMergeTrustDaysByUid.get(uid);
+    const emptyTrustsAuthoritativeClear = Boolean(deleteTrust?.has(d.day));
     if (workoutDayDebugEnabled() && isWorkoutDayDebugDate(d.day)) {
       logWorkoutDayDebug("merge-cache-row", {
         day: d.day,
         incomingHydrateWorkoutIds: d.workouts.map((w) => w.id),
         perDayCacheIdsBeforeMerge: getCachedWorkoutsForDay(uid, d.day).map((w) => w.id),
-        emptyIncomingPreservesCache: true,
+        emptyIncomingPreservesCache: d.workouts.length === 0 ? !emptyTrustsAuthoritativeClear : false,
       });
     }
     if (d.workouts.length === 0) {
+      if (deleteTrust?.has(d.day)) {
+        deleteTrust.delete(d.day);
+        if (deleteTrust.size === 0) {
+          deleteMergeTrustDaysByUid.delete(uid);
+        }
+        dayWorkoutsByUidDay.delete(k);
+      }
       /**
-       * Do not delete existing per-day cache. An empty bucket usually means the `observedAt`
-       * list window missed raw docs that still belong on this calendar day (see
+       * Without delete-trust: do not delete existing per-day cache. An empty bucket usually means
+       * the `observedAt` list window missed raw docs that still belong on this calendar day (see
        * `deriveWorkoutDayKey` vs API filter), not that the user has zero workouts. Overview
        * hydrates may have populated this key from a wider window.
        */
       continue;
+    }
+    deleteMergeTrustDaysByUid.get(uid)?.delete(d.day);
+    if (deleteMergeTrustDaysByUid.get(uid)?.size === 0) {
+      deleteMergeTrustDaysByUid.delete(uid);
     }
     const prev = dayWorkoutsByUidDay.get(k) ?? [];
     const byId = new Map<string, WorkoutHistoryItem>();
@@ -180,6 +282,31 @@ function mergeWorkoutsIntoDayCache(uid: string, days: WorkoutCalendarDay[]): voi
       });
     }
   }
+}
+
+/** Jest-only hook: run the same per-day cache merge as a successful range hydrate. */
+export function mergeWorkoutsIntoDayCacheForTests(uid: string, days: WorkoutCalendarDay[]): void {
+  mergeWorkoutsIntoDayCache(uid, days);
+}
+
+/** Jest-only: seed `lastGoodRangeByShape` the way a successful hydrate would. */
+export function seedLastGoodWorkoutCalendarRangeForTests(
+  uid: string,
+  start: DayKey,
+  end: DayKey,
+  kindsSig: string,
+  entry: CachedWorkoutCalendarRange,
+): void {
+  lastGoodRangeByShape.set(rangeShapeKey(uid, start, end, kindsSig), entry);
+}
+
+export function getLastGoodWorkoutCalendarRangeForTests(
+  uid: string,
+  start: DayKey,
+  end: DayKey,
+  kindsSig: string,
+): CachedWorkoutCalendarRange | undefined {
+  return lastGoodRangeByShape.get(rangeShapeKey(uid, start, end, kindsSig));
 }
 
 function workoutTruthPayloadPreview(payload: unknown): Record<string, unknown> {
@@ -582,7 +709,10 @@ async function hydrateWorkoutsForRange(
             continue;
           }
 
-          const item = parseWorkoutHistoryItem(resJson as never);
+          const item = parseWorkoutHistoryItem(resJson as never, {
+            authoritativeRawEventId: id,
+            isDeletableRawEvent: true,
+          });
           grouped.push({ day: derivedDayKey, workout: item });
           if (dbgTouch) {
             logWorkoutDayDebug("pipeline-row", {

--- a/lib/data/workouts/workoutSessionReconciliation.ts
+++ b/lib/data/workouts/workoutSessionReconciliation.ts
@@ -258,3 +258,41 @@ export function deriveSessionTypeFlags(
   }
   return { hasStrength, hasCardio };
 }
+
+/**
+ * Re-match a reconciled session from a previous render to the current day's workouts after hydrate/refresh.
+ * UI code often keeps `ReconciledWorkoutSession` in React state while `workouts` on that day update
+ * (merge, delete, sync). Session `id` is derived from member raw ids, so it can change when membership changes.
+ */
+export function matchReconciledWorkoutSessionToLatestDayWorkouts(
+  day: DayKey,
+  staleSession: ReconciledWorkoutSession,
+  latestDayWorkouts: WorkoutHistoryItem[],
+): ReconciledWorkoutSession | null {
+  const freshSessions = reconcileWorkoutSessionsForDay(day, latestDayWorkouts);
+  const exact = freshSessions.find((s) => s.id === staleSession.id);
+  if (exact) return exact;
+  const staleIds = new Set(staleSession.workouts.map((w) => w.id));
+  return freshSessions.find((s) => s.workouts.some((w) => staleIds.has(w.id))) ?? null;
+}
+
+export type WorkoutCalendarDayLikeForSessionResolve = {
+  day: DayKey;
+  workouts: WorkoutHistoryItem[];
+};
+
+/**
+ * Strength/Cardio overview menus: resolve `selectedWorkoutForMenu.session` against latest calendar rows
+ * so delete/edit targets stay aligned after background refetch while the overflow menu stays open.
+ */
+export function resolveReconciledSessionWithLatestCalendarDays(
+  days: readonly WorkoutCalendarDayLikeForSessionResolve[],
+  selection: { day: DayKey; session: ReconciledWorkoutSession },
+): ReconciledWorkoutSession {
+  const row = days.find((d) => d.day === selection.day);
+  if (!row) return selection.session;
+  return (
+    matchReconciledWorkoutSessionToLatestDayWorkouts(selection.day, selection.session, row.workouts) ??
+    selection.session
+  );
+}

--- a/lib/data/workouts/workoutSessionSurface.ts
+++ b/lib/data/workouts/workoutSessionSurface.ts
@@ -1,5 +1,6 @@
 import {
   resolveWorkoutIngestProvider,
+  strengthWorkoutRowEligibleForDeleteFromOli,
   type WorkoutHistoryItem,
 } from "@/lib/data/workouts/parseWorkoutFromRawEvent";
 import type { WorkoutOverride } from "@/lib/data/workouts/workoutOverrides";
@@ -21,6 +22,18 @@ import type { DayKey } from "@/lib/ui/calendar/types";
 export function pickWorkoutForSessionActions(session: ReconciledWorkoutSession): WorkoutHistoryItem | null {
   const manual = session.workouts.find((w) => resolveWorkoutIngestProvider(w) === "manual");
   return manual ?? session.workouts[0] ?? null;
+}
+
+/**
+ * Strength DELETE target: prefer a hydrate-backed manual row, else any hydrate-backed deletable row.
+ * Unlike {@link pickWorkoutForSessionActions}, skips rows without `isDeletableRawEvent` (non–raw-events list).
+ */
+export function pickStrengthDeleteTargetWorkout(session: ReconciledWorkoutSession): WorkoutHistoryItem | null {
+  const manual = session.workouts.find(
+    (w) => resolveWorkoutIngestProvider(w) === "manual" && strengthWorkoutRowEligibleForDeleteFromOli(w),
+  );
+  if (manual) return manual;
+  return session.workouts.find((w) => strengthWorkoutRowEligibleForDeleteFromOli(w)) ?? null;
 }
 
 function overrideHasPatch(o: WorkoutOverride): boolean {

--- a/services/api/src/routes/__tests__/events.delete.test.ts
+++ b/services/api/src/routes/__tests__/events.delete.test.ts
@@ -57,16 +57,22 @@ describe("DELETE /ingest/:rawEventId", () => {
     };
 
     const deleteMock = jest.fn(async () => undefined);
+    const suppressSetMock = jest.fn(async () => undefined);
 
-    (userCollection as jest.Mock).mockReturnValue({
-      doc: () => ({
-        get: async () =>
-          ({
-            exists: true,
-            data: () => rawEvent,
-          }) as const,
-        delete: deleteMock,
-      }),
+    (userCollection as jest.Mock).mockImplementation((_uid: string, name: string) => {
+      if (name === "rawEventIngestSuppressions") {
+        return { doc: () => ({ set: suppressSetMock }) };
+      }
+      return {
+        doc: () => ({
+          get: async () =>
+            ({
+              exists: true,
+              data: () => rawEvent,
+            }) as const,
+          delete: deleteMock,
+        }),
+      };
     });
 
     const res = await fetch(`${baseUrl}/ingest/${rawEventId}`, { method: "DELETE" });
@@ -76,10 +82,11 @@ describe("DELETE /ingest/:rawEventId", () => {
     expect(json.ok).toBe(true);
     expect(json.rawEventId).toBe(rawEventId);
     expect(deleteMock).toHaveBeenCalledTimes(1);
+    expect(suppressSetMock).not.toHaveBeenCalled();
   });
 
   test("deletes an apple_health strength_workout raw event (removes Oli record only)", async () => {
-    const rawEventId = "apple_hk_str_1";
+    const rawEventId = "appleHealth:v2:workout:2025-01-02T00_2025-01-02T01_50_com.example.app";
     const rawEvent = {
       schemaVersion: 1,
       id: rawEventId,
@@ -98,22 +105,51 @@ describe("DELETE /ingest/:rawEventId", () => {
     };
 
     const deleteMock = jest.fn(async () => undefined);
+    const suppressSetMock = jest.fn(async () => undefined);
 
-    (userCollection as jest.Mock).mockReturnValue({
-      doc: () => ({
-        get: async () =>
-          ({
-            exists: true,
-            data: () => rawEvent,
-          }) as const,
-        delete: deleteMock,
-      }),
+    (userCollection as jest.Mock).mockImplementation((_uid: string, name: string) => {
+      if (name === "rawEventIngestSuppressions") {
+        return { doc: () => ({ set: suppressSetMock }) };
+      }
+      return {
+        doc: () => ({
+          get: async () =>
+            ({
+              exists: true,
+              data: () => rawEvent,
+            }) as const,
+          delete: deleteMock,
+        }),
+      };
     });
 
-    const res = await fetch(`${baseUrl}/ingest/${rawEventId}`, { method: "DELETE" });
+    const res = await fetch(`${baseUrl}/ingest/${encodeURIComponent(rawEventId)}`, { method: "DELETE" });
 
     expect(res.status).toBe(200);
     expect(deleteMock).toHaveBeenCalledTimes(1);
+    expect(suppressSetMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("404 delete still records Apple Health workout suppression for resurrection guard", async () => {
+    const rawEventId = "appleHealth:v2:workout:gone_but_suppress_50_com.example.app";
+    const suppressSetMock = jest.fn(async () => undefined);
+
+    (userCollection as jest.Mock).mockImplementation((_uid: string, name: string) => {
+      if (name === "rawEventIngestSuppressions") {
+        return { doc: () => ({ set: suppressSetMock }) };
+      }
+      return {
+        doc: () => ({
+          get: async () => ({ exists: false }) as const,
+          delete: jest.fn(),
+        }),
+      };
+    });
+
+    const res = await fetch(`${baseUrl}/ingest/${encodeURIComponent(rawEventId)}`, { method: "DELETE" });
+
+    expect(res.status).toBe(404);
+    expect(suppressSetMock).toHaveBeenCalledTimes(1);
   });
 
   test("rejects delete for unsupported workout provider", async () => {
@@ -138,21 +174,28 @@ describe("DELETE /ingest/:rawEventId", () => {
     };
 
     const deleteMock = jest.fn(async () => undefined);
+    const suppressSetMock = jest.fn(async () => undefined);
 
-    (userCollection as jest.Mock).mockReturnValue({
-      doc: () => ({
-        get: async () =>
-          ({
-            exists: true,
-            data: () => rawEvent,
-          }) as const,
-        delete: deleteMock,
-      }),
+    (userCollection as jest.Mock).mockImplementation((_uid: string, name: string) => {
+      if (name === "rawEventIngestSuppressions") {
+        return { doc: () => ({ set: suppressSetMock }) };
+      }
+      return {
+        doc: () => ({
+          get: async () =>
+            ({
+              exists: true,
+              data: () => rawEvent,
+            }) as const,
+          delete: deleteMock,
+        }),
+      };
     });
 
     const res = await fetch(`${baseUrl}/ingest/${rawEventId}`, { method: "DELETE" });
 
     expect(res.status).toBe(403);
     expect(deleteMock).not.toHaveBeenCalled();
+    expect(suppressSetMock).not.toHaveBeenCalled();
   });
 });

--- a/services/api/src/routes/__tests__/events.ingest.apple-health-workout-suppression.test.ts
+++ b/services/api/src/routes/__tests__/events.ingest.apple-health-workout-suppression.test.ts
@@ -1,0 +1,104 @@
+/**
+ * POST /ingest — Apple Health workout idempotency keys suppressed after DELETE /ingest
+ * must not recreate rawEvents (HealthKit re-sync resurrection).
+ */
+import { describe, it, expect, jest, beforeEach, afterEach } from "@jest/globals";
+import express from "express";
+
+const mockRawDocRef = {
+  id: "appleHealth:v2:workout:start_end_50_com.example.app",
+  get: jest.fn().mockResolvedValue({ exists: false }),
+  create: jest.fn().mockResolvedValue(undefined),
+};
+
+const mockSuppressDocRef = {
+  get: jest.fn().mockResolvedValue({ exists: true }),
+};
+
+const mockUserCollection = jest.fn((_uid: string, name: string) => {
+  if (name === "rawEventIngestSuppressions") {
+    return { doc: () => mockSuppressDocRef };
+  }
+  if (name === "rawEvents") {
+    return { doc: () => mockRawDocRef };
+  }
+  return { doc: () => mockRawDocRef };
+});
+
+jest.mock("../../db", () => ({
+  userCollection: (...args: unknown[]) => mockUserCollection(...args),
+}));
+
+function createIngestApp(): express.Express {
+  const router = require("../events").default as express.Router;
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as unknown as { uid?: string }).uid = "user_suppress_1";
+    next();
+  });
+  app.use("/ingest", router);
+  return app;
+}
+
+describe("POST /ingest — Apple Health workout ingest suppression", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRawDocRef.get.mockResolvedValue({ exists: false });
+    mockSuppressDocRef.get.mockResolvedValue({ exists: true });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("returns 202 with ingestSuppressed and does not create rawEvents when suppression exists", async () => {
+    const app = createIngestApp();
+    const server = app.listen(0);
+    const addr = server.address();
+    if (!addr || typeof addr === "string") {
+      server.close();
+      throw new Error("Failed to bind");
+    }
+    const idem =
+      "appleHealth:v2:workout:2026-04-18T08:09:59.736-0400_2026-04-18T08:12:42.433-0400_50_com.myzonemoves.app.MYZONE";
+    try {
+      const res = await fetch(`http://127.0.0.1:${addr.port}/ingest`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "Idempotency-Key": idem,
+        },
+        body: JSON.stringify({
+          provider: "apple_health",
+          sourceId: "healthkit",
+          kind: "workout",
+          observedAt: "2026-04-18T12:09:59.736Z",
+          timeZone: "America/New_York",
+          payload: {
+            start: "2026-04-18T12:09:59.736Z",
+            end: "2026-04-18T12:12:42.433Z",
+            timezone: "America/New_York",
+            sport: "Other",
+            durationMinutes: 3,
+            hk: { sourceId: "com.myzonemoves.app.MYZONE", activityId: 50 },
+          },
+        }),
+      });
+      expect(res.status).toBe(202);
+      const json = (await res.json()) as {
+        ok: boolean;
+        ingestSuppressed?: boolean;
+        idempotentReplay?: boolean;
+        rawEventId: string;
+      };
+      expect(json.ok).toBe(true);
+      expect(json.ingestSuppressed).toBe(true);
+      expect(json.idempotentReplay).toBe(true);
+      expect(json.rawEventId).toBe(idem);
+      expect(mockRawDocRef.create).not.toHaveBeenCalled();
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/services/api/src/routes/events.ts
+++ b/services/api/src/routes/events.ts
@@ -12,6 +12,32 @@ import { userCollection } from "../db";
 
 const router = Router();
 
+/** Firestore doc id / Idempotency-Key for Apple Health workout rows (client + server aligned). */
+function isAppleHealthWorkoutRawEventDocId(rawEventId: string): boolean {
+  return rawEventId.startsWith("appleHealth:v2:workout:");
+}
+
+async function recordAppleHealthWorkoutIngestSuppression(uid: string, rawEventId: string): Promise<void> {
+  if (!isAppleHealthWorkoutRawEventDocId(rawEventId)) return;
+  try {
+    await userCollection(uid, "rawEventIngestSuppressions")
+      .doc(rawEventId)
+      .set({ suppressedAt: new Date().toISOString() });
+  } catch {
+    // best-effort: deletion already succeeded or 404 response is still correct without tombstone
+  }
+}
+
+async function isAppleHealthWorkoutIngestSuppressed(uid: string, idempotencyKey: string): Promise<boolean> {
+  if (!isAppleHealthWorkoutRawEventDocId(idempotencyKey)) return false;
+  try {
+    const snap = await userCollection(uid, "rawEventIngestSuppressions").doc(idempotencyKey).get();
+    return snap.exists;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Request id from middleware (same source as other routes).
  */
@@ -365,6 +391,21 @@ router.post("/", async (req: AuthedRequest, res: Response) => {
     day = canonicalDayKeyFromObservedAt(observedAt, timeZone);
   }
 
+  if (
+    body.provider === "apple_health" &&
+    (body.kind === "workout" || body.kind === "strength_workout") &&
+    (await isAppleHealthWorkoutIngestSuppressed(uid, idempotencyKey))
+  ) {
+    return res.status(202).json({
+      ok: true as const,
+      rawEventId: idempotencyKey,
+      day,
+      idempotentReplay: true as const,
+      ingestSuppressed: true as const,
+      requestId,
+    });
+  }
+
   // Phase 1: gateway currently represents manual ingestion
   const sourceType = "manual" as const;
   const schemaVersion = 1 as const;
@@ -575,6 +616,7 @@ router.delete("/:rawEventId", async (req: AuthedRequest, res: Response) => {
   }
 
   if (!snap.exists) {
+    await recordAppleHealthWorkoutIngestSuppression(uid, rawEventId);
     return res.status(404).json({
       ok: false as const,
       error: {
@@ -662,6 +704,8 @@ router.delete("/:rawEventId", async (req: AuthedRequest, res: Response) => {
       requestId,
     });
   }
+
+  await recordAppleHealthWorkoutIngestSuppression(uid, rawEventId);
 
   return res.status(200).json({
     ok: true as const,


### PR DESCRIPTION
…vent resurrection

Root fix:
- deleting workouts could be undone by Apple Health re-ingest (idempotent POST /ingest)
- UI eviction worked, but backend hydrate reintroduced deleted workouts
- caused ghost workouts + incorrect weekly/session totals

Backend:
- add rawEventIngestSuppressions collection
- block POST /ingest for appleHealth:v2:workout:* if suppressed
- record suppression on:
  - successful delete (200)
  - missing delete (404)

Client:
- authoritative eviction (applyAuthoritativeWorkoutDeletionLocal)
- remove deleted/stale workouts from:
  - per-day cache
  - merged sessions
  - lastGoodRange snapshot
- prevent cache resurrection via delete-merge-trust
- recompute This Week / Last Week totals immediately

Tests:
- suppression prevents re-ingest
- delete (200 + 404) both converge to correct UI
- cache no longer preserves deleted workouts
- regression coverage for session reconciliation + parsing

Result:
- delete is now fully trustworthy
- workouts no longer reappear after refresh
- session counts remain correct after deletion

All checks passing:
- typecheck ✅
- lint ✅
- tests ✅
- invariants ✅