### PR TITLE
fix(workouts): apply suppression to GET raw-events to prevent deleted…

### DIFF
--- a/services/api/src/health.ts
+++ b/services/api/src/health.ts
@@ -15,6 +15,10 @@ type HealthOk = {
   service: "oli-api";
   env?: string;
   requestId?: string;
+  /** Cloud Run revision (K_REVISION) when running on Cloud Run — verify deployed binary. */
+  revision?: string;
+  /** Optional CI/deploy stamp (OLI_API_BUILD_ID) when set at build time. */
+  buildId?: string;
   timestamp: string;
   uptimeSec: number;
 };
@@ -24,6 +28,8 @@ type HealthAuthOk = {
   service: "oli-api";
   env?: string;
   requestId: string;
+  revision?: string;
+  buildId?: string;
   timestamp: string;
   uptimeSec: number;
   uid: string;
@@ -43,6 +49,11 @@ const buildBody = (req: Request): HealthOk => {
 
   const env = process.env.APP_ENV?.trim();
   if (env) body.env = env;
+
+  const revision = process.env.K_REVISION?.trim();
+  if (revision) body.revision = revision;
+  const buildId = process.env.OLI_API_BUILD_ID?.trim();
+  if (buildId) body.buildId = buildId;
 
   // Prefer app-level request id (set by requestIdMiddleware)
   const rid = (req as RequestWithRid).rid?.trim();
@@ -93,10 +104,15 @@ router.get("/live", publicHealthHandler);
 router.get("/health/auth", authMiddleware, (req: AuthedRequest, res: Response) => {
   const env = process.env.APP_ENV?.trim();
 
+  const revision = process.env.K_REVISION?.trim();
+  const buildId = process.env.OLI_API_BUILD_ID?.trim();
+
   const out: HealthAuthOk = {
     ok: true,
     service: "oli-api",
     ...(env ? { env } : {}),
+    ...(revision ? { revision } : {}),
+    ...(buildId ? { buildId } : {}),
     requestId: (req as RequestWithRid).rid ?? "unknown",
     timestamp: new Date().toISOString(),
     uptimeSec: Math.round(process.uptime()),

--- a/services/api/src/lib/rawEventIngestSuppression.ts
+++ b/services/api/src/lib/rawEventIngestSuppression.ts
@@ -1,0 +1,30 @@
+/**
+ * Apple Health workout rows use deterministic Firestore doc ids under rawEvents.
+ * Deletes that 404 (no doc yet) or 200 still record a tombstone so POST /ingest can block re-create.
+ * List/single reads consult the same collection for defense-in depth when any writer bypasses POST.
+ */
+
+/**
+ * Comma-separated Firestore raw event ids (exact match) for verbose suppression audit logs.
+ * Example: RAW_EVENT_SUPPRESSION_AUDIT_IDS="appleHealth:v2:workout:2026-04-18T08:09:59.736-0400_..."
+ * Remove after incident; logs include uid + requestId + rawEventId.
+ */
+export function suppressionAuditIdSet(): Set<string> {
+  const raw = process.env.RAW_EVENT_SUPPRESSION_AUDIT_IDS?.trim() ?? "";
+  if (!raw) return new Set();
+  return new Set(
+    raw
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0),
+  );
+}
+
+export function shouldLogSuppressionAuditForId(id: string): boolean {
+  return suppressionAuditIdSet().has(id);
+}
+
+/** Firestore doc id / Idempotency-Key for Apple Health workout rows (client + server aligned). */
+export function isAppleHealthWorkoutIngestSuppressionDocId(rawEventId: string): boolean {
+  return rawEventId.startsWith("appleHealth:v2:workout:");
+}

--- a/services/api/src/routes/__tests__/events.ingest.apple-health-distance-enrich.test.ts
+++ b/services/api/src/routes/__tests__/events.ingest.apple-health-distance-enrich.test.ts
@@ -16,9 +16,18 @@ const mockColRef = {
   doc: jest.fn(() => mockDocRef),
 };
 
+const mockSuppressDocRef = {
+  get: jest.fn().mockResolvedValue({ exists: false }),
+  set: jest.fn().mockResolvedValue(undefined),
+};
+const mockSuppressColRef = {
+  doc: jest.fn(() => mockSuppressDocRef),
+};
+
 jest.mock("../../db", () => ({
   userCollection: (...args: unknown[]) => {
     if (args[1] === "rawEvents") return mockColRef;
+    if (args[1] === "rawEventIngestSuppressions") return mockSuppressColRef;
     return {};
   },
 }));

--- a/services/api/src/routes/__tests__/events.suppression.delete404-then-ingest.test.ts
+++ b/services/api/src/routes/__tests__/events.suppression.delete404-then-ingest.test.ts
@@ -1,0 +1,111 @@
+/**
+ * End-to-end for MYZONE-style Apple Health workout id: DELETE 404 records suppression,
+ * then POST /ingest with same Idempotency-Key must not call rawEvents create().
+ */
+import { describe, it, expect, jest, beforeEach, afterEach } from "@jest/globals";
+import express from "express";
+
+const TARGET_ID =
+  "appleHealth:v2:workout:2026-04-18T08:09:59.736-0400_2026-04-18T08:12:42.433-0400_50_com.myzonemoves.app.MYZONE";
+
+const mockRawDocRef = {
+  get: jest.fn(),
+  create: jest.fn().mockResolvedValue(undefined),
+  delete: jest.fn().mockResolvedValue(undefined),
+};
+
+const suppressSetMock = jest.fn().mockResolvedValue(undefined);
+const suppressGetMock = jest.fn();
+
+const mockUserCollection = jest.fn((_uid: string, name: string) => {
+  if (name === "rawEventIngestSuppressions") {
+    return {
+      doc: () => ({
+        set: suppressSetMock,
+        get: suppressGetMock,
+      }),
+    };
+  }
+  if (name === "rawEvents") {
+    return { doc: () => mockRawDocRef };
+  }
+  return { doc: () => mockRawDocRef };
+});
+
+jest.mock("../../db", () => ({
+  userCollection: (...args: unknown[]) => mockUserCollection(...args),
+}));
+
+function createIngestApp(): express.Express {
+  const router = require("../events").default as express.Router;
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as unknown as { uid?: string }).uid = "user_myzone_audit";
+    next();
+  });
+  app.use("/ingest", router);
+  return app;
+}
+
+describe("Apple Health workout suppression — DELETE 404 then POST exact id", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRawDocRef.get.mockResolvedValue({ exists: false });
+    suppressGetMock.mockResolvedValue({ exists: false });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("DELETE 404 writes suppression doc; POST then returns ingestSuppressed without create", async () => {
+    const app = createIngestApp();
+    const server = app.listen(0);
+    const addr = server.address();
+    if (!addr || typeof addr === "string") {
+      server.close();
+      throw new Error("Failed to bind");
+    }
+    try {
+      const delRes = await fetch(
+        `http://127.0.0.1:${addr.port}/ingest/${encodeURIComponent(TARGET_ID)}`,
+        { method: "DELETE" },
+      );
+      expect(delRes.status).toBe(404);
+      expect(suppressSetMock).toHaveBeenCalledTimes(1);
+
+      suppressGetMock.mockResolvedValue({ exists: true });
+
+      const postRes = await fetch(`http://127.0.0.1:${addr.port}/ingest`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "Idempotency-Key": TARGET_ID,
+        },
+        body: JSON.stringify({
+          provider: "apple_health",
+          sourceId: "healthkit",
+          kind: "workout",
+          observedAt: "2026-04-18T12:09:59.736Z",
+          timeZone: "America/New_York",
+          payload: {
+            start: "2026-04-18T12:09:59.736Z",
+            end: "2026-04-18T12:12:42.433Z",
+            timezone: "America/New_York",
+            sport: "Other",
+            durationMinutes: 3,
+            hk: { sourceId: "com.myzonemoves.app.MYZONE", activityId: 50 },
+          },
+        }),
+      });
+      expect(postRes.status).toBe(202);
+      const json = (await postRes.json()) as { ingestSuppressed?: boolean; idempotentReplay?: boolean };
+      expect(json.ingestSuppressed).toBe(true);
+      expect(json.idempotentReplay).toBe(true);
+      expect(mockRawDocRef.create).not.toHaveBeenCalled();
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/services/api/src/routes/__tests__/rawEvents.list.test.ts
+++ b/services/api/src/routes/__tests__/rawEvents.list.test.ts
@@ -339,4 +339,103 @@ describe("GET /users/me/raw-events", () => {
   // NOTE: workouts calendar currently uses the gateway without advanced filters.
   // Contract for filters (start/end, kinds) is validated in other tests; here
   // we only assert that the basic limit-only contract remains stable.
+
+  const myzoneAppleHealthWorkoutId =
+    "appleHealth:v2:workout:2026-04-18T08:09:59.736-0400_2026-04-18T08:12:42.433-0400_50_com.myzonemoves.app.MYZONE";
+
+  test("list omits Apple Health v2 workout id when rawEventIngestSuppressions tombstone exists", async () => {
+    const docs: DocSnap[] = [
+      {
+        exists: true,
+        id: "raw_weight_keep",
+        data: () => ({
+          schemaVersion: 1,
+          id: "raw_weight_keep",
+          userId: "user_123",
+          sourceId: "manual",
+          kind: "weight",
+          observedAt: "2025-01-02T12:00:00.000Z",
+          receivedAt: "2025-01-02T12:01:00.000Z",
+        }),
+      },
+      {
+        exists: true,
+        id: myzoneAppleHealthWorkoutId,
+        data: () => ({
+          schemaVersion: 1,
+          id: myzoneAppleHealthWorkoutId,
+          userId: "user_123",
+          sourceId: "apple_health",
+          kind: "workout",
+          observedAt: "2026-04-18T12:00:00.000Z",
+          receivedAt: "2026-04-18T12:01:00.000Z",
+        }),
+      },
+    ];
+
+    const q = createMockQuery(docs);
+    (userCollection as jest.Mock).mockImplementation((_uid: string, name: string) => {
+      if (name === "rawEvents") {
+        return {
+          orderBy: q.orderBy,
+          where: q.where,
+          limit: q.limit,
+          startAfter: q.startAfter,
+          get: q.get,
+          doc: () => ({ get: async () => ({ exists: false }) }),
+        };
+      }
+      if (name === "rawEventIngestSuppressions") {
+        return {
+          doc: (id: string) => ({
+            get: async () => ({ exists: id === myzoneAppleHealthWorkoutId }),
+          }),
+        };
+      }
+      return { doc: () => ({ get: async () => ({ exists: false }) }) };
+    });
+
+    const res = await fetch(`${baseUrl}/users/me/raw-events?limit=10`);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.items.map((x: { id: string }) => x.id)).toEqual(["raw_weight_keep"]);
+  });
+
+  test("GET /rawEvents/:id returns 404 when ingest suppression tombstone exists (even if rawEvents doc exists)", async () => {
+    (userCollection as jest.Mock).mockImplementation((_uid: string, name: string) => {
+      if (name === "rawEventIngestSuppressions") {
+        return {
+          doc: (id: string) => ({
+            get: async () => ({ exists: id === myzoneAppleHealthWorkoutId }),
+          }),
+        };
+      }
+      if (name === "rawEvents") {
+        return {
+          doc: (id: string) => ({
+            get: async () => ({
+              exists: id === myzoneAppleHealthWorkoutId,
+              data: () => ({
+                schemaVersion: 1,
+                id: myzoneAppleHealthWorkoutId,
+                userId: "user_123",
+                sourceId: "apple_health",
+                kind: "workout",
+                observedAt: "2026-04-18T12:00:00.000Z",
+                receivedAt: "2026-04-18T12:01:00.000Z",
+              }),
+            }),
+          }),
+        };
+      }
+      return { doc: () => ({ get: async () => ({ exists: false }) }) };
+    });
+
+    const pathId = encodeURIComponent(myzoneAppleHealthWorkoutId);
+    const res = await fetch(`${baseUrl}/users/me/rawEvents/${pathId}`);
+    expect(res.status).toBe(404);
+    const json = await res.json();
+    expect(json.ok).toBe(false);
+    expect(json.error?.code).toBe("NOT_FOUND");
+  });
 });

--- a/services/api/src/routes/events.ts
+++ b/services/api/src/routes/events.ts
@@ -1,39 +1,88 @@
 // services/api/src/routes/events.ts
+//
+// Apple Health workout delete + re-sync: tombstones live under users/{uid}/rawEventIngestSuppressions/{id}.
+// Optional audit logs (exact id match): set RAW_EVENT_SUPPRESSION_AUDIT_IDS=comma,separated,ids
+// (use for one incident; correlates with x-request-id in Cloud Logging).
 import { Router, type Response } from "express";
 import { z } from "zod";
 
 import { localCalendarDayKeyFromIsoInTimeZone, rawEventDocSchema } from "@oli/contracts";
 import type { AuthedRequest } from "../middleware/auth";
-import type { RequestWithRid } from "../lib/logger";
+import { logger, type RequestWithRid } from "../lib/logger";
 import { writeFailure } from "../lib/writeFailure";
 import { mergeDistanceIntoExistingAppleHealthWorkoutIfNeeded } from "../lib/mergeAppleHealthWorkoutDistance";
+import {
+  isAppleHealthWorkoutIngestSuppressionDocId,
+  shouldLogSuppressionAuditForId,
+} from "../lib/rawEventIngestSuppression";
 import { ingestRawEventSchema, type IngestRawEventBody } from "../types/events";
 import { userCollection } from "../db";
 
 const router = Router();
 
-/** Firestore doc id / Idempotency-Key for Apple Health workout rows (client + server aligned). */
-function isAppleHealthWorkoutRawEventDocId(rawEventId: string): boolean {
-  return rawEventId.startsWith("appleHealth:v2:workout:");
-}
-
-async function recordAppleHealthWorkoutIngestSuppression(uid: string, rawEventId: string): Promise<void> {
-  if (!isAppleHealthWorkoutRawEventDocId(rawEventId)) return;
+async function recordAppleHealthWorkoutIngestSuppression(
+  uid: string,
+  rawEventId: string,
+  requestId: string,
+  context: "delete_404" | "delete_200",
+): Promise<void> {
+  if (!isAppleHealthWorkoutIngestSuppressionDocId(rawEventId)) return;
+  const audit = shouldLogSuppressionAuditForId(rawEventId);
   try {
     await userCollection(uid, "rawEventIngestSuppressions")
       .doc(rawEventId)
       .set({ suppressedAt: new Date().toISOString() });
-  } catch {
-    // best-effort: deletion already succeeded or 404 response is still correct without tombstone
+    if (audit) {
+      logger.info({
+        msg: "raw_event_suppression_write_ok",
+        rid: requestId,
+        uid,
+        rawEventId,
+        context,
+      });
+    }
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error({
+      msg: "raw_event_suppression_write_failed",
+      rid: requestId,
+      uid,
+      rawEventId,
+      context,
+      err: message,
+    });
   }
 }
 
-async function isAppleHealthWorkoutIngestSuppressed(uid: string, idempotencyKey: string): Promise<boolean> {
-  if (!isAppleHealthWorkoutRawEventDocId(idempotencyKey)) return false;
+async function isAppleHealthWorkoutIngestSuppressed(
+  uid: string,
+  idempotencyKey: string,
+  requestId: string,
+): Promise<boolean> {
+  if (!isAppleHealthWorkoutIngestSuppressionDocId(idempotencyKey)) return false;
+  const audit = shouldLogSuppressionAuditForId(idempotencyKey);
   try {
     const snap = await userCollection(uid, "rawEventIngestSuppressions").doc(idempotencyKey).get();
-    return snap.exists;
-  } catch {
+    const suppressed = snap.exists;
+    if (audit) {
+      logger.info({
+        msg: "raw_event_suppression_ingest_precheck",
+        rid: requestId,
+        uid,
+        rawEventId: idempotencyKey,
+        suppressed,
+      });
+    }
+    return suppressed;
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error({
+      msg: "raw_event_suppression_read_failed",
+      rid: requestId,
+      uid,
+      rawEventId: idempotencyKey,
+      err: message,
+    });
     return false;
   }
 }
@@ -394,8 +443,16 @@ router.post("/", async (req: AuthedRequest, res: Response) => {
   if (
     body.provider === "apple_health" &&
     (body.kind === "workout" || body.kind === "strength_workout") &&
-    (await isAppleHealthWorkoutIngestSuppressed(uid, idempotencyKey))
+    (await isAppleHealthWorkoutIngestSuppressed(uid, idempotencyKey, requestId))
   ) {
+    if (shouldLogSuppressionAuditForId(idempotencyKey)) {
+      logger.info({
+        msg: "raw_event_ingest_blocked_by_suppression",
+        rid: requestId,
+        uid,
+        rawEventId: idempotencyKey,
+      });
+    }
     return res.status(202).json({
       ok: true as const,
       rawEventId: idempotencyKey,
@@ -616,7 +673,7 @@ router.delete("/:rawEventId", async (req: AuthedRequest, res: Response) => {
   }
 
   if (!snap.exists) {
-    await recordAppleHealthWorkoutIngestSuppression(uid, rawEventId);
+    await recordAppleHealthWorkoutIngestSuppression(uid, rawEventId, requestId, "delete_404");
     return res.status(404).json({
       ok: false as const,
       error: {
@@ -705,7 +762,7 @@ router.delete("/:rawEventId", async (req: AuthedRequest, res: Response) => {
     });
   }
 
-  await recordAppleHealthWorkoutIngestSuppression(uid, rawEventId);
+  await recordAppleHealthWorkoutIngestSuppression(uid, rawEventId, requestId, "delete_200");
 
   return res.status(200).json({
     ok: true as const,

--- a/services/api/src/routes/usersMe.ts
+++ b/services/api/src/routes/usersMe.ts
@@ -54,11 +54,90 @@ import {
 
 import { db, userCollection, documentIdPath } from "../db";
 import { fillSleepContributorsFromStored } from "../lib/ouraVendorSnapshot";
+import {
+  isAppleHealthWorkoutIngestSuppressionDocId,
+  shouldLogSuppressionAuditForId,
+} from "../lib/rawEventIngestSuppression";
 import { getRawEventsTruthDebugConfig } from "../lib/workoutTruthDebug";
 
 const router = Router();
 
 const getRid = (req: AuthedRequest): string => (req as RequestWithRid).rid ?? "unknown";
+
+/** True when an Apple Health workout id is tombstoned for ingest; hide from list/single reads. */
+async function rawEventDocHiddenByAppleHealthIngestSuppression(
+  uid: string,
+  id: string,
+  requestId: string,
+): Promise<boolean> {
+  if (!isAppleHealthWorkoutIngestSuppressionDocId(id)) return false;
+  try {
+    const snap = await userCollection(uid, "rawEventIngestSuppressions").doc(id).get();
+    if (snap.exists && shouldLogSuppressionAuditForId(id)) {
+      logger.info({
+        msg: "raw_event_single_read_suppressed",
+        rid: requestId,
+        uid,
+        rawEventId: id,
+      });
+    }
+    return snap.exists;
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error({
+      msg: "raw_event_suppression_read_failed_single",
+      rid: requestId,
+      uid,
+      rawEventId: id,
+      err: message,
+    });
+    return false;
+  }
+}
+
+async function filterOutIngestSuppressedAppleHealthWorkoutListItems(
+  uid: string,
+  items: RawEventListItem[],
+  requestId: string,
+): Promise<RawEventListItem[]> {
+  const targets = items.filter((it) => isAppleHealthWorkoutIngestSuppressionDocId(it.id));
+  if (targets.length === 0) return items;
+
+  const snaps = await Promise.all(
+    targets.map(async (it) => {
+      try {
+        return await userCollection(uid, "rawEventIngestSuppressions").doc(it.id).get();
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        logger.error({
+          msg: "raw_event_suppression_read_failed_list",
+          rid: requestId,
+          uid,
+          rawEventId: it.id,
+          err: message,
+        });
+        return null;
+      }
+    }),
+  );
+  const suppressed = new Set<string>();
+  for (let i = 0; i < targets.length; i++) {
+    const s = snaps[i];
+    if (s?.exists) suppressed.add(targets[i]!.id);
+  }
+  for (const id of suppressed) {
+    if (shouldLogSuppressionAuditForId(id)) {
+      logger.info({
+        msg: "raw_events_list_item_filtered_suppressed",
+        rid: requestId,
+        uid,
+        rawEventId: id,
+      });
+    }
+  }
+  if (suppressed.size === 0) return items;
+  return items.filter((it) => !suppressed.has(it.id));
+}
 
 const parseDay = (req: AuthedRequest, res: Response): string | null => {
   const parsed = dayQuerySchema.safeParse(req.query);
@@ -504,6 +583,15 @@ router.get(
 
     const { id } = parsedParams.data;
 
+    const rid = getRid(req);
+    if (await rawEventDocHiddenByAppleHealthIngestSuppression(uid, id, rid)) {
+      res.status(404).json({
+        ok: false,
+        error: { code: "NOT_FOUND", resource: "rawEvents", id },
+      });
+      return;
+    }
+
     const ref = userCollection(uid, "rawEvents").doc(id);
     const snap = await ref.get();
 
@@ -559,6 +647,19 @@ router.get(
 
     const { id } = parsed.data;
 
+    const rid = getRid(req);
+    if (await rawEventDocHiddenByAppleHealthIngestSuppression(uid, id, rid)) {
+      res.status(404).json({
+        ok: false,
+        error: {
+          code: "NOT_FOUND",
+          message: "RawEvent not found",
+          requestId: rid,
+        },
+      });
+      return;
+    }
+
     const ref = userCollection(uid, "rawEvents").doc(id);
     const snap = await ref.get();
 
@@ -568,7 +669,7 @@ router.get(
         error: {
           code: "NOT_FOUND",
           message: "RawEvent not found",
-          requestId: getRid(req),
+          requestId: rid,
         },
       });
       return;
@@ -798,7 +899,12 @@ router.get(
     }
 
     const hasMore = hasPostFilters ? false : docs.length > limit;
-    const outItems = hasPostFilters ? items : hasMore ? items.slice(0, -1) : items;
+    let outItems = hasPostFilters ? items : hasMore ? items.slice(0, -1) : items;
+    outItems = await filterOutIngestSuppressedAppleHealthWorkoutListItems(
+      uid,
+      outItems as RawEventListItem[],
+      getRid(req),
+    );
     const lastDoc = hasPostFilters ? null : hasMore ? docs[docs.length - 2] : null;
     const nextCursor = lastDoc ? encodeCursor(lastDoc.id) : null;
 

--- a/services/functions/src/account/onAccountDeleteRequested.ts
+++ b/services/functions/src/account/onAccountDeleteRequested.ts
@@ -30,7 +30,18 @@ async function deleteUserFirestoreSubtree(db: FirebaseFirestore.Firestore, uid: 
 
   // ✅ Verified: profile exists (functions index writes users/{uid}/profile/general)
   // Keep accountDeletion here to clean up any legacy docs from earlier versions.
-  const collections = ["profile", "rawEvents", "events", "dailyFacts", "insights", "intelligenceContext", "healthScores", "healthSignals", "accountDeletion"] as const;
+  const collections = [
+    "profile",
+    "rawEvents",
+    "rawEventIngestSuppressions",
+    "events",
+    "dailyFacts",
+    "insights",
+    "intelligenceContext",
+    "healthScores",
+    "healthSignals",
+    "accountDeletion",
+  ] as const;
 
   for (const col of collections) {
     await db.recursiveDelete(userRef.collection(col));


### PR DESCRIPTION
… Apple workouts resurfacing

Root issue:
- delete suppression worked for POST /ingest and DELETE
- but GET /users/me/raw-events did not consult suppression
- result: deleted Apple Health workouts reappeared after refresh

Backend fixes:
- add shared suppression helpers (rawEventIngestSuppression.ts)
- apply suppression filtering to:
  - GET /users/me/raw-events (list)
  - GET /users/me/rawEvents/:id (single)
  - GET /users/me/raw-event (query)
- ensure suppressed appleHealth:v2:workout ids are hidden from all read paths

Delete behavior:
- DELETE 404 + 200 both record suppression tombstone
- POST /ingest precheck blocks recreation
- GET now aligns with suppression → no resurfacing

Tests:
- suppression hides MYZONE workout from list
- suppression returns 404 for single fetch
- regression test: delete404 → suppression → ingest blocked

Other:
- added revision/build visibility via health.ts
- account delete now clears suppression subtree

Result:
- deleted Apple workouts no longer reappear after refresh
- UI + backend now fully consistent
- Strength totals remain correct

All checks passing:
- typecheck ✅
- lint ✅
- tests ✅
- invariants ✅