### PR TITLE
fix(workouts): end-to-end delete reliability (gateway + backend + cli…

### DIFF
--- a/app/(app)/workouts/__tests__/overview-workout-actions.test.tsx
+++ b/app/(app)/workouts/__tests__/overview-workout-actions.test.tsx
@@ -9,7 +9,7 @@ const mockClearWorkoutOverride = jest.fn(async () => undefined);
 const mockDeleteIngestedRawEventAuthed = jest.fn(async () => ({
   ok: true as const,
   status: 200 as const,
-  data: { ok: true as const, rawEventId: "w1", requestId: "rid" },
+  data: { ok: true as const, rawEventId: "w1", requestId: "rid", suppressionWritten: false },
   requestId: "rid" as string | null,
 }));
 let mockOverridesState: Record<string, unknown> = {};
@@ -349,7 +349,7 @@ describe("overview workout actions", () => {
     mockDeleteIngestedRawEventAuthed.mockResolvedValue({
       ok: true as const,
       status: 200 as const,
-      data: { ok: true as const, rawEventId: "w1", requestId: "rid" },
+      data: { ok: true as const, rawEventId: "w1", requestId: "rid", suppressionWritten: false },
       requestId: "rid" as string | null,
     });
   });
@@ -497,15 +497,20 @@ describe("overview workout actions", () => {
     expect(mockDeleteIngestedRawEventAuthed).toHaveBeenCalledWith("w4", "token");
     expect(mockClearWorkoutOverride).toHaveBeenCalledWith("w4");
     expect(applyDeletionMock).toHaveBeenCalledWith("u1", "w4");
+    expect(jest.mocked(Alert.alert)).not.toHaveBeenCalled();
   });
 
   it("delete 404 still evicts locally and does not show a blocking failure alert", async () => {
     mockDeleteIngestedRawEventAuthed.mockResolvedValue({
-      ok: false as const,
-      status: 404,
-      requestId: "rid-404",
-      kind: "http",
-      error: "Not found",
+      ok: true as const,
+      status: 404 as const,
+      data: {
+        ok: true as const,
+        rawEventId: "w2",
+        requestId: "rid-404",
+        suppressionWritten: false,
+      },
+      requestId: "rid-404" as string | null,
     });
     const test = await mountTrainingOverview();
     act(() => {
@@ -519,6 +524,52 @@ describe("overview workout actions", () => {
       await Promise.resolve();
     });
     expect(applyDeletionMock).toHaveBeenCalledWith("u1", "w2");
+    expect(jest.mocked(Alert.alert)).not.toHaveBeenCalled();
+  });
+
+  it("delete HTTP 500 does not evict locally and shows an error alert", async () => {
+    mockDeleteIngestedRawEventAuthed.mockResolvedValue({
+      ok: false as const,
+      status: 500,
+      requestId: "rid-500",
+      kind: "http",
+      error: "HTTP 500",
+    });
+    const test = await mountTrainingOverview();
+    act(() => {
+      test.root.findByProps({ accessibilityLabel: "Workout actions w6" }).props.onPress();
+    });
+    act(() => {
+      test.root.findByProps({ accessibilityLabel: "Delete workout" }).props.onPress();
+    });
+    await act(async () => {
+      test.root.findByProps({ accessibilityLabel: "Confirm delete workout" }).props.onPress();
+      await Promise.resolve();
+    });
+    expect(applyDeletionMock).not.toHaveBeenCalled();
+    expect(jest.mocked(Alert.alert)).toHaveBeenCalled();
+  });
+
+  it("delete HTTP 401 does not evict locally and does not show an error alert", async () => {
+    mockDeleteIngestedRawEventAuthed.mockResolvedValue({
+      ok: false as const,
+      status: 401,
+      requestId: "rid-401",
+      kind: "http",
+      error: "Unauthorized",
+    });
+    const test = await mountTrainingOverview();
+    act(() => {
+      test.root.findByProps({ accessibilityLabel: "Workout actions w7" }).props.onPress();
+    });
+    act(() => {
+      test.root.findByProps({ accessibilityLabel: "Delete workout" }).props.onPress();
+    });
+    await act(async () => {
+      test.root.findByProps({ accessibilityLabel: "Confirm delete workout" }).props.onPress();
+      await Promise.resolve();
+    });
+    expect(applyDeletionMock).not.toHaveBeenCalled();
     expect(jest.mocked(Alert.alert)).not.toHaveBeenCalled();
   });
 

--- a/app/(app)/workouts/overview.tsx
+++ b/app/(app)/workouts/overview.tsx
@@ -893,23 +893,21 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
       return;
     }
 
-    if (res.status === 404) {
-      if (user?.uid) {
-        applyAuthoritativeWorkoutDeletionLocal(user.uid, id);
-      }
-      await clearWorkoutOverride(id);
-      await reload();
-      setPendingDeleteWorkoutId(null);
-      setWorkoutsCalendarRefreshEpoch((n) => n + 1);
+    setPendingDeleteWorkoutId(null);
+
+    const showDeleteFailureAlert =
+      res.kind === "network" || res.status === 500 || res.status === 403;
+    if (!showDeleteFailureAlert) {
       return;
     }
-
-    setPendingDeleteWorkoutId(null);
 
     let message = "Something went wrong. Your workouts were not changed.";
     if (res.status === 403) {
       message = "This workout can't be removed from Oli.";
     } else if (res.kind === "http" && typeof res.error === "string" && res.error.trim().length > 0) {
+      const short = res.error.trim();
+      if (short.length <= 140) message = short;
+    } else if (res.kind === "network" && typeof res.error === "string" && res.error.trim().length > 0) {
       const short = res.error.trim();
       if (short.length <= 140) message = short;
     }

--- a/docs/runbooks/gateway-and-cloudrun.md
+++ b/docs/runbooks/gateway-and-cloudrun.md
@@ -21,20 +21,46 @@ Environment:
 ### 1.1 Build image
 ```bash
 scripts/deploy/phase3a-withings-build-api-image.sh
-1.2 Deploy Cloud Run
+```
+
+### 1.2 Deploy Cloud Run
+```bash
 scripts/deploy/phase3a-withings-deploy-cloudrun.sh <commit_short_sha>
-1.3 Deploy Gateway
+```
+
+### 1.3 Deploy Gateway (repo `infra/gateway/openapi.yaml` → new api-config → `oli-gateway`)
+```bash
+# Preflight: gcloud project must be oli-staging-fdbba (the script exits otherwise).
 scripts/deploy/phase3a-withings-deploy-gateway.sh
-2. Confirm Active Revision
+```
+
+## 2. Confirm active revision
+```bash
 gcloud run services describe oli-api \
   --region us-central1 \
+  --project oli-staging-fdbba \
   --format="value(status.traffic[0].revisionName,status.url)"
-3. Confirm Gateway Config
+```
+
+## 3. Confirm gateway config
+```bash
 gcloud api-gateway gateways describe oli-gateway \
   --location us-central1 \
   --project oli-staging-fdbba \
   --format="yaml(apiConfig,defaultHostname,state)"
-4. 401 vs 403 Diagnosis
+```
+
+### Log correlation: `apiConfig` vs `serviceConfigId`
+`gateways describe` returns **`apiConfig`** like `.../configs/oli-api-config-YYYYMMDD-HHMMSS`. ESP / GFE logs often show a longer **`serviceConfigId`** (same base id plus a Google-managed suffix). They refer to the same rollout when `api-configs describe` reports that `serviceConfigId`:
+
+```bash
+gcloud api-gateway api-configs describe oli-api-config-YYYYMMDD-HHMMSS \
+  --api=oli-api \
+  --project=oli-staging-fdbba \
+  --format="yaml(name,serviceConfigId,createTime,state)"
+```
+
+## 4. 401 vs 403 diagnosis
 401 from Gateway
 
 Cause:
@@ -112,6 +138,16 @@ Route missing from openapi.yaml
 Gateway not redeployed
 
 Wrong hostname used
+
+If Gateway / ESPv2 shows **`api_method: "<Unknown Operation Name>"`** and **`response_code_detail: "direct_response"`**, the request **did not match any OpenAPI path** (no `operationId`). The rejection happens **before** Cloud Run. Typical causes: the method + path is missing from the **deployed** api-config (OpenAPI never redeployed after a repo change), or the wrong hostname was used.
+
+Workout delete example: **`DELETE /ingest/{rawEventId}`** must be declared separately from **`POST /ingest`** in `infra/gateway/openapi.yaml`, then **`scripts/deploy/phase3a-withings-deploy-gateway.sh`** must be run so that config is live. To prove what was bundled into an existing api-config timestamp, compare the repo at deploy time, for example:
+
+```bash
+git show <commit_or_date_ref>:infra/gateway/openapi.yaml | sed -n '/^  \\/ingest/,/^  \\/export/p'
+```
+
+Regression coverage: `services/api/src/routes/__tests__/gateway-openapi-ingest-delete.contract.test.ts` (runs under `npm test` with other `services/api/src/routes/__tests__` suites).
 
 6. Confirm PUBLIC_BASE_URL
 gcloud run services describe oli-api \

--- a/infra/gateway/openapi.yaml
+++ b/infra/gateway/openapi.yaml
@@ -198,6 +198,43 @@ paths:
         200:
           description: OK
 
+  # DELETE workout raw event (path param is percent-encoded in requests, e.g. %3A for ':').
+  # Must be declared separately from POST /ingest so API Gateway matches DELETE /ingest/{rawEventId}.
+  /ingest/{rawEventId}:
+    parameters:
+      - name: rawEventId
+        in: path
+        required: true
+        type: string
+        description: >
+          Firestore rawEvents document id (URL path segment; encode reserved chars per RFC 3986).
+          Gateway forwards path to Cloud Run with APPEND_PATH_TO_ADDRESS; ESPv2 decodes the segment for the backend.
+    options:
+      operationId: ingestByRawEventIdOptions
+      security: []
+      responses:
+        204:
+          description: No Content
+    delete:
+      operationId: ingestRawEventDelete
+      security:
+        - firebase: []
+      produces:
+        - application/json
+      responses:
+        200:
+          description: OK — workout removed from Oli
+        400:
+          description: Bad Request
+        401:
+          description: Unauthorized
+        403:
+          description: Forbidden
+        404:
+          description: Not Found — no raw doc (tombstone may still be written for Apple Health v2 workout ids)
+        500:
+          description: Server Error
+
   /export:
     options:
       operationId: exportOptions

--- a/lib/api/__tests__/delete-ingest-raw-event-authed.test.ts
+++ b/lib/api/__tests__/delete-ingest-raw-event-authed.test.ts
@@ -1,0 +1,102 @@
+import { deleteIngestedRawEventAuthed } from "@/lib/api/ingest";
+import { apiDeleteJsonAuthed } from "@/lib/api/http";
+
+jest.mock("@/lib/api/http", () => ({
+  apiDeleteJsonAuthed: jest.fn(),
+}));
+
+const mockApiDeleteJsonAuthed = jest.mocked(apiDeleteJsonAuthed);
+
+describe("deleteIngestedRawEventAuthed", () => {
+  beforeEach(() => {
+    mockApiDeleteJsonAuthed.mockReset();
+  });
+
+  it("treats HTTP 200 with full JSON body as success", async () => {
+    mockApiDeleteJsonAuthed.mockResolvedValue({
+      ok: true,
+      status: 200,
+      requestId: "hdr-rid",
+      json: {
+        ok: true,
+        rawEventId: "w1",
+        requestId: "body-rid",
+        suppressionWritten: false,
+      },
+    });
+
+    const out = await deleteIngestedRawEventAuthed("w1", "tok");
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.status).toBe(200);
+    expect(out.data).toEqual({
+      ok: true,
+      rawEventId: "w1",
+      requestId: "body-rid",
+      suppressionWritten: false,
+    });
+  });
+
+  it("treats HTTP 200 with omitted body requestId as success (header fallback)", async () => {
+    mockApiDeleteJsonAuthed.mockResolvedValue({
+      ok: true,
+      status: 200,
+      requestId: "from-header",
+      json: {
+        ok: true,
+        rawEventId: "w1",
+        suppressionWritten: true,
+      },
+    });
+
+    const out = await deleteIngestedRawEventAuthed("w1", "tok");
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.status).toBe(200);
+    expect(out.data.requestId).toBe("from-header");
+    expect(out.data.suppressionWritten).toBe(true);
+  });
+
+  it("treats HTTP 200 with empty JSON body as success using path id + header requestId", async () => {
+    mockApiDeleteJsonAuthed.mockResolvedValue({
+      ok: true,
+      status: 200,
+      requestId: "rid-empty-body",
+      json: null,
+    });
+
+    const out = await deleteIngestedRawEventAuthed("w9", "tok");
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.data).toEqual({
+      ok: true,
+      rawEventId: "w9",
+      requestId: "rid-empty-body",
+      suppressionWritten: false,
+    });
+  });
+
+  it("treats HTTP 404 with NOT_FOUND body as success (already deleted)", async () => {
+    mockApiDeleteJsonAuthed.mockResolvedValue({
+      ok: false,
+      status: 404,
+      kind: "http",
+      error: "HTTP 404",
+      requestId: "rid-404",
+      json: {
+        ok: false,
+        error: { code: "NOT_FOUND", message: "Workout record not found" },
+        requestId: "rid-404",
+        suppressionWritten: true,
+      },
+    });
+
+    const out = await deleteIngestedRawEventAuthed("appleHealth:v2:workout:x", "tok");
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.status).toBe(404);
+    expect(out.data.ok).toBe(true);
+    expect(out.data.rawEventId).toBe("appleHealth:v2:workout:x");
+    expect(out.data.suppressionWritten).toBe(true);
+  });
+});

--- a/lib/api/ingest.ts
+++ b/lib/api/ingest.ts
@@ -1,7 +1,9 @@
 // lib/api/ingest.ts
 import type { ApiFailure } from "./http";
-import { apiDeleteZodAuthed, apiPostZodAuthed } from "./validate";
+import { apiDeleteJsonAuthed } from "./http";
+import { apiPostZodAuthed } from "./validate";
 import {
+  deleteRawEventDelete404ResponseBodySchema,
   deleteRawEventResponseDtoSchema,
   ingestAcceptedResponseDtoSchema,
   type DeleteRawEventResponseDto,
@@ -75,7 +77,8 @@ export async function ingestRawEventAuthed(
 
 export type DeleteIngestedRawEventOk = {
   ok: true;
-  status: 200;
+  /** 200 = deleted now; 404 = already absent (idempotent delete). */
+  status: 200 | 404;
   data: DeleteRawEventResponseDto;
   requestId: string | null;
 };
@@ -98,20 +101,84 @@ export async function deleteIngestedRawEventAuthed(
   opts?: { timeoutMs?: number },
 ): Promise<DeleteIngestedRawEventOk | DeleteIngestedRawEventFail> {
   const path = `/ingest/${encodeURIComponent(rawEventId)}`;
-  const res = await apiDeleteZodAuthed(path, idToken, deleteRawEventResponseDtoSchema, {
+  const res = await apiDeleteJsonAuthed<unknown>(path, idToken, {
     ...(typeof opts?.timeoutMs === "number" ? { timeoutMs: opts.timeoutMs } : {}),
   });
 
-  if (res.ok) {
-    return { ok: true, status: 200, data: res.json, requestId: res.requestId };
+  const headerRequestId = res.requestId?.trim() ? res.requestId : null;
+
+  if (!res.ok && res.status === 404) {
+    const parsed404 = deleteRawEventDelete404ResponseBodySchema.safeParse(res.json);
+    if (parsed404.success) {
+      const data: DeleteRawEventResponseDto = {
+        ok: true,
+        rawEventId,
+        requestId:
+          parsed404.data.requestId.trim().length > 0 ? parsed404.data.requestId : headerRequestId ?? "unknown",
+        suppressionWritten: parsed404.data.suppressionWritten,
+      };
+      return { ok: true, status: 404, data, requestId: headerRequestId ?? parsed404.data.requestId };
+    }
+    return {
+      ok: false,
+      status: 404,
+      requestId: res.requestId,
+      kind: "contract",
+      error: "Invalid response shape",
+      ...(res.json !== undefined ? { json: res.json as ApiFailure["json"] } : {}),
+    };
+  }
+
+  if (!res.ok) {
+    return {
+      ok: false,
+      status: res.status,
+      requestId: res.requestId,
+      kind: res.kind,
+      error: res.error,
+      ...(res.json !== undefined ? { json: res.json as ApiFailure["json"] } : {}),
+    };
+  }
+
+  if (res.json === null || res.json === undefined) {
+    return {
+      ok: true,
+      status: 200,
+      data: {
+        ok: true,
+        rawEventId,
+        requestId: headerRequestId ?? "unknown",
+        suppressionWritten: false,
+      },
+      requestId: res.requestId,
+    };
+  }
+
+  const parsed200 = deleteRawEventResponseDtoSchema.safeParse(res.json);
+  if (parsed200.success) {
+    const row = parsed200.data;
+    const mergedRequestId =
+      row.requestId === "unknown" && headerRequestId && headerRequestId.length > 0
+        ? headerRequestId
+        : row.requestId;
+    return {
+      ok: true,
+      status: 200,
+      data: { ...row, requestId: mergedRequestId },
+      requestId: res.requestId,
+    };
   }
 
   return {
     ok: false,
     status: res.status,
     requestId: res.requestId,
-    kind: res.kind,
-    error: res.error,
-    ...(res.json !== undefined ? { json: res.json } : {}),
+    kind: "contract",
+    error: "Invalid response shape",
+    ...(isRecord(res.json) ? { json: res.json as ApiFailure["json"] } : {}),
   };
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
 }

--- a/lib/contracts/rawEvent.ts
+++ b/lib/contracts/rawEvent.ts
@@ -104,16 +104,47 @@ export type IngestAcceptedResponseDto = z.infer<typeof ingestAcceptedResponseDto
 
 /**
  * DELETE /ingest/:rawEventId — successful removal of an ingested RawEvent (manual workouts only; server-enforced).
+ * `suppressionWritten` is true when an Apple Health v2 workout tombstone was persisted at
+ * `users/{uid}/rawEventIngestSuppressions/{rawEventId}` (blocks re-ingest); false when not applicable (e.g. manual id).
+ *
+ * `requestId` may be omitted in some proxy paths; clients fall back to the `x-request-id` header (see lib/api/ingest.ts).
  */
 export const deleteRawEventResponseDtoSchema = z
   .object({
     ok: z.literal(true),
     rawEventId: z.string().min(1),
-    requestId: z.string().min(1),
+    requestId: z.string().min(1).optional().nullable(),
+    suppressionWritten: z.boolean(),
+  })
+  .strip()
+  .transform((o) => ({
+    ok: true as const,
+    rawEventId: o.rawEventId,
+    requestId:
+      o.requestId != null && String(o.requestId).trim().length > 0
+        ? String(o.requestId).trim()
+        : "unknown",
+    suppressionWritten: o.suppressionWritten,
+  }));
+
+export type DeleteRawEventResponseDto = z.infer<typeof deleteRawEventResponseDtoSchema>;
+
+/** HTTP 404 body from DELETE /ingest/:rawEventId (doc already absent; may still write suppression). */
+export const deleteRawEventDelete404ResponseBodySchema = z
+  .object({
+    ok: z.literal(false),
+    error: z
+      .object({
+        code: z.string(),
+        message: z.string().optional(),
+      })
+      .optional(),
+    requestId: z.string(),
+    suppressionWritten: z.boolean(),
   })
   .strip();
 
-export type DeleteRawEventResponseDto = z.infer<typeof deleteRawEventResponseDtoSchema>;
+export type DeleteRawEventDelete404ResponseBody = z.infer<typeof deleteRawEventDelete404ResponseBodySchema>;
 
 // -----------------------------
 // Payloads

--- a/services/api/src/routes/__tests__/events.delete.test.ts
+++ b/services/api/src/routes/__tests__/events.delete.test.ts
@@ -5,6 +5,7 @@ import { AddressInfo } from "net";
 
 import eventsRoutes from "../events";
 import { userCollection } from "../../db";
+import { allowConsoleForThisTest } from "../../../../../scripts/test/consoleGuard";
 
 jest.mock("../../db", () => ({
   userCollection: jest.fn(),
@@ -78,9 +79,10 @@ describe("DELETE /ingest/:rawEventId", () => {
     const res = await fetch(`${baseUrl}/ingest/${rawEventId}`, { method: "DELETE" });
 
     expect(res.status).toBe(200);
-    const json = (await res.json()) as { ok: boolean; rawEventId: string };
+    const json = (await res.json()) as { ok: boolean; rawEventId: string; suppressionWritten: boolean };
     expect(json.ok).toBe(true);
     expect(json.rawEventId).toBe(rawEventId);
+    expect(json.suppressionWritten).toBe(false);
     expect(deleteMock).toHaveBeenCalledTimes(1);
     expect(suppressSetMock).not.toHaveBeenCalled();
   });
@@ -126,6 +128,8 @@ describe("DELETE /ingest/:rawEventId", () => {
     const res = await fetch(`${baseUrl}/ingest/${encodeURIComponent(rawEventId)}`, { method: "DELETE" });
 
     expect(res.status).toBe(200);
+    const json200 = (await res.json()) as { suppressionWritten: boolean };
+    expect(json200.suppressionWritten).toBe(true);
     expect(deleteMock).toHaveBeenCalledTimes(1);
     expect(suppressSetMock).toHaveBeenCalledTimes(1);
   });
@@ -150,6 +154,110 @@ describe("DELETE /ingest/:rawEventId", () => {
 
     expect(res.status).toBe(404);
     expect(suppressSetMock).toHaveBeenCalledTimes(1);
+    const json404 = (await res.json()) as { suppressionWritten: boolean; error?: { code: string } };
+    expect(json404.suppressionWritten).toBe(true);
+    expect(json404.error?.code).toBe("NOT_FOUND");
+  });
+
+  test("404 delete returns suppressionWritten false and does not write tombstone for non-Apple-workout doc ids", async () => {
+    const rawEventId = "manual_missing_doc_1";
+    const suppressSetMock = jest.fn(async () => undefined);
+    (userCollection as jest.Mock).mockImplementation((_uid: string, name: string) => {
+      if (name === "rawEventIngestSuppressions") {
+        return { doc: () => ({ set: suppressSetMock }) };
+      }
+      return {
+        doc: () => ({
+          get: async () => ({ exists: false }) as const,
+        }),
+      };
+    });
+
+    const res = await fetch(`${baseUrl}/ingest/${encodeURIComponent(rawEventId)}`, { method: "DELETE" });
+    expect(res.status).toBe(404);
+    expect(suppressSetMock).not.toHaveBeenCalled();
+    const body = (await res.json()) as { suppressionWritten: boolean };
+    expect(body.suppressionWritten).toBe(false);
+  });
+
+  test("Apple Health workout DELETE 404 returns 500 when suppression set() throws (failure not swallowed)", async () => {
+    allowConsoleForThisTest({ error: [/raw_event_suppression_write_failed/] });
+    const rawEventId = "appleHealth:v2:workout:fail_suppress_write_50_com.example.app";
+    const suppressSetMock = jest.fn(async () => {
+      throw new Error("permission_denied");
+    });
+
+    (userCollection as jest.Mock).mockImplementation((_uid: string, name: string) => {
+      if (name === "rawEventIngestSuppressions") {
+        return { doc: () => ({ set: suppressSetMock }) };
+      }
+      return {
+        doc: () => ({
+          get: async () => ({ exists: false }) as const,
+        }),
+      };
+    });
+
+    const res = await fetch(`${baseUrl}/ingest/${encodeURIComponent(rawEventId)}`, { method: "DELETE" });
+    expect(res.status).toBe(500);
+    expect(suppressSetMock).toHaveBeenCalledTimes(1);
+    const errBody = (await res.json()) as {
+      suppressionWritten: boolean;
+      error?: { code: string; details?: { message: string } };
+    };
+    expect(errBody.suppressionWritten).toBe(false);
+    expect(errBody.error?.code).toBe("SUPPRESSION_WRITE_FAILED");
+    expect(errBody.error?.details?.message).toContain("permission_denied");
+  });
+
+  test("DELETE 200 returns 500 when Apple suppression write fails after raw delete", async () => {
+    allowConsoleForThisTest({ error: [/raw_event_suppression_write_failed/] });
+    const rawEventId = "appleHealth:v2:workout:post_delete_suppress_fail_50_com.example.app";
+    const rawEvent = {
+      schemaVersion: 1,
+      id: rawEventId,
+      userId: "user_123",
+      sourceId: "healthkit",
+      provider: "apple_health",
+      sourceType: "apple_health",
+      kind: "strength_workout",
+      receivedAt: "2025-01-02T00:00:00.000Z",
+      observedAt: "2025-01-02T00:00:00.000Z",
+      payload: {
+        startedAt: "2025-01-02T00:00:00.000Z",
+        timeZone: "America/New_York",
+        exercises: [{ name: "Squat", sets: [{ reps: 5, load: 60, unit: "kg" as const }] }],
+      },
+    };
+
+    const deleteMock = jest.fn(async () => undefined);
+    const suppressSetMock = jest.fn(async () => {
+      throw new Error("after_delete_tombstone_failed");
+    });
+
+    (userCollection as jest.Mock).mockImplementation((_uid: string, name: string) => {
+      if (name === "rawEventIngestSuppressions") {
+        return { doc: () => ({ set: suppressSetMock }) };
+      }
+      return {
+        doc: () => ({
+          get: async () =>
+            ({
+              exists: true,
+              data: () => rawEvent,
+            }) as const,
+          delete: deleteMock,
+        }),
+      };
+    });
+
+    const res = await fetch(`${baseUrl}/ingest/${encodeURIComponent(rawEventId)}`, { method: "DELETE" });
+    expect(res.status).toBe(500);
+    expect(deleteMock).toHaveBeenCalledTimes(1);
+    expect(suppressSetMock).toHaveBeenCalledTimes(1);
+    const failBody = (await res.json()) as { suppressionWritten: boolean; error?: { code: string } };
+    expect(failBody.suppressionWritten).toBe(false);
+    expect(failBody.error?.code).toBe("SUPPRESSION_WRITE_FAILED");
   });
 
   test("rejects delete for unsupported workout provider", async () => {

--- a/services/api/src/routes/__tests__/events.suppression.delete404-then-ingest.test.ts
+++ b/services/api/src/routes/__tests__/events.suppression.delete404-then-ingest.test.ts
@@ -74,6 +74,9 @@ describe("Apple Health workout suppression — DELETE 404 then POST exact id", (
       );
       expect(delRes.status).toBe(404);
       expect(suppressSetMock).toHaveBeenCalledTimes(1);
+      const delJson = (await delRes.json()) as { suppressionWritten?: boolean; error?: { code: string } };
+      expect(delJson.suppressionWritten).toBe(true);
+      expect(delJson.error?.code).toBe("NOT_FOUND");
 
       suppressGetMock.mockResolvedValue({ exists: true });
 

--- a/services/api/src/routes/__tests__/gateway-openapi-ingest-delete.contract.test.ts
+++ b/services/api/src/routes/__tests__/gateway-openapi-ingest-delete.contract.test.ts
@@ -1,0 +1,21 @@
+/**
+ * Contract: API Gateway OpenAPI must expose DELETE /ingest/{rawEventId} so encoded workout ids
+ * (e.g. %3A) reach Cloud Run. A missing path yields ESPv2 "Unknown Operation Name" / direct_response.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/** From services/api/src/routes/__tests__ → repo root (oli/) */
+const repoRoot = join(__dirname, "..", "..", "..", "..", "..");
+const openApiPath = join(repoRoot, "infra", "gateway", "openapi.yaml");
+
+describe("infra/gateway/openapi.yaml — DELETE /ingest/{rawEventId}", () => {
+  it("declares /ingest/{rawEventId} delete with path param (no restrictive pattern)", () => {
+    const text = readFileSync(openApiPath, "utf8");
+    expect(text).toContain("/ingest/{rawEventId}:");
+    expect(text).toContain("operationId: ingestRawEventDelete");
+    expect(text).toContain("in: path");
+    expect(text).toContain("name: rawEventId");
+    expect(text).toMatch(/delete:\s*\n\s*operationId:\s*ingestRawEventDelete/);
+  });
+});

--- a/services/api/src/routes/events.ts
+++ b/services/api/src/routes/events.ts
@@ -1,8 +1,9 @@
 // services/api/src/routes/events.ts
 //
 // Apple Health workout delete + re-sync: tombstones live under users/{uid}/rawEventIngestSuppressions/{id}.
-// Optional audit logs (exact id match): set RAW_EVENT_SUPPRESSION_AUDIT_IDS=comma,separated,ids
-// (use for one incident; correlates with x-request-id in Cloud Logging).
+// Every attempted tombstone write logs raw_event_suppression_write_success or raw_event_suppression_write_failed;
+// failures propagate (DELETE returns 500 SUPPRESSION_WRITE_FAILED) — never swallowed.
+// Optional ingest precheck audit: RAW_EVENT_SUPPRESSION_AUDIT_IDS=comma,separated,ids
 import { Router, type Response } from "express";
 import { z } from "zod";
 
@@ -20,27 +21,33 @@ import { userCollection } from "../db";
 
 const router = Router();
 
+/**
+ * Writes tombstone at `users/{uid}/rawEventIngestSuppressions/{rawEventId}` (ref.path is that exact path).
+ * @returns true if Firestore set() ran for an Apple Health v2 workout id; false if id does not use suppression.
+ * @throws on Firestore/set failure (caller must surface — never swallow).
+ */
 async function recordAppleHealthWorkoutIngestSuppression(
   uid: string,
   rawEventId: string,
   requestId: string,
   context: "delete_404" | "delete_200",
-): Promise<void> {
-  if (!isAppleHealthWorkoutIngestSuppressionDocId(rawEventId)) return;
-  const audit = shouldLogSuppressionAuditForId(rawEventId);
+): Promise<boolean> {
+  if (!isAppleHealthWorkoutIngestSuppressionDocId(rawEventId)) {
+    return false;
+  }
+  const ref = userCollection(uid, "rawEventIngestSuppressions").doc(rawEventId);
+  const firestorePath = ref.path;
   try {
-    await userCollection(uid, "rawEventIngestSuppressions")
-      .doc(rawEventId)
-      .set({ suppressedAt: new Date().toISOString() });
-    if (audit) {
-      logger.info({
-        msg: "raw_event_suppression_write_ok",
-        rid: requestId,
-        uid,
-        rawEventId,
-        context,
-      });
-    }
+    await ref.set({ suppressedAt: new Date().toISOString() });
+    logger.info({
+      msg: "raw_event_suppression_write_success",
+      rid: requestId,
+      uid,
+      rawEventId,
+      context,
+      firestorePath,
+    });
+    return true;
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     logger.error({
@@ -49,8 +56,10 @@ async function recordAppleHealthWorkoutIngestSuppression(
       uid,
       rawEventId,
       context,
+      firestorePath,
       err: message,
     });
+    throw err;
   }
 }
 
@@ -92,6 +101,20 @@ async function isAppleHealthWorkoutIngestSuppressed(
  */
 function getRid(req: AuthedRequest): string {
   return (req as RequestWithRid).rid ?? (req.header("x-request-id") ?? "unknown").toString();
+}
+
+function respondIngestDeleteSuppressionFailure(res: Response, requestId: string, err: unknown): void {
+  const message = err instanceof Error ? err.message : String(err);
+  res.status(500).json({
+    ok: false as const,
+    error: {
+      code: "SUPPRESSION_WRITE_FAILED" as const,
+      message: "Could not record workout deletion tombstone. Retry deletion or contact support.",
+      details: { message },
+    },
+    requestId,
+    suppressionWritten: false as const,
+  });
 }
 
 /** Day key YYYY-MM-DD in UTC (for failure entries when event day is not available). */
@@ -617,6 +640,19 @@ const DELETABLE_WORKOUT_EVENT_PROVIDERS = new Set(["manual", "apple_health"]);
  */
 router.delete("/:rawEventId", async (req: AuthedRequest, res: Response) => {
   const requestId = getRid(req);
+  const urlPath =
+    typeof req.originalUrl === "string"
+      ? req.originalUrl.split("?")[0] ?? req.originalUrl
+      : req.path;
+  logger.info({
+    msg: "delete_raw_event_enter",
+    rid: requestId,
+    uid: typeof req.uid === "string" ? req.uid : null,
+    path: req.path,
+    urlPath,
+    rawEventIdParam: req.params.rawEventId,
+  });
+
   const uid = req.uid;
 
   if (!uid) {
@@ -673,7 +709,18 @@ router.delete("/:rawEventId", async (req: AuthedRequest, res: Response) => {
   }
 
   if (!snap.exists) {
-    await recordAppleHealthWorkoutIngestSuppression(uid, rawEventId, requestId, "delete_404");
+    let suppressionWritten = false;
+    try {
+      suppressionWritten = await recordAppleHealthWorkoutIngestSuppression(
+        uid,
+        rawEventId,
+        requestId,
+        "delete_404",
+      );
+    } catch (err: unknown) {
+      respondIngestDeleteSuppressionFailure(res, requestId, err);
+      return;
+    }
     return res.status(404).json({
       ok: false as const,
       error: {
@@ -681,6 +728,7 @@ router.delete("/:rawEventId", async (req: AuthedRequest, res: Response) => {
         message: "Workout record not found",
       },
       requestId,
+      suppressionWritten,
     });
   }
 
@@ -762,12 +810,24 @@ router.delete("/:rawEventId", async (req: AuthedRequest, res: Response) => {
     });
   }
 
-  await recordAppleHealthWorkoutIngestSuppression(uid, rawEventId, requestId, "delete_200");
+  let suppressionWritten = false;
+  try {
+    suppressionWritten = await recordAppleHealthWorkoutIngestSuppression(
+      uid,
+      rawEventId,
+      requestId,
+      "delete_200",
+    );
+  } catch (err: unknown) {
+    respondIngestDeleteSuppressionFailure(res, requestId, err);
+    return;
+  }
 
   return res.status(200).json({
     ok: true as const,
     rawEventId,
     requestId,
+    suppressionWritten,
   });
 });
 


### PR DESCRIPTION
…ent)

Root issue:
- DELETE /ingest was blocked at API Gateway (route not deployed)
- resulted in 404 'Unknown Operation Name' (never reached backend)
- even after backend fixes, UI misinterpreted successful responses as failure

Fixes applied:

Gateway:
- added DELETE /ingest/{rawEventId} to openapi.yaml
- deployed new API config so gateway routes DELETE correctly

Backend:
- ensured suppression tombstone is written on DELETE (200 + 404)
- added structured logging for suppression writes
- aligned DTO with suppressionWritten flag

Client:
- fixed deleteIngestedRawEventAuthed handling:
  - treat 200 and 404 as success
  - corrected response parsing + validation
- updated overview.tsx to avoid false error alerts
- ensured UI reflects backend truth

Tests:
- added delete-ingest-raw-event-authed.test.ts
- added gateway-openapi-ingest-delete.contract.test.ts
- updated existing delete + suppression tests

Docs:
- updated gateway-and-cloudrun runbook with 'Unknown Operation Name' diagnosis

Result:
- DELETE reaches backend
- suppression is written
- workout is removed and does not reappear
- UI correctly reflects success

All checks passing:
- typecheck ✅
- lint ✅
- tests ✅
- invariants ✅