### PR TITLE
feat(cardio): fix cardio session classification, unify weekly selecto…

### DIFF
--- a/app/(app)/cardio/recent-workouts-full.tsx
+++ b/app/(app)/cardio/recent-workouts-full.tsx
@@ -1,40 +1,650 @@
-/**
- * Placeholder: full cardio session list (mirrors Strength recent-workouts-full).
- */
-
-import React, { useEffect } from "react";
-import { View, StyleSheet } from "react-native";
-import { useNavigation } from "expo-router";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { View, StyleSheet, Text, Pressable, FlatList, ScrollView } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useNavigation, useRouter } from "expo-router";
 import { HeaderBackButton } from "@/lib/ui/HeaderBackButton";
 import {
   WORKOUTS_SCREEN_CONTENT_BG,
   workoutsStackNavigationOptions,
 } from "@/lib/ui/headers/workoutsStackHeader";
-import { EmptyState } from "@/lib/ui/ScreenStates";
+import { EmptyState, ErrorState, LoadingState, ScreenContainer } from "@/lib/ui/ScreenStates";
+import { getTodayDayKeyLocal } from "@/lib/ui/calendar/dateUtils";
+import { computeWorkoutOverviewSharedCalendarRange } from "@/lib/data/workouts/workoutOverviewSharedCalendarRange";
+import { useWorkoutsCalendarRange } from "@/lib/data/workouts/useWorkoutsCalendar";
+import { mapWorkoutCalendarDaysForDomain } from "@/lib/data/workouts/workoutDomain";
+import { reconcileWorkoutSessionsForDay, type ReconciledWorkoutSession } from "@/lib/data/workouts/workoutSessionReconciliation";
+import { useWorkoutOverrides } from "@/lib/data/workouts/workoutOverrides";
+import {
+  buildWorkoutSessionSurfaceModel,
+  pickWorkoutForSessionActions,
+  pickWorkoutOverrideForSession,
+} from "@/lib/data/workouts/workoutSessionSurface";
+import {
+  cardioSessionDistanceMiles,
+  filterCardioHistoryRowsDedupeOverlappingOther,
+  formatCardioSessionSubtitle,
+  isDisplayableCardioHistorySession,
+} from "@/lib/data/workouts/cardioSessionPresentation";
+import {
+  formatWorkoutDurationLabel,
+  resolveWorkoutDisplay,
+  resolveWorkoutDisplayDurationMinutes,
+} from "@/lib/data/workouts/workoutDisplay";
+import { WorkoutActionSheet, type WorkoutActionAnchor } from "@/lib/ui/WorkoutActionSheet";
+import type { DayKey } from "@/lib/ui/calendar/types";
+import { SYSTEM_ACCENT, SYSTEM_ACCENT_FILL_14 } from "@/lib/ui/theme/systemAccent";
+
+const WEEKDAY_SHORT = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
+const MONTH_SHORT = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"] as const;
+
+const HISTORY_SCREEN_HORIZONTAL_GUTTER = 24;
+
+const MONTH_HEADER_ROW_TEXT = {
+  fontSize: 27,
+  fontWeight: "700" as const,
+  lineHeight: 32,
+  letterSpacing: -0.45,
+} as const;
+
+/** Matches Strength overview “This Week” card list row title (`overview.tsx` styles.recentTitle). */
+const THIS_WEEK_CARD_RECENT_TITLE_STYLE = {
+  fontSize: 17,
+  fontWeight: "600" as const,
+  color: "#1C1C1E",
+  letterSpacing: -0.28,
+  lineHeight: 21,
+};
+
+const MONTH_FULL = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+] as const;
+
+type HistoryRow = {
+  key: string;
+  day: DayKey;
+  session: ReconciledWorkoutSession;
+};
+
+function toYear(day: DayKey): number {
+  return Number(day.slice(0, 4));
+}
+
+function toMonthIndex(day: DayKey): number {
+  return Number(day.slice(5, 7)) - 1;
+}
+
+function formatWorkoutDayLabel(dayKey: DayKey): string {
+  const d = new Date(`${dayKey}T12:00:00.000Z`);
+  const wd = WEEKDAY_SHORT[d.getUTCDay()] ?? "";
+  const mon = MONTH_SHORT[d.getUTCMonth()] ?? "";
+  const dayNum = d.getUTCDate();
+  return `${wd} • ${mon} ${dayNum}`;
+}
+
+function selectDefaultMonthForYear(args: {
+  selectedYear: number;
+  currentYear: number;
+  currentMonth: number;
+  monthsWithData: number[];
+}): number {
+  if (args.monthsWithData.length === 0) return args.currentMonth;
+  if (args.selectedYear === args.currentYear && args.monthsWithData.includes(args.currentMonth)) {
+    return args.currentMonth;
+  }
+  return args.monthsWithData[args.monthsWithData.length - 1] ?? args.currentMonth;
+}
+
+/** Miles label for month header / accessibility; one decimal when useful. */
+function formatMonthTotalMiles(sumMiles: number): string {
+  if (!Number.isFinite(sumMiles) || sumMiles <= 0) return "0 mi";
+  const nearestInt = Math.round(sumMiles);
+  if (Math.abs(sumMiles - nearestInt) < 0.05) return `${nearestInt} mi`;
+  return `${(Math.round(sumMiles * 10) / 10).toFixed(1)} mi`;
+}
+
+function formatMilesSegmentForRow(miles: number): string {
+  const nearestInt = Math.round(miles);
+  if (Math.abs(miles - nearestInt) < 0.05) return `${nearestInt} mi`;
+  return `${(Math.round(miles * 10) / 10).toFixed(1)} mi`;
+}
+
+function formatCardioHistoryMetadataLine(
+  session: ReconciledWorkoutSession,
+  durationMinutes: number | null,
+): string {
+  const miles = cardioSessionDistanceMiles(session);
+  const parts: string[] = [];
+  if (miles != null && Number.isFinite(miles) && miles > 0) {
+    parts.push(formatMilesSegmentForRow(miles));
+  }
+  const dur = formatWorkoutDurationLabel(durationMinutes);
+  if (dur !== "—") parts.push(dur);
+  return parts.join(" · ");
+}
+
+function sumCardioMilesForSessions(sessions: readonly ReconciledWorkoutSession[]): number {
+  let sum = 0;
+  for (const s of sessions) {
+    const m = cardioSessionDistanceMiles(s);
+    if (m != null && Number.isFinite(m) && m > 0) sum += m;
+  }
+  return sum;
+}
 
 export default function CardioRecentSessionsFullScreen() {
   const navigation = useNavigation();
+  const router = useRouter();
+  const today = getTodayDayKeyLocal();
+  const [refreshEpoch] = useState(0);
+  const [selectedYear, setSelectedYear] = useState<number | null>(null);
+  const [selectedMonth, setSelectedMonth] = useState<number | null>(null);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [menuAnchor, setMenuAnchor] = useState<WorkoutActionAnchor | null>(null);
+  const [selectedWorkoutForMenu, setSelectedWorkoutForMenu] = useState<{ day: DayKey; session: ReconciledWorkoutSession } | null>(
+    null,
+  );
+
+  const { start, end } = useMemo(() => computeWorkoutOverviewSharedCalendarRange(today), [today]);
+  const calendarRange = useWorkoutsCalendarRange(start, end, {
+    refreshEpoch,
+    debugHydrateLabel: "cardio-history-full",
+  });
+  const days = calendarRange.status === "ready" ? mapWorkoutCalendarDaysForDomain(calendarRange.days, "cardio") : [];
+  const durableTitlesByWorkoutId = calendarRange.status === "ready" ? calendarRange.durableTitlesByWorkoutId : {};
+
+  const allRowsAscending = useMemo<HistoryRow[]>(() => {
+    const rows: HistoryRow[] = [];
+    for (const d of days) {
+      const sessions = reconcileWorkoutSessionsForDay(d.day, d.workouts);
+      for (const session of sessions) {
+        rows.push({
+          key: `${d.day}:${session.id}`,
+          day: d.day as DayKey,
+          session,
+        });
+      }
+    }
+    rows.sort((a, b) => {
+      if (a.day !== b.day) return a.day < b.day ? -1 : 1;
+      const aStart = a.session.start ?? "";
+      const bStart = b.session.start ?? "";
+      if (aStart === bStart) return a.session.id.localeCompare(b.session.id);
+      return aStart.localeCompare(bStart);
+    });
+    const displayable = rows.filter((r) => isDisplayableCardioHistorySession(r.session));
+    return filterCardioHistoryRowsDedupeOverlappingOther(displayable);
+  }, [days]);
+
+  const now = useMemo(() => new Date(), []);
+  const currentYear = now.getFullYear();
+  const currentMonth = now.getMonth();
+
+  const yearsWithData = useMemo(() => {
+    const years = new Set<number>();
+    for (const row of allRowsAscending) years.add(toYear(row.day));
+    return [...years].sort((a, b) => a - b);
+  }, [allRowsAscending]);
+
+  const monthsWithDataByYear = useMemo(() => {
+    const byYear = new Map<number, number[]>();
+    for (const year of yearsWithData) byYear.set(year, []);
+    for (const row of allRowsAscending) {
+      const y = toYear(row.day);
+      const m = toMonthIndex(row.day);
+      const list = byYear.get(y) ?? [];
+      if (!list.includes(m)) list.push(m);
+      byYear.set(y, list);
+    }
+    for (const [year, months] of byYear.entries()) {
+      byYear.set(
+        year,
+        months.sort((a, b) => a - b),
+      );
+    }
+    return byYear;
+  }, [allRowsAscending, yearsWithData]);
+
+  const workoutIdsForOverrides = useMemo(
+    () => allRowsAscending.flatMap((entry) => entry.session.workouts.map((w) => w.id)),
+    [allRowsAscending],
+  );
+  const { overridesByWorkoutId } = useWorkoutOverrides(workoutIdsForOverrides);
+
+  useEffect(() => {
+    if (calendarRange.status !== "ready") return;
+    if (selectedYear != null && selectedMonth != null) return;
+    const defaultYear =
+      yearsWithData.includes(currentYear) ? currentYear : (yearsWithData[yearsWithData.length - 1] ?? currentYear);
+    const monthsWithData = monthsWithDataByYear.get(defaultYear) ?? [];
+    const defaultMonth = selectDefaultMonthForYear({
+      selectedYear: defaultYear,
+      currentYear,
+      currentMonth,
+      monthsWithData,
+    });
+    setSelectedYear(defaultYear);
+    setSelectedMonth(defaultMonth);
+  }, [calendarRange.status, selectedYear, selectedMonth, yearsWithData, currentYear, currentMonth, monthsWithDataByYear]);
+
+  useEffect(() => {
+    if (selectedYear == null) return;
+    if (selectedMonth == null) return;
+    const monthsWithData = monthsWithDataByYear.get(selectedYear) ?? [];
+    if (monthsWithData.length === 0) return;
+    if (monthsWithData.includes(selectedMonth)) return;
+    setSelectedMonth(
+      selectDefaultMonthForYear({
+        selectedYear,
+        currentYear,
+        currentMonth,
+        monthsWithData,
+      }),
+    );
+  }, [selectedYear, selectedMonth, monthsWithDataByYear, currentYear, currentMonth]);
+
+  const visibleRows = useMemo(() => {
+    if (selectedYear == null || selectedMonth == null) return [] as HistoryRow[];
+    return allRowsAscending.filter(
+      (entry) => toYear(entry.day) === selectedYear && toMonthIndex(entry.day) === selectedMonth,
+    );
+  }, [allRowsAscending, selectedYear, selectedMonth]);
+
+  const monthTotalMiles = useMemo(
+    () => sumCardioMilesForSessions(visibleRows.map((r) => r.session)),
+    [visibleRows],
+  );
+
+  const closeMenu = useCallback(() => {
+    setMenuOpen(false);
+    setMenuAnchor(null);
+    setSelectedWorkoutForMenu(null);
+  }, []);
+
+  const selectedMenuSessionRef = useRef<ReconciledWorkoutSession | null>(null);
+  selectedMenuSessionRef.current = selectedWorkoutForMenu?.session ?? null;
+
+  const openEditRoute = useCallback(
+    (mode: "rename" | "duration" | "type") => {
+      if (!selectedWorkoutForMenu) return;
+      const session = selectedMenuSessionRef.current ?? selectedWorkoutForMenu.session;
+      const workout = pickWorkoutForSessionActions(session);
+      if (!workout) return;
+      const journalSummary = null;
+      const surface = buildWorkoutSessionSurfaceModel(
+        session,
+        overridesByWorkoutId,
+        "cardio",
+        journalSummary,
+        durableTitlesByWorkoutId,
+      );
+      const sessionOverride = pickWorkoutOverrideForSession(session, overridesByWorkoutId);
+      const resolvedAction = resolveWorkoutDisplay(
+        workout,
+        sessionOverride ?? overridesByWorkoutId[workout.id] ?? null,
+      );
+      const resolvedMetrics = resolveWorkoutDisplay(
+        surface.metricsWorkout,
+        sessionOverride ?? overridesByWorkoutId[surface.metricsWorkout.id] ?? null,
+      );
+      closeMenu();
+      router.push({
+        pathname: `/(app)/workouts/edit/${mode}`,
+        params: {
+          workoutId: workout.id,
+          currentTitle: surface.displayTitle,
+          titleAnchorObservedAt: workout.start ?? workout.observedAt,
+          currentDurationMinutes:
+            typeof resolvedMetrics.displayDurationMinutes === "number"
+              ? String(Math.round(resolvedMetrics.displayDurationMinutes))
+              : "",
+          currentWorkoutType: resolvedAction.displayWorkoutType,
+        },
+      });
+    },
+    [selectedWorkoutForMenu, overridesByWorkoutId, durableTitlesByWorkoutId, closeMenu, router],
+  );
 
   useEffect(() => {
     navigation.setOptions({
       ...workoutsStackNavigationOptions("detail"),
-      headerLeft: () => <HeaderBackButton onPress={() => navigation.goBack()} />,
+      headerStyle: { backgroundColor: WORKOUTS_SCREEN_CONTENT_BG },
+      headerLeft: () => <HeaderBackButton onPress={() => navigation.goBack()} accessibilityLabel="Go back" />,
+      headerTitle: () => (
+        <Pressable
+          onPress={() => {
+            // Year picker is deferred; make this interactive now.
+          }}
+          accessibilityRole="button"
+          accessibilityLabel={`Selected year ${selectedYear ?? currentYear}. Double tap to change year.`}
+          hitSlop={8}
+          style={({ pressed }) => [styles.yearPressable, pressed && styles.yearPressablePressed]}
+        >
+          <Text style={styles.yearTitle}>{selectedYear ?? currentYear}</Text>
+        </Pressable>
+      ),
+      title: "",
     });
-  }, [navigation]);
+  }, [navigation, selectedYear, currentYear]);
+
+  const renderRow = useCallback(
+    ({ item, index }: { item: HistoryRow; index: number }) => {
+      const surface = buildWorkoutSessionSurfaceModel(
+        item.session,
+        overridesByWorkoutId,
+        "cardio",
+        null,
+        durableTitlesByWorkoutId,
+      );
+      const sessionOverride = pickWorkoutOverrideForSession(item.session, overridesByWorkoutId);
+      const resolvedMetrics = resolveWorkoutDisplay(
+        surface.metricsWorkout,
+        sessionOverride ?? overridesByWorkoutId[surface.metricsWorkout.id] ?? null,
+      );
+      const resolvedDuration = resolveWorkoutDisplayDurationMinutes({
+        overrideDurationMinutes: resolvedMetrics.displayDurationMinutes,
+        sessionDurationMinutes: null,
+        fallbackWorkoutDurationMinutes: surface.metricsWorkout.durationMinutes ?? item.session.durationMinutes,
+      });
+      const titleLine = formatCardioSessionSubtitle(item.session);
+      const metaLine = formatCardioHistoryMetadataLine(item.session, resolvedDuration);
+      const isLast = index === visibleRows.length - 1;
+
+      return (
+        <View style={styles.recentRowWrap}>
+          <Pressable
+            style={({ pressed }) => [styles.recentRow, pressed && styles.recentRowPressed]}
+            onPress={() => {
+              router.push({
+                pathname: "/(app)/cardio/day/[day]",
+                params: { day: item.day },
+              });
+            }}
+            accessibilityRole="button"
+            accessibilityLabel={`Open workout details ${surface.actionWorkout.id}`}
+          >
+            <View style={styles.recentRowTextCol}>
+              <Text style={styles.recentDate}>{formatWorkoutDayLabel(item.day)}</Text>
+              <Text style={styles.recentTitle} numberOfLines={2} ellipsizeMode="tail">
+                {titleLine}
+              </Text>
+              <Text style={styles.recentMeta} numberOfLines={2} ellipsizeMode="tail">
+                {metaLine}
+              </Text>
+            </View>
+            <Pressable
+              onPress={(e) => {
+                e?.stopPropagation?.();
+                const native = e?.nativeEvent;
+                setMenuAnchor({
+                  x: typeof native?.pageX === "number" ? native.pageX : 320,
+                  y: typeof native?.pageY === "number" ? native.pageY : 220,
+                  width: 44,
+                  height: 44,
+                });
+                setSelectedWorkoutForMenu({ day: item.day, session: item.session });
+                setMenuOpen(true);
+              }}
+              accessibilityRole="button"
+              accessibilityLabel={`Workout actions ${surface.actionWorkout.id}`}
+              hitSlop={8}
+              style={styles.rowMenuBtn}
+            >
+              <Ionicons name="ellipsis-horizontal" size={22} color="#8E8E93" />
+            </Pressable>
+          </Pressable>
+          {!isLast ? <View style={styles.rowDividerInset} /> : null}
+        </View>
+      );
+    },
+    [router, overridesByWorkoutId, durableTitlesByWorkoutId, visibleRows.length],
+  );
+
+  const monthSectionTitle = selectedMonth != null ? (MONTH_FULL[selectedMonth] ?? "") : "";
+  const monthMilesLabel = formatMonthTotalMiles(monthTotalMiles);
+
+  const listSectionHeader =
+    selectedMonth != null ? (
+      <View
+        style={styles.listSectionHeaderRow}
+        accessible
+        accessibilityRole="header"
+        accessibilityLabel={`${monthSectionTitle}. Total distance ${monthMilesLabel}.`}
+      >
+        <Text style={styles.listSectionMonth} importantForAccessibility="no">
+          {monthSectionTitle}
+        </Text>
+        <Text style={styles.listSectionCount} importantForAccessibility="no">
+          {monthMilesLabel}
+        </Text>
+      </View>
+    ) : null;
+
+  const monthSelector = (
+    <View style={styles.monthSelectorWrap}>
+      <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.monthSelectorContent}>
+        {MONTH_SHORT.map((label, idx) => {
+          const selected = selectedMonth === idx;
+          return (
+            <Pressable
+              key={label}
+              onPress={() => setSelectedMonth(idx)}
+              accessibilityRole="button"
+              accessibilityLabel={`Select ${label}`}
+              accessibilityState={{ selected }}
+              style={({ pressed }) => [
+                styles.monthPill,
+                selected && styles.monthPillSelected,
+                pressed && styles.monthPillPressed,
+              ]}
+            >
+              <Text style={[styles.monthPillLabel, selected && styles.monthPillLabelSelected]}>{label}</Text>
+            </Pressable>
+          );
+        })}
+      </ScrollView>
+    </View>
+  );
+
+  const screenEdges = ["left", "right", "bottom"] as const;
+
+  if (calendarRange.status === "partial") {
+    return (
+      <ScreenContainer backgroundColor={WORKOUTS_SCREEN_CONTENT_BG} padded={false} edges={[...screenEdges]}>
+        <LoadingState message="Loading cardio history…" />
+      </ScreenContainer>
+    );
+  }
+
+  if (calendarRange.status === "error") {
+    return (
+      <ScreenContainer backgroundColor={WORKOUTS_SCREEN_CONTENT_BG} padded={false} edges={[...screenEdges]}>
+        <ErrorState message={calendarRange.error} requestId={calendarRange.requestId} />
+      </ScreenContainer>
+    );
+  }
 
   return (
-    <View style={styles.body}>
-      <View style={styles.inner}>
-        <EmptyState
-          title="Full history soon"
-          description="Your complete cardio history will appear here."
+    <ScreenContainer backgroundColor={WORKOUTS_SCREEN_CONTENT_BG} padded={false} edges={[...screenEdges]}>
+      <View style={styles.body}>
+        {monthSelector}
+        <FlatList
+          data={visibleRows}
+          renderItem={renderRow}
+          keyExtractor={(item) => item.key}
+          contentContainerStyle={styles.listContent}
+          ListHeaderComponent={
+            listSectionHeader != null ? <View style={styles.listSectionHeaderWrap}>{listSectionHeader}</View> : null
+          }
+          ListEmptyComponent={
+            <View style={styles.emptyWrap}>
+              <EmptyState
+                title="No cardio sessions yet"
+                description="Cardio sessions logged this month will appear here."
+              />
+            </View>
+          }
+        />
+        <WorkoutActionSheet
+          visible={menuOpen && !!selectedWorkoutForMenu}
+          anchor={menuAnchor}
+          onClose={closeMenu}
+          onViewDetails={() => {
+            if (!selectedWorkoutForMenu) return;
+            const day = selectedWorkoutForMenu.day;
+            closeMenu();
+            router.push({ pathname: "/(app)/cardio/day/[day]", params: { day } });
+          }}
+          onDoItAgain={() => {
+            closeMenu();
+            router.push("/(app)/cardio/log");
+          }}
+          onRename={() => openEditRoute("rename")}
+          onEditDuration={() => openEditRoute("duration")}
+          onEditType={() => openEditRoute("type")}
         />
       </View>
-    </View>
+    </ScreenContainer>
   );
 }
 
 const styles = StyleSheet.create({
   body: { flex: 1, backgroundColor: WORKOUTS_SCREEN_CONTENT_BG },
-  inner: { flex: 1, paddingHorizontal: 16 },
+  yearPressable: {
+    paddingHorizontal: 10,
+    paddingVertical: 2,
+    borderRadius: 8,
+  },
+  yearPressablePressed: {
+    opacity: 0.72,
+  },
+  yearTitle: {
+    fontSize: 20,
+    fontWeight: "700",
+    color: "#1C1C1E",
+    letterSpacing: -0.35,
+  },
+  monthSelectorWrap: {
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: "rgba(60,60,67,0.12)",
+    paddingTop: 6,
+    paddingBottom: 6,
+  },
+  monthSelectorContent: {
+    paddingHorizontal: HISTORY_SCREEN_HORIZONTAL_GUTTER,
+    gap: 10,
+    alignItems: "center",
+  },
+  monthPill: {
+    minHeight: 40,
+    minWidth: 44,
+    paddingHorizontal: 14,
+    borderRadius: 20,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  monthPillSelected: {
+    backgroundColor: SYSTEM_ACCENT_FILL_14,
+  },
+  monthPillPressed: {
+    opacity: 0.75,
+  },
+  monthPillLabel: {
+    fontSize: 14,
+    fontWeight: "500",
+    color: "#3C3C43",
+  },
+  monthPillLabelSelected: {
+    color: SYSTEM_ACCENT,
+    fontWeight: "700",
+  },
+  listSectionHeaderRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    width: "100%",
+    gap: 12,
+  },
+  listSectionHeaderWrap: {
+    paddingTop: 8,
+    paddingBottom: 10,
+  },
+  listSectionMonth: {
+    ...MONTH_HEADER_ROW_TEXT,
+    flex: 1,
+    minWidth: 0,
+    color: "#1C1C1E",
+  },
+  listSectionCount: {
+    ...MONTH_HEADER_ROW_TEXT,
+    flexShrink: 0,
+    color: "#8E8E93",
+    fontVariant: ["tabular-nums"],
+  },
+  listContent: {
+    paddingHorizontal: HISTORY_SCREEN_HORIZONTAL_GUTTER,
+    paddingBottom: 32,
+    flexGrow: 1,
+  },
+  emptyWrap: {
+    paddingTop: 36,
+  },
+  recentRowWrap: {
+    width: "100%",
+    paddingVertical: 6,
+  },
+  recentRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingTop: 0,
+    paddingBottom: 0,
+  },
+  recentRowPressed: {
+    opacity: 0.7,
+  },
+  recentRowTextCol: {
+    flex: 1,
+    minWidth: 0,
+  },
+  recentDate: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: "#636366",
+    letterSpacing: -0.08,
+    marginBottom: 5,
+  },
+  recentTitle: {
+    ...THIS_WEEK_CARD_RECENT_TITLE_STYLE,
+    marginBottom: 8,
+  },
+  recentMeta: {
+    fontSize: 14,
+    fontWeight: "500",
+    color: "#636366",
+    letterSpacing: -0.12,
+    marginBottom: 14,
+  },
+  rowDividerInset: {
+    height: StyleSheet.hairlineWidth,
+    backgroundColor: "#E5E5EA",
+    marginLeft: 16,
+    marginRight: 56,
+    marginBottom: 0,
+  },
+  rowMenuBtn: {
+    justifyContent: "center",
+    alignItems: "center",
+    minWidth: 44,
+    minHeight: 44,
+  },
 });

--- a/app/(app)/workouts/__tests__/overview-cardio-baseline.test.tsx
+++ b/app/(app)/workouts/__tests__/overview-cardio-baseline.test.tsx
@@ -1,7 +1,3 @@
-/**
- * Regression: Strength This Week card lists only local-calendar-week sessions,
- * earliest-first; hydrated days outside the week slice must not appear as rows.
- */
 import React from "react";
 import renderer, { act } from "react-test-renderer";
 
@@ -44,50 +40,93 @@ jest.mock("@/lib/preferences/PreferencesProvider", () => ({
   }),
 }));
 
-jest.mock("@/lib/data/workouts/useWorkoutsCalendar", () => {
-  const strengthW = (id: string, start: string) => ({
-    id,
-    observedAt: start,
-    sourceId: "manual",
-    title: "Lift",
-    workoutType: "strength" as const,
-    start,
-    end: null,
-    durationMinutes: 45,
-    calories: null,
-  });
-  return {
-    useWorkoutsCalendarRange: () => ({
-      status: "ready" as const,
-      durableTitlesByWorkoutId: {},
-      days: [
-        {
-          day: "2026-03-08",
-          workouts: [strengthW("prior-week-strength", "2026-03-08T18:00:00.000Z")],
-        },
-        { day: "2026-03-09", workouts: [] },
-        {
-          day: "2026-03-10",
-          workouts: [strengthW("early-week-strength", "2026-03-10T09:00:00.000Z")],
-        },
-        { day: "2026-03-11", workouts: [] },
-        {
-          day: "2026-03-12",
-          workouts: [strengthW("later-week-strength", "2026-03-12T16:00:00.000Z")],
-        },
-        { day: "2026-03-13", workouts: [] },
-        { day: "2026-03-14", workouts: [] },
-        { day: "2026-03-15", workouts: [] },
-      ],
-    }),
-  };
-});
+jest.mock("@/lib/data/workouts/useWorkoutsCalendar", () => ({
+  useWorkoutsCalendarRange: () => ({
+    status: "ready" as const,
+    durableTitlesByWorkoutId: {},
+    days: [
+      {
+        day: "2026-03-08",
+        workouts: [
+          {
+            id: "c4",
+            observedAt: "2026-03-08T07:00:00.000Z",
+            sourceId: "apple_health",
+            title: "Running",
+            workoutType: "cardio" as const,
+            start: "2026-03-08T07:00:00.000Z",
+            end: "2026-03-08T07:40:00.000Z",
+            durationMinutes: null,
+            calories: null,
+            distanceMeters: 4956.77952,
+            activityName: "Running",
+          },
+        ],
+      },
+      {
+        day: "2026-03-09",
+        workouts: [
+          {
+            id: "c3",
+            observedAt: "2026-03-09T12:00:00.000Z",
+            sourceId: "apple_health",
+            title: "Other",
+            workoutType: "cardio" as const,
+            start: "2026-03-09T12:00:00.000Z",
+            end: "2026-03-09T12:31:00.000Z",
+            durationMinutes: 31,
+            calories: null,
+            distanceMeters: 16093.44,
+            activityName: "Other",
+          },
+        ],
+      },
+      {
+        day: "2026-03-10",
+        workouts: [
+          {
+            id: "c2",
+            observedAt: "2026-03-10T09:00:00.000Z",
+            sourceId: "apple_health",
+            title: "Cycling",
+            workoutType: "cardio" as const,
+            start: "2026-03-10T09:00:00.000Z",
+            end: "2026-03-10T09:22:00.000Z",
+            durationMinutes: 22,
+            calories: null,
+            distanceMeters: 4377.41568,
+            activityName: "Cycling",
+          },
+        ],
+      },
+      {
+        day: "2026-03-11",
+        workouts: [
+          {
+            id: "c1",
+            observedAt: "2026-03-11T10:00:00.000Z",
+            sourceId: "apple_health",
+            title: "Walking",
+            workoutType: "cardio" as const,
+            start: "2026-03-11T10:00:00.000Z",
+            end: "2026-03-11T10:31:00.000Z",
+            durationMinutes: 31,
+            calories: null,
+            distanceMeters: 4956.77952,
+            activityName: "Walking",
+          },
+        ],
+      },
+    ],
+  }),
+}));
 
 jest.mock("@/lib/ui/calendar/dateUtils", () => ({
   ...jest.requireActual("@/lib/ui/calendar/dateUtils"),
   getTodayDayKeyLocal: () => "2026-03-12" as const,
   getWeekDaysForAnchor: () =>
     [
+      "2026-03-08",
       "2026-03-09",
       "2026-03-10",
       "2026-03-11",
@@ -165,10 +204,6 @@ jest.mock("@/lib/data/workouts/workoutOverrides", () => ({
   useWorkoutOverrides: () => ({ overridesByWorkoutId: {}, reload: jest.fn() }),
 }));
 
-jest.mock("@/lib/workouts/journal/manualWorkoutSummary", () => ({
-  listManualWorkoutDaySummaries: jest.fn().mockResolvedValue([]),
-}));
-
 jest.mock("@react-navigation/native", () => ({
   useFocusEffect: jest.fn(),
 }));
@@ -183,33 +218,42 @@ jest.mock("react-native-safe-area-context", () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
 }));
 
-import StrengthTrainingOverviewScreen from "../overview";
+import CardioOverviewScreen from "@/app/(app)/cardio/index";
 
-describe("Strength overview week slice list", () => {
-  it("shows This Week in ascending order and excludes prior-week rows", async () => {
+describe("Cardio overview baseline layout", () => {
+  it("renders Cardio Baseline + This Week + Cardio history summary and removes recent card", async () => {
     let tree!: renderer.ReactTestRenderer;
     await act(async () => {
-      tree = renderer.create(<StrengthTrainingOverviewScreen />);
+      tree = renderer.create(<CardioOverviewScreen />);
     });
     const json = JSON.stringify(tree.toJSON());
-    const iThisWeekHeading = json.indexOf('"This Week"');
-    const iHistoryHeading = json.indexOf('"7 Day"');
-    expect(iThisWeekHeading).toBeGreaterThan(-1);
-    expect(iHistoryHeading).toBeGreaterThan(-1);
-
-    const thisWeekSegment = json.slice(iThisWeekHeading, iHistoryHeading);
-    expect(thisWeekSegment).not.toContain("prior-week-strength");
-    expect(thisWeekSegment).toContain("early-week-strength");
-    expect(thisWeekSegment).toContain("later-week-strength");
-
-    expect(json).not.toContain("Open workout details prior-week-strength");
-    expect(json).not.toContain('"Last Week"');
-
-    const iEarly = json.indexOf("Open workout details early-week-strength");
-    const iLate = json.indexOf("Open workout details later-week-strength");
-    expect(iEarly).toBeGreaterThan(-1);
-    expect(iLate).toBeGreaterThan(-1);
-    expect(iEarly).toBeLessThan(iLate);
-    expect(iLate).toBeLessThan(iHistoryHeading);
+    expect(json).toContain("Cardio Baseline");
+    expect(json).toContain("mi ·");
+    expect(json).toContain("min/wk");
+    expect(json).toContain("This Week");
+    expect(json).toContain("18.9 mi this week");
+    expect(json).not.toContain("Recent cardio sessions");
+    expect(json).toContain("7 Day");
+    expect(json).toContain("30 Day");
+    expect(json).toContain("YTD");
+    expect(json).toContain("12 Month");
+    expect(json).toContain("mi ·");
+    expect(json).toContain("cardio-history-progress-day7");
+    expect(json).toContain("cardio-history-progress-day30");
+    expect(json).toContain("cardio-history-progress-ytd");
+    expect(json).toContain("cardio-history-progress-month12");
+    expect(json).toContain("Data will appear when enough history is available");
+    expect(json).toContain("—");
+    expect(json).toContain("Sun 3/8");
+    expect(json).toContain("Tue 3/10");
+    expect(json).toContain("Wed 3/11");
+    expect(json.indexOf("Sun 3/8")).toBeLessThan(json.indexOf("Tue 3/10"));
+    expect(json.indexOf("Tue 3/10")).toBeLessThan(json.indexOf("Wed 3/11"));
+    expect(json).toContain("3.08 mi / 31 min");
+    expect(json).toContain("Walking");
+    expect(json).toContain("31 min");
+    expect(json).toContain("3.08 mi");
+    expect(json).not.toContain("undefined");
+    expect(json).not.toContain('"children":["2026"]');
   });
 });

--- a/app/(app)/workouts/__tests__/overview-strength-main-layout.test.tsx
+++ b/app/(app)/workouts/__tests__/overview-strength-main-layout.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Strength overview main body: Baseline, This Week + Last Week combined week lists;
+ * Strength overview main body: Baseline, This Week + Strength history summary;
  * analytics detail charts stay off this screen.
  */
 import React from "react";
@@ -177,7 +177,7 @@ describe("Strength overview main layout", () => {
     workoutsOverviewExpoMocks().setOptions.mockClear();
   });
 
-  it("renders Strength Baseline, This Week + Last Week blocks and omits Weekly Insights / weekly/monthly analytics cards", async () => {
+  it("renders Strength Baseline, This Week, and Strength history summary", async () => {
     let tree!: renderer.ReactTestRenderer;
     await act(async () => {
       tree = renderer.create(<StrengthTrainingOverviewScreen />);
@@ -185,15 +185,21 @@ describe("Strength overview main layout", () => {
     const json = JSON.stringify(tree.toJSON());
     const iBaseline = json.indexOf('"Strength Baseline"');
     const iThisWeek = json.indexOf('"This Week"');
-    const iLastWeek = json.indexOf('"Last Week"');
+    const iHistory7 = json.indexOf('"7 Day"');
     expect(iBaseline).toBeGreaterThan(-1);
     expect(iThisWeek).toBeGreaterThan(-1);
-    expect(iLastWeek).toBeGreaterThan(-1);
+    expect(iHistory7).toBeGreaterThan(-1);
     expect(json).not.toContain("strength-this-week-frequency-bar");
     expect(json).not.toContain('"Overview"');
     expect(json).not.toContain('"Recent Workouts"');
     expect(iBaseline).toBeLessThan(iThisWeek);
-    expect(iThisWeek).toBeLessThan(iLastWeek);
+    expect(iThisWeek).toBeLessThan(iHistory7);
+    expect(json).not.toContain("Last Week");
+    expect(json).toContain("30 Day");
+    expect(json).toContain("YTD");
+    expect(json).toContain("12 Month");
+    expect(json).toContain("strength-history-summary-card");
+    expect(json).toContain("wo");
     expect(json).not.toContain("Weekly Insights");
     expect(json).not.toContain("Weekly Strength");
     expect(json).not.toContain("Weekly Muscle Group");

--- a/app/(app)/workouts/overview.tsx
+++ b/app/(app)/workouts/overview.tsx
@@ -48,12 +48,10 @@ import {
 import { filterWorkoutCalendarDaysInclusive } from "@/lib/data/workouts/overviewCalendarRangeSlices";
 import {
   buildWorkoutOverviewAnalyticsFromCalendarDays,
-  getRecentWorkoutSessionsFromCalendarDays,
+  getCardioOverviewTabSessionsForCalendarDaysNewestFirst,
   getStrengthOverviewTabSessionsForCalendarDaysAscending,
-  WORKOUT_OVERVIEW_RECENT_SESSION_CAP,
   WORKOUT_OVERVIEW_ANALYTICS_RANGE_END,
   WORKOUT_OVERVIEW_ANALYTICS_RANGE_START,
-  WORKOUT_OVERVIEW_ANALYTICS_YEAR,
 } from "@/lib/data/workouts/workoutsCalendarModel";
 import type { WorkoutProductDomain } from "@/lib/data/workouts/workoutDomain";
 import { mapWorkoutCalendarDaysForDomain } from "@/lib/data/workouts/workoutDomain";
@@ -97,6 +95,18 @@ import {
   resolveWorkoutDisplayDurationMinutes,
 } from "@/lib/data/workouts/workoutDisplay";
 import {
+  cardioDistanceTierFromWeeklyMiles,
+  cardioDistanceTierIndexForBar,
+  cardioDistanceTierLabel,
+  cardioSessionDistanceMeters,
+  cardioWeeklyMilesScaleFill01,
+  formatCardioSessionHeadline,
+  formatCardioSessionSubtitle,
+  formatThisWeekCardioDistanceSummary,
+  getThisWeekCardioSessions,
+  sumDisplayableCardioDistanceMilesForWeekEntries,
+} from "@/lib/data/workouts/cardioSessionPresentation";
+import {
   deriveSessionTypeFlags,
   reconcileWorkoutSessionsForDay,
   resolveReconciledSessionWithLatestCalendarDays,
@@ -116,19 +126,22 @@ import {
   listManualWorkoutDaySummaries,
   type ManualWorkoutDaySummary,
 } from "@/lib/workouts/journal/manualWorkoutSummary";
-import { WorkoutAnalyticsChart } from "@/lib/ui/workouts/WorkoutAnalyticsChart";
 import { workoutOverviewInCardHeaderStyles } from "@/lib/ui/workouts/workoutOverviewInCardHeaderStyles";
 import { WorkoutsOverviewBottomNav } from "@/lib/ui/workouts/WorkoutsOverviewBottomNav";
 import { buildStrengthBaselineCardModel } from "@/lib/data/workouts/strengthBaselineCardModel";
 import { computeWorkoutOverviewSharedCalendarRange } from "@/lib/data/workouts/workoutOverviewSharedCalendarRange";
 import {
-  buildStrengthLastWeekCardModel,
   buildStrengthThisWeekCardModel,
-  formatStrengthLastWeekSessionsMicroCaption,
   formatStrengthThisWeekSessionsMicroCaption,
 } from "@/lib/data/workouts/strengthThisWeekCardModel";
 import { StrengthBaselineCard } from "@/lib/ui/workouts/StrengthBaselineCard";
 import { StrengthFrequencyMetricCard } from "@/lib/ui/workouts/StrengthFrequencyMetricCard";
+import { buildStrengthHistorySummaryModel } from "@/lib/data/workouts/strengthHistorySummaryModel";
+import { StrengthHistorySummaryCard } from "@/lib/ui/workouts/StrengthHistorySummaryCard";
+import { buildCardioBaselineCardModel } from "@/lib/data/workouts/cardioBaselineCardModel";
+import { buildCardioHistorySummaryModel } from "@/lib/data/workouts/cardioHistorySummaryModel";
+import { CardioBaselineCard } from "@/lib/ui/workouts/CardioBaselineCard";
+import { CardioHistorySummaryCard } from "@/lib/ui/workouts/CardioHistorySummaryCard";
 import { elevatedCardSurfaceStyle } from "@/lib/ui/theme/elevatedCardSurface";
 type ConnectionStatus = "loading" | "not_available" | "not_connected" | "connected";
 
@@ -252,8 +265,6 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
   const weekDaysFull = getWeekDaysForAnchor(anchorDay);
   const weekStart = weekDaysFull[0]!;
   const weekEnd = weekDaysFull[weekDaysFull.length - 1]!;
-  const prevWeekStart = useMemo(() => addCalendarDaysToDayKey(weekStart, -7), [weekStart]);
-  const prevWeekEnd = useMemo(() => addCalendarDaysToDayKey(weekEnd, -7), [weekEnd]);
   const recentRangeStart = addCalendarDaysToDayKey(today, -120);
   const recentRangeEnd = today;
   const analyticsRangeStart = WORKOUT_OVERVIEW_ANALYTICS_RANGE_START;
@@ -304,10 +315,6 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
   const weekDaysSlice = useMemo(
     () => filterWorkoutCalendarDaysInclusive(domainSharedDays, weekStart, weekEnd),
     [domainSharedDays, weekStart, weekEnd],
-  );
-  const lastWeekDaysSlice = useMemo(
-    () => filterWorkoutCalendarDaysInclusive(domainSharedDays, prevWeekStart, prevWeekEnd),
-    [domainSharedDays, prevWeekStart, prevWeekEnd],
   );
   const recentDaysSlice = useMemo(
     () => filterWorkoutCalendarDaysInclusive(domainSharedDays, recentRangeStart, recentRangeEnd),
@@ -430,25 +437,10 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
     [overviewSharedRange.status, weekDaysSlice, weekDaysFull],
   );
 
-  const recentWorkouts = useMemo(() => {
-    if (overviewSharedRange.status !== "ready") return [];
-    return getRecentWorkoutSessionsFromCalendarDays(recentDaysSlice, WORKOUT_OVERVIEW_RECENT_SESSION_CAP);
-  }, [overviewSharedRange.status, recentDaysSlice]);
-
-  const recentSessionsShownOnOverview = useMemo((): typeof recentWorkouts => {
-    if (domain === "strength") return [];
-    return recentWorkouts;
-  }, [domain, recentWorkouts]);
-
   const strengthWeekSessionsAscending = useMemo(() => {
     if (overviewSharedRange.status !== "ready" || domain !== "strength") return [];
     return getStrengthOverviewTabSessionsForCalendarDaysAscending(weekDaysSlice);
   }, [overviewSharedRange.status, domain, weekDaysSlice]);
-
-  const strengthLastWeekSessionsAscending = useMemo(() => {
-    if (overviewSharedRange.status !== "ready" || domain !== "strength") return [];
-    return getStrengthOverviewTabSessionsForCalendarDaysAscending(lastWeekDaysSlice);
-  }, [overviewSharedRange.status, domain, lastWeekDaysSlice]);
 
   const weekWorkoutIds = useMemo(
     () =>
@@ -458,29 +450,20 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
     [weekDaysSlice],
   );
 
-  const lastWeekWorkoutIds = useMemo(
-    () =>
-      lastWeekDaysSlice.flatMap((d) =>
-        reconcileWorkoutSessionsForDay(d.day, d.workouts).flatMap((s) => s.workouts.map((w) => w.id)),
-      ),
-    [lastWeekDaysSlice],
-  );
-
   const recentWorkoutIds = useMemo(
     () =>
       domain === "strength"
         ? strengthWeekSessionsAscending.flatMap((entry) => entry.session.workouts.map((w) => w.id))
-        : recentSessionsShownOnOverview.flatMap((entry) => entry.session.workouts.map((w) => w.id)),
-    [domain, strengthWeekSessionsAscending, recentSessionsShownOnOverview],
+        : [],
+    [domain, strengthWeekSessionsAscending],
   );
 
   const workoutIdsForOverrides = useMemo(() => {
     const uniq = new Set<string>();
     for (const id of recentWorkoutIds) uniq.add(id);
     for (const id of weekWorkoutIds) uniq.add(id);
-    for (const id of lastWeekWorkoutIds) uniq.add(id);
     return [...uniq];
-  }, [recentWorkoutIds, weekWorkoutIds, lastWeekWorkoutIds]);
+  }, [recentWorkoutIds, weekWorkoutIds]);
 
   const { overridesByWorkoutId, reload } = useWorkoutOverrides(workoutIdsForOverrides);
 
@@ -524,16 +507,51 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
     });
   }, [domain, overviewSharedRange.status, domainSharedDays, today, weekStart, weekEnd]);
 
-  const strengthLastWeekModel = useMemo(() => {
+  const strengthHistorySummaryModel = useMemo(() => {
     if (domain !== "strength") return null;
     if (overviewSharedRange.status !== "ready") return null;
-    return buildStrengthLastWeekCardModel({
+    return buildStrengthHistorySummaryModel({
       strengthCalendarDays: domainSharedDays,
       todayDayKey: today,
-      lastWeekStartDay: prevWeekStart,
-      lastWeekEndDay: prevWeekEnd,
+      availableRangeStart: overviewRangeStart,
+      availableRangeEnd: overviewRangeEnd,
     });
-  }, [domain, overviewSharedRange.status, domainSharedDays, today, prevWeekStart, prevWeekEnd]);
+  }, [domain, overviewSharedRange.status, domainSharedDays, today, overviewRangeStart, overviewRangeEnd]);
+
+  const cardioBaselineModel = useMemo(() => {
+    if (domain !== "cardio") return null;
+    if (overviewSharedRange.status !== "ready") return null;
+    return buildCardioBaselineCardModel({
+      cardioCalendarDays: domainSharedDays,
+      todayDayKey: today,
+    });
+  }, [domain, overviewSharedRange.status, domainSharedDays, today]);
+
+  const cardioHistorySummaryModel = useMemo(() => {
+    if (domain !== "cardio") return null;
+    if (overviewSharedRange.status !== "ready") return null;
+    return buildCardioHistorySummaryModel({
+      cardioCalendarDays: domainSharedDays,
+      todayDayKey: today,
+      availableRangeStart: overviewRangeStart,
+      availableRangeEnd: overviewRangeEnd,
+    });
+  }, [domain, overviewSharedRange.status, domainSharedDays, today, overviewRangeStart, overviewRangeEnd]);
+
+  const cardioWeekSessionsNewestFirst = useMemo(() => {
+    if (overviewSharedRange.status !== "ready" || domain !== "cardio") return [];
+    return getCardioOverviewTabSessionsForCalendarDaysNewestFirst(weekDaysSlice);
+  }, [overviewSharedRange.status, domain, weekDaysSlice]);
+
+  const cardioThisWeekSessions = useMemo(
+    () => getThisWeekCardioSessions(cardioWeekSessionsNewestFirst, weekDaysFull),
+    [cardioWeekSessionsNewestFirst, weekDaysFull],
+  );
+
+  const cardioThisWeekTotalMiles = useMemo(
+    () => sumDisplayableCardioDistanceMilesForWeekEntries(cardioWeekSessionsNewestFirst),
+    [cardioWeekSessionsNewestFirst],
+  );
 
   useEffect(() => {
     if (!__DEV__ || process.env.JEST_WORKER_ID) return;
@@ -1087,33 +1105,33 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
       </View>
     ) : null;
 
-  const strengthLastWeekCombinedCard =
-    domain === "strength" ? (
+  const cardioThisWeekCard =
+    domain === "cardio" ? (
       <View style={styles.strengthRecentCombinedCard}>
         <StrengthFrequencyMetricCard
           variant="embedded"
-          headingTitle="Last Week"
+          headingTitle="This Week"
           loading={overviewSharedRange.status !== "ready"}
           model={
-            strengthLastWeekModel != null
-              ? {
-                  compactValuePrimary: strengthLastWeekModel.compactValuePrimary,
-                  ratingLabel: strengthLastWeekModel.ratingLabel,
-                  activityTierIndexForBar: strengthLastWeekModel.activityTierIndexForBar,
-                  fillWidth01Override: strengthLastWeekModel.fillWidth01Override,
+            overviewSharedRange.status !== "ready"
+              ? null
+              : {
+                  compactValuePrimary: `${cardioThisWeekTotalMiles.toFixed(1)} mi`,
+                  ratingLabel: cardioDistanceTierLabel(
+                    cardioDistanceTierFromWeeklyMiles(cardioThisWeekTotalMiles),
+                  ),
+                  activityTierIndexForBar: cardioDistanceTierIndexForBar(
+                    cardioDistanceTierFromWeeklyMiles(cardioThisWeekTotalMiles),
+                  ),
+                  fillWidth01Override: cardioWeeklyMilesScaleFill01(cardioThisWeekTotalMiles),
                 }
-              : null
           }
           footerCaption=""
           showFrequencyTrack={false}
           showFrequencyMarkers={false}
           showFooterCaption={false}
           compactTitlePillSpacing
-          mutedMicroCaption={
-            strengthLastWeekModel != null
-              ? formatStrengthLastWeekSessionsMicroCaption(strengthLastWeekModel.totalWorkoutsThisWeek)
-              : null
-          }
+          mutedMicroCaption={formatThisWeekCardioDistanceSummary(cardioThisWeekTotalMiles)}
           titleRowTrailing={
             <Pressable
               onPress={() => router.push(`${basePath}/recent-workouts-full`)}
@@ -1124,27 +1142,27 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
                 workoutOverviewInCardHeaderStyles.linkHit,
                 pressed && workoutOverviewInCardHeaderStyles.linkPressed,
               ]}
-              testID="strength-recent-last-week-combined-view-more"
+              testID="cardio-this-week-view-more"
             >
               <Text style={workoutOverviewInCardHeaderStyles.link}>View All →</Text>
             </Pressable>
           }
-          ratingPillTestID="strength-last-week-rating-pill"
-          frequencyBarTestID="strength-last-week-frequency-bar"
-          instrumentClusterTestID="strength-last-week-instrument-cluster"
+          ratingPillTestID="cardio-this-week-rating-pill"
+          frequencyBarTestID="cardio-this-week-frequency-bar"
+          instrumentClusterTestID="cardio-this-week-instrument-cluster"
         />
         <View style={styles.strengthRecentSectionDivider} />
-        {overviewSharedRange.status !== "ready" ? null : strengthLastWeekSessionsAscending.length === 0 ? (
-          <Text style={styles.placeholder}>No strength workouts last week yet</Text>
+        {overviewSharedRange.status !== "ready" ? null : cardioThisWeekSessions.length === 0 ? (
+          <Text style={styles.placeholder}>No cardio sessions this week yet</Text>
         ) : (
-          strengthLastWeekSessionsAscending.map(({ day, session }, rowIndex) => {
+          cardioThisWeekSessions.map(({ day, session }, rowIndex) => {
             const representative = session.workouts[0];
             if (!representative) return null;
-            const journalSummary = pickJournalSummaryForStrengthSession(day, session, manualWorkoutSummaries);
+            const journalSummary = null;
             const surface = buildWorkoutSessionSurfaceModel(
               session,
               overridesByWorkoutId,
-              "strength",
+              domain,
               journalSummary,
               durableTitlesByWorkoutId,
             );
@@ -1153,18 +1171,20 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
               surface.metricsWorkout,
               sessionOverride ?? overridesByWorkoutId[surface.metricsWorkout.id] ?? null,
             );
-            const durationLabel = formatWorkoutDurationLabel(
-              resolveWorkoutDisplayDurationMinutes({
-                overrideDurationMinutes: resolvedMetrics.displayDurationMinutes,
-                sessionDurationMinutes: null,
-                fallbackWorkoutDurationMinutes:
-                  surface.metricsWorkout.durationMinutes ?? session.durationMinutes,
-              }),
-            );
-            const metaLine = formatRecentWorkoutMetaLine("strength", durationLabel, journalSummary);
+            const resolvedDuration = resolveWorkoutDisplayDurationMinutes({
+              overrideDurationMinutes: resolvedMetrics.displayDurationMinutes,
+              sessionDurationMinutes: null,
+              fallbackWorkoutDurationMinutes:
+                surface.metricsWorkout.durationMinutes ?? session.durationMinutes,
+            });
+            const headline = formatCardioSessionHeadline({
+              distanceMeters: cardioSessionDistanceMeters(session),
+              durationMinutes: resolvedDuration,
+            });
+            const subtitle = formatCardioSessionSubtitle(session);
             return (
               <Pressable
-                key={`last-${session.id}`}
+                key={`week-${session.id}`}
                 style={({ pressed }) => [
                   styles.recentRow,
                   rowIndex === 0 && styles.recentRowFirst,
@@ -1172,7 +1192,7 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
                 ]}
                 onPress={() => {
                   router.push({
-                    pathname: "/(app)/workouts/day/[day]",
+                    pathname: "/(app)/cardio/day/[day]",
                     params: { day },
                   });
                 }}
@@ -1182,10 +1202,10 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
                 <View style={styles.recentRowTextCol}>
                   <Text style={styles.recentDate}>{formatWorkoutDayLabel(day)}</Text>
                   <Text style={styles.recentTitle} numberOfLines={2} ellipsizeMode="tail">
-                    {surface.displayTitle}
+                    {headline}
                   </Text>
                   <Text style={styles.recentMeta} numberOfLines={1} ellipsizeMode="tail">
-                    {metaLine}
+                    {subtitle}
                   </Text>
                 </View>
                 <Pressable
@@ -1215,104 +1235,6 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
       </View>
     ) : null;
 
-  const cardioRecentCard = (
-    <View style={styles.card}>
-      <View style={workoutOverviewInCardHeaderStyles.row}>
-        <Text style={workoutOverviewInCardHeaderStyles.title}>Recent cardio sessions</Text>
-        <Pressable
-          onPress={() => router.push(`${basePath}/recent-workouts-full`)}
-          accessibilityRole="button"
-          accessibilityLabel="View more"
-          hitSlop={8}
-          style={({ pressed }) => [
-            workoutOverviewInCardHeaderStyles.linkHit,
-            pressed && workoutOverviewInCardHeaderStyles.linkPressed,
-          ]}
-        >
-          <Text style={workoutOverviewInCardHeaderStyles.link}>View More</Text>
-        </Pressable>
-      </View>
-      {recentWorkouts.length === 0 ? (
-        <Text style={styles.placeholder}>No cardio sessions yet</Text>
-      ) : (
-        recentSessionsShownOnOverview.map(({ day, session }, rowIndex) => {
-          const representative = session.workouts[0];
-          if (!representative) return null;
-          const journalSummary = null;
-          const surface = buildWorkoutSessionSurfaceModel(
-            session,
-            overridesByWorkoutId,
-            domain,
-            journalSummary,
-            durableTitlesByWorkoutId,
-          );
-          const sessionOverride = pickWorkoutOverrideForSession(session, overridesByWorkoutId);
-          const resolvedMetrics = resolveWorkoutDisplay(
-            surface.metricsWorkout,
-            sessionOverride ?? overridesByWorkoutId[surface.metricsWorkout.id] ?? null,
-          );
-          const durationLabel = formatWorkoutDurationLabel(
-            resolveWorkoutDisplayDurationMinutes({
-              overrideDurationMinutes: resolvedMetrics.displayDurationMinutes,
-              sessionDurationMinutes: null,
-              fallbackWorkoutDurationMinutes:
-                surface.metricsWorkout.durationMinutes ?? session.durationMinutes,
-            }),
-          );
-          const metaLine = formatRecentWorkoutMetaLine(domain, durationLabel, journalSummary);
-          return (
-            <Pressable
-              key={session.id}
-              style={({ pressed }) => [
-                styles.recentRow,
-                rowIndex === 0 && styles.recentRowFirst,
-                pressed && styles.recentRowPressed,
-              ]}
-              onPress={() => {
-                router.push({
-                  pathname: "/(app)/cardio/day/[day]",
-                  params: { day },
-                });
-              }}
-              accessibilityRole="button"
-              accessibilityLabel={`Open workout details ${surface.actionWorkout.id}`}
-            >
-              <View style={styles.recentRowTextCol}>
-                <Text style={styles.recentDate}>{formatWorkoutDayLabel(day)}</Text>
-                <Text style={styles.recentTitle} numberOfLines={2} ellipsizeMode="tail">
-                  {surface.displayTitle}
-                </Text>
-                <Text style={styles.recentMeta} numberOfLines={1} ellipsizeMode="tail">
-                  {metaLine}
-                </Text>
-              </View>
-              <Pressable
-                onPress={(e) => {
-                  e?.stopPropagation?.();
-                  const native = e?.nativeEvent;
-                  setWorkoutMenuAnchor({
-                    x: typeof native?.pageX === "number" ? native.pageX : 320,
-                    y: typeof native?.pageY === "number" ? native.pageY : 220,
-                    width: 24,
-                    height: 24,
-                  });
-                  setSelectedWorkoutForMenu({ day, session });
-                  setWorkoutMenuOpen(true);
-                }}
-                accessibilityRole="button"
-                accessibilityLabel={`Workout actions ${surface.actionWorkout.id}`}
-                hitSlop={10}
-                style={styles.rowMenuBtn}
-              >
-                <Text style={styles.rowMenuText}>•••</Text>
-              </Pressable>
-            </Pressable>
-          );
-        })
-      )}
-    </View>
-  );
-
   const content = (
     <View style={styles.pageBody}>
       {domain === "strength" ? (
@@ -1330,19 +1252,24 @@ export function TrainingOverviewScreen({ domain }: { domain: WorkoutProductDomai
             />
           </Pressable>
           {strengthRecentWeekCombinedCard}
-          {strengthLastWeekCombinedCard}
+          {strengthHistorySummaryModel ? <StrengthHistorySummaryCard model={strengthHistorySummaryModel} /> : null}
         </>
       ) : (
         <>
-          <WorkoutAnalyticsChart
-            layout="single"
-            domain={domain}
-            headerTitle={String(WORKOUT_OVERVIEW_ANALYTICS_YEAR)}
-            onViewMore={() => router.push(`${basePath}/analytics-detail`)}
-            chartPoints={overviewAnalytics.chartPoints}
-            metrics={overviewAnalytics.metrics}
-          />
-          {cardioRecentCard}
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Open cardio analytics"
+            onPress={() => router.push(`${basePath}/analytics-detail`)}
+            style={({ pressed }) => [styles.strengthBaselineCardPressable, pressed && styles.strengthBaselineCardPressed]}
+            testID="cardio-baseline-card-nav"
+          >
+            <CardioBaselineCard
+              loading={overviewSharedRange.status !== "ready"}
+              model={cardioBaselineModel}
+            />
+          </Pressable>
+          {cardioThisWeekCard}
+          {cardioHistorySummaryModel ? <CardioHistorySummaryCard model={cardioHistorySummaryModel} /> : null}
         </>
       )}
 

--- a/app/(app)/workouts/recent-workouts-full.tsx
+++ b/app/(app)/workouts/recent-workouts-full.tsx
@@ -1,40 +1,759 @@
-/**
- * Placeholder: full workout history list (beyond overview recent rows).
- */
-
-import React, { useEffect } from "react";
-import { View, StyleSheet } from "react-native";
-import { useNavigation } from "expo-router";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { View, StyleSheet, Text, Pressable, FlatList, ScrollView, Modal, Alert } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useNavigation, useRouter } from "expo-router";
 import { HeaderBackButton } from "@/lib/ui/HeaderBackButton";
 import {
   WORKOUTS_SCREEN_CONTENT_BG,
   workoutsStackNavigationOptions,
 } from "@/lib/ui/headers/workoutsStackHeader";
-import { EmptyState } from "@/lib/ui/ScreenStates";
+import { EmptyState, ErrorState, LoadingState, ScreenContainer } from "@/lib/ui/ScreenStates";
+import { getTodayDayKeyLocal } from "@/lib/ui/calendar/dateUtils";
+import { computeWorkoutOverviewSharedCalendarRange } from "@/lib/data/workouts/workoutOverviewSharedCalendarRange";
+import { useWorkoutsCalendarRange, applyAuthoritativeWorkoutDeletionLocal } from "@/lib/data/workouts/useWorkoutsCalendar";
+import { mapWorkoutCalendarDaysForDomain } from "@/lib/data/workouts/workoutDomain";
+import { reconcileWorkoutSessionsForDay, type ReconciledWorkoutSession } from "@/lib/data/workouts/workoutSessionReconciliation";
+import { useWorkoutOverrides, clearWorkoutOverride } from "@/lib/data/workouts/workoutOverrides";
+import { useAuth } from "@/lib/auth/AuthProvider";
+import {
+  buildWorkoutSessionSurfaceModel,
+  pickJournalSummaryForStrengthSession,
+  pickStrengthDeleteTargetWorkout,
+  pickWorkoutForSessionActions,
+  pickWorkoutOverrideForSession,
+} from "@/lib/data/workouts/workoutSessionSurface";
+import { listManualWorkoutDaySummaries, type ManualWorkoutDaySummary } from "@/lib/workouts/journal/manualWorkoutSummary";
+import { formatWorkoutDurationLabel, resolveWorkoutDisplay, resolveWorkoutDisplayDurationMinutes } from "@/lib/data/workouts/workoutDisplay";
+import { WorkoutActionSheet, type WorkoutActionAnchor } from "@/lib/ui/WorkoutActionSheet";
+import { deleteIngestedRawEventAuthed } from "@/lib/api/ingest";
+import type { DayKey } from "@/lib/ui/calendar/types";
+import { SYSTEM_ACCENT, SYSTEM_ACCENT_FILL_14 } from "@/lib/ui/theme/systemAccent";
+
+const WEEKDAY_SHORT = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
+const MONTH_SHORT = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"] as const;
+/** Matches premium list inset on this screen (aligned with month strip + rows). */
+const HISTORY_SCREEN_HORIZONTAL_GUTTER = 24;
+
+/** Month name + “N wo” share these metrics; hierarchy is color-only. */
+const MONTH_HEADER_ROW_TEXT = {
+  fontSize: 27,
+  fontWeight: "700" as const,
+  lineHeight: 32,
+  letterSpacing: -0.45,
+} as const;
+
+/** Matches Strength overview “This Week” card list row title (`overview.tsx` styles.recentTitle). */
+const THIS_WEEK_CARD_RECENT_TITLE_STYLE = {
+  fontSize: 17,
+  fontWeight: "600" as const,
+  color: "#1C1C1E",
+  letterSpacing: -0.28,
+  lineHeight: 21,
+};
+
+const MONTH_FULL = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+] as const;
+
+type HistoryRow = {
+  key: string;
+  day: DayKey;
+  session: ReconciledWorkoutSession;
+};
+
+function toYear(day: DayKey): number {
+  return Number(day.slice(0, 4));
+}
+
+function toMonthIndex(day: DayKey): number {
+  return Number(day.slice(5, 7)) - 1;
+}
+
+function formatWorkoutDayLabel(dayKey: DayKey): string {
+  const d = new Date(`${dayKey}T12:00:00.000Z`);
+  const wd = WEEKDAY_SHORT[d.getUTCDay()] ?? "";
+  const mon = MONTH_SHORT[d.getUTCMonth()] ?? "";
+  const dayNum = d.getUTCDate();
+  return `${wd} • ${mon} ${dayNum}`;
+}
+
+function countJournalSetsForDisplay(summary: ManualWorkoutDaySummary | null): number {
+  if (summary == null) return 0;
+  let n = 0;
+  for (const ex of summary.exercises) n += ex.sets.length;
+  return n;
+}
+
+function formatStrengthMetaLine(durationLabel: string, journalSummary: ManualWorkoutDaySummary | null): string {
+  const n = countJournalSetsForDisplay(journalSummary);
+  if (n > 0) return `${durationLabel} · ${n} set${n === 1 ? "" : "s"}`;
+  return durationLabel;
+}
+
+function selectDefaultMonthForYear(args: {
+  selectedYear: number;
+  currentYear: number;
+  currentMonth: number;
+  monthsWithData: number[];
+}): number {
+  if (args.monthsWithData.length === 0) return args.currentMonth;
+  if (args.selectedYear === args.currentYear && args.monthsWithData.includes(args.currentMonth)) {
+    return args.currentMonth;
+  }
+  return args.monthsWithData[args.monthsWithData.length - 1] ?? args.currentMonth;
+}
 
 export default function RecentWorkoutsFullScreen() {
   const navigation = useNavigation();
+  const router = useRouter();
+  const { user, getIdToken } = useAuth();
+  const today = getTodayDayKeyLocal();
+  const [refreshEpoch, setRefreshEpoch] = useState(0);
+  const [selectedYear, setSelectedYear] = useState<number | null>(null);
+  const [selectedMonth, setSelectedMonth] = useState<number | null>(null);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [menuAnchor, setMenuAnchor] = useState<WorkoutActionAnchor | null>(null);
+  const [selectedWorkoutForMenu, setSelectedWorkoutForMenu] = useState<{ day: DayKey; session: ReconciledWorkoutSession } | null>(null);
+  const [pendingDeleteWorkoutId, setPendingDeleteWorkoutId] = useState<string | null>(null);
+  const [deleteWorkoutSubmitting, setDeleteWorkoutSubmitting] = useState(false);
+  const [manualWorkoutSummaries, setManualWorkoutSummaries] = useState<ManualWorkoutDaySummary[]>([]);
+  const { start, end } = useMemo(() => computeWorkoutOverviewSharedCalendarRange(today), [today]);
+  const calendarRange = useWorkoutsCalendarRange(start, end, { refreshEpoch, debugHydrateLabel: "strength-history-full" });
+  const days = calendarRange.status === "ready" ? mapWorkoutCalendarDaysForDomain(calendarRange.days, "strength") : [];
+  const durableTitlesByWorkoutId = calendarRange.status === "ready" ? calendarRange.durableTitlesByWorkoutId : {};
+
+  const allRowsAscending = useMemo<HistoryRow[]>(() => {
+    const rows: HistoryRow[] = [];
+    for (const d of days) {
+      const sessions = reconcileWorkoutSessionsForDay(d.day, d.workouts);
+      for (const session of sessions) {
+        rows.push({
+          key: `${d.day}:${session.id}`,
+          day: d.day as DayKey,
+          session,
+        });
+      }
+    }
+    rows.sort((a, b) => {
+      if (a.day !== b.day) return a.day < b.day ? -1 : 1;
+      const aStart = a.session.start ?? "";
+      const bStart = b.session.start ?? "";
+      if (aStart === bStart) return a.session.id.localeCompare(b.session.id);
+      return aStart.localeCompare(bStart);
+    });
+    return rows;
+  }, [days]);
+
+  const now = useMemo(() => new Date(), []);
+  const currentYear = now.getFullYear();
+  const currentMonth = now.getMonth();
+
+  const yearsWithData = useMemo(() => {
+    const years = new Set<number>();
+    for (const row of allRowsAscending) years.add(toYear(row.day));
+    return [...years].sort((a, b) => a - b);
+  }, [allRowsAscending]);
+
+  const monthsWithDataByYear = useMemo(() => {
+    const byYear = new Map<number, number[]>();
+    for (const year of yearsWithData) byYear.set(year, []);
+    for (const row of allRowsAscending) {
+      const y = toYear(row.day);
+      const m = toMonthIndex(row.day);
+      const list = byYear.get(y) ?? [];
+      if (!list.includes(m)) list.push(m);
+      byYear.set(y, list);
+    }
+    for (const [year, months] of byYear.entries()) {
+      byYear.set(
+        year,
+        months.sort((a, b) => a - b),
+      );
+    }
+    return byYear;
+  }, [allRowsAscending, yearsWithData]);
+
+  const workoutIdsForOverrides = useMemo(
+    () => allRowsAscending.flatMap((entry) => entry.session.workouts.map((w) => w.id)),
+    [allRowsAscending],
+  );
+  const { overridesByWorkoutId, reload } = useWorkoutOverrides(workoutIdsForOverrides);
+
+  useEffect(() => {
+    if (calendarRange.status !== "ready") return;
+    if (selectedYear != null && selectedMonth != null) return;
+    const defaultYear =
+      yearsWithData.includes(currentYear) ? currentYear : (yearsWithData[yearsWithData.length - 1] ?? currentYear);
+    const monthsWithData = monthsWithDataByYear.get(defaultYear) ?? [];
+    const defaultMonth = selectDefaultMonthForYear({
+      selectedYear: defaultYear,
+      currentYear,
+      currentMonth,
+      monthsWithData,
+    });
+    setSelectedYear(defaultYear);
+    setSelectedMonth(defaultMonth);
+  }, [calendarRange.status, selectedYear, selectedMonth, yearsWithData, currentYear, currentMonth, monthsWithDataByYear]);
+
+  useEffect(() => {
+    if (selectedYear == null) return;
+    if (selectedMonth == null) return;
+    const monthsWithData = monthsWithDataByYear.get(selectedYear) ?? [];
+    if (monthsWithData.length === 0) return;
+    if (monthsWithData.includes(selectedMonth)) return;
+    setSelectedMonth(
+      selectDefaultMonthForYear({
+        selectedYear,
+        currentYear,
+        currentMonth,
+        monthsWithData,
+      }),
+    );
+  }, [selectedYear, selectedMonth, monthsWithDataByYear, currentYear, currentMonth]);
+
+  const visibleRows = useMemo(() => {
+    if (selectedYear == null || selectedMonth == null) return [] as HistoryRow[];
+    return allRowsAscending.filter((entry) => toYear(entry.day) === selectedYear && toMonthIndex(entry.day) === selectedMonth);
+  }, [allRowsAscending, selectedYear, selectedMonth]);
+
+  const closeMenu = useCallback(() => {
+    setMenuOpen(false);
+    setMenuAnchor(null);
+    setSelectedWorkoutForMenu(null);
+  }, []);
+
+  const selectedMenuSessionRef = useRef<ReconciledWorkoutSession | null>(null);
+  selectedMenuSessionRef.current = selectedWorkoutForMenu?.session ?? null;
+
+  const openEditRoute = useCallback(
+    (mode: "rename" | "duration" | "type") => {
+      if (!selectedWorkoutForMenu) return;
+      const session = selectedMenuSessionRef.current ?? selectedWorkoutForMenu.session;
+      const workout = pickWorkoutForSessionActions(session);
+      if (!workout) return;
+      const journalSummary = pickJournalSummaryForStrengthSession(
+        selectedWorkoutForMenu.day,
+        session,
+        manualWorkoutSummaries,
+      );
+      const surface = buildWorkoutSessionSurfaceModel(
+        session,
+        overridesByWorkoutId,
+        "strength",
+        journalSummary,
+        durableTitlesByWorkoutId,
+      );
+      const sessionOverride = pickWorkoutOverrideForSession(session, overridesByWorkoutId);
+      const resolvedAction = resolveWorkoutDisplay(
+        workout,
+        sessionOverride ?? overridesByWorkoutId[workout.id] ?? null,
+      );
+      const resolvedMetrics = resolveWorkoutDisplay(
+        surface.metricsWorkout,
+        sessionOverride ?? overridesByWorkoutId[surface.metricsWorkout.id] ?? null,
+      );
+      closeMenu();
+      router.push({
+        pathname: `/(app)/workouts/edit/${mode}`,
+        params: {
+          workoutId: workout.id,
+          currentTitle: surface.displayTitle,
+          titleAnchorObservedAt: workout.start ?? workout.observedAt,
+          currentDurationMinutes:
+            typeof resolvedMetrics.displayDurationMinutes === "number"
+              ? String(Math.round(resolvedMetrics.displayDurationMinutes))
+              : "",
+          currentWorkoutType: resolvedAction.displayWorkoutType,
+        },
+      });
+    },
+    [selectedWorkoutForMenu, manualWorkoutSummaries, overridesByWorkoutId, durableTitlesByWorkoutId, closeMenu, router],
+  );
 
   useEffect(() => {
     navigation.setOptions({
       ...workoutsStackNavigationOptions("detail"),
-      headerLeft: () => <HeaderBackButton onPress={() => navigation.goBack()} />,
+      headerStyle: { backgroundColor: WORKOUTS_SCREEN_CONTENT_BG },
+      headerLeft: () => <HeaderBackButton onPress={() => navigation.goBack()} accessibilityLabel="Go back" />,
+      headerTitle: () => (
+        <Pressable
+          onPress={() => {
+            // Year picker is deferred; make this interactive now.
+          }}
+          accessibilityRole="button"
+          accessibilityLabel={`Selected year ${selectedYear ?? currentYear}. Double tap to change year.`}
+          hitSlop={8}
+          style={({ pressed }) => [styles.yearPressable, pressed && styles.yearPressablePressed]}
+        >
+          <Text style={styles.yearTitle}>{selectedYear ?? currentYear}</Text>
+        </Pressable>
+      ),
+      title: "",
     });
-  }, [navigation]);
+  }, [navigation, selectedYear, currentYear]);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (process.env.JEST_WORKER_ID) return;
+    if (!user?.uid) {
+      setManualWorkoutSummaries([]);
+      return;
+    }
+    void listManualWorkoutDaySummaries(user.uid, () => getIdToken(false)).then((rows) => {
+      if (cancelled) return;
+      setManualWorkoutSummaries(rows);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [user?.uid, getIdToken, refreshEpoch]);
+
+  const confirmDeleteStrengthWorkout = useCallback(async () => {
+    if (!pendingDeleteWorkoutId) return;
+    const token = await getIdToken(false);
+    if (!token) {
+      setPendingDeleteWorkoutId(null);
+      Alert.alert("Couldn't delete workout", "Sign in again and try once more.");
+      return;
+    }
+    setDeleteWorkoutSubmitting(true);
+    const res = await deleteIngestedRawEventAuthed(pendingDeleteWorkoutId, token);
+    setDeleteWorkoutSubmitting(false);
+    if (res.ok) {
+      if (user?.uid) applyAuthoritativeWorkoutDeletionLocal(user.uid, pendingDeleteWorkoutId);
+      await clearWorkoutOverride(pendingDeleteWorkoutId);
+      await reload();
+      setPendingDeleteWorkoutId(null);
+      setRefreshEpoch((n) => n + 1);
+      return;
+    }
+    setPendingDeleteWorkoutId(null);
+    Alert.alert("Couldn't delete workout", "Something went wrong. Your workouts were not changed.");
+  }, [pendingDeleteWorkoutId, getIdToken, user?.uid, reload]);
+
+  const renderRow = useCallback(
+    ({ item, index }: { item: HistoryRow; index: number }) => {
+      const journalSummary = pickJournalSummaryForStrengthSession(item.day, item.session, manualWorkoutSummaries);
+      const surface = buildWorkoutSessionSurfaceModel(
+        item.session,
+        overridesByWorkoutId,
+        "strength",
+        journalSummary,
+        durableTitlesByWorkoutId,
+      );
+      const sessionOverride = pickWorkoutOverrideForSession(item.session, overridesByWorkoutId);
+      const resolvedMetrics = resolveWorkoutDisplay(
+        surface.metricsWorkout,
+        sessionOverride ?? overridesByWorkoutId[surface.metricsWorkout.id] ?? null,
+      );
+      const durationLabel = formatWorkoutDurationLabel(
+        resolveWorkoutDisplayDurationMinutes({
+          overrideDurationMinutes: resolvedMetrics.displayDurationMinutes,
+          sessionDurationMinutes: null,
+          fallbackWorkoutDurationMinutes: surface.metricsWorkout.durationMinutes ?? item.session.durationMinutes,
+        }),
+      );
+      const metaLine = formatStrengthMetaLine(durationLabel, journalSummary);
+
+      const isLast = index === visibleRows.length - 1;
+
+      return (
+        <View style={styles.recentRowWrap}>
+          <Pressable
+            style={({ pressed }) => [styles.recentRow, pressed && styles.recentRowPressed]}
+            onPress={() => {
+              router.push({
+                pathname: "/(app)/workouts/day/[day]",
+                params: { day: item.day },
+              });
+            }}
+            accessibilityRole="button"
+            accessibilityLabel={`Open workout details ${surface.actionWorkout.id}`}
+          >
+            <View style={styles.recentRowTextCol}>
+              <Text style={styles.recentDate}>{formatWorkoutDayLabel(item.day)}</Text>
+              <Text style={styles.recentTitle} numberOfLines={2} ellipsizeMode="tail">
+                {surface.displayTitle}
+              </Text>
+              <Text style={styles.recentMeta} numberOfLines={1} ellipsizeMode="tail">
+                {metaLine}
+              </Text>
+            </View>
+            <Pressable
+              onPress={(e) => {
+                e?.stopPropagation?.();
+                const native = e?.nativeEvent;
+                setMenuAnchor({
+                  x: typeof native?.pageX === "number" ? native.pageX : 320,
+                  y: typeof native?.pageY === "number" ? native.pageY : 220,
+                  width: 44,
+                  height: 44,
+                });
+                setSelectedWorkoutForMenu({ day: item.day, session: item.session });
+                setMenuOpen(true);
+              }}
+              accessibilityRole="button"
+              accessibilityLabel={`Workout actions ${surface.actionWorkout.id}`}
+              hitSlop={8}
+              style={styles.rowMenuBtn}
+            >
+              <Ionicons name="ellipsis-horizontal" size={22} color="#8E8E93" />
+            </Pressable>
+          </Pressable>
+          {!isLast ? <View style={styles.rowDividerInset} /> : null}
+        </View>
+      );
+    },
+    [router, manualWorkoutSummaries, overridesByWorkoutId, durableTitlesByWorkoutId, visibleRows.length],
+  );
+
+  const monthSectionTitle =
+    selectedMonth != null ? (MONTH_FULL[selectedMonth] ?? "") : "";
+  const monthWorkoutCount = visibleRows.length;
+  const monthWorkoutCountWoLabel = `${monthWorkoutCount} wo`;
+
+  const listSectionHeader =
+    selectedMonth != null ? (
+      <View
+        style={styles.listSectionHeaderRow}
+        accessible
+        accessibilityRole="header"
+        accessibilityLabel={`${monthSectionTitle}, ${monthWorkoutCount} ${monthWorkoutCount === 1 ? "workout" : "workouts"}`}
+      >
+        <Text style={styles.listSectionMonth} importantForAccessibility="no">
+          {monthSectionTitle}
+        </Text>
+        <Text style={styles.listSectionCount} importantForAccessibility="no">
+          {monthWorkoutCountWoLabel}
+        </Text>
+      </View>
+    ) : null;
+
+  const monthSelector = (
+    <View style={styles.monthSelectorWrap}>
+      <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.monthSelectorContent}>
+        {MONTH_SHORT.map((label, idx) => {
+          const selected = selectedMonth === idx;
+          return (
+            <Pressable
+              key={label}
+              onPress={() => setSelectedMonth(idx)}
+              accessibilityRole="button"
+              accessibilityLabel={`Select ${label}`}
+              accessibilityState={{ selected }}
+              style={({ pressed }) => [
+                styles.monthPill,
+                selected && styles.monthPillSelected,
+                pressed && styles.monthPillPressed,
+              ]}
+            >
+              <Text style={[styles.monthPillLabel, selected && styles.monthPillLabelSelected]}>{label}</Text>
+            </Pressable>
+          );
+        })}
+      </ScrollView>
+    </View>
+  );
+
+  const screenEdges = ["left", "right", "bottom"] as const;
+
+  if (calendarRange.status === "partial") {
+    return (
+      <ScreenContainer backgroundColor={WORKOUTS_SCREEN_CONTENT_BG} padded={false} edges={[...screenEdges]}>
+        <LoadingState message="Loading strength history…" />
+      </ScreenContainer>
+    );
+  }
+
+  if (calendarRange.status === "error") {
+    return (
+      <ScreenContainer backgroundColor={WORKOUTS_SCREEN_CONTENT_BG} padded={false} edges={[...screenEdges]}>
+        <ErrorState message={calendarRange.error} requestId={calendarRange.requestId} />
+      </ScreenContainer>
+    );
+  }
 
   return (
-    <View style={styles.body}>
-      <View style={styles.inner}>
-        <EmptyState
-          title="Full history soon"
-          description="Your complete workout history will appear here."
+    <ScreenContainer backgroundColor={WORKOUTS_SCREEN_CONTENT_BG} padded={false} edges={[...screenEdges]}>
+      <View style={styles.body}>
+        {monthSelector}
+        <FlatList
+          data={visibleRows}
+          renderItem={renderRow}
+          keyExtractor={(item) => item.key}
+          contentContainerStyle={styles.listContent}
+          ListHeaderComponent={
+            listSectionHeader != null ? <View style={styles.listSectionHeaderWrap}>{listSectionHeader}</View> : null
+          }
+          ListEmptyComponent={
+            <View style={styles.emptyWrap}>
+              <EmptyState
+                title="No workouts yet"
+                description="Start logging your strength sessions to see them here."
+              />
+            </View>
+          }
         />
+        <WorkoutActionSheet
+          visible={menuOpen && !!selectedWorkoutForMenu}
+          anchor={menuAnchor}
+          onClose={closeMenu}
+          onViewDetails={() => {
+            if (!selectedWorkoutForMenu) return;
+            const day = selectedWorkoutForMenu.day;
+            closeMenu();
+            router.push({ pathname: "/(app)/workouts/day/[day]", params: { day } });
+          }}
+          onDoItAgain={() => {
+            closeMenu();
+            router.push("/(app)/workouts/log");
+          }}
+          onRename={() => openEditRoute("rename")}
+          onEditDuration={() => openEditRoute("duration")}
+          onEditType={() => openEditRoute("type")}
+          {...(selectedWorkoutForMenu && pickStrengthDeleteTargetWorkout(selectedWorkoutForMenu.session) != null
+            ? {
+                onDeleteWorkout: () => {
+                  const session = selectedMenuSessionRef.current ?? selectedWorkoutForMenu.session;
+                  const workout = pickStrengthDeleteTargetWorkout(session);
+                  if (!workout) return;
+                  const id = (workout.id ?? "").trim();
+                  if (!id) return;
+                  closeMenu();
+                  setPendingDeleteWorkoutId(id);
+                },
+              }
+            : {})}
+        />
+        <Modal
+          visible={pendingDeleteWorkoutId != null}
+          transparent
+          animationType="fade"
+          onRequestClose={() => {
+            if (!deleteWorkoutSubmitting) setPendingDeleteWorkoutId(null);
+          }}
+          presentationStyle="overFullScreen"
+        >
+          <Pressable
+            style={styles.deleteConfirmBackdrop}
+            onPress={() => {
+              if (!deleteWorkoutSubmitting) setPendingDeleteWorkoutId(null);
+            }}
+            accessibilityLabel="Close delete workout confirmation"
+          >
+            <Pressable style={styles.deleteConfirmCard} onPress={(e) => e.stopPropagation()}>
+              <Text style={styles.deleteConfirmTitle}>Delete workout?</Text>
+              <Text style={styles.deleteConfirmBody} accessibilityLabel="Delete workout confirmation body">
+                This will remove this workout from Oli and update your strength history.
+              </Text>
+              <View style={styles.deleteConfirmActions}>
+                <Pressable
+                  onPress={() => {
+                    if (!deleteWorkoutSubmitting) setPendingDeleteWorkoutId(null);
+                  }}
+                  style={styles.deleteConfirmCancelBtn}
+                  accessibilityRole="button"
+                  accessibilityLabel="Cancel delete workout"
+                >
+                  <Text style={styles.deleteConfirmCancelLabel}>Cancel</Text>
+                </Pressable>
+                <Pressable
+                  onPress={() => void confirmDeleteStrengthWorkout()}
+                  disabled={deleteWorkoutSubmitting}
+                  style={[styles.deleteConfirmDangerBtn, deleteWorkoutSubmitting && styles.deleteConfirmDangerBtnDisabled]}
+                  accessibilityRole="button"
+                  accessibilityLabel="Confirm delete workout"
+                >
+                  <Text style={styles.deleteConfirmDangerLabel}>Delete</Text>
+                </Pressable>
+              </View>
+            </Pressable>
+          </Pressable>
+        </Modal>
       </View>
-    </View>
+    </ScreenContainer>
   );
 }
 
 const styles = StyleSheet.create({
   body: { flex: 1, backgroundColor: WORKOUTS_SCREEN_CONTENT_BG },
-  inner: { flex: 1, paddingHorizontal: 16 },
+  yearPressable: {
+    paddingHorizontal: 10,
+    paddingVertical: 2,
+    borderRadius: 8,
+  },
+  yearPressablePressed: {
+    opacity: 0.72,
+  },
+  yearTitle: {
+    fontSize: 20,
+    fontWeight: "700",
+    color: "#1C1C1E",
+    letterSpacing: -0.35,
+  },
+  monthSelectorWrap: {
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: "rgba(60,60,67,0.12)",
+    paddingTop: 6,
+    paddingBottom: 6,
+  },
+  monthSelectorContent: {
+    paddingHorizontal: HISTORY_SCREEN_HORIZONTAL_GUTTER,
+    gap: 10,
+    alignItems: "center",
+  },
+  monthPill: {
+    minHeight: 40,
+    minWidth: 44,
+    paddingHorizontal: 14,
+    borderRadius: 20,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  // Light accent wash: matches Strength calendar ring fill (systemAccent).
+  monthPillSelected: {
+    backgroundColor: SYSTEM_ACCENT_FILL_14,
+  },
+  monthPillPressed: {
+    opacity: 0.75,
+  },
+  monthPillLabel: {
+    fontSize: 14,
+    fontWeight: "500",
+    color: "#3C3C43",
+  },
+  monthPillLabelSelected: {
+    color: SYSTEM_ACCENT,
+    fontWeight: "700",
+  },
+  listSectionHeaderRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    width: "100%",
+    gap: 12,
+  },
+  listSectionHeaderWrap: {
+    paddingTop: 8,
+    /** Breathing room below month row → first workout (~8–10px before first row’s own padding). */
+    paddingBottom: 10,
+  },
+  listSectionMonth: {
+    ...MONTH_HEADER_ROW_TEXT,
+    flex: 1,
+    minWidth: 0,
+    color: "#1C1C1E",
+  },
+  listSectionCount: {
+    ...MONTH_HEADER_ROW_TEXT,
+    flexShrink: 0,
+    color: "#8E8E93",
+    fontVariant: ["tabular-nums"],
+  },
+  listContent: {
+    paddingHorizontal: HISTORY_SCREEN_HORIZONTAL_GUTTER,
+    paddingBottom: 32,
+    flexGrow: 1,
+  },
+  emptyWrap: {
+    paddingTop: 36,
+  },
+  recentRowWrap: {
+    width: "100%",
+    paddingVertical: 6,
+  },
+  recentRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingTop: 0,
+    paddingBottom: 0,
+  },
+  recentRowPressed: {
+    opacity: 0.7,
+  },
+  recentRowTextCol: {
+    flex: 1,
+    minWidth: 0,
+  },
+  recentDate: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: "#636366",
+    letterSpacing: -0.08,
+    marginBottom: 5,
+  },
+  recentTitle: {
+    ...THIS_WEEK_CARD_RECENT_TITLE_STYLE,
+    marginBottom: 8,
+  },
+  recentMeta: {
+    fontSize: 14,
+    fontWeight: "500",
+    color: "#636366",
+    letterSpacing: -0.12,
+    marginBottom: 14,
+  },
+  rowDividerInset: {
+    height: StyleSheet.hairlineWidth,
+    backgroundColor: "#E5E5EA",
+    /** Inset within padded list column; stays clear of the trailing ••• control. */
+    marginLeft: 16,
+    marginRight: 56,
+    marginBottom: 0,
+  },
+  rowMenuBtn: {
+    justifyContent: "center",
+    alignItems: "center",
+    minWidth: 44,
+    minHeight: 44,
+  },
+  deleteConfirmBackdrop: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.4)",
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 24,
+  },
+  deleteConfirmCard: {
+    backgroundColor: "#FFFFFF",
+    borderRadius: 16,
+    padding: 20,
+    width: "100%",
+    maxWidth: 320,
+  },
+  deleteConfirmTitle: { fontSize: 18, fontWeight: "800", color: "#1C1C1E", marginBottom: 8 },
+  deleteConfirmBody: { fontSize: 14, color: "#6E6E73", lineHeight: 20 },
+  deleteConfirmActions: { flexDirection: "row", gap: 12, marginTop: 16 },
+  deleteConfirmCancelBtn: {
+    flex: 1,
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderRadius: 10,
+    backgroundColor: "#F2F2F7",
+    alignItems: "center",
+  },
+  deleteConfirmCancelLabel: { fontSize: 15, fontWeight: "700", color: "#1C1C1E" },
+  deleteConfirmDangerBtn: {
+    flex: 1,
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderRadius: 10,
+    backgroundColor: "#FFF5F5",
+    borderWidth: 1,
+    borderColor: "#FFD6D6",
+    alignItems: "center",
+  },
+  deleteConfirmDangerBtnDisabled: { opacity: 0.55 },
+  deleteConfirmDangerLabel: { fontSize: 15, fontWeight: "700", color: "#FF3B30" },
 });

--- a/lib/data/workouts/__tests__/appleHealthKitWorkoutActivityType.test.ts
+++ b/lib/data/workouts/__tests__/appleHealthKitWorkoutActivityType.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  displayLabelForAppleHealthKitWorkoutActivityType,
+  HK_WORKOUT_ACTIVITY_TYPE_OTHER,
+} from "@/lib/data/workouts/appleHealthKitWorkoutActivityType";
+
+describe("displayLabelForAppleHealthKitWorkoutActivityType", () => {
+  it("maps Walking and Running ids to user-facing labels", () => {
+    expect(displayLabelForAppleHealthKitWorkoutActivityType(52)).toBe("Walking");
+    expect(displayLabelForAppleHealthKitWorkoutActivityType(37)).toBe("Running");
+    expect(displayLabelForAppleHealthKitWorkoutActivityType(13)).toBe("Cycling");
+  });
+
+  it("returns null for Other and unknown ids", () => {
+    expect(displayLabelForAppleHealthKitWorkoutActivityType(HK_WORKOUT_ACTIVITY_TYPE_OTHER)).toBe(null);
+    expect(displayLabelForAppleHealthKitWorkoutActivityType(999_999)).toBe(null);
+    expect(displayLabelForAppleHealthKitWorkoutActivityType(null)).toBe(null);
+  });
+});

--- a/lib/data/workouts/__tests__/cardioBaselineCardModel.test.ts
+++ b/lib/data/workouts/__tests__/cardioBaselineCardModel.test.ts
@@ -1,0 +1,120 @@
+import { buildCardioBaselineCardModel } from "../cardioBaselineCardModel";
+
+function cardioWorkout(day: string, id: string, miles: number) {
+  return {
+    day: day as `${string}-${string}-${string}`,
+    workouts: [
+      {
+        id,
+        observedAt: `${day}T10:00:00.000Z`,
+        sourceId: "apple_health",
+        title: "Run",
+        workoutType: "cardio" as const,
+        start: `${day}T10:00:00.000Z`,
+        end: `${day}T10:30:00.000Z`,
+        durationMinutes: 30,
+        calories: null,
+        distanceMeters: miles * 1609.344,
+      },
+    ],
+  };
+}
+
+describe("buildCardioBaselineCardModel", () => {
+  const today = "2026-06-15" as const;
+
+  it("uses trailing 90 completed days and excludes today", () => {
+    const model = buildCardioBaselineCardModel({
+      cardioCalendarDays: [
+        cardioWorkout("2026-06-14", "y", 10),
+        cardioWorkout("2026-06-15", "t", 20),
+      ],
+      todayDayKey: today,
+    });
+    expect(model.kind).toBe("ready");
+    if (model.kind !== "ready") return;
+    expect(model.totalMiles90d).toBeCloseTo(10, 5);
+    expect(model.averageMilesPerWeek90d).toBeCloseTo((10 * 7) / 90, 10);
+  });
+
+  it("computes weekly average from total 90-day miles", () => {
+    const model = buildCardioBaselineCardModel({
+      cardioCalendarDays: [
+        cardioWorkout("2026-04-01", "a", 5),
+        cardioWorkout("2026-05-01", "b", 10),
+      ],
+      todayDayKey: today,
+    });
+    expect(model.kind).toBe("ready");
+    if (model.kind !== "ready") return;
+    expect(model.totalMiles90d).toBeCloseTo(15, 5);
+    expect(model.averageMilesPerWeek90d).toBeCloseTo((15 * 7) / 90, 10);
+    expect(model.totalMinutes90d).toBe(60);
+    expect(model.averageMinutesPerWeek90d).toBeCloseTo((60 * 7) / 90, 10);
+    expect(model.formattedAverageMilesPerWeek).toBe("1.2 mi/wk");
+    expect(model.formattedAverageMinutesPerWeek).toBe("5 min/wk");
+    expect(model.headlineLabel).toBe("1.2 mi · 5 min/wk");
+  });
+
+  it("returns insufficient_data when no cardio distance is available", () => {
+    const model = buildCardioBaselineCardModel({
+      cardioCalendarDays: [],
+      todayDayKey: today,
+    });
+    expect(model).toEqual({ kind: "insufficient_data" });
+  });
+
+  it("maps CDC/AHA product tier boundaries", () => {
+    const cases = [
+      { milesPerWeek: 2.4, tier: "very_low" },
+      { milesPerWeek: 2.5, tier: "low" },
+      { milesPerWeek: 7.4, tier: "low" },
+      { milesPerWeek: 7.5, tier: "active" },
+      { milesPerWeek: 14.9, tier: "active" },
+      { milesPerWeek: 15, tier: "high" },
+      { milesPerWeek: 24.9, tier: "high" },
+      { milesPerWeek: 25, tier: "very_high" },
+    ] as const;
+
+    for (const entry of cases) {
+      const totalMiles90d = (entry.milesPerWeek * 90) / 7;
+      const model = buildCardioBaselineCardModel({
+        cardioCalendarDays: [cardioWorkout("2026-06-14", `c-${entry.milesPerWeek}`, totalMiles90d)],
+        todayDayKey: today,
+      });
+      expect(model.kind).toBe("ready");
+      if (model.kind !== "ready") continue;
+      expect(model.tier).toBe(entry.tier);
+    }
+  });
+
+  it("returns minutes-only headline when distance is unavailable", () => {
+    const day = "2026-06-14";
+    const model = buildCardioBaselineCardModel({
+      cardioCalendarDays: [
+        {
+          day: day as `${string}-${string}-${string}`,
+          workouts: [
+            {
+              id: "m-only",
+              observedAt: `${day}T10:00:00.000Z`,
+              sourceId: "apple_health",
+              title: "Run",
+              workoutType: "cardio" as const,
+              start: `${day}T10:00:00.000Z`,
+              end: `${day}T10:30:00.000Z`,
+              durationMinutes: 30,
+              calories: null,
+            },
+          ],
+        },
+      ],
+      todayDayKey: today,
+    });
+    expect(model.kind).toBe("ready");
+    if (model.kind !== "ready") return;
+    expect(model.totalMiles90d).toBe(0);
+    expect(model.totalMinutes90d).toBe(30);
+    expect(model.headlineLabel).toBe("2 min/wk");
+  });
+});

--- a/lib/data/workouts/__tests__/cardioHistorySummaryModel.test.ts
+++ b/lib/data/workouts/__tests__/cardioHistorySummaryModel.test.ts
@@ -1,0 +1,187 @@
+import {
+  activityTrailingNDaysInclusive,
+  activityYtdInclusiveThroughEndDay,
+  getActivityOverviewAnchorEndDay,
+} from "@/lib/data/activity/activityOverviewRanges";
+import { buildCardioHistorySummaryModel } from "../cardioHistorySummaryModel";
+
+function cardioWorkout(day: string, id: string, miles: number, title = "Running") {
+  return {
+    day: day as `${string}-${string}-${string}`,
+    workouts: [
+      {
+        id,
+        observedAt: `${day}T10:00:00.000Z`,
+        sourceId: "apple_health",
+        title,
+        workoutType: "cardio" as const,
+        start: `${day}T10:00:00.000Z`,
+        end: `${day}T10:30:00.000Z`,
+        durationMinutes: 30,
+        calories: null,
+        distanceMeters: miles * 1609.344,
+        activityName: title,
+      },
+    ],
+  };
+}
+
+describe("buildCardioHistorySummaryModel", () => {
+  it("builds 7/30/YTD rows as mi/wk and excludes unsupported modalities", () => {
+    const model = buildCardioHistorySummaryModel({
+      todayDayKey: "2026-03-12",
+      availableRangeStart: "2025-12-01",
+      availableRangeEnd: "2026-03-12",
+      cardioCalendarDays: [
+        cardioWorkout("2026-03-10", "run", 3, "Running"),
+        cardioWorkout("2026-03-09", "other", 10, "Other"),
+        cardioWorkout("2026-01-10", "walk", 7, "Walking"),
+      ],
+    });
+
+    expect(model.rows.map((row) => row.label)).toEqual(["7 Day", "30 Day", "YTD", "12 Month"]);
+    const day30 = model.rows.find((row) => row.key === "day30");
+    expect(day30?.hasEnoughData).toBe(true);
+    expect(day30?.displayValue).toContain("mi ·");
+    expect(day30?.displayValue).toContain("min/wk");
+    expect(day30?.displayValue).not.toContain("mi/wk ·");
+    expect(day30?.totalMiles).toBeCloseTo(3, 5);
+    expect(day30?.totalMinutes).toBe(30);
+  });
+
+  it("marks 12 month as insufficient when hydration range does not cover trailing year", () => {
+    const model = buildCardioHistorySummaryModel({
+      todayDayKey: "2026-03-12",
+      availableRangeStart: "2026-01-01",
+      availableRangeEnd: "2026-03-12",
+      cardioCalendarDays: [cardioWorkout("2026-03-10", "run", 3, "Running")],
+    });
+    const month12 = model.rows.find((row) => row.key === "month12");
+    expect(month12).toMatchObject({
+      hasEnoughData: false,
+      displayValue: "—",
+      helperText: "Data will appear when enough history is available",
+      progressFill01: null,
+    });
+  });
+
+  it("computes min/wk as totalMinutes * 7 / calendar days for 7 Day, 30 Day, YTD, and 12 Month", () => {
+    const todayDayKey = "2026-06-15";
+    const anchor = getActivityOverviewAnchorEndDay(todayDayKey);
+    const minutes = 300;
+    const model = buildCardioHistorySummaryModel({
+      todayDayKey,
+      availableRangeStart: "2020-01-01",
+      availableRangeEnd: anchor,
+      cardioCalendarDays: [
+        {
+          day: anchor,
+          workouts: [
+            {
+              id: "run",
+              observedAt: `${anchor}T10:00:00.000Z`,
+              sourceId: "apple_health",
+              title: "Running",
+              workoutType: "cardio" as const,
+              start: `${anchor}T10:00:00.000Z`,
+              end: `${anchor}T11:00:00.000Z`,
+              durationMinutes: minutes,
+              calories: null,
+              distanceMeters: 5 * 1609.344,
+              activityName: "Running",
+            },
+          ],
+        },
+      ],
+    });
+
+    const day7Len = activityTrailingNDaysInclusive(anchor, 7).length;
+    const day30Len = activityTrailingNDaysInclusive(anchor, 30).length;
+    const ytdLen = activityYtdInclusiveThroughEndDay(anchor).length;
+    const month12Len = activityTrailingNDaysInclusive(anchor, 365).length;
+
+    const day7 = model.rows.find((r) => r.key === "day7");
+    const day30 = model.rows.find((r) => r.key === "day30");
+    const ytd = model.rows.find((r) => r.key === "ytd");
+    const month12 = model.rows.find((r) => r.key === "month12");
+
+    expect(day7?.averageMinutesPerWeek).toBeCloseTo((minutes * 7) / day7Len, 8);
+    expect(day30?.averageMinutesPerWeek).toBeCloseTo((minutes * 7) / day30Len, 8);
+    expect(ytd?.averageMinutesPerWeek).toBeCloseTo((minutes * 7) / ytdLen, 8);
+    expect(month12?.averageMinutesPerWeek).toBeCloseTo((minutes * 7) / month12Len, 8);
+  });
+
+  it("excludes generic Other without distance from range totals", () => {
+    const todayDayKey = "2026-06-15";
+    const anchor = getActivityOverviewAnchorEndDay(todayDayKey);
+    const model = buildCardioHistorySummaryModel({
+      todayDayKey,
+      availableRangeStart: "2020-01-01",
+      availableRangeEnd: anchor,
+      cardioCalendarDays: [
+        {
+          day: anchor,
+          workouts: [
+            {
+              id: "noise",
+              observedAt: `${anchor}T10:00:00.000Z`,
+              sourceId: "apple_health",
+              title: "Other",
+              workoutType: "cardio" as const,
+              start: `${anchor}T10:00:00.000Z`,
+              end: `${anchor}T10:30:00.000Z`,
+              durationMinutes: 120,
+              calories: null,
+              activityName: "Other",
+            },
+            {
+              id: "run",
+              observedAt: `${anchor}T12:00:00.000Z`,
+              sourceId: "apple_health",
+              title: "Running",
+              workoutType: "cardio" as const,
+              start: `${anchor}T12:00:00.000Z`,
+              end: `${anchor}T12:20:00.000Z`,
+              durationMinutes: 20,
+              calories: null,
+              distanceMeters: 2 * 1609.344,
+              activityName: "Running",
+            },
+          ],
+        },
+      ],
+    });
+    const day7 = model.rows.find((r) => r.key === "day7");
+    expect(day7?.totalMinutes).toBe(20);
+    expect(day7?.totalMiles).toBeCloseTo(2, 5);
+  });
+
+  it("renders minutes-only display when range has duration but no distance", () => {
+    const model = buildCardioHistorySummaryModel({
+      todayDayKey: "2026-03-12",
+      availableRangeStart: "2025-03-01",
+      availableRangeEnd: "2026-03-12",
+      cardioCalendarDays: [
+        {
+          day: "2026-03-10",
+          workouts: [
+            {
+              id: "run-min-only",
+              observedAt: "2026-03-10T10:00:00.000Z",
+              sourceId: "apple_health",
+              title: "Running",
+              workoutType: "cardio" as const,
+              start: "2026-03-10T10:00:00.000Z",
+              end: "2026-03-10T10:45:00.000Z",
+              durationMinutes: 45,
+              calories: null,
+              activityName: "Running",
+            },
+          ],
+        },
+      ],
+    });
+    const day7 = model.rows.find((row) => row.key === "day7");
+    expect(day7?.displayValue).toBe("45 min/wk");
+  });
+});

--- a/lib/data/workouts/__tests__/cardioRangeMetrics.test.ts
+++ b/lib/data/workouts/__tests__/cardioRangeMetrics.test.ts
@@ -1,0 +1,82 @@
+import {
+  aggregateDisplayableCardioForCalendarDays,
+  aggregateDisplayableCardioForInclusiveDayRange,
+  averagePerWeekFromTotals,
+} from "../cardioRangeMetrics";
+import type { WorkoutCalendarDayLike } from "../workoutsCalendarModel";
+
+describe("averagePerWeekFromTotals", () => {
+  it("returns total * 7 / calendarDays for positive inputs", () => {
+    expect(averagePerWeekFromTotals(70, 7)).toBe(70);
+    expect(averagePerWeekFromTotals(300, 30)).toBeCloseTo(70, 10);
+    expect(averagePerWeekFromTotals(900, 90)).toBeCloseTo(70, 10);
+    expect(averagePerWeekFromTotals(100, 365)).toBeCloseTo((100 * 7) / 365, 10);
+  });
+
+  it("returns 0 for non-positive calendar span or non-finite total", () => {
+    expect(averagePerWeekFromTotals(10, 0)).toBe(0);
+    expect(averagePerWeekFromTotals(10, -1)).toBe(0);
+    expect(averagePerWeekFromTotals(Number.NaN, 7)).toBe(0);
+  });
+});
+
+function runningDay(day: string, id: string, miles: number, durationMinutes: number): WorkoutCalendarDayLike {
+  return {
+    day: day as `${string}-${string}-${string}`,
+    workouts: [
+      {
+        id,
+        observedAt: `${day}T10:00:00.000Z`,
+        sourceId: "apple_health",
+        title: "Running",
+        workoutType: "cardio",
+        start: `${day}T10:00:00.000Z`,
+        end: `${day}T10:30:00.000Z`,
+        durationMinutes,
+        calories: null,
+        distanceMeters: miles * 1609.344,
+        activityName: "Running",
+      },
+    ],
+  };
+}
+
+describe("aggregateDisplayableCardioForCalendarDays", () => {
+  it("excludes generic Other with no distance (duration-only)", () => {
+    const days: WorkoutCalendarDayLike[] = [
+      {
+        day: "2026-04-01",
+        workouts: [
+          {
+            id: "other-no-dist",
+            observedAt: "2026-04-01T10:00:00.000Z",
+            sourceId: "apple_health",
+            title: "Other",
+            workoutType: "cardio",
+            start: "2026-04-01T10:00:00.000Z",
+            end: "2026-04-01T10:30:00.000Z",
+            durationMinutes: 45,
+            calories: null,
+            activityName: "Other",
+          },
+        ],
+      },
+      runningDay("2026-04-01", "run", 2, 20),
+    ];
+    const t = aggregateDisplayableCardioForCalendarDays(days);
+    expect(t.sessionCount).toBe(1);
+    expect(t.totalMiles).toBeCloseTo(2, 5);
+    expect(t.totalMinutes).toBe(20);
+  });
+
+  it("sums inclusive range helper over calendar keys only", () => {
+    const days: WorkoutCalendarDayLike[] = [
+      runningDay("2026-04-01", "a", 1, 10),
+      runningDay("2026-04-03", "b", 2, 20),
+    ];
+    const t = aggregateDisplayableCardioForInclusiveDayRange(days, "2026-04-01", "2026-04-02");
+    expect(t.totalMiles).toBeCloseTo(1, 5);
+    expect(t.totalMinutes).toBe(10);
+    expect(t.sessionCount).toBe(1);
+  });
+});

--- a/lib/data/workouts/__tests__/cardioSessionPresentation.test.ts
+++ b/lib/data/workouts/__tests__/cardioSessionPresentation.test.ts
@@ -1,0 +1,232 @@
+import type { ReconciledWorkoutSession } from "@/lib/data/workouts/workoutSessionReconciliation";
+import {
+  cardioDistanceTierFromWeeklyMiles,
+  filterCardioHistoryRowsDedupeOverlappingOther,
+  formatCardioWeeklyDistanceAndMinutes,
+  formatCardioSessionHeadline,
+  formatCardioSessionSubtitle,
+  formatThisWeekCardioDistanceSummary,
+  getThisWeekCardioSessions,
+  isDisplayableCardioHistorySession,
+  sessionsHaveOverlappingTimeWindows,
+  sumDisplayableCardioDistanceMilesForWeekEntries,
+} from "@/lib/data/workouts/cardioSessionPresentation";
+
+function cardioSession(
+  id: string,
+  day: `${string}-${string}-${string}`,
+  opts: { title?: string; distanceMeters?: number; durationMinutes?: number; hkActivityId?: number },
+): ReconciledWorkoutSession {
+  return {
+    id,
+    day,
+    sessionType: "cardio",
+    title: opts.title ?? "Workout",
+    titleSource: "provider",
+    start: `${day}T10:00:00.000Z`,
+    end: `${day}T10:30:00.000Z`,
+    durationMinutes: opts.durationMinutes ?? null,
+    calories: null,
+    sourceSummaries: [],
+    sourceCount: 1,
+    workouts: [
+      {
+        id: `${id}-w`,
+        observedAt: `${day}T10:00:00.000Z`,
+        sourceId: "apple_health",
+        title: opts.title ?? "Workout",
+        workoutType: "cardio",
+        start: `${day}T10:00:00.000Z`,
+        end: `${day}T10:30:00.000Z`,
+        durationMinutes: opts.durationMinutes ?? null,
+        calories: null,
+        ...(opts.distanceMeters != null ? { distanceMeters: opts.distanceMeters } : {}),
+        ...(opts.hkActivityId != null
+          ? { hk: { sourceId: "healthkit", activityId: opts.hkActivityId } }
+          : {}),
+      },
+    ],
+  };
+}
+
+describe("cardioSessionPresentation", () => {
+  it("formats headline as distance and duration when both are present", () => {
+    expect(
+      formatCardioSessionHeadline({
+        distanceMeters: 3.08 * 1609.344,
+        durationMinutes: 31,
+      }),
+    ).toBe("3.08 mi / 31 min");
+  });
+
+  it("handles missing distance/duration fallbacks without undefined", () => {
+    expect(formatCardioSessionHeadline({ distanceMeters: null, durationMinutes: 31 })).toBe("31 min");
+    expect(formatCardioSessionHeadline({ distanceMeters: 3.08 * 1609.344, durationMinutes: null })).toBe("3.08 mi");
+    expect(formatCardioSessionHeadline({ distanceMeters: null, durationMinutes: null })).toBe("—");
+  });
+
+  it("formats cardio subtitle from type-like session naming", () => {
+    const session = cardioSession("s1", "2026-04-28", { title: "Walking", distanceMeters: 1609.344 });
+    expect(formatCardioSessionSubtitle(session)).toBe("Walking");
+  });
+
+  it("maps HK Walking activity id over misleading Other strings", () => {
+    const session = cardioSession("s1", "2026-04-28", {
+      title: "Other",
+      hkActivityId: 52,
+      distanceMeters: 4956,
+    });
+    expect(formatCardioSessionSubtitle(session)).toBe("Walking");
+  });
+
+  it("lists all this-week sessions Sun→Sat and excludes mixed + junk Other", () => {
+    const entries = [
+      { day: "2026-04-28" as const, session: cardioSession("a", "2026-04-28", { title: "Run" }) },
+      { day: "2026-04-26" as const, session: cardioSession("sun", "2026-04-26", { title: "Walking" }) },
+      {
+        day: "2026-04-27" as const,
+        session: { ...cardioSession("b", "2026-04-27", { title: "Walk" }), sessionType: "mixed" as const },
+      },
+      { day: "2026-04-29" as const, session: cardioSession("other", "2026-04-29", { title: "Other", hkActivityId: 3000 }) },
+      { day: "2026-04-30" as const, session: cardioSession("c", "2026-04-30", { title: "Cycle" }) },
+      { day: "2026-04-25" as const, session: cardioSession("d", "2026-04-25", { title: "Run" }) },
+    ];
+    const weekDays = [
+      "2026-04-26",
+      "2026-04-27",
+      "2026-04-28",
+      "2026-04-29",
+      "2026-04-30",
+      "2026-05-01",
+      "2026-05-02",
+    ] as const;
+    const out = getThisWeekCardioSessions(entries, weekDays);
+    expect(out).toHaveLength(3);
+    expect(out.map((e) => e.session.id)).toEqual(["sun", "a", "c"]);
+  });
+
+  it("Sun–Wed sessions appear in calendar order with no row cap", () => {
+    const entries = [
+      { day: "2026-04-26" as const, session: cardioSession("sun", "2026-04-26", { title: "Walking", distanceMeters: 1609 }) },
+      { day: "2026-04-27" as const, session: cardioSession("mon", "2026-04-27", { title: "Running", distanceMeters: 3218 }) },
+      { day: "2026-04-28" as const, session: cardioSession("tue", "2026-04-28", { title: "Walking", distanceMeters: 4956 }) },
+      { day: "2026-04-29" as const, session: cardioSession("wed", "2026-04-29", { title: "Walking", distanceMeters: 1609 }) },
+    ];
+    const weekDays = [
+      "2026-04-26",
+      "2026-04-27",
+      "2026-04-28",
+      "2026-04-29",
+      "2026-04-30",
+      "2026-05-01",
+      "2026-05-02",
+    ] as const;
+    const out = getThisWeekCardioSessions(entries, weekDays);
+    expect(out).toHaveLength(4);
+    expect(out.map((e) => e.session.id)).toEqual(["sun", "mon", "tue", "wed"]);
+  });
+
+  it("weekly mileage sum matches every displayable session in the slice (same set as This Week list)", () => {
+    const entries = [
+      { day: "2026-04-26" as const, session: cardioSession("sun", "2026-04-26", { title: "Walking", distanceMeters: 1609 }) },
+      { day: "2026-04-27" as const, session: cardioSession("mon", "2026-04-27", { title: "Running", distanceMeters: 1609 }) },
+      { day: "2026-04-28" as const, session: cardioSession("tue", "2026-04-28", { title: "Walking", distanceMeters: 1609 }) },
+      { day: "2026-04-29" as const, session: cardioSession("wed", "2026-04-29", { title: "Walking", distanceMeters: 1609 }) },
+    ];
+    const weekDays = [
+      "2026-04-26",
+      "2026-04-27",
+      "2026-04-28",
+      "2026-04-29",
+      "2026-04-30",
+      "2026-05-01",
+      "2026-05-02",
+    ] as const;
+    expect(sumDisplayableCardioDistanceMilesForWeekEntries(entries)).toBeCloseTo(4, 0);
+    const listed = getThisWeekCardioSessions(entries, weekDays);
+    expect(listed).toHaveLength(4);
+    expect(listed.map((e) => e.session.id)).toEqual(["sun", "mon", "tue", "wed"]);
+  });
+
+  it("isDisplayableCardioHistorySession hides generic Other without distance", () => {
+    const junk = cardioSession("j", "2026-04-29", { title: "Other", hkActivityId: 3000, durationMinutes: 39 });
+    expect(isDisplayableCardioHistorySession(junk)).toBe(false);
+    const ok = cardioSession("w", "2026-04-29", { title: "Walking", distanceMeters: 1609 });
+    expect(isDisplayableCardioHistorySession(ok)).toBe(true);
+  });
+
+  it("filterCardioHistoryRowsDedupeOverlappingOther removes overlapping duration-only Other when Walking has distance", () => {
+    const walk = cardioSession("walk", "2026-04-28", {
+      title: "Walking",
+      hkActivityId: 52,
+      distanceMeters: 4956,
+      durationMinutes: 31,
+    });
+    walk.start = "2026-04-28T14:00:00.000Z";
+    walk.end = "2026-04-28T14:31:00.000Z";
+    walk.workouts[0]!.start = walk.start;
+    walk.workouts[0]!.end = walk.end;
+
+    const otherDup = cardioSession("other", "2026-04-28", {
+      title: "Other",
+      hkActivityId: 3000,
+      durationMinutes: 39,
+    });
+    otherDup.start = "2026-04-28T14:00:00.000Z";
+    otherDup.end = "2026-04-28T14:39:00.000Z";
+    otherDup.workouts[0]!.start = otherDup.start;
+    otherDup.workouts[0]!.end = otherDup.end;
+
+    const rows = filterCardioHistoryRowsDedupeOverlappingOther([
+      { day: "2026-04-28", session: walk },
+      { day: "2026-04-28", session: otherDup },
+    ]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.session.id).toBe("walk");
+  });
+
+  it("sessionsHaveOverlappingTimeWindows detects same-window workouts", () => {
+    const a = cardioSession("a", "2026-04-28", { title: "Running", durationMinutes: 30 });
+    const b = cardioSession("b", "2026-04-28", { title: "Running", durationMinutes: 30 });
+    expect(sessionsHaveOverlappingTimeWindows(a, b)).toBe(true);
+  });
+
+  it("maps cardio tiers to requested weekly mileage boundaries", () => {
+    expect(cardioDistanceTierFromWeeklyMiles(2.4)).toBe("very_low");
+    expect(cardioDistanceTierFromWeeklyMiles(2.5)).toBe("low");
+    expect(cardioDistanceTierFromWeeklyMiles(7.5)).toBe("active");
+    expect(cardioDistanceTierFromWeeklyMiles(15)).toBe("high");
+    expect(cardioDistanceTierFromWeeklyMiles(25)).toBe("very_high");
+  });
+
+  it("formats this-week summary in miles", () => {
+    expect(formatThisWeekCardioDistanceSummary(5.84)).toBe("5.8 mi this week");
+  });
+
+  it("formats weekly distance and minutes with fallbacks", () => {
+    expect(
+      formatCardioWeeklyDistanceAndMinutes({
+        averageMilesPerWeek: 2.9,
+        averageMinutesPerWeek: 44.2,
+      }),
+    ).toBe("2.9 mi · 44 min/wk");
+    expect(
+      formatCardioWeeklyDistanceAndMinutes({
+        averageMilesPerWeek: null,
+        averageMinutesPerWeek: 44.2,
+      }),
+    ).toBe("44 min/wk");
+    expect(
+      formatCardioWeeklyDistanceAndMinutes({
+        averageMilesPerWeek: 2.9,
+        averageMinutesPerWeek: null,
+      }),
+    ).toBe("2.9 mi/wk");
+    expect(
+      formatCardioWeeklyDistanceAndMinutes({
+        averageMilesPerWeek: null,
+        averageMinutesPerWeek: null,
+      }),
+    ).toBe("—");
+  });
+});

--- a/lib/data/workouts/__tests__/strengthBaselineCardModel.test.ts
+++ b/lib/data/workouts/__tests__/strengthBaselineCardModel.test.ts
@@ -20,6 +20,25 @@ function strengthDay(day: string, id: string) {
   };
 }
 
+function strengthDayWithDuration(day: string, id: string, durationMinutes: number) {
+  return {
+    day: day as `${string}-${string}-${string}`,
+    workouts: [
+      {
+        id,
+        observedAt: `${day}T10:00:00.000Z`,
+        sourceId: "apple_health",
+        title: "Lift",
+        workoutType: "strength" as const,
+        start: `${day}T10:00:00.000Z`,
+        end: `${day}T10:30:00.000Z`,
+        durationMinutes,
+        calories: null,
+      },
+    ],
+  };
+}
+
 describe("buildStrengthBaselineCardModel", () => {
   const today = "2026-06-15" as const;
 
@@ -39,6 +58,8 @@ describe("buildStrengthBaselineCardModel", () => {
       todayDayKey: today,
     });
     expect(baselineYesterday.avgWorkoutsPerWeek).toBeCloseTo(7 / 90, 10);
+    expect(baselineYesterday.avgMinutesPerWeek).toBeCloseTo((30 * 7) / 90, 10);
+    expect(baselineYesterday.compactValuePrimary).toBe("0.1 wo · 2 min/wk");
 
     const regressionMerged = buildStrengthBaselineCardModel({
       strengthCalendarDays: [onlyYesterday, onlyToday],
@@ -73,5 +94,59 @@ describe("buildStrengthBaselineCardModel", () => {
 
     expect(oneToday.avgWorkoutsPerWeek).toBe(twoToday.avgWorkoutsPerWeek);
     expect(oneToday.avgWorkoutsPerWeek).toBeCloseTo(7 / 90, 10);
+    expect(oneToday.avgMinutesPerWeek).toBe(twoToday.avgMinutesPerWeek);
+  });
+
+  it("does not double count workout durations when session duration already exists", () => {
+    const day = "2026-06-14";
+    const model = buildStrengthBaselineCardModel({
+      strengthCalendarDays: [
+        {
+          day: day as `${string}-${string}-${string}`,
+          workouts: [
+            {
+              id: "s1",
+              observedAt: `${day}T10:00:00.000Z`,
+              sourceId: "apple_health",
+              title: "Lift",
+              workoutType: "strength" as const,
+              start: `${day}T10:00:00.000Z`,
+              end: `${day}T10:45:00.000Z`,
+              durationMinutes: 45,
+              calories: null,
+            },
+            {
+              id: "s2",
+              observedAt: `${day}T10:05:00.000Z`,
+              sourceId: "apple_health",
+              title: "Lift",
+              workoutType: "strength" as const,
+              start: `${day}T10:05:00.000Z`,
+              end: `${day}T10:40:00.000Z`,
+              durationMinutes: 35,
+              calories: null,
+            },
+          ],
+        },
+      ],
+      todayDayKey: today,
+    });
+    expect(model.totalMinutes90d).toBe(45);
+    expect(model.compactValuePrimary).toBe("0.1 wo · 4 min/wk");
+  });
+
+  it("computes baseline minutes/week as total90d divided by 90/7", () => {
+    const days = Array.from({ length: 30 }, (_, i) => {
+      const dayNum = i + 1;
+      const day = `2026-05-${String(dayNum).padStart(2, "0")}`;
+      return strengthDayWithDuration(day, `d-${i}`, 30);
+    });
+    const model = buildStrengthBaselineCardModel({
+      strengthCalendarDays: days,
+      todayDayKey: today,
+    });
+    expect(model.totalMinutes90d).toBe(900);
+    expect(model.avgMinutesPerWeek).toBeCloseTo(70, 10);
+    expect(model.compactValuePrimary).toContain("70 min/wk");
   });
 });

--- a/lib/data/workouts/__tests__/strengthHistorySummaryModel.test.ts
+++ b/lib/data/workouts/__tests__/strengthHistorySummaryModel.test.ts
@@ -1,0 +1,165 @@
+import { buildStrengthHistorySummaryModel } from "../strengthHistorySummaryModel";
+
+function strengthWorkout(day: string, id: string, durationMinutes: number) {
+  return {
+    day: day as `${string}-${string}-${string}`,
+    workouts: [
+      {
+        id,
+        observedAt: `${day}T10:00:00.000Z`,
+        sourceId: "apple_health",
+        title: "Lift",
+        workoutType: "strength" as const,
+        start: `${day}T10:00:00.000Z`,
+        end: `${day}T10:30:00.000Z`,
+        durationMinutes,
+        calories: null,
+      },
+    ],
+  };
+}
+
+function strengthWorkoutNoDuration(day: string, id: string) {
+  return {
+    day: day as `${string}-${string}-${string}`,
+    workouts: [
+      {
+        id,
+        observedAt: `${day}T10:00:00.000Z`,
+        sourceId: "apple_health",
+        title: "Lift",
+        workoutType: "strength" as const,
+        start: `${day}T10:00:00.000Z`,
+        end: `${day}T10:30:00.000Z`,
+        durationMinutes: null,
+        calories: null,
+      },
+    ],
+  };
+}
+
+describe("buildStrengthHistorySummaryModel", () => {
+  it("builds 7/30/YTD rows with sessions and minutes per week", () => {
+    const model = buildStrengthHistorySummaryModel({
+      todayDayKey: "2026-03-12",
+      availableRangeStart: "2025-12-01",
+      availableRangeEnd: "2026-03-12",
+      strengthCalendarDays: [
+        strengthWorkout("2026-03-10", "a", 40),
+        strengthWorkout("2026-03-11", "b", 30),
+      ],
+    });
+    const day7 = model.rows.find((row) => row.key === "day7");
+    expect(day7?.hasEnoughData).toBe(true);
+    expect(day7?.displayValue).toContain("wo ·");
+    expect(day7?.displayValue).toContain("min/wk");
+    expect(day7?.totalSessions).toBe(2);
+    expect(day7?.totalMinutes).toBe(70);
+  });
+
+  it("computes 30 day minutes/week correctly", () => {
+    const model = buildStrengthHistorySummaryModel({
+      todayDayKey: "2026-03-12",
+      availableRangeStart: "2025-01-01",
+      availableRangeEnd: "2026-03-12",
+      strengthCalendarDays: [
+        strengthWorkout("2026-03-10", "a", 60),
+        strengthWorkout("2026-03-11", "b", 30),
+      ],
+    });
+    const day30 = model.rows.find((row) => row.key === "day30");
+    expect(day30?.averageMinutesPerWeek).toBeCloseTo((90 * 7) / 30, 10);
+    expect(day30?.displayValue).toBe("0.5 wo · 21 min/wk");
+  });
+
+  it("does not double count merged session durations", () => {
+    const model = buildStrengthHistorySummaryModel({
+      todayDayKey: "2026-03-12",
+      availableRangeStart: "2025-01-01",
+      availableRangeEnd: "2026-03-12",
+      strengthCalendarDays: [
+        {
+          day: "2026-03-10",
+          workouts: [
+            {
+              id: "x1",
+              observedAt: "2026-03-10T10:00:00.000Z",
+              sourceId: "apple_health",
+              title: "Lift",
+              workoutType: "strength" as const,
+              start: "2026-03-10T10:00:00.000Z",
+              end: "2026-03-10T10:45:00.000Z",
+              durationMinutes: 45,
+              calories: null,
+            },
+            {
+              id: "x2",
+              observedAt: "2026-03-10T10:05:00.000Z",
+              sourceId: "apple_health",
+              title: "Lift",
+              workoutType: "strength" as const,
+              start: "2026-03-10T10:05:00.000Z",
+              end: "2026-03-10T10:40:00.000Z",
+              durationMinutes: 35,
+              calories: null,
+            },
+          ],
+        },
+      ],
+    });
+    const day7 = model.rows.find((row) => row.key === "day7");
+    expect(day7?.totalMinutes).toBe(45);
+  });
+
+  it("falls back safely when durations are missing", () => {
+    const model = buildStrengthHistorySummaryModel({
+      todayDayKey: "2026-03-12",
+      availableRangeStart: "2025-01-01",
+      availableRangeEnd: "2026-03-12",
+      strengthCalendarDays: [strengthWorkoutNoDuration("2026-03-10", "n1")],
+    });
+    const day7 = model.rows.find((row) => row.key === "day7");
+    expect(day7?.displayValue).toBe("1.0 wo/wk");
+  });
+
+  it("computes YTD minutes/week from elapsed YTD days", () => {
+    const ytdDays = [
+      "2026-01-05",
+      "2026-01-15",
+      "2026-01-25",
+      "2026-02-05",
+      "2026-02-15",
+      "2026-02-25",
+      "2026-03-05",
+      "2026-03-15",
+      "2026-03-25",
+      "2026-04-05",
+    ];
+    const model = buildStrengthHistorySummaryModel({
+      todayDayKey: "2026-05-01",
+      availableRangeStart: "2025-01-01",
+      availableRangeEnd: "2026-05-01",
+      strengthCalendarDays: ytdDays.map((day, idx) => strengthWorkout(day, `ytd-${idx}`, 120)),
+    });
+    const ytd = model.rows.find((row) => row.key === "ytd");
+    expect(ytd?.totalMinutes).toBe(1200);
+    expect(ytd?.averageMinutesPerWeek).toBeCloseTo(70, 10);
+    expect(ytd?.displayValue).toContain("70 min/wk");
+  });
+
+  it("marks 12 month as insufficient when hydrated range is short", () => {
+    const model = buildStrengthHistorySummaryModel({
+      todayDayKey: "2026-03-12",
+      availableRangeStart: "2026-01-01",
+      availableRangeEnd: "2026-03-12",
+      strengthCalendarDays: [strengthWorkout("2026-03-10", "a", 40)],
+    });
+    const month12 = model.rows.find((row) => row.key === "month12");
+    expect(month12).toMatchObject({
+      hasEnoughData: false,
+      displayValue: "—",
+      helperText: "Data will appear when enough history is available",
+      progressFill01: null,
+    });
+  });
+});

--- a/lib/data/workouts/__tests__/workoutMarkerFlags.test.ts
+++ b/lib/data/workouts/__tests__/workoutMarkerFlags.test.ts
@@ -44,6 +44,24 @@ describe("deriveWorkoutMarkerFlags", () => {
     ).toBe("cardio");
   });
 
+  it("classifies Indoor Walk compact token as cardio", () => {
+    expect(
+      classifyWorkoutType({
+        rawKind: "workout",
+        sport: "Indoor Walk",
+      }),
+    ).toBe("cardio");
+  });
+
+  it("classifies Outdoor Run compact token as cardio", () => {
+    expect(
+      classifyWorkoutType({
+        rawKind: "workout",
+        sport: "Outdoor Run",
+      }),
+    ).toBe("cardio");
+  });
+
   it("marks strength-only days", () => {
     expect(deriveWorkoutMarkerFlags([workout({ workoutType: "strength" })])).toEqual({
       hasStrength: true,

--- a/lib/data/workouts/__tests__/workoutSessionSurface.test.ts
+++ b/lib/data/workouts/__tests__/workoutSessionSurface.test.ts
@@ -259,8 +259,45 @@ describe("workoutSessionSurface", () => {
       }),
     ];
     const [session] = reconcileWorkoutSessionsForDay(day, workouts);
-    const m = pickMetricsWorkoutForSession(session!);
+    const m = pickMetricsWorkoutForSession(session!, "strength");
     expect(m?.id).toBe("apple1");
+  });
+
+  it("pickMetricsWorkoutForSession for cardio prefers distance-bearing Apple row over companion Other", () => {
+    const day = "2026-04-28";
+    const workouts = [
+      item({
+        id: "otherDup",
+        sourceId: "apple_health",
+        provider: "apple_health",
+        title: "Other",
+        sport: "Other",
+        start: "2026-04-28T14:00:00.000Z",
+        end: "2026-04-28T14:39:00.000Z",
+        durationMinutes: 39,
+        workoutType: "cardio",
+        rawKind: "workout",
+        hk: { sourceId: "com.apple.health", activityId: 3000 },
+      }),
+      item({
+        id: "walkMain",
+        sourceId: "apple_health",
+        provider: "apple_health",
+        title: "Walking",
+        sport: "Walking",
+        start: "2026-04-28T14:00:05.000Z",
+        end: "2026-04-28T14:31:00.000Z",
+        durationMinutes: 31,
+        workoutType: "cardio",
+        rawKind: "workout",
+        distanceMeters: 5000,
+        hk: { sourceId: "com.apple.health", activityId: 52 },
+      }),
+    ];
+    const [session] = reconcileWorkoutSessionsForDay(day, workouts);
+    expect(session?.workouts).toHaveLength(2);
+    const m = pickMetricsWorkoutForSession(session!, "cardio");
+    expect(m?.id).toBe("walkMain");
   });
 
   it("pickJournalSummaryForStrengthSession picks journal closest to manual raw anchor when two share a day", () => {

--- a/lib/data/workouts/__tests__/workoutsCalendarModel.test.ts
+++ b/lib/data/workouts/__tests__/workoutsCalendarModel.test.ts
@@ -8,6 +8,7 @@ import {
   deriveOverviewTabSessionCounts,
   getRecentWorkoutsFromCalendarDays,
   getRecentWorkoutSessionsFromCalendarDays,
+  getCardioOverviewTabSessionsForCalendarDaysNewestFirst,
   getStrengthOverviewTabSessionsForCalendarDaysAscending,
   sortWorkoutsChronologicalAsc,
   WORKOUT_OVERVIEW_ANALYTICS_RANGE_END,
@@ -182,6 +183,29 @@ describe("workoutsCalendarModel", () => {
     ]);
     expect(monthly).toHaveLength(1);
     expect(monthly[0]?.workouts).toBe(1);
+  });
+
+  it("cardio overview week list is not truncated by getRecentWorkoutSessions global cap", () => {
+    const mk = (id: string, day: string): WorkoutHistoryItem => ({
+      id,
+      observedAt: `${day}T10:00:00.000Z`,
+      sourceId: "apple_health",
+      title: "Running",
+      workoutType: "cardio",
+      rawKind: "workout",
+      start: `${day}T10:00:00.000Z`,
+      end: null,
+      durationMinutes: 30,
+      calories: null,
+    });
+    const days = Array.from({ length: 15 }, (_, i) => {
+      const day = `2026-04-${String(10 + i).padStart(2, "0")}`;
+      return { day: day as `${string}-${string}-${string}`, workouts: [mk(`w${i}`, day)] };
+    });
+    const cardioAll = getCardioOverviewTabSessionsForCalendarDaysNewestFirst(days);
+    const recentLimited = getRecentWorkoutSessionsFromCalendarDays(days, 14);
+    expect(cardioAll.length).toBe(15);
+    expect(recentLimited.length).toBe(14);
   });
 
   it("monthly analytics and recent sessions use the same reconciled session count from shared days", () => {

--- a/lib/data/workouts/appleHealthKitWorkoutActivityType.ts
+++ b/lib/data/workouts/appleHealthKitWorkoutActivityType.ts
@@ -1,0 +1,112 @@
+import { formatWorkoutTitle } from "@/lib/data/workouts/workoutDisplay";
+
+/**
+ * Apple `HKWorkoutActivityType` raw values (HealthKit). Source: Apple HealthKit enum (mirrored in
+ * .NET docs). Used when ingest carries `hk.activityId` but the string name is missing or wrong
+ * (e.g. react-native-health maps unknown enum cases to `"Other"`).
+ *
+ * @see https://learn.microsoft.com/en-us/dotnet/api/healthkit.hkworkoutactivitytype
+ */
+export const HK_WORKOUT_ACTIVITY_TYPE_OTHER = 3000;
+
+/** PascalCase names match Apple's enum identifiers for {@link formatWorkoutTitle}. */
+const HK_WORKOUT_ACTIVITY_ID_TO_ENUM_NAME: Record<number, string> = {
+  1: "AmericanFootball",
+  2: "Archery",
+  3: "AustralianFootball",
+  4: "Badminton",
+  5: "Baseball",
+  6: "Basketball",
+  7: "Bowling",
+  8: "Boxing",
+  9: "Climbing",
+  10: "Cricket",
+  11: "CrossTraining",
+  12: "Curling",
+  13: "Cycling",
+  14: "Dance",
+  15: "DanceInspiredTraining",
+  16: "Elliptical",
+  17: "EquestrianSports",
+  18: "Fencing",
+  19: "Fishing",
+  20: "FunctionalStrengthTraining",
+  21: "Golf",
+  22: "Gymnastics",
+  23: "Handball",
+  24: "Hiking",
+  25: "Hockey",
+  26: "Hunting",
+  27: "Lacrosse",
+  28: "MartialArts",
+  29: "MindAndBody",
+  30: "MixedMetabolicCardioTraining",
+  31: "PaddleSports",
+  32: "Play",
+  33: "PreparationAndRecovery",
+  34: "Racquetball",
+  35: "Rowing",
+  36: "Rugby",
+  37: "Running",
+  38: "Sailing",
+  39: "SkatingSports",
+  40: "SnowSports",
+  41: "Soccer",
+  42: "Softball",
+  43: "Squash",
+  44: "StairClimbing",
+  45: "SurfingSports",
+  46: "Swimming",
+  47: "TableTennis",
+  48: "Tennis",
+  49: "TrackAndField",
+  50: "TraditionalStrengthTraining",
+  51: "Volleyball",
+  52: "Walking",
+  53: "WaterFitness",
+  54: "WaterPolo",
+  55: "WaterSports",
+  56: "Wrestling",
+  57: "Yoga",
+  58: "Barre",
+  59: "CoreTraining",
+  60: "CrossCountrySkiing",
+  61: "DownhillSkiing",
+  62: "Flexibility",
+  63: "HighIntensityIntervalTraining",
+  64: "JumpRope",
+  65: "Kickboxing",
+  66: "Pilates",
+  67: "Snowboarding",
+  68: "Stairs",
+  69: "StepTraining",
+  70: "WheelchairWalkPace",
+  71: "WheelchairRunPace",
+  72: "TaiChi",
+  73: "MixedCardio",
+  74: "HandCycling",
+  75: "DiscSports",
+  76: "FitnessGaming",
+  77: "CardioDance",
+  78: "SocialDance",
+  79: "Pickleball",
+  80: "Cooldown",
+  82: "SwimBikeRun",
+  83: "Transition",
+  84: "UnderwaterDiving",
+};
+
+/**
+ * User-facing workout modality label from HealthKit activity type id, or `null` if unknown / generic.
+ * Does not return a label for {@link HK_WORKOUT_ACTIVITY_TYPE_OTHER} so callers fall back to strings on the row.
+ */
+export function displayLabelForAppleHealthKitWorkoutActivityType(
+  activityId: number | null | undefined,
+): string | null {
+  if (activityId == null || !Number.isFinite(activityId)) return null;
+  const id = Math.trunc(activityId);
+  if (id === HK_WORKOUT_ACTIVITY_TYPE_OTHER) return null;
+  const pascal = HK_WORKOUT_ACTIVITY_ID_TO_ENUM_NAME[id];
+  if (!pascal) return null;
+  return formatWorkoutTitle(pascal);
+}

--- a/lib/data/workouts/cardioBaselineCardModel.ts
+++ b/lib/data/workouts/cardioBaselineCardModel.ts
@@ -1,0 +1,98 @@
+import {
+  ACTIVITY_BASELINE_TRAILING_DAY_COUNT,
+  activityTrailingNDaysInclusive,
+  getActivityOverviewAnchorEndDay,
+} from "@/lib/data/activity/activityOverviewRanges";
+import {
+  aggregateDisplayableCardioForCalendarDays,
+  averagePerWeekFromTotals,
+} from "@/lib/data/workouts/cardioRangeMetrics";
+import { filterWorkoutCalendarDaysInclusive } from "@/lib/data/workouts/overviewCalendarRangeSlices";
+import { formatCardioWeeklyDistanceAndMinutes } from "@/lib/data/workouts/cardioSessionPresentation";
+import type { WorkoutCalendarDayLike } from "@/lib/data/workouts/workoutsCalendarModel";
+import type { DayKey } from "@/lib/ui/calendar/types";
+
+const CARDIO_BASELINE_MAX_PROGRESS_MILES_PER_WEEK = 25;
+
+export type CardioBaselineTier = "very_low" | "low" | "active" | "high" | "very_high";
+
+export type CardioBaselineCardModelReady = {
+  kind: "ready";
+  averageMilesPerWeek90d: number;
+  totalMiles90d: number;
+  sessions90d: number;
+  totalMinutes90d: number;
+  averageMinutesPerWeek90d: number;
+  tier: CardioBaselineTier;
+  formattedAverageMilesPerWeek: string;
+  formattedAverageMinutesPerWeek: string;
+  headlineLabel: string;
+  /** 0..25+ display scale value (capped at 25 for progress fill). */
+  progressMilesPerWeekScaleValue: number;
+};
+
+export type CardioBaselineCardModel =
+  | { kind: "insufficient_data" }
+  | CardioBaselineCardModelReady;
+
+function cardioTierFromMilesPerWeek(avgMilesPerWeek: number): CardioBaselineTier {
+  if (avgMilesPerWeek <= 2.4) return "very_low";
+  if (avgMilesPerWeek <= 7.4) return "low";
+  if (avgMilesPerWeek <= 14.9) return "active";
+  if (avgMilesPerWeek <= 24.9) return "high";
+  return "very_high";
+}
+
+function formatMilesPerWeek(avgMilesPerWeek: number): string {
+  return `${avgMilesPerWeek.toFixed(1)} mi/wk`;
+}
+
+function formatMinutesPerWeek(avgMinutesPerWeek: number): string {
+  return `${Math.round(avgMinutesPerWeek)} min/wk`;
+}
+
+/**
+ * Cardio Baseline: average cardio miles/week over the trailing 90 completed local days
+ * ending on local yesterday (today excluded by construction).
+ */
+export function buildCardioBaselineCardModel(input: {
+  cardioCalendarDays: readonly WorkoutCalendarDayLike[];
+  todayDayKey: DayKey;
+}): CardioBaselineCardModel {
+  const anchorEnd = getActivityOverviewAnchorEndDay(input.todayDayKey);
+  const windowKeys = activityTrailingNDaysInclusive(anchorEnd, ACTIVITY_BASELINE_TRAILING_DAY_COUNT);
+  const windowStart = windowKeys[0]!;
+  const sortedDays = [...input.cardioCalendarDays].sort((a, b) => (a.day < b.day ? -1 : a.day > b.day ? 1 : 0));
+  const slice = filterWorkoutCalendarDaysInclusive(sortedDays, windowStart, anchorEnd);
+
+  const totals = aggregateDisplayableCardioForCalendarDays(slice);
+  const totalMiles90d = totals.totalMiles;
+  const totalMinutes90d = totals.totalMinutes;
+  const sessions90d = totals.sessionCount;
+  const averageMilesPerWeek90d = averagePerWeekFromTotals(totalMiles90d, ACTIVITY_BASELINE_TRAILING_DAY_COUNT);
+  const averageMinutesPerWeek90d = averagePerWeekFromTotals(totalMinutes90d, ACTIVITY_BASELINE_TRAILING_DAY_COUNT);
+
+  if (sessions90d <= 0 || (totalMiles90d <= 0 && totalMinutes90d <= 0)) {
+    return { kind: "insufficient_data" };
+  }
+
+  return {
+    kind: "ready",
+    averageMilesPerWeek90d,
+    totalMiles90d,
+    sessions90d,
+    totalMinutes90d,
+    averageMinutesPerWeek90d,
+    tier: cardioTierFromMilesPerWeek(averageMilesPerWeek90d),
+    formattedAverageMilesPerWeek: formatMilesPerWeek(averageMilesPerWeek90d),
+    formattedAverageMinutesPerWeek: formatMinutesPerWeek(averageMinutesPerWeek90d),
+    headlineLabel: formatCardioWeeklyDistanceAndMinutes({
+      averageMilesPerWeek: averageMilesPerWeek90d,
+      averageMinutesPerWeek: averageMinutesPerWeek90d,
+    }),
+    progressMilesPerWeekScaleValue: Math.min(
+      CARDIO_BASELINE_MAX_PROGRESS_MILES_PER_WEEK,
+      Math.max(0, averageMilesPerWeek90d),
+    ),
+  };
+}

--- a/lib/data/workouts/cardioHistorySummaryModel.ts
+++ b/lib/data/workouts/cardioHistorySummaryModel.ts
@@ -1,0 +1,169 @@
+import { activityTrailingNDaysInclusive, getActivityOverviewAnchorEndDay } from "@/lib/data/activity/activityOverviewRanges";
+import {
+  aggregateDisplayableCardioForInclusiveDayRange,
+  averagePerWeekFromTotals,
+} from "@/lib/data/workouts/cardioRangeMetrics";
+import {
+  cardioDistanceTierFromWeeklyMiles,
+  cardioDistanceTierLabel,
+  cardioDistanceTierIndexForBar,
+} from "@/lib/data/workouts/cardioSessionPresentation";
+import type { WorkoutCalendarDayLike } from "@/lib/data/workouts/workoutsCalendarModel";
+import { cardioBaselineMilesToVisualScale01 } from "@/lib/ui/workouts/cardioBaselineScale";
+import type { DayKey } from "@/lib/ui/calendar/types";
+import { enumerateDaysInclusive } from "@/lib/ui/calendar/dateUtils";
+
+export type CardioHistoryRangeKey = "day7" | "day30" | "ytd" | "month12";
+
+export type CardioHistorySummaryRow = {
+  key: CardioHistoryRangeKey;
+  label: "7 Day" | "30 Day" | "YTD" | "12 Month";
+  hasEnoughData: boolean;
+  totalMiles: number | null;
+  averageMilesPerWeek: number | null;
+  totalMinutes: number | null;
+  averageMinutesPerWeek: number | null;
+  displayValue: string;
+  tierLabel: string | null;
+  tierIndexForBar: number | null;
+  progressFill01: number | null;
+  helperText?: string;
+};
+
+export type CardioHistorySummaryModel = {
+  rows: readonly CardioHistorySummaryRow[];
+};
+
+function ytdStartFor(anchorEndDay: DayKey): DayKey {
+  return `${anchorEndDay.slice(0, 4)}-01-01` as DayKey;
+}
+
+function formatHistoryDisplayValue(input: {
+  averageMilesPerWeek: number;
+  averageMinutesPerWeek: number;
+}): string {
+  const miles =
+    Number.isFinite(input.averageMilesPerWeek) && input.averageMilesPerWeek > 0
+      ? `${input.averageMilesPerWeek.toFixed(1)} mi`
+      : null;
+  const minutes =
+    Number.isFinite(input.averageMinutesPerWeek) && input.averageMinutesPerWeek > 0
+      ? `${Math.round(input.averageMinutesPerWeek)} min/wk`
+      : null;
+  if (miles && minutes) return `${miles} · ${minutes}`;
+  if (miles) return `${miles}/wk`;
+  if (minutes) return minutes;
+  return "—";
+}
+
+function buildRow(args: {
+  key: CardioHistoryRangeKey;
+  label: CardioHistorySummaryRow["label"];
+  rangeStart: DayKey;
+  rangeEnd: DayKey;
+  availableStart: DayKey;
+  availableEnd: DayKey;
+  cardioCalendarDays: readonly WorkoutCalendarDayLike[];
+}): CardioHistorySummaryRow {
+  const covered = args.rangeStart >= args.availableStart && args.rangeEnd <= args.availableEnd;
+  if (!covered) {
+    return {
+      key: args.key,
+      label: args.label,
+      hasEnoughData: false,
+      totalMiles: null,
+      averageMilesPerWeek: null,
+      totalMinutes: null,
+      averageMinutesPerWeek: null,
+      displayValue: "—",
+      tierLabel: null,
+      tierIndexForBar: null,
+      progressFill01: null,
+      ...(args.key === "month12"
+        ? { helperText: "Data will appear when enough history is available" }
+        : {}),
+    };
+  }
+
+  const daysInRange = enumerateDaysInclusive(args.rangeStart, args.rangeEnd);
+  const totals = aggregateDisplayableCardioForInclusiveDayRange(
+    args.cardioCalendarDays,
+    args.rangeStart,
+    args.rangeEnd,
+  );
+  const { totalMiles, totalMinutes } = totals;
+  const dayCount = daysInRange.length;
+  const weeklyMiles = averagePerWeekFromTotals(totalMiles, dayCount);
+  const weeklyMinutes = averagePerWeekFromTotals(totalMinutes, dayCount);
+  const tier = cardioDistanceTierFromWeeklyMiles(weeklyMiles);
+  return {
+    key: args.key,
+    label: args.label,
+    hasEnoughData: true,
+    totalMiles,
+    averageMilesPerWeek: weeklyMiles,
+    totalMinutes,
+    averageMinutesPerWeek: weeklyMinutes,
+    displayValue: formatHistoryDisplayValue({
+      averageMilesPerWeek: weeklyMiles,
+      averageMinutesPerWeek: weeklyMinutes,
+    }),
+    tierLabel: cardioDistanceTierLabel(tier),
+    tierIndexForBar: cardioDistanceTierIndexForBar(tier),
+    progressFill01: cardioBaselineMilesToVisualScale01(weeklyMiles),
+  };
+}
+
+export function buildCardioHistorySummaryModel(input: {
+  cardioCalendarDays: readonly WorkoutCalendarDayLike[];
+  todayDayKey: DayKey;
+  availableRangeStart: DayKey;
+  availableRangeEnd: DayKey;
+}): CardioHistorySummaryModel {
+  const anchorEnd = getActivityOverviewAnchorEndDay(input.todayDayKey);
+  const day7 = activityTrailingNDaysInclusive(anchorEnd, 7);
+  const day30 = activityTrailingNDaysInclusive(anchorEnd, 30);
+  const day365 = activityTrailingNDaysInclusive(anchorEnd, 365);
+  const ytdStart = ytdStartFor(anchorEnd);
+
+  const rows: CardioHistorySummaryRow[] = [
+    buildRow({
+      key: "day7",
+      label: "7 Day",
+      rangeStart: day7[0]!,
+      rangeEnd: anchorEnd,
+      availableStart: input.availableRangeStart,
+      availableEnd: input.availableRangeEnd,
+      cardioCalendarDays: input.cardioCalendarDays,
+    }),
+    buildRow({
+      key: "day30",
+      label: "30 Day",
+      rangeStart: day30[0]!,
+      rangeEnd: anchorEnd,
+      availableStart: input.availableRangeStart,
+      availableEnd: input.availableRangeEnd,
+      cardioCalendarDays: input.cardioCalendarDays,
+    }),
+    buildRow({
+      key: "ytd",
+      label: "YTD",
+      rangeStart: ytdStart,
+      rangeEnd: anchorEnd,
+      availableStart: input.availableRangeStart,
+      availableEnd: input.availableRangeEnd,
+      cardioCalendarDays: input.cardioCalendarDays,
+    }),
+    buildRow({
+      key: "month12",
+      label: "12 Month",
+      rangeStart: day365[0]!,
+      rangeEnd: anchorEnd,
+      availableStart: input.availableRangeStart,
+      availableEnd: input.availableRangeEnd,
+      cardioCalendarDays: input.cardioCalendarDays,
+    }),
+  ];
+
+  return { rows };
+}

--- a/lib/data/workouts/cardioRangeMetrics.ts
+++ b/lib/data/workouts/cardioRangeMetrics.ts
@@ -1,0 +1,67 @@
+import {
+  cardioSessionDistanceMiles,
+  isDisplayableCardioHistorySession,
+  isSupportedCardioSessionModality,
+} from "@/lib/data/workouts/cardioSessionPresentation";
+import type { WorkoutCalendarDayLike } from "@/lib/data/workouts/workoutsCalendarModel";
+import { reconcileWorkoutSessionsForDay } from "@/lib/data/workouts/workoutSessionReconciliation";
+import type { DayKey } from "@/lib/ui/calendar/types";
+import { enumerateDaysInclusive } from "@/lib/ui/calendar/dateUtils";
+
+export type CardioRangeTotals = {
+  totalMiles: number;
+  totalMinutes: number;
+  sessionCount: number;
+};
+
+/**
+ * Sums distance and duration for **displayable + modality-supported** cardio sessions on the given calendar days
+ * (same rules as Cardio Full History / This Week).
+ */
+export function aggregateDisplayableCardioForCalendarDays(
+  days: readonly WorkoutCalendarDayLike[],
+): CardioRangeTotals {
+  let totalMiles = 0;
+  let totalMinutes = 0;
+  let sessionCount = 0;
+  for (const day of days) {
+    const sessions = reconcileWorkoutSessionsForDay(day.day, day.workouts);
+    for (const session of sessions) {
+      if (session.sessionType !== "cardio") continue;
+      if (!isDisplayableCardioHistorySession(session)) continue;
+      if (!isSupportedCardioSessionModality(session)) continue;
+      sessionCount += 1;
+      totalMiles += cardioSessionDistanceMiles(session) ?? 0;
+      if (
+        typeof session.durationMinutes === "number" &&
+        Number.isFinite(session.durationMinutes) &&
+        session.durationMinutes > 0
+      ) {
+        totalMinutes += session.durationMinutes;
+      }
+    }
+  }
+  return { totalMiles, totalMinutes, sessionCount };
+}
+
+/**
+ * Totals for every calendar day in `[rangeStart, rangeEnd]` that appear in `cardioCalendarDays`.
+ */
+export function aggregateDisplayableCardioForInclusiveDayRange(
+  cardioCalendarDays: readonly WorkoutCalendarDayLike[],
+  rangeStart: DayKey,
+  rangeEnd: DayKey,
+): CardioRangeTotals {
+  const daySet = new Set(enumerateDaysInclusive(rangeStart, rangeEnd));
+  const slice = cardioCalendarDays.filter((d) => daySet.has(d.day));
+  return aggregateDisplayableCardioForCalendarDays(slice);
+}
+
+/**
+ * Canonical “per week” rate over a calendar span: `total × 7 / calendarDaysInRange`
+ * (same for miles and minutes). Used for 7 Day, 30 Day, YTD, 12 Month, and 90 Day baseline.
+ */
+export function averagePerWeekFromTotals(total: number, calendarDaysInRange: number): number {
+  if (calendarDaysInRange <= 0 || !Number.isFinite(total)) return 0;
+  return (total * 7) / calendarDaysInRange;
+}

--- a/lib/data/workouts/cardioSessionPresentation.ts
+++ b/lib/data/workouts/cardioSessionPresentation.ts
@@ -1,0 +1,312 @@
+import type { WorkoutHistoryItem } from "@/lib/data/workouts/parseWorkoutFromRawEvent";
+import type { RecentWorkoutSessionEntry } from "@/lib/data/workouts/workoutsCalendarModel";
+import { displayLabelForAppleHealthKitWorkoutActivityType } from "@/lib/data/workouts/appleHealthKitWorkoutActivityType";
+import { formatWorkoutDurationLabel, formatWorkoutTitle } from "@/lib/data/workouts/workoutDisplay";
+import type { ReconciledWorkoutSession } from "@/lib/data/workouts/workoutSessionReconciliation";
+import type { DayKey } from "@/lib/ui/calendar/types";
+
+const METERS_PER_MILE = 1609.344;
+const CARDIO_MILES_WEEK_SCALE_MAX = 25;
+
+export type CardioDistanceTier = "very_low" | "low" | "active" | "high" | "very_high";
+
+export function cardioDistanceTierFromWeeklyMiles(weeklyMiles: number): CardioDistanceTier {
+  if (weeklyMiles <= 2.4) return "very_low";
+  if (weeklyMiles <= 7.4) return "low";
+  if (weeklyMiles <= 14.9) return "active";
+  if (weeklyMiles <= 24.9) return "high";
+  return "very_high";
+}
+
+export function cardioDistanceTierLabel(tier: CardioDistanceTier): string {
+  if (tier === "very_low") return "Very Low";
+  if (tier === "very_high") return "Very High";
+  if (tier === "low") return "Low";
+  if (tier === "active") return "Active";
+  return "High";
+}
+
+export function cardioDistanceTierIndexForBar(tier: CardioDistanceTier): number {
+  if (tier === "very_low") return 0;
+  if (tier === "low") return 1;
+  if (tier === "active") return 2;
+  if (tier === "high") return 3;
+  return 4;
+}
+
+export function cardioWeeklyMilesScaleFill01(weeklyMiles: number): number {
+  if (!Number.isFinite(weeklyMiles)) return 0;
+  return Math.min(1, Math.max(0, weeklyMiles / CARDIO_MILES_WEEK_SCALE_MAX));
+}
+
+export function cardioSessionDistanceMeters(session: ReconciledWorkoutSession): number | null {
+  let total = 0;
+  let hasValue = false;
+  for (const workout of session.workouts) {
+    if (
+      typeof workout.distanceMeters === "number" &&
+      Number.isFinite(workout.distanceMeters) &&
+      workout.distanceMeters > 0
+    ) {
+      total += workout.distanceMeters;
+      hasValue = true;
+    }
+  }
+  return hasValue ? total : null;
+}
+
+export function cardioSessionDistanceMiles(session: ReconciledWorkoutSession): number | null {
+  const meters = cardioSessionDistanceMeters(session);
+  if (meters == null) return null;
+  return meters / METERS_PER_MILE;
+}
+
+export function formatCardioSessionHeadline(input: {
+  distanceMeters?: number | null;
+  durationMinutes?: number | null;
+}): string {
+  const parts: string[] = [];
+  if (
+    typeof input.distanceMeters === "number" &&
+    Number.isFinite(input.distanceMeters) &&
+    input.distanceMeters > 0
+  ) {
+    parts.push(`${(input.distanceMeters / METERS_PER_MILE).toFixed(2)} mi`);
+  }
+  const duration = formatWorkoutDurationLabel(input.durationMinutes ?? null);
+  if (duration !== "—") {
+    parts.push(duration);
+  }
+  if (parts.length === 0) return "—";
+  return parts.join(" / ");
+}
+
+function stringLabelScore(label: string): number {
+  const n = label.trim().toLowerCase();
+  if (n.length === 0 || n === "workout" || n === "cardio") return 0;
+  if (n === "other" || n === "unknown" || n === "uncategorized") return 2;
+  return 40;
+}
+
+function workoutSubtitleCandidates(workout: WorkoutHistoryItem): { label: string; score: number }[] {
+  const out: { label: string; score: number }[] = [];
+  const hkLabel = displayLabelForAppleHealthKitWorkoutActivityType(workout.hk?.activityId ?? null);
+  if (hkLabel) {
+    out.push({ label: hkLabel, score: 120 });
+  }
+  const raw = workout.activityName ?? workout.sport ?? workout.title;
+  const fromStrings = formatWorkoutTitle(raw);
+  if (fromStrings !== "Workout") {
+    let score = stringLabelScore(fromStrings);
+    if (typeof workout.distanceMeters === "number" && workout.distanceMeters > 0) score += 25;
+    out.push({ label: fromStrings, score });
+  }
+  return out;
+}
+
+/**
+ * Picks the best modality label across merged raw rows (e.g. duplicate HK samples): prefers
+ * {@link displayLabelForAppleHealthKitWorkoutActivityType}, then non-generic strings, favoring rows with distance.
+ */
+function pickSessionTypeLikeLabel(session: ReconciledWorkoutSession): string {
+  let best = "";
+  let bestScore = -1;
+  for (const workout of session.workouts) {
+    for (const { label, score } of workoutSubtitleCandidates(workout)) {
+      if (score > bestScore) {
+        bestScore = score;
+        best = label;
+      }
+    }
+  }
+  if (bestScore >= 0 && best.length > 0) return best;
+  const fallback = formatWorkoutTitle(session.title);
+  return fallback === "Workout" ? "Cardio" : fallback;
+}
+
+export function formatCardioSessionSubtitle(session: ReconciledWorkoutSession): string {
+  return pickSessionTypeLikeLabel(session);
+}
+
+function isUnsupportedCardioModalityLabel(label: string): boolean {
+  const normalized = label.trim().toLowerCase();
+  if (normalized.length === 0) return true;
+  return (
+    normalized === "other" ||
+    normalized === "unknown" ||
+    normalized === "uncategorized" ||
+    normalized === "workout" ||
+    normalized === "cardio"
+  );
+}
+
+export function isSupportedCardioModalityLabel(label: string): boolean {
+  return !isUnsupportedCardioModalityLabel(label);
+}
+
+export function isSupportedCardioSessionModality(session: ReconciledWorkoutSession): boolean {
+  return isSupportedCardioModalityLabel(formatCardioSessionSubtitle(session));
+}
+
+/**
+ * Full History / week lists: drops generic Apple “Other” rows with no distance (duration-only noise).
+ * Named modalities (Walking, Running, …) stay visible even when distance is missing.
+ */
+export function isDisplayableCardioHistorySession(session: ReconciledWorkoutSession): boolean {
+  if (session.sessionType !== "cardio") return false;
+  const subtitle = formatCardioSessionSubtitle(session).trim().toLowerCase();
+  const miles = cardioSessionDistanceMiles(session);
+  const hasDistance = miles != null && miles > 0;
+
+  if (subtitle === "other" || subtitle === "unknown" || subtitle === "uncategorized") {
+    return hasDistance;
+  }
+  return true;
+}
+
+/** Weekly mileage banner: sum distances for every displayable cardio session in the slice (not only the 3 visible rows). */
+export function sumDisplayableCardioDistanceMilesForWeekEntries(
+  sessions: readonly RecentWorkoutSessionEntry[],
+): number {
+  let sum = 0;
+  for (const entry of sessions) {
+    if (entry.session.sessionType !== "cardio") continue;
+    if (!isDisplayableCardioHistorySession(entry.session)) continue;
+    const miles = cardioSessionDistanceMiles(entry.session);
+    if (miles != null && Number.isFinite(miles)) sum += Math.max(0, miles);
+  }
+  return sum;
+}
+
+function parseSessionInstantMs(iso: string | null | undefined): number | null {
+  if (!iso) return null;
+  const t = Date.parse(iso);
+  return Number.isNaN(t) ? null : t;
+}
+
+/**
+ * Whether two reconciled sessions overlap in time on the calendar (same-day duplicate detection).
+ */
+export function sessionsHaveOverlappingTimeWindows(a: ReconciledWorkoutSession, b: ReconciledWorkoutSession): boolean {
+  const aStart =
+    parseSessionInstantMs(a.start) ??
+    parseSessionInstantMs(a.workouts[0]?.start ?? a.workouts[0]?.observedAt ?? null);
+  const bStart =
+    parseSessionInstantMs(b.start) ??
+    parseSessionInstantMs(b.workouts[0]?.start ?? b.workouts[0]?.observedAt ?? null);
+  if (aStart == null || bStart == null) return false;
+
+  const aEnd =
+    parseSessionInstantMs(a.end) ??
+    (typeof a.durationMinutes === "number" && a.durationMinutes > 0
+      ? aStart + Math.round(a.durationMinutes * 60_000)
+      : aStart);
+  const bEnd =
+    parseSessionInstantMs(b.end) ??
+    (typeof b.durationMinutes === "number" && b.durationMinutes > 0
+      ? bStart + Math.round(b.durationMinutes * 60_000)
+      : bStart);
+
+  const al = Math.min(aStart, aEnd);
+  const ar = Math.max(aStart, aEnd);
+  const bl = Math.min(bStart, bEnd);
+  const br = Math.max(bStart, bEnd);
+  return al <= br && ar >= bl;
+}
+
+/**
+ * Drops duration-only “Other” sessions that overlap a distance-bearing, well-modality cardio session the same day
+ * (companion duplicate from Apple Health).
+ */
+export function filterCardioHistoryRowsDedupeOverlappingOther<
+  T extends { day: DayKey; session: ReconciledWorkoutSession },
+>(rows: readonly T[]): T[] {
+  const byDay = new Map<DayKey, T[]>();
+  for (const r of rows) {
+    const arr = byDay.get(r.day) ?? [];
+    arr.push(r);
+    byDay.set(r.day, arr);
+  }
+
+  const dropIds = new Set<string>();
+  for (const dayRows of byDay.values()) {
+    for (const r of dayRows) {
+      const s = r.session;
+      const sub = formatCardioSessionSubtitle(s).trim().toLowerCase();
+      const hasDist = (cardioSessionDistanceMiles(s) ?? 0) > 0;
+      if (sub !== "other" || hasDist) continue;
+
+      for (const other of dayRows) {
+        if (other.session.id === s.id) continue;
+        const o = other.session;
+        const odist = (cardioSessionDistanceMiles(o) ?? 0) > 0;
+        const modalityOk = odist && isSupportedCardioModalityLabel(formatCardioSessionSubtitle(o));
+        if (modalityOk && sessionsHaveOverlappingTimeWindows(s, o)) {
+          dropIds.add(s.id);
+          break;
+        }
+      }
+    }
+  }
+
+  return rows.filter((r) => !dropIds.has(r.session.id));
+}
+
+function sessionChronologicalSortKey(session: ReconciledWorkoutSession): string {
+  return session.start ?? session.workouts[0]?.start ?? session.workouts[0]?.observedAt ?? "";
+}
+
+/**
+ * Cardio “This Week”: every displayable, modality-supported cardio session in the selected week,
+ * sorted **Sun → Sat** by calendar slot in `weekDaysInOrder`, then earliest start time within a day.
+ */
+export function getThisWeekCardioSessions(
+  sessions: readonly RecentWorkoutSessionEntry[],
+  weekDaysInOrder: readonly string[],
+): RecentWorkoutSessionEntry[] {
+  const dayOrder = new Map(weekDaysInOrder.map((day, idx) => [day, idx]));
+  const filtered = sessions.filter((entry) => {
+    if (entry.session.sessionType !== "cardio") return false;
+    if (!dayOrder.has(entry.day)) return false;
+    if (!isDisplayableCardioHistorySession(entry.session)) return false;
+    return isSupportedCardioSessionModality(entry.session);
+  });
+  filtered.sort((a, b) => {
+    const dayA = dayOrder.get(a.day) ?? Number.MAX_SAFE_INTEGER;
+    const dayB = dayOrder.get(b.day) ?? Number.MAX_SAFE_INTEGER;
+    if (dayA !== dayB) return dayA - dayB;
+    const ka = sessionChronologicalSortKey(a.session);
+    const kb = sessionChronologicalSortKey(b.session);
+    const t = ka.localeCompare(kb);
+    if (t !== 0) return t;
+    return a.session.id.localeCompare(b.session.id);
+  });
+  return filtered;
+}
+
+export function formatThisWeekCardioDistanceSummary(totalMiles: number): string {
+  const normalized = Number.isFinite(totalMiles) ? Math.max(0, totalMiles) : 0;
+  return `${normalized.toFixed(1)} mi this week`;
+}
+
+export function formatCardioWeeklyDistanceAndMinutes(input: {
+  averageMilesPerWeek?: number | null;
+  averageMinutesPerWeek?: number | null;
+}): string {
+  const miles =
+    typeof input.averageMilesPerWeek === "number" &&
+    Number.isFinite(input.averageMilesPerWeek) &&
+    input.averageMilesPerWeek > 0
+      ? `${input.averageMilesPerWeek.toFixed(1)} mi/wk`
+      : null;
+  const minutes =
+    typeof input.averageMinutesPerWeek === "number" &&
+    Number.isFinite(input.averageMinutesPerWeek) &&
+    input.averageMinutesPerWeek > 0
+      ? `${Math.round(input.averageMinutesPerWeek)} min/wk`
+      : null;
+  if (miles && minutes) return `${miles.replace("/wk", "")} · ${minutes}`;
+  if (miles) return miles;
+  if (minutes) return minutes;
+  return "—";
+}

--- a/lib/data/workouts/strengthBaselineCardModel.ts
+++ b/lib/data/workouts/strengthBaselineCardModel.ts
@@ -12,6 +12,10 @@ import {
 } from "@/lib/utils/strengthWeeklyFrequencyRating";
 import { collectStrengthOverviewTabSessions } from "@/lib/data/workouts/strengthOverviewCardModel";
 import { filterWorkoutCalendarDaysInclusive } from "@/lib/data/workouts/overviewCalendarRangeSlices";
+import {
+  formatStrengthWeeklyWorkoutsAndMinutes,
+  strengthSessionDurationMinutes,
+} from "@/lib/data/workouts/strengthSessionPresentation";
 import type { WorkoutCalendarDayLike } from "@/lib/data/workouts/workoutsCalendarModel";
 import type { DayKey } from "@/lib/ui/calendar/types";
 import { enumerateDaysInclusive } from "@/lib/ui/calendar/dateUtils";
@@ -21,6 +25,8 @@ export type StrengthBaselineCardModel = {
   avgWorkoutsPerWeek: number;
   /** Primary figure for the header row (display: `X.X/wk`). */
   compactValuePrimary: string;
+  totalMinutes90d: number;
+  avgMinutesPerWeek: number;
   ratingBucket: StrengthWeeklyFrequencyRatingBucket;
   ratingLabel: string;
   /** Pass to {@link ActivityTierProgressTrack} tier coloring. */
@@ -48,12 +54,22 @@ export function buildStrengthBaselineCardModel(input: {
   const slice = filterWorkoutCalendarDaysInclusive(sortedDays, windowStart, anchorEnd);
   const sessions = collectStrengthOverviewTabSessions(slice);
   const total = sessions.length;
+  const totalMinutes90d = sessions.reduce((sum, session) => {
+    const minutes = strengthSessionDurationMinutes(session);
+    return sum + (minutes ?? 0);
+  }, 0);
   const avgWorkoutsPerWeek = elapsedDays > 0 ? (total * 7) / elapsedDays : 0;
-  const compactValuePrimary = `${avgWorkoutsPerWeek.toFixed(1)}/wk`;
+  const avgMinutesPerWeek = elapsedDays > 0 ? (totalMinutes90d * 7) / elapsedDays : 0;
+  const compactValuePrimary = formatStrengthWeeklyWorkoutsAndMinutes({
+    averageWorkoutsPerWeek: avgWorkoutsPerWeek,
+    averageMinutesPerWeek: avgMinutesPerWeek,
+  });
   const ratingBucket = strengthWeeklyFrequencyRatingBucketFromAvg(avgWorkoutsPerWeek);
   return {
     avgWorkoutsPerWeek,
     compactValuePrimary,
+    totalMinutes90d,
+    avgMinutesPerWeek,
     ratingBucket,
     ratingLabel: strengthWeeklyFrequencyRatingLabelFromBucket(ratingBucket),
     activityTierIndexForBar: strengthWeeklyFrequencyActivityTierIndexForBar(ratingBucket),

--- a/lib/data/workouts/strengthHistorySummaryModel.ts
+++ b/lib/data/workouts/strengthHistorySummaryModel.ts
@@ -1,0 +1,155 @@
+import { activityTrailingNDaysInclusive, getActivityOverviewAnchorEndDay } from "@/lib/data/activity/activityOverviewRanges";
+import { collectStrengthOverviewTabSessions } from "@/lib/data/workouts/strengthOverviewCardModel";
+import {
+  formatStrengthWeeklyWorkoutsAndMinutes,
+  strengthSessionDurationMinutes,
+} from "@/lib/data/workouts/strengthSessionPresentation";
+import type { WorkoutCalendarDayLike } from "@/lib/data/workouts/workoutsCalendarModel";
+import type { DayKey } from "@/lib/ui/calendar/types";
+import { enumerateDaysInclusive } from "@/lib/ui/calendar/dateUtils";
+import {
+  strengthWeeklyFrequencyActivityTierIndexForBar,
+  strengthWeeklyFrequencyDisplayScaleFill01,
+  strengthWeeklyFrequencyRatingBucketFromAvg,
+  strengthWeeklyFrequencyRatingLabelFromBucket,
+} from "@/lib/utils/strengthWeeklyFrequencyRating";
+
+export type StrengthHistoryRangeKey = "day7" | "day30" | "ytd" | "month12";
+
+export type StrengthHistorySummaryRow = {
+  key: StrengthHistoryRangeKey;
+  label: "7 Day" | "30 Day" | "YTD" | "12 Month";
+  hasEnoughData: boolean;
+  totalSessions: number | null;
+  averageSessionsPerWeek: number | null;
+  totalMinutes: number | null;
+  averageMinutesPerWeek: number | null;
+  displayValue: string;
+  tierLabel: string | null;
+  tierIndexForBar: number | null;
+  progressFill01: number | null;
+  helperText?: string;
+};
+
+export type StrengthHistorySummaryModel = {
+  rows: readonly StrengthHistorySummaryRow[];
+};
+
+function ytdStartFor(anchorEndDay: DayKey): DayKey {
+  return `${anchorEndDay.slice(0, 4)}-01-01` as DayKey;
+}
+
+function avgPerWeek(total: number, daysCount: number): number {
+  if (daysCount <= 0) return 0;
+  return (total * 7) / daysCount;
+}
+
+function buildRow(args: {
+  key: StrengthHistoryRangeKey;
+  label: StrengthHistorySummaryRow["label"];
+  rangeStart: DayKey;
+  rangeEnd: DayKey;
+  availableStart: DayKey;
+  availableEnd: DayKey;
+  strengthCalendarDays: readonly WorkoutCalendarDayLike[];
+}): StrengthHistorySummaryRow {
+  const covered = args.rangeStart >= args.availableStart && args.rangeEnd <= args.availableEnd;
+  if (!covered) {
+    return {
+      key: args.key,
+      label: args.label,
+      hasEnoughData: false,
+      totalSessions: null,
+      averageSessionsPerWeek: null,
+      totalMinutes: null,
+      averageMinutesPerWeek: null,
+      displayValue: "—",
+      tierLabel: null,
+      tierIndexForBar: null,
+      progressFill01: null,
+      ...(args.key === "month12" ? { helperText: "Data will appear when enough history is available" } : {}),
+    };
+  }
+
+  const daysInRange = enumerateDaysInclusive(args.rangeStart, args.rangeEnd);
+  const daySet = new Set(daysInRange);
+  const sessions = collectStrengthOverviewTabSessions(args.strengthCalendarDays.filter((day) => daySet.has(day.day)));
+  const totalSessions = sessions.length;
+  const totalMinutes = sessions.reduce((sum, session) => {
+    const minutes = strengthSessionDurationMinutes(session);
+    return sum + (minutes ?? 0);
+  }, 0);
+  const averageSessionsPerWeek = avgPerWeek(totalSessions, daysInRange.length);
+  const averageMinutesPerWeek = avgPerWeek(totalMinutes, daysInRange.length);
+  const bucket = strengthWeeklyFrequencyRatingBucketFromAvg(averageSessionsPerWeek);
+  return {
+    key: args.key,
+    label: args.label,
+    hasEnoughData: true,
+    totalSessions,
+    averageSessionsPerWeek,
+    totalMinutes,
+    averageMinutesPerWeek,
+    displayValue: formatStrengthWeeklyWorkoutsAndMinutes({
+      averageWorkoutsPerWeek: averageSessionsPerWeek,
+      averageMinutesPerWeek,
+    }),
+    tierLabel: strengthWeeklyFrequencyRatingLabelFromBucket(bucket),
+    tierIndexForBar: strengthWeeklyFrequencyActivityTierIndexForBar(bucket),
+    progressFill01: strengthWeeklyFrequencyDisplayScaleFill01(averageSessionsPerWeek),
+  };
+}
+
+export function buildStrengthHistorySummaryModel(input: {
+  strengthCalendarDays: readonly WorkoutCalendarDayLike[];
+  todayDayKey: DayKey;
+  availableRangeStart: DayKey;
+  availableRangeEnd: DayKey;
+}): StrengthHistorySummaryModel {
+  const anchorEnd = getActivityOverviewAnchorEndDay(input.todayDayKey);
+  const day7 = activityTrailingNDaysInclusive(anchorEnd, 7);
+  const day30 = activityTrailingNDaysInclusive(anchorEnd, 30);
+  const day365 = activityTrailingNDaysInclusive(anchorEnd, 365);
+  const ytdStart = ytdStartFor(anchorEnd);
+
+  return {
+    rows: [
+      buildRow({
+        key: "day7",
+        label: "7 Day",
+        rangeStart: day7[0]!,
+        rangeEnd: anchorEnd,
+        availableStart: input.availableRangeStart,
+        availableEnd: input.availableRangeEnd,
+        strengthCalendarDays: input.strengthCalendarDays,
+      }),
+      buildRow({
+        key: "day30",
+        label: "30 Day",
+        rangeStart: day30[0]!,
+        rangeEnd: anchorEnd,
+        availableStart: input.availableRangeStart,
+        availableEnd: input.availableRangeEnd,
+        strengthCalendarDays: input.strengthCalendarDays,
+      }),
+      buildRow({
+        key: "ytd",
+        label: "YTD",
+        rangeStart: ytdStart,
+        rangeEnd: anchorEnd,
+        availableStart: input.availableRangeStart,
+        availableEnd: input.availableRangeEnd,
+        strengthCalendarDays: input.strengthCalendarDays,
+      }),
+      buildRow({
+        key: "month12",
+        label: "12 Month",
+        rangeStart: day365[0]!,
+        rangeEnd: anchorEnd,
+        availableStart: input.availableRangeStart,
+        availableEnd: input.availableRangeEnd,
+        strengthCalendarDays: input.strengthCalendarDays,
+      }),
+    ],
+  };
+}

--- a/lib/data/workouts/strengthSessionPresentation.ts
+++ b/lib/data/workouts/strengthSessionPresentation.ts
@@ -1,0 +1,42 @@
+import type { ReconciledWorkoutSession } from "@/lib/data/workouts/workoutSessionReconciliation";
+
+export function strengthSessionDurationMinutes(session: ReconciledWorkoutSession): number | null {
+  if (
+    typeof session.durationMinutes === "number" &&
+    Number.isFinite(session.durationMinutes) &&
+    session.durationMinutes > 0
+  ) {
+    return session.durationMinutes;
+  }
+  let maxDuration: number | null = null;
+  for (const workout of session.workouts) {
+    if (
+      typeof workout.durationMinutes === "number" &&
+      Number.isFinite(workout.durationMinutes) &&
+      workout.durationMinutes > 0
+    ) {
+      maxDuration = maxDuration == null ? workout.durationMinutes : Math.max(maxDuration, workout.durationMinutes);
+    }
+  }
+  return maxDuration;
+}
+
+export function formatStrengthWeeklyWorkoutsAndMinutes(input: {
+  averageWorkoutsPerWeek?: number | null;
+  averageMinutesPerWeek?: number | null;
+}): string {
+  const workouts =
+    typeof input.averageWorkoutsPerWeek === "number" && Number.isFinite(input.averageWorkoutsPerWeek)
+      ? `${input.averageWorkoutsPerWeek.toFixed(1)} wo`
+      : null;
+  const minutes =
+    typeof input.averageMinutesPerWeek === "number" &&
+    Number.isFinite(input.averageMinutesPerWeek) &&
+    input.averageMinutesPerWeek > 0
+      ? `${Math.round(input.averageMinutesPerWeek)} min/wk`
+      : null;
+  if (workouts && minutes) return `${workouts} · ${minutes}`;
+  if (workouts) return `${workouts}/wk`;
+  if (minutes) return minutes;
+  return "—";
+}

--- a/lib/data/workouts/workoutMarkerFlags.ts
+++ b/lib/data/workouts/workoutMarkerFlags.ts
@@ -27,6 +27,11 @@ const STRENGTH_TERMS = [
 const CARDIO_TERMS = [
   "running",
   "walking",
+  /** Matches compacted "IndoorWalk", "OutdoorWalk" (Apple Fitness / HK strings). */
+  "indoorwalk",
+  "outdoorwalk",
+  "indoordrun",
+  "outdoorrun",
   "hiking",
   "cycling",
   "biking",

--- a/lib/data/workouts/workoutSessionSurface.ts
+++ b/lib/data/workouts/workoutSessionSurface.ts
@@ -7,6 +7,7 @@ import type { WorkoutOverride } from "@/lib/data/workouts/workoutOverrides";
 import { formatWorkoutTitle } from "@/lib/data/workouts/workoutDisplay";
 import type { ReconciledWorkoutSession } from "@/lib/data/workouts/workoutSessionReconciliation";
 import type { WorkoutProductDomain } from "@/lib/data/workouts/workoutDomain";
+import { HK_WORKOUT_ACTIVITY_TYPE_OTHER } from "@/lib/data/workouts/appleHealthKitWorkoutActivityType";
 import {
   computeStrengthMetricsFromExercises,
   type ManualWorkoutDaySummary,
@@ -145,8 +146,45 @@ export function pickJournalSummaryForStrengthSession(
   return best;
 }
 
-/** Apple / HealthKit row for duration, calories, distance, zones when present in a merged session. */
-export function pickMetricsWorkoutForSession(session: ReconciledWorkoutSession): WorkoutHistoryItem | null {
+function scoreAppleHealthCardioMetricsCandidate(w: WorkoutHistoryItem): number {
+  let score = 0;
+  if (typeof w.distanceMeters === "number" && Number.isFinite(w.distanceMeters) && w.distanceMeters > 0) {
+    score += 10_000 + Math.min(w.distanceMeters, 500_000) / 1000;
+  }
+  const aid = w.hk?.activityId;
+  if (typeof aid === "number" && Number.isFinite(aid)) {
+    if (Math.trunc(aid) === HK_WORKOUT_ACTIVITY_TYPE_OTHER) score -= 5000;
+    else score += 500;
+  }
+  const blob = `${w.activityName ?? ""} ${w.sport ?? ""} ${w.title ?? ""}`.toLowerCase();
+  if (blob.includes("other")) score -= 2000;
+  if (typeof w.durationMinutes === "number" && Number.isFinite(w.durationMinutes) && w.durationMinutes > 0) {
+    score += Math.min(w.durationMinutes, 600);
+  }
+  return score;
+}
+
+/**
+ * Apple / HealthKit row for duration, calories, distance, zones when present in a merged session.
+ * Cardio: when multiple Apple rows were merged, prefer the sample with distance and a specific HK activity type
+ * over companion “Other” / duplicate rows so duration and distance match the watch-backed workout.
+ */
+export function pickMetricsWorkoutForSession(
+  session: ReconciledWorkoutSession,
+  domain: WorkoutProductDomain = "strength",
+): WorkoutHistoryItem | null {
+  if (domain === "cardio") {
+    const candidates = session.workouts.filter(
+      (w) => resolveWorkoutIngestProvider(w) === "apple_health" || w.hk != null,
+    );
+    if (candidates.length > 1) {
+      const ranked = [...candidates].sort(
+        (a, b) => scoreAppleHealthCardioMetricsCandidate(b) - scoreAppleHealthCardioMetricsCandidate(a),
+      );
+      return ranked[0] ?? null;
+    }
+    if (candidates.length === 1) return candidates[0] ?? null;
+  }
   const apple = session.workouts.find((w) => resolveWorkoutIngestProvider(w) === "apple_health");
   if (apple) return apple;
   const hk = session.workouts.find((w) => w.hk != null);
@@ -201,7 +239,7 @@ export function buildWorkoutSessionSurfaceModel(
     throw new Error("buildWorkoutSessionSurfaceModel: session has no workouts");
   }
   const actionWorkout = pickWorkoutForSessionActions(session) ?? representative;
-  const metricsWorkout = pickMetricsWorkoutForSession(session) ?? representative;
+  const metricsWorkout = pickMetricsWorkoutForSession(session, domain) ?? representative;
   const displayTitle = resolveWorkoutSessionSurfaceTitle(
     session,
     representative,

--- a/lib/data/workouts/workoutsCalendarModel.ts
+++ b/lib/data/workouts/workoutsCalendarModel.ts
@@ -421,6 +421,35 @@ export function getRecentWorkoutSessionsFromCalendarDays(
 }
 
 /**
+ * Cardio Overview “This Week”: every **cardio** reconciled session in the calendar slice, newest-first,
+ * with **no global session cap** (unlike {@link getRecentWorkoutSessionsFromCalendarDays}, which truncates
+ * cross-domain lists). Aligns with Strength’s uncapped weekly tab sessions.
+ */
+export function getCardioOverviewTabSessionsForCalendarDaysNewestFirst(
+  days: readonly WorkoutCalendarDayLike[],
+): RecentWorkoutSessionEntry[] {
+  const entries: RecentWorkoutSessionEntry[] = [];
+  for (const d of days) {
+    const sessions = reconcileWorkoutSessionsForDay(d.day, d.workouts);
+    for (const session of sessions) {
+      if (session.sessionType !== "cardio") continue;
+      entries.push({ day: d.day, session });
+    }
+  }
+  entries.sort((a, b) => {
+    const ka = a.session.start ?? a.session.workouts[0]?.observedAt ?? "";
+    const kb = b.session.start ?? b.session.workouts[0]?.observedAt ?? "";
+    if (!ka && !kb) return a.session.id.localeCompare(b.session.id);
+    if (!ka) return 1;
+    if (!kb) return -1;
+    const t = kb.localeCompare(ka);
+    if (t !== 0) return t;
+    return a.session.id.localeCompare(b.session.id);
+  });
+  return entries;
+}
+
+/**
  * Strength overview tab sessions only ({@link sessionMatchesOverviewStrengthTab}), ordered **earliest first**
  * (reverse of {@link getRecentWorkoutSessionsFromCalendarDays}). Use with domain-filtered days for the local week slice.
  */

--- a/lib/ui/workouts/CardioBaselineCard.tsx
+++ b/lib/ui/workouts/CardioBaselineCard.tsx
@@ -1,0 +1,158 @@
+import React from "react";
+import { StyleSheet, Text, View } from "react-native";
+
+import type { CardioBaselineCardModel } from "@/lib/data/workouts/cardioBaselineCardModel";
+import { ActivityRatingPill } from "@/lib/ui/activity/ActivityRatingPill";
+import { ACTIVITY_DETAILS_SUBTLE_PILL_LABEL_TYPOGRAPHY } from "@/lib/ui/activity/activityUiTypography";
+import { LoadingState } from "@/lib/ui/ScreenStates";
+import { StrengthBaselineFrequencyTrack } from "@/lib/ui/workouts/StrengthBaselineFrequencyTrack";
+import { strengthMetricCardTitleTextStyle } from "@/lib/ui/workouts/strengthMetricCardTitleStyle";
+import { ACTIVITY_STEP_RATING_TIERS } from "@/lib/utils/activityStepRating";
+import { elevatedCardSurfaceStyle } from "@/lib/ui/theme/elevatedCardSurface";
+import { cardioBaselineMilesToVisualScale01 } from "@/lib/ui/workouts/cardioBaselineScale";
+
+const CARDIO_BASELINE_CARD_DEFINITION_SENTENCE =
+  "Your typical weekly cardio distance based on the past 90 days";
+const CARDIO_BASELINE_MARKERS = ["0", "2.5", "7.5", "15", "25"] as const;
+
+type CardioBaselineCardProps = {
+  loading: boolean;
+  model: CardioBaselineCardModel | null;
+};
+
+function tierLabel(tier: "very_low" | "low" | "active" | "high" | "very_high"): string {
+  if (tier === "very_low") return "Very Low";
+  if (tier === "very_high") return "Very High";
+  if (tier === "low") return "Low";
+  if (tier === "active") return "Active";
+  return "High";
+}
+
+function tierIndex(tier: "very_low" | "low" | "active" | "high" | "very_high"): number {
+  if (tier === "very_low") return 0;
+  if (tier === "low") return 1;
+  if (tier === "active") return 2;
+  if (tier === "high") return 3;
+  return 4;
+}
+
+export function CardioBaselineCard({ loading, model }: CardioBaselineCardProps) {
+  const isReady = model?.kind === "ready";
+  const activeTierIndex = isReady ? tierIndex(model.tier) : 0;
+  const tierChrome = ACTIVITY_STEP_RATING_TIERS[activeTierIndex]!;
+  const fillWidth01 =
+    isReady && Number.isFinite(model.progressMilesPerWeekScaleValue)
+      ? cardioBaselineMilesToVisualScale01(model.progressMilesPerWeekScaleValue)
+      : 0;
+  const progressPercent = Math.round(fillWidth01 * 100);
+
+  return (
+    <View style={styles.card}>
+      <View style={styles.topRow} accessibilityRole="header">
+        <View style={styles.titlePillGroup}>
+          <Text style={styles.cardTitle}>Cardio Baseline</Text>
+          {!loading ? (
+            <ActivityRatingPill
+              label={isReady ? tierLabel(model.tier) : "Insufficient data"}
+              color={tierChrome.color}
+              backgroundColor={tierChrome.backgroundColor}
+              emphasis="subtle"
+              compactChrome
+              labelTypography={ACTIVITY_DETAILS_SUBTLE_PILL_LABEL_TYPOGRAPHY}
+              testID="cardio-baseline-rating-pill"
+            />
+          ) : null}
+        </View>
+        {!loading && isReady ? (
+          <Text style={styles.primaryValueFigure} numberOfLines={1}>
+            {model.headlineLabel}
+          </Text>
+        ) : null}
+      </View>
+
+      {loading ? <LoadingState variant="inline" message="Loading workouts…" /> : null}
+
+      {!loading && isReady ? (
+        <View style={styles.progressCluster} testID="cardio-baseline-instrument-cluster">
+          <StrengthBaselineFrequencyTrack
+            testID="cardio-baseline-frequency-bar"
+            tierIndex={activeTierIndex}
+            fillWidth01={fillWidth01}
+            wrapperProps={{
+              accessibilityRole: "progressbar",
+              accessibilityValue: { now: progressPercent, min: 0, max: 100 },
+            }}
+          />
+          <View style={styles.markerRow} testID="cardio-baseline-frequency-markers">
+            {CARDIO_BASELINE_MARKERS.map((label) => (
+              <Text key={label} style={styles.markerLabel}>
+                {label}
+              </Text>
+            ))}
+          </View>
+        </View>
+      ) : null}
+
+      <Text style={styles.footerCaption}>{CARDIO_BASELINE_CARD_DEFINITION_SENTENCE}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: "#FFFFFF",
+    borderRadius: 12,
+    padding: 15,
+    gap: 11,
+    ...elevatedCardSurfaceStyle,
+  },
+  topRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "baseline",
+    gap: 10,
+    paddingBottom: 2,
+  },
+  titlePillGroup: {
+    flexDirection: "row",
+    alignItems: "baseline",
+    flex: 1,
+    minWidth: 0,
+    gap: 7,
+  },
+  cardTitle: {
+    ...strengthMetricCardTitleTextStyle,
+  },
+  primaryValueFigure: {
+    fontSize: 19,
+    lineHeight: 24,
+    fontWeight: "600",
+    fontVariant: ["tabular-nums"],
+    color: "#1C1C1E",
+    letterSpacing: -0.34,
+    flexShrink: 1,
+    textAlign: "right",
+  },
+  progressCluster: {
+    gap: 6,
+  },
+  markerRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+  markerLabel: {
+    fontSize: 10,
+    fontWeight: "500",
+    color: "#636366",
+    letterSpacing: -0.08,
+  },
+  footerCaption: {
+    fontSize: 14,
+    lineHeight: 22,
+    fontWeight: "400",
+    color: "#8E8E93",
+    letterSpacing: -0.2,
+    marginBottom: 6,
+  },
+});

--- a/lib/ui/workouts/CardioHistorySummaryCard.tsx
+++ b/lib/ui/workouts/CardioHistorySummaryCard.tsx
@@ -1,0 +1,120 @@
+import React from "react";
+import { StyleSheet, Text, View } from "react-native";
+
+import type { CardioHistorySummaryModel } from "@/lib/data/workouts/cardioHistorySummaryModel";
+import { ActivityRatingPill } from "@/lib/ui/activity/ActivityRatingPill";
+import { ACTIVITY_OVERVIEW_SUBTLE_PILL_LABEL_TYPOGRAPHY } from "@/lib/ui/activity/activityUiTypography";
+import { moduleOverviewMetricLayoutStyles } from "@/lib/ui/overview/moduleOverviewMetricLayout";
+import { StrengthBaselineFrequencyTrack } from "@/lib/ui/workouts/StrengthBaselineFrequencyTrack";
+import { elevatedCardSurfaceStyle } from "@/lib/ui/theme/elevatedCardSurface";
+import { ACTIVITY_STEP_RATING_TIERS } from "@/lib/utils/activityStepRating";
+
+type CardProps = {
+  model: CardioHistorySummaryModel;
+};
+
+export function CardioHistorySummaryCard({ model }: CardProps) {
+  return (
+    <View style={styles.card} testID="cardio-history-summary-card">
+      <View style={styles.metricGroups}>
+        {model.rows.map((row) => {
+          const tierChrome =
+            row.tierIndexForBar != null ? ACTIVITY_STEP_RATING_TIERS[row.tierIndexForBar] : null;
+          const a11y = row.tierLabel
+            ? `${row.label}. ${row.tierLabel}. ${row.displayValue}.`
+            : `${row.label}. ${row.displayValue}.`;
+          return (
+            <View key={row.key} style={styles.metricBlock} accessible accessibilityLabel={a11y}>
+              <View style={[moduleOverviewMetricLayoutStyles.topRow, styles.rowTop]}>
+                <View style={styles.titlePillLeftGroup}>
+                  <Text style={styles.rowLabel} numberOfLines={1}>
+                    {row.label}
+                  </Text>
+                  {row.tierLabel && tierChrome ? (
+                    <ActivityRatingPill
+                      label={row.tierLabel}
+                      color={tierChrome.color}
+                      backgroundColor={tierChrome.backgroundColor}
+                      emphasis="subtle"
+                      compactChrome
+                      labelTypography={ACTIVITY_OVERVIEW_SUBTLE_PILL_LABEL_TYPOGRAPHY}
+                      testID={`cardio-history-tier-${row.key}`}
+                    />
+                  ) : null}
+                </View>
+                <Text style={row.hasEnoughData ? styles.rowFigure : styles.rowNonNumeric} numberOfLines={1}>
+                  {row.displayValue}
+                </Text>
+              </View>
+              {row.helperText ? <Text style={styles.helperText}>{row.helperText}</Text> : null}
+              <StrengthBaselineFrequencyTrack
+                testID={`cardio-history-progress-${row.key}`}
+                tierIndex={row.tierIndexForBar ?? 0}
+                fillWidth01={row.progressFill01 ?? 0}
+              />
+            </View>
+          );
+        })}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: "#FFFFFF",
+    borderRadius: 12,
+    padding: 15,
+    gap: 11,
+    ...elevatedCardSurfaceStyle,
+  },
+  metricGroups: {
+    gap: 12,
+  },
+  metricBlock: {
+    gap: 8,
+  },
+  rowTop: {
+    alignItems: "baseline",
+  },
+  titlePillLeftGroup: {
+    flex: 1,
+    minWidth: 0,
+    flexDirection: "row",
+    alignItems: "baseline",
+    gap: 7,
+  },
+  rowLabel: {
+    flexShrink: 1,
+    minWidth: 0,
+    fontSize: 19,
+    lineHeight: 24,
+    fontWeight: "600",
+    color: "#1C1C1E",
+    letterSpacing: -0.34,
+  },
+  rowFigure: {
+    fontSize: 19,
+    lineHeight: 24,
+    fontWeight: "600",
+    fontVariant: ["tabular-nums"],
+    color: "#1C1C1E",
+    letterSpacing: -0.34,
+    flexShrink: 1,
+    textAlign: "right",
+  },
+  rowNonNumeric: {
+    flexShrink: 0,
+    fontSize: 19,
+    lineHeight: 24,
+    fontWeight: "600",
+    color: "#8E8E93",
+    letterSpacing: -0.34,
+  },
+  helperText: {
+    fontSize: 13,
+    lineHeight: 17,
+    color: "#8E8E93",
+    letterSpacing: -0.08,
+  },
+});

--- a/lib/ui/workouts/StrengthBaselineCard.tsx
+++ b/lib/ui/workouts/StrengthBaselineCard.tsx
@@ -1,8 +1,19 @@
 import React from "react";
+import { StyleSheet, Text, View } from "react-native";
 
 import type { StrengthBaselineCardModel } from "@/lib/data/workouts/strengthBaselineCardModel";
 import { STRENGTH_BASELINE_CARD_DEFINITION_SENTENCE } from "@/lib/ui/workouts/strengthBaselineCopy";
-import { StrengthFrequencyMetricCard } from "@/lib/ui/workouts/StrengthFrequencyMetricCard";
+import { ActivityRatingPill } from "@/lib/ui/activity/ActivityRatingPill";
+import { ACTIVITY_DETAILS_SUBTLE_PILL_LABEL_TYPOGRAPHY } from "@/lib/ui/activity/activityUiTypography";
+import { LoadingState } from "@/lib/ui/ScreenStates";
+import { elevatedCardSurfaceStyle } from "@/lib/ui/theme/elevatedCardSurface";
+import { StrengthBaselineFrequencyMarkers } from "@/lib/ui/workouts/StrengthBaselineFrequencyMarkers";
+import {
+  StrengthBaselineFrequencyTrack,
+  strengthBaselineFrequencyTrackAccessibilityPercent,
+} from "@/lib/ui/workouts/StrengthBaselineFrequencyTrack";
+import { strengthMetricCardTitleTextStyle } from "@/lib/ui/workouts/strengthMetricCardTitleStyle";
+import { ACTIVITY_STEP_RATING_TIERS } from "@/lib/utils/activityStepRating";
 
 type StrengthBaselineCardProps = {
   loading: boolean;
@@ -10,25 +21,129 @@ type StrengthBaselineCardProps = {
 };
 
 export function StrengthBaselineCard({ loading, model }: StrengthBaselineCardProps) {
-  const display =
+  const tierIdx = model != null ? Math.min(model.activityTierIndexForBar, ACTIVITY_STEP_RATING_TIERS.length - 1) : 0;
+  const tierPill = ACTIVITY_STEP_RATING_TIERS[tierIdx]!;
+  const percent =
     model != null
-      ? {
-          compactValuePrimary: model.compactValuePrimary,
-          ratingLabel: model.ratingLabel,
-          activityTierIndexForBar: model.activityTierIndexForBar,
-          fillWidth01Override: model.fillWidth01Override,
-        }
-      : null;
+      ? strengthBaselineFrequencyTrackAccessibilityPercent(
+          model.activityTierIndexForBar,
+          model.fillWidth01Override,
+        )
+      : 0;
+  const baselineA11y =
+    model == null
+      ? "Strength Baseline"
+      : `Strength Baseline. ${model.ratingLabel}. 90 Day Avg ${model.compactValuePrimary}.`;
 
   return (
-    <StrengthFrequencyMetricCard
-      headingTitle="Strength Baseline"
-      loading={loading}
-      model={display}
-      footerCaption={STRENGTH_BASELINE_CARD_DEFINITION_SENTENCE}
-      ratingPillTestID="strength-baseline-rating-pill"
-      frequencyBarTestID="strength-baseline-frequency-bar"
-      instrumentClusterTestID="strength-baseline-instrument-cluster"
-    />
+    <View style={styles.card}>
+      <View style={styles.topRow} accessibilityRole="header" accessible accessibilityLabel={baselineA11y}>
+        <View style={styles.titlePillGroup}>
+          <Text style={styles.cardTitle} numberOfLines={1} ellipsizeMode="tail">
+            Strength Baseline
+          </Text>
+          {!loading && model != null ? (
+            <ActivityRatingPill
+              label={model.ratingLabel}
+              color={tierPill.color}
+              backgroundColor={tierPill.backgroundColor}
+              emphasis="subtle"
+              compactChrome
+              labelTypography={ACTIVITY_DETAILS_SUBTLE_PILL_LABEL_TYPOGRAPHY}
+              testID="strength-baseline-rating-pill"
+            />
+          ) : null}
+        </View>
+      </View>
+
+      {loading ? <LoadingState variant="inline" message="Loading workouts…" /> : null}
+
+      {!loading && model != null ? (
+        <>
+          <View style={styles.metricRow}>
+            <Text style={styles.metricLabel}>90 Day Avg</Text>
+            <Text style={styles.metricValue} numberOfLines={1}>
+              {model.compactValuePrimary}
+            </Text>
+          </View>
+          <View style={styles.progressCluster} testID="strength-baseline-instrument-cluster">
+            <StrengthBaselineFrequencyTrack
+              testID="strength-baseline-frequency-bar"
+              tierIndex={model.activityTierIndexForBar}
+              fillWidth01={model.fillWidth01Override}
+              wrapperProps={{
+                accessibilityRole: "progressbar",
+                accessibilityValue: { now: percent, min: 0, max: 100 },
+              }}
+            />
+            <StrengthBaselineFrequencyMarkers />
+          </View>
+        </>
+      ) : null}
+
+      <Text style={styles.footerCaption}>{STRENGTH_BASELINE_CARD_DEFINITION_SENTENCE}</Text>
+    </View>
   );
 }
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: "#FFFFFF",
+    borderRadius: 12,
+    padding: 15,
+    gap: 11,
+    ...elevatedCardSurfaceStyle,
+  },
+  topRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "baseline",
+    gap: 10,
+    paddingBottom: 2,
+  },
+  titlePillGroup: {
+    flexDirection: "row",
+    alignItems: "baseline",
+    flex: 1,
+    minWidth: 0,
+    gap: 7,
+  },
+  cardTitle: {
+    ...strengthMetricCardTitleTextStyle,
+  },
+  metricRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "baseline",
+    gap: 12,
+    paddingTop: 1,
+  },
+  metricLabel: {
+    fontSize: 13,
+    lineHeight: 17,
+    fontWeight: "500",
+    color: "#8E8E93",
+    letterSpacing: -0.08,
+  },
+  metricValue: {
+    fontSize: 18,
+    lineHeight: 22,
+    fontWeight: "600",
+    color: "#1C1C1E",
+    letterSpacing: -0.28,
+    fontVariant: ["tabular-nums"],
+    textAlign: "right",
+    flexShrink: 1,
+  },
+  progressCluster: {
+    gap: 3,
+  },
+  footerCaption: {
+    fontSize: 14,
+    lineHeight: 22,
+    fontWeight: "400",
+    color: "#8E8E93",
+    letterSpacing: -0.2,
+    marginBottom: 6,
+  },
+});

--- a/lib/ui/workouts/StrengthFrequencyMetricCard.tsx
+++ b/lib/ui/workouts/StrengthFrequencyMetricCard.tsx
@@ -252,13 +252,14 @@ const styles = StyleSheet.create({
     ...strengthMetricCardTitleTextStyle,
   },
   primaryValueFigure: {
-    fontSize: 23,
-    lineHeight: 28,
+    fontSize: 18,
+    lineHeight: 22,
     fontWeight: "600",
     fontVariant: ["tabular-nums"],
     color: "#1C1C1E",
-    letterSpacing: -0.44,
-    flexShrink: 0,
+    letterSpacing: -0.28,
+    flexShrink: 1,
+    textAlign: "right",
   },
   footerCaption: {
     fontSize: 14,

--- a/lib/ui/workouts/StrengthHistorySummaryCard.tsx
+++ b/lib/ui/workouts/StrengthHistorySummaryCard.tsx
@@ -1,0 +1,119 @@
+import React from "react";
+import { StyleSheet, Text, View } from "react-native";
+
+import type { StrengthHistorySummaryModel } from "@/lib/data/workouts/strengthHistorySummaryModel";
+import { ActivityRatingPill } from "@/lib/ui/activity/ActivityRatingPill";
+import { ACTIVITY_OVERVIEW_SUBTLE_PILL_LABEL_TYPOGRAPHY } from "@/lib/ui/activity/activityUiTypography";
+import { moduleOverviewMetricLayoutStyles } from "@/lib/ui/overview/moduleOverviewMetricLayout";
+import { elevatedCardSurfaceStyle } from "@/lib/ui/theme/elevatedCardSurface";
+import { StrengthBaselineFrequencyTrack } from "@/lib/ui/workouts/StrengthBaselineFrequencyTrack";
+import { ACTIVITY_STEP_RATING_TIERS } from "@/lib/utils/activityStepRating";
+
+type Props = {
+  model: StrengthHistorySummaryModel;
+};
+
+export function StrengthHistorySummaryCard({ model }: Props) {
+  return (
+    <View style={styles.card} testID="strength-history-summary-card">
+      <View style={styles.metricGroups}>
+        {model.rows.map((row) => {
+          const chrome = row.tierIndexForBar != null ? ACTIVITY_STEP_RATING_TIERS[row.tierIndexForBar] : null;
+          const a11y = row.tierLabel
+            ? `${row.label}. ${row.tierLabel}. ${row.displayValue}.`
+            : `${row.label}. ${row.displayValue}.`;
+          return (
+            <View key={row.key} style={styles.metricBlock} accessible accessibilityLabel={a11y}>
+              <View style={[moduleOverviewMetricLayoutStyles.topRow, styles.rowTop]}>
+                <View style={styles.titlePillLeftGroup}>
+                  <Text style={styles.rowLabel} numberOfLines={1}>
+                    {row.label}
+                  </Text>
+                  {row.tierLabel && chrome ? (
+                    <ActivityRatingPill
+                      label={row.tierLabel}
+                      color={chrome.color}
+                      backgroundColor={chrome.backgroundColor}
+                      emphasis="subtle"
+                      compactChrome
+                      labelTypography={ACTIVITY_OVERVIEW_SUBTLE_PILL_LABEL_TYPOGRAPHY}
+                      testID={`strength-history-tier-${row.key}`}
+                    />
+                  ) : null}
+                </View>
+                <Text style={row.hasEnoughData ? styles.rowFigure : styles.rowNonNumeric} numberOfLines={1}>
+                  {row.displayValue}
+                </Text>
+              </View>
+              {row.helperText ? <Text style={styles.helperText}>{row.helperText}</Text> : null}
+              <StrengthBaselineFrequencyTrack
+                testID={`strength-history-progress-${row.key}`}
+                tierIndex={row.tierIndexForBar ?? 0}
+                fillWidth01={row.progressFill01 ?? 0}
+              />
+            </View>
+          );
+        })}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: "#FFFFFF",
+    borderRadius: 12,
+    padding: 15,
+    gap: 11,
+    ...elevatedCardSurfaceStyle,
+  },
+  metricGroups: {
+    gap: 12,
+  },
+  metricBlock: {
+    gap: 8,
+  },
+  rowTop: {
+    alignItems: "baseline",
+  },
+  titlePillLeftGroup: {
+    flex: 1,
+    minWidth: 0,
+    flexDirection: "row",
+    alignItems: "baseline",
+    gap: 7,
+  },
+  rowLabel: {
+    flexShrink: 1,
+    minWidth: 0,
+    fontSize: 19,
+    lineHeight: 24,
+    fontWeight: "600",
+    color: "#1C1C1E",
+    letterSpacing: -0.34,
+  },
+  rowFigure: {
+    fontSize: 18,
+    lineHeight: 22,
+    fontWeight: "600",
+    fontVariant: ["tabular-nums"],
+    color: "#1C1C1E",
+    letterSpacing: -0.28,
+    flexShrink: 1,
+    textAlign: "right",
+  },
+  rowNonNumeric: {
+    flexShrink: 0,
+    fontSize: 18,
+    lineHeight: 22,
+    fontWeight: "600",
+    color: "#8E8E93",
+    letterSpacing: -0.28,
+  },
+  helperText: {
+    fontSize: 13,
+    lineHeight: 17,
+    color: "#8E8E93",
+    letterSpacing: -0.08,
+  },
+});

--- a/lib/ui/workouts/__tests__/CardioBaselineCard.test.tsx
+++ b/lib/ui/workouts/__tests__/CardioBaselineCard.test.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import renderer, { act } from "react-test-renderer";
+
+import type { CardioBaselineCardModel } from "@/lib/data/workouts/cardioBaselineCardModel";
+import { CardioBaselineCard } from "@/lib/ui/workouts/CardioBaselineCard";
+
+const model: CardioBaselineCardModel = {
+  kind: "ready",
+  averageMilesPerWeek90d: 3,
+  totalMiles90d: (3 * 90) / 7,
+  sessions90d: 6,
+  totalMinutes90d: (44 * 90) / 7,
+  averageMinutesPerWeek90d: 44,
+  tier: "low",
+  formattedAverageMilesPerWeek: "3.0 mi/wk",
+  formattedAverageMinutesPerWeek: "44 min/wk",
+  headlineLabel: "3.0 mi · 44 min/wk",
+  progressMilesPerWeekScaleValue: 3,
+};
+
+describe("CardioBaselineCard", () => {
+  it("renders all cardio numeric tick labels", async () => {
+    let tree!: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<CardioBaselineCard loading={false} model={model} />);
+    });
+    const json = JSON.stringify(tree.toJSON());
+    expect(json).toContain("Cardio Baseline");
+    expect(json).toContain("3.0 mi · 44 min/wk");
+    expect(json).not.toContain("3.0 mi/wk · 44 min/wk");
+    expect(json).toContain("cardio-baseline-frequency-bar");
+    expect(json).toContain("cardio-baseline-frequency-markers");
+    expect(json).toContain('"children":["0"]');
+    expect(json).toContain('"children":["2.5"]');
+    expect(json).toContain('"children":["7.5"]');
+    expect(json).toContain('"children":["15"]');
+    expect(json).toContain('"children":["25"]');
+  });
+});

--- a/lib/ui/workouts/__tests__/CardioHistorySummaryCard.test.tsx
+++ b/lib/ui/workouts/__tests__/CardioHistorySummaryCard.test.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import renderer, { act } from "react-test-renderer";
+
+import type { CardioHistorySummaryModel } from "@/lib/data/workouts/cardioHistorySummaryModel";
+import { CardioHistorySummaryCard } from "@/lib/ui/workouts/CardioHistorySummaryCard";
+import { ACTIVITY_STEP_RATING_TIERS } from "@/lib/utils/activityStepRating";
+
+describe("CardioHistorySummaryCard", () => {
+  it("uses ACTIVITY_STEP_RATING_TIERS chrome for Low (tier index 1), not legacy blue", async () => {
+    const tierChrome = ACTIVITY_STEP_RATING_TIERS[1]!;
+    const model: CardioHistorySummaryModel = {
+      rows: [
+        {
+          key: "day7",
+          label: "7 Day",
+          hasEnoughData: true,
+          totalMiles: 1,
+          averageMilesPerWeek: 1,
+          totalMinutes: 10,
+          averageMinutesPerWeek: 10,
+          displayValue: "1.0 mi · 10 min/wk",
+          tierLabel: "Low",
+          tierIndexForBar: 1,
+          progressFill01: 0.2,
+        },
+      ],
+    };
+    let tree!: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<CardioHistorySummaryCard model={model} />);
+    });
+    const json = JSON.stringify(tree.toJSON());
+    expect(json).toContain(tierChrome.color);
+    expect(json).toContain(tierChrome.backgroundColor);
+    expect(json).not.toContain("#0A84FF");
+    expect(json).toContain("Low");
+  });
+});

--- a/lib/ui/workouts/__tests__/StrengthBaselineCard.test.tsx
+++ b/lib/ui/workouts/__tests__/StrengthBaselineCard.test.tsx
@@ -38,11 +38,14 @@ describe("StrengthBaselineCard", () => {
     expect(json).toContain("Strength Baseline");
     expect(json).toContain("strength-baseline-frequency-bar");
     expect(json).toContain("strength-baseline-frequency-markers");
+    expect(json).toContain("90 Day Avg");
     for (const d of [0, 1, 2, 3, 4, 5, 6, 7] as const) {
       expect(json).toContain(`"children":["${d}"]`);
     }
     expect(json).toContain(STRENGTH_BASELINE_CARD_DEFINITION_SENTENCE);
     expect(json).toContain("/wk");
+    expect(json).toContain("wo");
+    expect(json).toContain("min/wk");
     expect(json).not.toContain("workouts / week");
   });
 });

--- a/lib/ui/workouts/__tests__/StrengthHistorySummaryCard.test.tsx
+++ b/lib/ui/workouts/__tests__/StrengthHistorySummaryCard.test.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import renderer, { act } from "react-test-renderer";
+
+import type { StrengthHistorySummaryModel } from "@/lib/data/workouts/strengthHistorySummaryModel";
+import { StrengthHistorySummaryCard } from "@/lib/ui/workouts/StrengthHistorySummaryCard";
+
+const model: StrengthHistorySummaryModel = {
+  rows: [
+    {
+      key: "day7",
+      label: "7 Day",
+      hasEnoughData: true,
+      totalSessions: 3,
+      averageSessionsPerWeek: 3,
+      totalMinutes: 90,
+      averageMinutesPerWeek: 90,
+      displayValue: "3.0 wo · 90 min/wk",
+      tierLabel: "Great",
+      tierIndexForBar: 3,
+      progressFill01: 0.5,
+    },
+    {
+      key: "month12",
+      label: "12 Month",
+      hasEnoughData: false,
+      totalSessions: null,
+      averageSessionsPerWeek: null,
+      totalMinutes: null,
+      averageMinutesPerWeek: null,
+      displayValue: "—",
+      tierLabel: null,
+      tierIndexForBar: null,
+      progressFill01: null,
+      helperText: "Data will appear when enough history is available",
+    },
+  ],
+};
+
+describe("StrengthHistorySummaryCard", () => {
+  it("renders history rows with value format and insufficient helper", async () => {
+    let tree!: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<StrengthHistorySummaryCard model={model} />);
+    });
+    const json = JSON.stringify(tree.toJSON());
+    expect(json).toContain("strength-history-summary-card");
+    expect(json).toContain("7 Day");
+    expect(json).toContain("3.0 wo · 90 min/wk");
+    expect(json).toContain("12 Month");
+    expect(json).toContain("—");
+    expect(json).toContain("Data will appear when enough history is available");
+  });
+});

--- a/lib/ui/workouts/__tests__/cardioBaselineScale.test.ts
+++ b/lib/ui/workouts/__tests__/cardioBaselineScale.test.ts
@@ -1,0 +1,27 @@
+import {
+  cardioBaselineMarkerVisualPosition01,
+  cardioBaselineMilesToVisualScale01,
+  CARDIO_BASELINE_MARKER_VISUAL_POSITIONS_01,
+  CARDIO_BASELINE_MARKER_VALUES_MILES,
+} from "@/lib/ui/workouts/cardioBaselineScale";
+
+describe("cardio baseline scale mapping", () => {
+  it("maps tick markers to evenly spaced visual positions", () => {
+    expect(cardioBaselineMarkerVisualPosition01(0)).toBeCloseTo(0, 10);
+    expect(cardioBaselineMarkerVisualPosition01(2.5)).toBeCloseTo(0.25, 10);
+    expect(cardioBaselineMarkerVisualPosition01(7.5)).toBeCloseTo(0.5, 10);
+    expect(cardioBaselineMarkerVisualPosition01(15)).toBeCloseTo(0.75, 10);
+    expect(cardioBaselineMarkerVisualPosition01(25)).toBeCloseTo(1, 10);
+    expect(CARDIO_BASELINE_MARKER_VALUES_MILES).toEqual([0, 2.5, 7.5, 15, 25]);
+    expect(CARDIO_BASELINE_MARKER_VISUAL_POSITIONS_01).toEqual([0, 0.25, 0.5, 0.75, 1]);
+  });
+
+  it("maps fill across visual tier scale segments", () => {
+    expect(cardioBaselineMilesToVisualScale01(2.5)).toBeCloseTo(0.25, 10);
+    expect(cardioBaselineMilesToVisualScale01(3.0)).toBeGreaterThan(0.25);
+    expect(cardioBaselineMilesToVisualScale01(3.0)).toBeLessThan(0.5);
+    expect(cardioBaselineMilesToVisualScale01(7.5)).toBeCloseTo(0.5, 10);
+    expect(cardioBaselineMilesToVisualScale01(15)).toBeCloseTo(0.75, 10);
+    expect(cardioBaselineMilesToVisualScale01(25)).toBeCloseTo(1, 10);
+  });
+});

--- a/lib/ui/workouts/cardioBaselineScale.ts
+++ b/lib/ui/workouts/cardioBaselineScale.ts
@@ -1,0 +1,19 @@
+export const CARDIO_BASELINE_SCALE_MIN_MILES = 0;
+export const CARDIO_BASELINE_SCALE_MAX_MILES = 25;
+export const CARDIO_BASELINE_MARKER_VALUES_MILES = [0, 2.5, 7.5, 15, 25] as const;
+export const CARDIO_BASELINE_MARKER_VISUAL_POSITIONS_01 = [0, 0.25, 0.5, 0.75, 1] as const;
+
+export function cardioBaselineMilesToVisualScale01(milesPerWeek: number): number {
+  if (!Number.isFinite(milesPerWeek)) return 0;
+  const v = Math.min(CARDIO_BASELINE_SCALE_MAX_MILES, Math.max(CARDIO_BASELINE_SCALE_MIN_MILES, milesPerWeek));
+  if (v <= 2.5) return (v / 2.5) * 0.25;
+  if (v <= 7.5) return 0.25 + ((v - 2.5) / (7.5 - 2.5)) * 0.25;
+  if (v <= 15) return 0.5 + ((v - 7.5) / (15 - 7.5)) * 0.25;
+  return 0.75 + ((v - 15) / (25 - 15)) * 0.25;
+}
+
+export function cardioBaselineMarkerVisualPosition01(milesMarker: number): number {
+  const idx = CARDIO_BASELINE_MARKER_VALUES_MILES.findIndex((v) => v === milesMarker);
+  if (idx < 0) return 0;
+  return CARDIO_BASELINE_MARKER_VISUAL_POSITIONS_01[idx]!;
+}

--- a/scripts/test/run-jest-with-firestore-emulator.mjs
+++ b/scripts/test/run-jest-with-firestore-emulator.mjs
@@ -130,6 +130,22 @@ function runAndGetExitCode(cmd, args, env = {}) {
   });
 }
 
+function isErrnoException(err) {
+  return typeof err === "object" && err !== null && "code" in err;
+}
+
+function canSignalProcess(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    if (isErrnoException(err) && err.code === "ESRCH") {
+      return false;
+    }
+    throw err;
+  }
+}
+
 async function main() {
   const repoRoot = findRepoRoot(process.cwd());
   const firebaseJsonPath = path.join(repoRoot, "firebase.json");
@@ -201,6 +217,7 @@ async function main() {
   };
 
   let emulatorChild = null;
+  let emulatorExited = false;
 
   try {
     // Start emulator in background so we control exit code (emulator can exit 2 on shutdown).
@@ -222,6 +239,9 @@ async function main() {
     );
     emulatorChild.on("error", (err) => {
       console.error("[emulator] spawn error", err);
+    });
+    emulatorChild.on("exit", () => {
+      emulatorExited = true;
     });
 
     await waitForPort(firestorePort, "127.0.0.1");
@@ -246,8 +266,14 @@ async function main() {
     );
     return restExit;
   } finally {
-    if (emulatorChild?.pid) {
-      process.kill(emulatorChild.pid, "SIGTERM");
+    if (emulatorChild?.pid && !emulatorExited && canSignalProcess(emulatorChild.pid)) {
+      try {
+        process.kill(emulatorChild.pid, "SIGTERM");
+      } catch (err) {
+        if (!(isErrnoException(err) && err.code === "ESRCH")) {
+          throw err;
+        }
+      }
       // Give it a moment to shut down; don't await indefinitely.
       await new Promise((r) => setTimeout(r, 2000));
     }


### PR DESCRIPTION
…rs, and implement full history + range metrics

- Fixed Apple Health activity mapping (Indoor Walk → Walking)
- Removed 14-session cap causing missing sessions in This Week
- Unified cardio selectors across This Week and Full History
- Filtered and deduped 'Other' duration-only sessions
- Corrected duration and distance prioritization logic
- Implemented cardio full-history screen with monthly aggregation
- Added shared cardio range metrics (7d, 30d, YTD, 12m, 90d baseline)
- Fixed min/week calculations using consistent denominator
- Aligned history card pill colors with baseline tiers
- Added comprehensive test coverage for cardio pipelines