### PR TITLE
feat: canonical sleep night pipeline with Oura physiology ingestion

### DIFF
--- a/app/(app)/(tabs)/__tests__/dash-accessibility.test.tsx
+++ b/app/(app)/(tabs)/__tests__/dash-accessibility.test.tsx
@@ -4,6 +4,8 @@
 import React, { act } from "react";
 import renderer from "react-test-renderer";
 
+import { emptyDailySleepCardModel } from "@/lib/data/dash/buildDailySleepCardModel";
+
 const mockUseTodayHealthHero = jest.fn();
 jest.mock("@/lib/hooks/useTodayHealthHero", () => ({
   useTodayHealthHero: (...args: unknown[]) => mockUseTodayHealthHero(...args),
@@ -109,6 +111,7 @@ jest.mock("react-native", () => ({
   View: "View",
   Text: "Text",
   Pressable: "Pressable",
+  Modal: "Modal",
   ScrollView: "ScrollView",
   ActivityIndicator: "ActivityIndicator",
   StyleSheet: { create: (s: unknown) => s },
@@ -137,6 +140,7 @@ jest.mock("react-native", () => ({
 
 jest.mock("react-native-safe-area-context", () => ({
   SafeAreaView: "SafeAreaView",
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
 }));
 
 jest.mock("expo-router", () => ({
@@ -175,6 +179,10 @@ describe("Dash accessibility", () => {
       energyLoading: false,
       energyError: null,
       energy: undefined,
+      sleepCard: emptyDailySleepCardModel("2026-05-11"),
+      sleepCardLoading: false,
+      sleepCardRefreshing: false,
+      sleepCardError: null,
       refetch: jest.fn(),
     });
     mockUseBodyCompositionDashCard.mockReset();
@@ -268,18 +276,23 @@ describe("Dash accessibility", () => {
     /** Daily Energy still renders. */
     expect(text).toContain("Daily Energy");
     expect(text).toContain("Daily Nutrition");
-    expect(text).not.toContain("Sleep");
-    expect(text).not.toContain("Recovery");
+    expect(text).toContain("Daily Sleep");
+    /** Legacy hero row used plain "Sleep" / "Recovery" labels; dedicated card uses "Daily Sleep". */
+    expect(text).not.toContain("Last night summary");
 
-    /** Today hero precedes Weekly Fitness; then Body Composition then Daily Energy. */
+    /** Today hero precedes Weekly Fitness; then Body Composition, Daily Energy, Daily Sleep, Daily Nutrition. */
     const idxHero = text.indexOf("Good afternoon");
     const idxWeeklyFitness = text.indexOf("Weekly Fitness");
     const idxBody = text.indexOf("Body Composition");
     const idxEnergy = text.indexOf("Daily Energy");
+    const idxSleepCard = text.indexOf("Daily Sleep");
+    const idxNutrition = text.indexOf("Daily Nutrition");
     expect(idxHero).toBeGreaterThan(-1);
     expect(idxWeeklyFitness).toBeGreaterThan(idxHero);
     expect(idxBody).toBeGreaterThan(idxWeeklyFitness);
     expect(idxEnergy).toBeGreaterThan(idxBody);
+    expect(idxSleepCard).toBeGreaterThan(idxEnergy);
+    expect(idxNutrition).toBeGreaterThan(idxSleepCard);
   });
 
   it("keeps at least one actionable button (Settings)", () => {

--- a/app/(app)/(tabs)/__tests__/dash-provenance.test.tsx
+++ b/app/(app)/(tabs)/__tests__/dash-provenance.test.tsx
@@ -4,6 +4,8 @@
 import React, { act } from "react";
 import renderer from "react-test-renderer";
 
+import { emptyDailySleepCardModel } from "@/lib/data/dash/buildDailySleepCardModel";
+
 const mockUseTodayHealthHero = jest.fn();
 jest.mock("@/lib/hooks/useTodayHealthHero", () => ({
   useTodayHealthHero: (...args: unknown[]) => mockUseTodayHealthHero(...args),
@@ -82,6 +84,7 @@ jest.mock("react-native", () => ({
   View: "View",
   Text: "Text",
   Pressable: "Pressable",
+  Modal: "Modal",
   ScrollView: "ScrollView",
   ActivityIndicator: "ActivityIndicator",
   StyleSheet: { create: (s: unknown) => s },
@@ -110,6 +113,7 @@ jest.mock("react-native", () => ({
 
 jest.mock("react-native-safe-area-context", () => ({
   SafeAreaView: "SafeAreaView",
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
 }));
 
 jest.mock("expo-router", () => ({
@@ -170,6 +174,10 @@ describe("Dash provenance", () => {
         },
         missingRequiredInputs: [],
       },
+      sleepCard: emptyDailySleepCardModel("2026-05-05"),
+      sleepCardLoading: false,
+      sleepCardRefreshing: false,
+      sleepCardError: null,
     });
   });
 
@@ -219,6 +227,10 @@ describe("Dash provenance", () => {
       energyError: null,
       refetch: jest.fn(),
       energy: undefined,
+      sleepCard: emptyDailySleepCardModel("2026-05-05"),
+      sleepCardLoading: false,
+      sleepCardRefreshing: false,
+      sleepCardError: null,
     });
     let test!: renderer.ReactTestRenderer;
     act(() => {

--- a/app/(app)/(tabs)/__tests__/dash-recap.test.tsx
+++ b/app/(app)/(tabs)/__tests__/dash-recap.test.tsx
@@ -4,10 +4,13 @@
 import React, { act } from "react";
 import renderer from "react-test-renderer";
 
+import { emptyDailySleepCardModel } from "@/lib/data/dash/buildDailySleepCardModel";
+
 jest.mock("react-native", () => ({
   View: "View",
   Text: "Text",
   Pressable: "Pressable",
+  Modal: "Modal",
   ScrollView: "ScrollView",
   StyleSheet: { create: (s: unknown) => s },
   ActivityIndicator: "ActivityIndicator",
@@ -36,6 +39,7 @@ jest.mock("react-native", () => ({
 
 jest.mock("react-native-safe-area-context", () => ({
   SafeAreaView: "SafeAreaView",
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
 }));
 
 jest.mock("expo-router", () => ({
@@ -195,6 +199,10 @@ describe("Dash Daily Energy card", () => {
         },
         missingRequiredInputs: [],
       },
+      sleepCard: emptyDailySleepCardModel("2026-05-05"),
+      sleepCardLoading: false,
+      sleepCardRefreshing: false,
+      sleepCardError: null,
     });
 
     let test!: renderer.ReactTestRenderer;
@@ -219,20 +227,21 @@ describe("Dash Daily Energy card", () => {
     expect(text).toContain("BMR");
     expect(text).toContain("NEAT");
     expect(text).toContain("Confidence");
-    expect(text).not.toContain("Sleep");
-    expect(text).not.toContain("Recovery");
+    expect(text).toContain("Daily Sleep");
 
-    /** Today hero precedes Weekly Fitness; then Body Composition, Daily Energy, Daily Nutrition. */
+    /** Today hero precedes Weekly Fitness; then Body Composition, Daily Energy, Daily Sleep, Daily Nutrition. */
     const idxHero = text.indexOf("Good afternoon");
     const idxWeeklyFitness = text.indexOf("Weekly Fitness");
     const idxBody = text.indexOf("Body Composition");
     const idxEnergy = text.indexOf("Daily Energy");
+    const idxSleep = text.indexOf("Daily Sleep");
     const idxNutrition = text.indexOf("Daily Nutrition");
     expect(idxHero).toBeGreaterThan(-1);
     expect(idxWeeklyFitness).toBeGreaterThan(idxHero);
     expect(idxBody).toBeGreaterThan(idxWeeklyFitness);
     expect(idxEnergy).toBeGreaterThan(idxBody);
-    expect(idxNutrition).toBeGreaterThan(idxEnergy);
+    expect(idxSleep).toBeGreaterThan(idxEnergy);
+    expect(idxNutrition).toBeGreaterThan(idxSleep);
   });
 
   it("shows loading copy while Daily Energy is hydrating", () => {
@@ -246,6 +255,10 @@ describe("Dash Daily Energy card", () => {
       energyError: null,
       refetch: jest.fn(),
       energy: undefined,
+      sleepCard: undefined,
+      sleepCardLoading: true,
+      sleepCardRefreshing: false,
+      sleepCardError: null,
     });
 
     let test!: renderer.ReactTestRenderer;
@@ -254,6 +267,8 @@ describe("Dash Daily Energy card", () => {
     });
     const text = collectAllText(test);
     expect(text).toContain("Loading daily energy");
+    expect(text).toContain("Daily Sleep");
+    expect(text).not.toContain("Loading daily sleep");
   });
 
   it("shows empty-state copy when energy is missing", () => {
@@ -263,6 +278,10 @@ describe("Dash Daily Energy card", () => {
       energyError: null,
       refetch: jest.fn(),
       energy: undefined,
+      sleepCard: emptyDailySleepCardModel("2026-05-05"),
+      sleepCardLoading: false,
+      sleepCardRefreshing: false,
+      sleepCardError: null,
     });
 
     let test!: renderer.ReactTestRenderer;

--- a/app/(app)/(tabs)/dash.tsx
+++ b/app/(app)/(tabs)/dash.tsx
@@ -16,6 +16,7 @@ import { useWeeklyFitnessCard } from "@/lib/data/dash/useWeeklyFitnessCard";
 import { useTodayHealthHero } from "@/lib/hooks/useTodayHealthHero";
 import { BodyCompositionCard } from "@/lib/ui/dash/BodyCompositionCard";
 import { DailyEnergyCard } from "@/lib/ui/dash/DailyEnergyCard";
+import { DailySleepCard } from "@/lib/ui/dash/DailySleepCard";
 import { DailyNutritionCard } from "@/lib/ui/dash/DailyNutritionCard";
 import { WeeklyFitnessCard } from "@/lib/ui/dash/WeeklyFitnessCard";
 import { getTodayDayKeyLocal } from "@/lib/ui/calendar/dateUtils";
@@ -24,7 +25,17 @@ export default function DashScreen() {
   const scrollPaddingBottom = useFloatingTabBarScrollPadding(40);
   const { user } = useAuth();
   const todayKey = getTodayDayKeyLocal();
-  const { vm: todayHero, energy, energyLoading, energyError, refetch } = useTodayHealthHero(todayKey);
+  const {
+    vm: todayHero,
+    energy,
+    energyLoading,
+    energyError,
+    sleepCard,
+    sleepCardLoading,
+    sleepCardRefreshing,
+    sleepCardError,
+    refetch,
+  } = useTodayHealthHero(todayKey);
   const weeklyFitness = useWeeklyFitnessCard();
   const bodyComposition = useBodyCompositionDashCard();
   const dailyNutrition = useDailyNutritionCard(todayKey);
@@ -65,6 +76,12 @@ export default function DashScreen() {
             />
 
             <DailyEnergyCard energy={energy} loading={energyLoading} error={energyError} />
+            <DailySleepCard
+              model={sleepCard}
+              loading={sleepCardLoading}
+              isRefreshing={sleepCardRefreshing}
+              error={sleepCardError}
+            />
             <DailyNutritionCard
               model={dailyNutrition.model}
               loading={dailyNutrition.loading}

--- a/infra/gateway/openapi.yaml
+++ b/infra/gateway/openapi.yaml
@@ -394,6 +394,38 @@ paths:
         200:
           description: OK
 
+  # Canonical SleepNight read (Firestore sleepNights; bounded resolution; 404 when none in window)
+  /users/me/sleep-night:
+    options:
+      operationId: sleepNightOptions
+      security: []
+      responses:
+        204:
+          description: No Content
+    get:
+      operationId: sleepNightGet
+      security:
+        - firebase: []
+      parameters:
+        - name: day
+          in: query
+          required: true
+          type: string
+          description: YYYY-MM-DD
+      produces:
+        - application/json
+      responses:
+        200:
+          description: SleepNight view (requestedDay, anchorDay, wakeDay, resolution, sleepNight)
+        400:
+          description: Bad Request (missing or invalid day)
+        401:
+          description: Unauthorized
+        404:
+          description: No complete SleepNight in bounded lookback
+        500:
+          description: Server Error
+
   # Oura Tier 1 — Sleep view (vendor snapshot read; 404 when no snapshot in window)
   /users/me/oura-sleep-view:
     options:

--- a/lib/api/usersMe.ts
+++ b/lib/api/usersMe.ts
@@ -56,10 +56,12 @@ import {
   healthSignalDocSchema,
   sleepViewDtoSchema,
   readinessViewDtoSchema,
+  sleepNightViewDtoSchema,
   type HealthScoreDoc,
   type HealthSignalDoc,
   type SleepViewDto,
   type ReadinessViewDto,
+  type SleepNightViewDto,
   workoutDaySummariesResponseDtoSchema,
   workoutDaySummariesRebuildResponseDtoSchema,
   workoutMonthSummariesResponseDtoSchema,
@@ -388,6 +390,20 @@ export const getOuraReadinessView = async (
     `/users/me/oura-readiness-view?day=${encodeURIComponent(day)}`,
     idToken,
     readinessViewDtoSchema,
+    truthGetOpts(opts),
+  );
+};
+
+/** GET /users/me/sleep-night?day= — canonical SleepNight for Dash / Sleep (404 when absent). */
+export const getSleepNight = async (
+  day: string,
+  idToken: string,
+  opts?: TruthGetOptions,
+): Promise<ApiResult<SleepNightViewDto>> => {
+  return apiGetZodAuthed(
+    `/users/me/sleep-night?day=${encodeURIComponent(day)}`,
+    idToken,
+    sleepNightViewDtoSchema,
     truthGetOpts(opts),
   );
 };

--- a/lib/contracts/__tests__/sleepNightViewDtoSchema.test.ts
+++ b/lib/contracts/__tests__/sleepNightViewDtoSchema.test.ts
@@ -1,0 +1,75 @@
+import { sleepNightViewDtoSchema } from "../sleepNight";
+
+describe("sleepNightViewDtoSchema", () => {
+  it("parses resolution + isFallback false", () => {
+    const parsed = sleepNightViewDtoSchema.safeParse({
+      requestedDay: "2026-05-13",
+      anchorDay: "2026-05-12",
+      wakeDay: "2026-05-13",
+      resolution: "latest_completed_prior_night",
+      isFallback: false,
+      sleepNight: {
+        anchorDay: "2026-05-12",
+        wakeDay: "2026-05-13",
+        provider: "oura",
+        source: "ouraVendorSleep",
+        sourceDocumentId: "s1",
+        isComplete: true,
+        score: 77,
+        updatedAt: "2026-05-13T12:00:00.000Z",
+      },
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.resolution).toBe("latest_completed_prior_night");
+      expect(parsed.data.isFallback).toBe(false);
+    }
+  });
+
+  it("parses lowestHeartRateBpm and averageHrvMs on sleepNight", () => {
+    const parsed = sleepNightViewDtoSchema.safeParse({
+      requestedDay: "2026-05-13",
+      anchorDay: "2026-05-12",
+      wakeDay: "2026-05-13",
+      resolution: "latest_completed_prior_night",
+      isFallback: false,
+      sleepNight: {
+        anchorDay: "2026-05-12",
+        wakeDay: "2026-05-13",
+        provider: "oura",
+        source: "ouraVendorSleep",
+        sourceDocumentId: "s1",
+        isComplete: true,
+        score: 77,
+        updatedAt: "2026-05-13T12:00:00.000Z",
+        lowestHeartRateBpm: 50,
+        averageHrvMs: 23,
+      },
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.sleepNight.lowestHeartRateBpm).toBe(50);
+      expect(parsed.data.sleepNight.averageHrvMs).toBe(23);
+    }
+  });
+
+  it("rejects isFallback true", () => {
+    const parsed = sleepNightViewDtoSchema.safeParse({
+      requestedDay: "2026-05-13",
+      anchorDay: "2026-05-12",
+      wakeDay: "2026-05-13",
+      resolution: "wake_day",
+      isFallback: true,
+      sleepNight: {
+        anchorDay: "2026-05-12",
+        wakeDay: "2026-05-13",
+        provider: "oura",
+        source: "ouraVendorSleep",
+        sourceDocumentId: "s1",
+        isComplete: true,
+        updatedAt: "2026-05-13T12:00:00.000Z",
+      },
+    });
+    expect(parsed.success).toBe(false);
+  });
+});

--- a/lib/contracts/__tests__/sleepViewDtoSchema.test.ts
+++ b/lib/contracts/__tests__/sleepViewDtoSchema.test.ts
@@ -1,0 +1,42 @@
+import { sleepViewDtoSchema } from "../ouraVendor";
+
+describe("sleepViewDtoSchema", () => {
+  it("accepts score as JSON number", () => {
+    const parsed = sleepViewDtoSchema.safeParse({
+      requestedDay: "2025-03-15",
+      resolvedDay: "2025-03-15",
+      isFallback: false,
+      day: "2025-03-15",
+      score: 82,
+      contributors: {},
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) expect(parsed.data.score).toBe(82);
+  });
+
+  it("coerces digit-string score to number at the trust boundary", () => {
+    const parsed = sleepViewDtoSchema.safeParse({
+      requestedDay: "2025-03-15",
+      resolvedDay: "2025-03-15",
+      isFallback: false,
+      day: "2025-03-15",
+      score: "96",
+      contributors: {},
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) expect(parsed.data.score).toBe(96);
+  });
+
+  it("maps JSON null score to undefined (no numeric score)", () => {
+    const parsed = sleepViewDtoSchema.safeParse({
+      requestedDay: "2025-03-15",
+      resolvedDay: "2025-03-15",
+      isFallback: false,
+      day: "2025-03-15",
+      score: null,
+      contributors: {},
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) expect(parsed.data.score).toBeUndefined();
+  });
+});

--- a/lib/contracts/dailyFacts.ts
+++ b/lib/contracts/dailyFacts.ts
@@ -140,6 +140,7 @@ export const dailyFactsDtoSchema = z
         hrvRmssd: z.number().finite().optional(),
         hrvRmssdBaseline: z.number().finite().optional(),
         hrvRmssdDeviation: z.number().finite().optional(),
+        restingHeartRate: z.number().finite().optional(),
       })
       .strip()
       .optional(),

--- a/lib/contracts/index.ts
+++ b/lib/contracts/index.ts
@@ -58,6 +58,9 @@ export * from "./provenance";
 // Oura Tier 1 — vendor snapshots and view DTOs (Sleep & Readiness)
 export * from "./ouraVendor";
 
+// Canonical sleep night read model (Oura → sleepNights + GET /users/me/sleep-night)
+export * from "./sleepNight";
+
 // Oli Sleep Score v1 (derived from DailyFacts.sleep)
 export * from "./oliSleepScore";
 

--- a/lib/contracts/ouraVendor.ts
+++ b/lib/contracts/ouraVendor.ts
@@ -9,6 +9,21 @@ import { dayKeySchema } from "./day";
 
 const contributorsSchema = z.record(z.string(), z.unknown()).optional();
 
+/**
+ * Oura / Firestore may expose sleep score as a JSON number or a digit string; normalize at the trust boundary.
+ */
+export const sleepViewScoreSchema = z.preprocess((val) => {
+  if (val === null || val === undefined || val === "") return undefined;
+  if (typeof val === "number" && Number.isFinite(val)) return val;
+  if (typeof val === "string") {
+    const t = val.trim();
+    if (t === "") return undefined;
+    const n = Number(t);
+    return Number.isFinite(n) ? n : undefined;
+  }
+  return undefined;
+}, z.number().min(0).max(100).optional()) as z.ZodType<number | undefined>;
+
 /** Stored snapshot for one Oura sleep document (score + contributors + display fields). */
 export const ouraSleepSnapshotSchema = z.object({
   id: z.string().min(1),
@@ -25,6 +40,10 @@ export const ouraSleepSnapshotSchema = z.object({
   restfulSleep: z.number().optional(),
   remSleep: z.number().optional(),
   deepSleep: z.number().optional(),
+  lowestHeartRateBpm: z.number().int().min(30).max(220).optional(),
+  averageHrvMs: z.number().min(0).max(50_000).optional(),
+  /** Full Oura API sleep document for backfill / field recovery. */
+  payload: z.record(z.string(), z.unknown()).optional(),
 });
 export type OuraSleepSnapshot = z.infer<typeof ouraSleepSnapshotSchema>;
 
@@ -37,6 +56,8 @@ export const ouraReadinessSnapshotSchema = z.object({
   source: z.literal("oura"),
   fetchedAt: z.string().min(1),
   updatedAt: z.string().min(1).optional(),
+  lowestHeartRateBpm: z.number().int().min(30).max(220).optional(),
+  averageHrvMs: z.number().min(0).max(50_000).optional(),
 });
 export type OuraReadinessSnapshot = z.infer<typeof ouraReadinessSnapshotSchema>;
 
@@ -47,7 +68,7 @@ export const sleepViewDtoSchema = z.object({
   isFallback: z.boolean(),
   day: dayKeySchema, // alias for resolvedDay (backward compat)
   sourceId: z.literal("oura").optional(),
-  score: z.number().min(0).max(100).nullable().optional(),
+  score: sleepViewScoreSchema,
   contributors: contributorsSchema,
   totalMinutes: z.number().optional(),
   efficiency: z.number().optional(),

--- a/lib/contracts/rawEvent.ts
+++ b/lib/contracts/rawEvent.ts
@@ -267,6 +267,8 @@ const manualHrvPayloadSchema = z
     rmssdMs: z.number().finite().nonnegative().nullable().optional(),
     sdnnMs: z.number().finite().nonnegative().nullable().optional(),
     measurementType: z.enum(["nightly", "spot"]).optional(),
+    /** Nightly resting / average HR from vendor readiness (bpm) when available. */
+    restingHeartRateBpm: z.number().finite().min(1).max(250).nullable().optional(),
   })
   .strip();
 

--- a/lib/contracts/sleepNight.ts
+++ b/lib/contracts/sleepNight.ts
@@ -1,0 +1,101 @@
+/**
+ * Canonical SleepNight read model — Firestore `users/{uid}/sleepNights/{anchorDay}` + GET /users/me/sleep-night.
+ */
+
+import { z } from "zod";
+
+import { dayKeySchema } from "./day";
+
+/** Coerce JSON number or digit string to 0–100 (matches vendor sleep score handling). */
+export const sleepNightScoreSchema = z.preprocess((val) => {
+  if (val === null || val === undefined || val === "") return undefined;
+  if (typeof val === "number" && Number.isFinite(val)) return val;
+  if (typeof val === "string") {
+    const t = val.trim();
+    if (t === "") return undefined;
+    const n = Number(t);
+    return Number.isFinite(n) ? n : undefined;
+  }
+  return undefined;
+}, z.number().min(0).max(100).optional()) as z.ZodType<number | undefined>;
+
+/** Coerce JSON number or digit string to integer bpm (Oura lowest HR range). */
+const sleepNightLowestHrBpmSchema = z.preprocess((val) => {
+  if (val === null || val === undefined || val === "") return undefined;
+  if (typeof val === "number" && Number.isFinite(val)) return Math.round(val);
+  if (typeof val === "string") {
+    const t = val.trim();
+    if (t === "") return undefined;
+    const n = Number(t);
+    return Number.isFinite(n) ? Math.round(n) : undefined;
+  }
+  return undefined;
+}, z.number().int().min(30).max(220).optional()) as z.ZodType<number | undefined>;
+
+/** Coerce JSON number or digit string to nightly HRV aggregate in ms (Oura readiness / vendor snapshot). */
+const sleepNightAverageHrvMsSchema = z.preprocess((val) => {
+  if (val === null || val === undefined || val === "") return undefined;
+  if (typeof val === "number" && Number.isFinite(val)) return Math.round(val);
+  if (typeof val === "string") {
+    const t = val.trim();
+    if (t === "") return undefined;
+    const n = Number(t);
+    return Number.isFinite(n) ? Math.round(n) : undefined;
+  }
+  return undefined;
+}, z.number().min(0).max(50_000).optional()) as z.ZodType<number | undefined>;
+
+/**
+ * Parsed SleepNight document (API omits undefined; optional fields may be absent).
+ */
+export const sleepNightDocumentSchema = z.object({
+  anchorDay: dayKeySchema,
+  wakeDay: dayKeySchema,
+  provider: z.literal("oura"),
+  source: z.literal("ouraVendorSleep"),
+  sourceDocumentId: z.string().min(1),
+  score: sleepNightScoreSchema,
+  rating: z.string().min(1).optional(),
+  totalSleepMinutes: z.number().nonnegative().optional(),
+  mainSleepMinutes: z.number().nonnegative().optional(),
+  efficiency: z.number().nonnegative().optional(),
+  remMinutes: z.number().nonnegative().optional(),
+  remPercent: z.number().min(0).max(100).optional(),
+  deepMinutes: z.number().nonnegative().optional(),
+  deepPercent: z.number().min(0).max(100).optional(),
+  latencyMinutes: z.number().nonnegative().optional(),
+  restfulnessLabel: z.string().min(1).optional(),
+  timingLabel: z.string().min(1).optional(),
+  isComplete: z.boolean(),
+  startedAt: z.string().min(1).optional(),
+  endedAt: z.string().min(1).optional(),
+  updatedAt: z.string().min(1).optional(),
+  /** From Oura sleep period and/or daily_readiness at ingest; not inferred on device. */
+  lowestHeartRateBpm: sleepNightLowestHrBpmSchema.optional(),
+  /** From Oura sleep `average_hrv` and/or daily_readiness aggregate (ms). */
+  averageHrvMs: sleepNightAverageHrvMsSchema.optional(),
+  /** Provenance when physiology was persisted at ingest. */
+  physiologySource: z.enum(["oura_sleep_doc", "oura_readiness", "oura_time_series"]).optional(),
+});
+
+export type SleepNightDocumentDto = z.infer<typeof sleepNightDocumentSchema>;
+
+export const sleepNightResolutionSchema = z.enum([
+  "exact_anchor",
+  "wake_day",
+  "latest_completed_prior_night",
+]);
+
+export type SleepNightResolution = z.infer<typeof sleepNightResolutionSchema>;
+
+export const sleepNightViewDtoSchema = z.object({
+  requestedDay: dayKeySchema,
+  anchorDay: dayKeySchema,
+  wakeDay: dayKeySchema,
+  resolution: sleepNightResolutionSchema,
+  /** Physiological mapping is not a stale vendor fallback; always false for this route. */
+  isFallback: z.literal(false),
+  sleepNight: sleepNightDocumentSchema,
+});
+
+export type SleepNightViewDto = z.infer<typeof sleepNightViewDtoSchema>;

--- a/lib/data/dash/__tests__/buildDailySleepCardModel.dashSequence.test.ts
+++ b/lib/data/dash/__tests__/buildDailySleepCardModel.dashSequence.test.ts
@@ -1,0 +1,41 @@
+import type { SleepNightDocumentDto } from "@oli/contracts";
+import { buildDailySleepCardModel } from "../buildDailySleepCardModel";
+
+const day = "2026-05-10";
+
+function minimalNight(over: Partial<SleepNightDocumentDto> = {}): SleepNightDocumentDto {
+  return {
+    anchorDay: day,
+    wakeDay: day,
+    provider: "oura",
+    source: "ouraVendorSleep",
+    sourceDocumentId: "s1",
+    isComplete: true,
+    updatedAt: "2026-05-10T12:00:00.000Z",
+    totalSleepMinutes: 480,
+    ...over,
+  };
+}
+
+/**
+ * Simulates Dash: SleepNight request settles — model picks up headline when `sleepNightSettled` is true.
+ */
+describe("buildDailySleepCardModel Dash sleep sequencing", () => {
+  it("renders headline after SleepNight arrives", () => {
+    const before = buildDailySleepCardModel({
+      day,
+      sleepNight: undefined,
+      sleepNightSettled: false,
+    });
+    expect(before.headlineValueText).toBeNull();
+
+    const after = buildDailySleepCardModel({
+      day,
+      sleepNight: minimalNight({ score: 96 }),
+      sleepNightSettled: true,
+    });
+    expect(after.scoreValueText).toBe("96");
+    expect(after.ratingLabel).toBe("Optimal");
+    expect(after.headlineValueText).toBe("8h");
+  });
+});

--- a/lib/data/dash/__tests__/buildDailySleepCardModel.test.ts
+++ b/lib/data/dash/__tests__/buildDailySleepCardModel.test.ts
@@ -1,0 +1,346 @@
+import type { SleepNightDocumentDto, SleepViewDto } from "@oli/contracts";
+import { isOuraViewAlignedToDay } from "../../oura/isOuraViewAlignedToDay";
+import {
+  buildDailySleepCardModel,
+  emptyDailySleepCardModel,
+} from "../buildDailySleepCardModel";
+import { normalizeOuraSleepStageToMinutes } from "../ouraSleepStageMinutes";
+
+const day = "2026-05-01";
+
+function sleepView(
+  over: Partial<SleepViewDto> & Pick<SleepViewDto, "requestedDay" | "resolvedDay" | "day">,
+): SleepViewDto {
+  return {
+    isFallback: false,
+    contributors: {},
+    ...over,
+  } as SleepViewDto;
+}
+
+function minimalNight(over: Partial<SleepNightDocumentDto> = {}): SleepNightDocumentDto {
+  return {
+    anchorDay: day,
+    wakeDay: day,
+    provider: "oura",
+    source: "ouraVendorSleep",
+    sourceDocumentId: "s1",
+    isComplete: true,
+    updatedAt: "2026-05-01T12:00:00.000Z",
+    ...over,
+  };
+}
+
+describe("isOuraViewAlignedToDay", () => {
+  it("returns true only when requested and resolved match the anchor day", () => {
+    expect(isOuraViewAlignedToDay(undefined, day)).toBe(false);
+    expect(
+      isOuraViewAlignedToDay(
+        sleepView({ requestedDay: day, resolvedDay: day, day, totalMinutes: 400 }),
+        day,
+      ),
+    ).toBe(true);
+    expect(
+      isOuraViewAlignedToDay(
+        sleepView({ requestedDay: day, resolvedDay: "2026-04-30", day: "2026-04-30" }),
+        day,
+      ),
+    ).toBe(false);
+  });
+
+  it("treats surrounding whitespace on day keys as ignorable when comparing alignment", () => {
+    expect(
+      isOuraViewAlignedToDay(
+        sleepView({
+          requestedDay: " 2026-05-01 ",
+          resolvedDay: " 2026-05-01 ",
+          day: "2026-05-01",
+        }),
+        "2026-05-01",
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("normalizeOuraSleepStageToMinutes", () => {
+  it("treats large values as seconds", () => {
+    expect(normalizeOuraSleepStageToMinutes(7200)).toBe(120);
+  });
+  it("treats modest values as minutes", () => {
+    expect(normalizeOuraSleepStageToMinutes(90)).toBe(90);
+  });
+});
+
+function settledArgs(over: Partial<Parameters<typeof buildDailySleepCardModel>[0]>) {
+  return {
+    day,
+    sleepNight: undefined as SleepNightDocumentDto | undefined,
+    sleepNightSettled: true,
+    ...over,
+  };
+}
+
+const EXPECTED_ROW_IDS = [
+  "deep_sleep",
+  "rem_sleep",
+  "sleep_efficiency",
+  "lowest_heart_rate",
+  "average_hrv",
+] as const;
+
+describe("buildDailySleepCardModel", () => {
+  it("puts main sleep duration in headlineValueText using main over total", () => {
+    const m = buildDailySleepCardModel(
+      settledArgs({
+        sleepNight: minimalNight({
+          mainSleepMinutes: 502,
+          totalSleepMinutes: 530,
+          efficiency: 0.94,
+          remMinutes: 90,
+          deepMinutes: 60,
+          score: 88,
+        }),
+      }),
+    );
+    expect(m.headlineValueText).toBe("8h 22m");
+    expect(m.metricRows.find((r) => r.id === "sleep_efficiency")?.value).toBe("94%");
+    expect(m.metricRows.map((r) => r.id)).toEqual([...EXPECTED_ROW_IDS]);
+  });
+
+  it("uses total sleep minutes for headline when main is absent", () => {
+    const m = buildDailySleepCardModel(
+      settledArgs({
+        sleepNight: minimalNight({
+          totalSleepMinutes: 400,
+          efficiency: 0.9,
+          remMinutes: 60,
+          deepMinutes: 50,
+          score: 70,
+        }),
+      }),
+    );
+    expect(m.headlineValueText).toBe("6h 40m");
+    expect(m.metricRows.find((r) => r.id === "sleep_efficiency")?.value).toBe("90%");
+  });
+
+  it("formats deep/rem from minute fields and keeps score on model", () => {
+    const m = buildDailySleepCardModel(
+      settledArgs({
+        sleepNight: minimalNight({
+          totalSleepMinutes: 480,
+          efficiency: 63,
+          remMinutes: 60,
+          deepMinutes: 45,
+          score: 80,
+        }),
+      }),
+    );
+    expect(m.headlineValueText).toBe("8h");
+    expect(m.metricRows.find((r) => r.id === "sleep_efficiency")?.value).toBe("63%");
+    expect(m.metricRows.find((r) => r.id === "deep_sleep")?.value).toBe("45m");
+    expect(m.metricRows.find((r) => r.id === "rem_sleep")?.value).toBe("1h");
+    expect(m.scoreValueText).toBe("80");
+  });
+
+  it("shows metrics without score when score is absent", () => {
+    const m = buildDailySleepCardModel(
+      settledArgs({
+        sleepNight: minimalNight({
+          totalSleepMinutes: 480,
+          efficiency: 0.9,
+          remMinutes: 60,
+          deepMinutes: 50,
+        }),
+      }),
+    );
+    expect(m.scoreValueText).toBeNull();
+    expect(m.headlineValueText).toBe("8h");
+    expect(m.hasAnySignal).toBe(true);
+  });
+
+  it("keeps score and rating on model when score is present", () => {
+    const m = buildDailySleepCardModel(
+      settledArgs({
+        sleepNight: minimalNight({
+          totalSleepMinutes: 480,
+          score: 82,
+        }),
+      }),
+    );
+    expect(m.scoreValueText).toBe("82");
+    expect(m.ratingLabel).toBe("Good");
+    expect(m.ratingTone).toBe("good");
+  });
+
+  it("keeps five metric rows in priority order without a Sleep duration row", () => {
+    const m = buildDailySleepCardModel(
+      settledArgs({
+        sleepNight: minimalNight({
+          totalSleepMinutes: 480,
+          efficiency: 0.9,
+          remMinutes: 90,
+          deepMinutes: 60,
+        }),
+      }),
+    );
+    expect(m.metricRows).toHaveLength(5);
+    expect(m.metricRows.map((r) => r.id)).toEqual([...EXPECTED_ROW_IDS]);
+  });
+
+  it("renders em dash for lowest heart rate and average HRV when absent on SleepNight", () => {
+    const m = buildDailySleepCardModel(
+      settledArgs({
+        sleepNight: minimalNight({
+          totalSleepMinutes: 480,
+          efficiency: 0.9,
+          remMinutes: 60,
+          deepMinutes: 50,
+        }),
+      }),
+    );
+    expect(m.metricRows.find((r) => r.id === "lowest_heart_rate")?.value).toBe("\u2014");
+    expect(m.metricRows.find((r) => r.id === "average_hrv")?.value).toBe("\u2014");
+  });
+
+  it("renders lowest heart rate and average HRV from SleepNight when present", () => {
+    const m = buildDailySleepCardModel(
+      settledArgs({
+        sleepNight: minimalNight({
+          totalSleepMinutes: 480,
+          efficiency: 0.9,
+          remMinutes: 60,
+          deepMinutes: 50,
+          lowestHeartRateBpm: 50,
+          averageHrvMs: 21,
+        }),
+      }),
+    );
+    expect(m.metricRows.find((r) => r.id === "lowest_heart_rate")?.value).toBe("50 bpm");
+    expect(m.metricRows.find((r) => r.id === "average_hrv")?.value).toBe("21 ms");
+  });
+
+  it("attaches detail payload to each metric row", () => {
+    const m = buildDailySleepCardModel(
+      settledArgs({
+        sleepNight: minimalNight({
+          totalSleepMinutes: 400,
+          efficiency: 0.9,
+          remMinutes: 60,
+          deepMinutes: 50,
+        }),
+      }),
+    );
+    for (const row of m.metricRows) {
+      expect(row.detail.title).toBe(row.label);
+      expect(row.detail.value).toBe(row.value);
+      expect(row.detail.body.length).toBeGreaterThan(10);
+    }
+  });
+
+  it("includes REM percent in REM row detail context when total sleep is known", () => {
+    const m = buildDailySleepCardModel(
+      settledArgs({
+        sleepNight: minimalNight({
+          totalSleepMinutes: 480,
+          efficiency: 0.9,
+          remMinutes: 120,
+        }),
+      }),
+    );
+    const rem = m.metricRows.find((r) => r.id === "rem_sleep");
+    expect(rem?.value).toBe("2h");
+    expect(rem?.detail.contextLine).toMatch(/25%/);
+  });
+
+  it("does not surface Readiness copy in the model", () => {
+    const m = buildDailySleepCardModel(
+      settledArgs({
+        sleepNight: minimalNight({ totalSleepMinutes: 400, score: 90 }),
+      }),
+    );
+    expect(JSON.stringify(m)).not.toMatch(/readiness/i);
+  });
+
+  it("uses sleepNight.anchorDay in metric detail when Dash day differs (prior night)", () => {
+    const requested = "2026-05-13";
+    const anchor = "2026-05-12";
+    const m = buildDailySleepCardModel(
+      settledArgs({
+        day: requested,
+        resolution: "wake_day",
+        sleepNight: minimalNight({
+          anchorDay: anchor,
+          wakeDay: requested,
+          totalSleepMinutes: 530,
+          score: 77,
+        }),
+      }),
+    );
+    expect(m.day).toBe(requested);
+    expect(m.scoreValueText).toBe("77");
+    expect(m.lastNightSubtitle).toBe("Last night\u2019s sleep");
+    expect(m.headlineValueText).toBe("8h 50m");
+    const deep = m.metricRows.find((r) => r.id === "deep_sleep");
+    expect(deep?.detail.contextLine).toContain(anchor);
+    expect(deep?.detail.contextLine).toContain(requested);
+  });
+
+  it("shows last-night subtitle whenever there is sleep signal including exact_anchor", () => {
+    const m = buildDailySleepCardModel(
+      settledArgs({
+        resolution: "exact_anchor",
+        sleepNight: minimalNight({ totalSleepMinutes: 400, score: 80 }),
+      }),
+    );
+    expect(m.lastNightSubtitle).toBe("Last night\u2019s sleep");
+  });
+
+  it("headline shows 9h 11m for 551 main sleep minutes", () => {
+    const m = buildDailySleepCardModel(
+      settledArgs({
+        sleepNight: minimalNight({
+          mainSleepMinutes: 551,
+          efficiency: 0.92,
+          remMinutes: 124,
+          deepMinutes: 76,
+        }),
+      }),
+    );
+    expect(m.headlineValueText).toBe("9h 11m");
+    expect(m.metricRows.find((r) => r.id === "rem_sleep")?.value).toBe("2h 4m");
+    expect(m.metricRows.find((r) => r.id === "deep_sleep")?.value).toBe("1h 16m");
+    expect(m.metricRows.find((r) => r.id === "sleep_efficiency")?.value).toBe("92%");
+  });
+
+  it("renders 96 Optimal on model from SleepNight score", () => {
+    const anchor = "2026-05-11";
+    const m = buildDailySleepCardModel(
+      settledArgs({
+        day: anchor,
+        sleepNight: minimalNight({
+          anchorDay: anchor,
+          wakeDay: anchor,
+          totalSleepMinutes: 400,
+          score: 96,
+        }),
+      }),
+    );
+    expect(m.day).toBe(anchor);
+    expect(m.scoreValueText).toBe("96");
+    expect(m.ratingLabel).toBe("Optimal");
+  });
+});
+
+describe("emptyDailySleepCardModel", () => {
+  it("returns five placeholder rows, no headline, and stable empty copy", () => {
+    const m = emptyDailySleepCardModel(day);
+    expect(m.hasAnySignal).toBe(false);
+    expect(m.headlineValueText).toBeNull();
+    expect(m.metricRows).toHaveLength(5);
+    expect(m.metricRows.every((r) => r.value === "\u2014")).toBe(true);
+    expect(m.summarySentence).toBe("");
+    expect(m.emptyStateTitle).toBe("No sleep data yet");
+    expect(m.emptyStateSubtitle).toMatch(/Sync Oura/);
+    expect(m.lastNightSubtitle).toBeNull();
+  });
+});

--- a/lib/data/dash/__tests__/useDashOuraViews.rerenderStability.test.tsx
+++ b/lib/data/dash/__tests__/useDashOuraViews.rerenderStability.test.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import renderer, { act } from "react-test-renderer";
+
+import type { SleepViewDto } from "@oli/contracts";
+
+const mockGetOuraSleepView = jest.fn();
+const mockGetOuraReadinessView = jest.fn();
+
+jest.mock("@/lib/api/usersMe", () => ({
+  getOuraSleepView: (...args: unknown[]) => mockGetOuraSleepView(...args),
+  getOuraReadinessView: (...args: unknown[]) => mockGetOuraReadinessView(...args),
+}));
+
+const mockAuthUser = { uid: "u1" };
+const mockGetIdToken = jest.fn().mockResolvedValue("id-token");
+
+jest.mock("@/lib/auth/AuthProvider", () => ({
+  useAuth: () => ({
+    user: mockAuthUser,
+    initializing: false,
+    getIdToken: mockGetIdToken,
+  }),
+}));
+
+import { useDashOuraViews } from "../useDashOuraViews";
+
+const alignedSleep: SleepViewDto = {
+  requestedDay: "2026-05-01",
+  resolvedDay: "2026-05-01",
+  isFallback: false,
+  day: "2026-05-01",
+  score: 96,
+  contributors: {},
+};
+
+describe("useDashOuraViews parent re-render stability", () => {
+  beforeEach(() => {
+    mockGetOuraSleepView.mockReset();
+    mockGetOuraReadinessView.mockReset();
+    mockGetOuraSleepView.mockResolvedValue({
+      ok: true,
+      status: 200,
+      requestId: null,
+      json: alignedSleep,
+    });
+    mockGetOuraReadinessView.mockResolvedValue({
+      ok: true,
+      status: 200,
+      requestId: null,
+      json: {
+        requestedDay: "2026-05-01",
+        resolvedDay: "2026-05-01",
+        isFallback: false,
+        day: "2026-05-01",
+        score: 1,
+        contributors: {},
+      },
+    });
+  });
+
+  it("does not start duplicate sleep fetches when the hook re-renders with the same day / uid / enabled", async () => {
+    const sink: React.MutableRefObject<ReturnType<typeof useDashOuraViews> | null> = { current: null };
+
+    function Inner(): null {
+      const s = useDashOuraViews("2026-05-01", { enabled: true });
+      sink.current = s;
+      return null;
+    }
+
+    let root!: renderer.ReactTestRenderer;
+    await act(async () => {
+      root = renderer.create(<Inner />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const callsAfterMount = mockGetOuraSleepView.mock.calls.length;
+
+    await act(async () => {
+      root.update(<Inner />);
+      await Promise.resolve();
+    });
+
+    expect(mockGetOuraSleepView.mock.calls.length).toBe(callsAfterMount);
+  });
+});

--- a/lib/data/dash/__tests__/useDashOuraViews.test.tsx
+++ b/lib/data/dash/__tests__/useDashOuraViews.test.tsx
@@ -1,0 +1,156 @@
+import React from "react";
+import renderer, { act } from "react-test-renderer";
+
+import type { SleepViewDto } from "@oli/contracts";
+
+const mockGetOuraSleepView = jest.fn();
+const mockGetOuraReadinessView = jest.fn();
+
+jest.mock("@/lib/api/usersMe", () => ({
+  getOuraSleepView: (...args: unknown[]) => mockGetOuraSleepView(...args),
+  getOuraReadinessView: (...args: unknown[]) => mockGetOuraReadinessView(...args),
+}));
+
+const mockAuthUser = { uid: "u1" };
+const mockGetIdToken = jest.fn().mockResolvedValue("id-token");
+
+jest.mock("@/lib/auth/AuthProvider", () => ({
+  useAuth: () => ({
+    user: mockAuthUser,
+    initializing: false,
+    getIdToken: mockGetIdToken,
+  }),
+}));
+
+import { useDashOuraViews } from "../useDashOuraViews";
+
+const alignedSleep: SleepViewDto = {
+  requestedDay: "2026-05-01",
+  resolvedDay: "2026-05-01",
+  isFallback: false,
+  day: "2026-05-01",
+  score: 96,
+  contributors: {},
+};
+
+function Harness({
+  sink,
+  enabled,
+}: {
+  sink: React.MutableRefObject<ReturnType<typeof useDashOuraViews> | null>;
+  enabled?: boolean;
+}): null {
+  const s = useDashOuraViews("2026-05-01", { enabled });
+  sink.current = s;
+  return null;
+}
+
+describe("useDashOuraViews", () => {
+  beforeEach(() => {
+    mockGetOuraSleepView.mockReset();
+    mockGetOuraReadinessView.mockReset();
+  });
+
+  it("calls getOuraSleepView immediately and does not block sleepView on readiness", async () => {
+    mockGetOuraSleepView.mockResolvedValue({
+      ok: true,
+      status: 200,
+      requestId: null,
+      json: alignedSleep,
+    });
+    mockGetOuraReadinessView.mockImplementation(
+      () =>
+        new Promise(() => {
+          /* never resolves */
+        }),
+    );
+
+    const sink: React.MutableRefObject<ReturnType<typeof useDashOuraViews> | null> = { current: null };
+
+    await act(async () => {
+      renderer.create(<Harness sink={sink} />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockGetOuraSleepView).toHaveBeenCalledWith("2026-05-01", "id-token", undefined);
+    expect(mockGetOuraReadinessView).toHaveBeenCalled();
+
+    const last = sink.current;
+    expect(last).not.toBeNull();
+    expect(last!.sleepView?.score).toBe(96);
+    expect(last!.sleepViewLoading).toBe(false);
+    expect(last!.readinessViewLoading).toBe(true);
+    expect(last!.loading).toBe(true);
+  });
+
+  it("skips network when enabled is false", async () => {
+    const sink: React.MutableRefObject<ReturnType<typeof useDashOuraViews> | null> = { current: null };
+
+    await act(async () => {
+      renderer.create(<Harness sink={sink} enabled={false} />);
+      await Promise.resolve();
+    });
+
+    expect(mockGetOuraSleepView).not.toHaveBeenCalled();
+    expect(mockGetOuraReadinessView).not.toHaveBeenCalled();
+    expect(sink.current?.sleepViewLoading).toBe(false);
+    expect(sink.current?.readinessViewLoading).toBe(false);
+  });
+
+  it("logs [DASH_OURA_SLEEP_FETCH_DONE] in finally with cancelled when enabled goes false mid-flight", async () => {
+    const logSpy = jest.spyOn(console, "log").mockImplementation((() => undefined) as (...args: unknown[]) => void);
+
+    let resolveSleep!: (v: unknown) => void;
+    mockGetOuraSleepView.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveSleep = resolve;
+        }),
+    );
+    mockGetOuraReadinessView.mockResolvedValue({
+      ok: true,
+      status: 200,
+      requestId: null,
+      json: {
+        requestedDay: "2026-05-01",
+        resolvedDay: "2026-05-01",
+        isFallback: false,
+        day: "2026-05-01",
+        score: 1,
+        contributors: {},
+      },
+    });
+
+    const sink: React.MutableRefObject<ReturnType<typeof useDashOuraViews> | null> = { current: null };
+    let root: renderer.ReactTestRenderer;
+
+    await act(async () => {
+      root = renderer.create(<Harness sink={sink} enabled />);
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      root.update(<Harness sink={sink} enabled={false} />);
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      resolveSleep({
+        ok: true,
+        status: 200,
+        requestId: null,
+        json: alignedSleep,
+      });
+      await Promise.resolve();
+    });
+
+    const doneArg = logSpy.mock.calls.find((c) => c[0] === "[DASH_OURA_SLEEP_FETCH_DONE]")?.[1] as
+      | { cancelled?: boolean; stale?: boolean }
+      | undefined;
+    expect(doneArg?.cancelled).toBe(true);
+    expect(doneArg?.stale).toBe(true);
+
+    logSpy.mockRestore();
+  });
+});

--- a/lib/data/dash/buildDailySleepCardModel.ts
+++ b/lib/data/dash/buildDailySleepCardModel.ts
@@ -1,0 +1,337 @@
+import type { SleepNightDocumentDto, SleepNightResolution } from "@oli/contracts";
+import { formatEfficiencyRatio } from "@/lib/format/sleepDisplay";
+import type { OuraRatingLabel } from "@/lib/format/ouraScore";
+import { formatSleepDurationMinutes, scoreToRatingLabel } from "@/lib/format/ouraScore";
+
+const EMPTY = "\u2014";
+
+export type DailySleepRatingTone = "optimal" | "good" | "watch" | "low";
+
+function ouraLabelToTone(label: OuraRatingLabel): DailySleepRatingTone {
+  switch (label) {
+    case "Optimal":
+      return "optimal";
+    case "Good":
+      return "good";
+    case "Fair":
+      return "watch";
+    case "Pay attention":
+      return "low";
+    default:
+      return "watch";
+  }
+}
+
+/** Detail payload for metric row bottom sheet. */
+export type DailySleepMetricDetail = {
+  title: string;
+  value: string;
+  body: string;
+  sourceLine?: string;
+  contextLine?: string;
+};
+
+export type DailySleepMetricRow = {
+  id: string;
+  label: string;
+  value: string;
+  detail: DailySleepMetricDetail;
+};
+
+export type DailySleepCardModel = {
+  /** Calendar day Dash requested (e.g. today). */
+  day: string;
+  /** Main headline (total sleep duration), same scale intent as Daily Energy `rangeValue`. */
+  headlineValueText: string | null;
+  scoreValueText: string | null;
+  ratingLabel: string | null;
+  ratingTone: DailySleepRatingTone | null;
+  summarySentence: string;
+  metricRows: DailySleepMetricRow[];
+  hasAnySignal: boolean;
+  emptyStateTitle: string | null;
+  emptyStateSubtitle: string | null;
+  /** Shown under title when there is sleep signal (matches Daily Energy subtitle pattern). */
+  lastNightSubtitle: string | null;
+};
+
+type MetricDetailCtx = {
+  requestedCalendarDay: string;
+  anchorDay: string;
+  remPercent: number | null;
+};
+
+function sleepNightContextLine(ctx: MetricDetailCtx): string {
+  if (ctx.requestedCalendarDay === ctx.anchorDay) return `Sleep night: ${ctx.anchorDay}`;
+  return `Sleep night: ${ctx.anchorDay} · Calendar day: ${ctx.requestedCalendarDay}`;
+}
+
+function formatLowestHeartRate(night: SleepNightDocumentDto): string {
+  const v = night.lowestHeartRateBpm;
+  if (typeof v !== "number" || !Number.isFinite(v)) return EMPTY;
+  return `${Math.round(v)} bpm`;
+}
+
+function formatAverageHrv(night: SleepNightDocumentDto): string {
+  const v = night.averageHrvMs;
+  if (typeof v !== "number" || !Number.isFinite(v)) return EMPTY;
+  return `${Math.round(v)} ms`;
+}
+
+export function buildSleepMetricDetail(
+  id: string,
+  label: string,
+  value: string,
+  ctx: MetricDetailCtx,
+): DailySleepMetricDetail {
+  const ctxLine = sleepNightContextLine(ctx);
+  switch (id) {
+    case "deep_sleep":
+      return {
+        title: label,
+        value,
+        body: "Deep sleep is one of the main sleep stages associated with physical restoration.",
+        contextLine: ctxLine,
+      };
+    case "rem_sleep": {
+      const pct =
+        ctx.remPercent != null
+          ? `REM was about ${ctx.remPercent}% of recorded sleep time used for this summary.`
+          : null;
+      const contextParts = [pct, ctxLine].filter((x): x is string => Boolean(x));
+      return {
+        title: label,
+        value,
+        body: "REM sleep supports learning, memory, and nervous system recovery.",
+        contextLine: contextParts.join(" "),
+      };
+    }
+    case "sleep_efficiency": {
+      return {
+        title: label,
+        value,
+        body: "Sleep efficiency compares time asleep against time in bed.",
+        sourceLine: "Wearable-reported efficiency from your stored sleep night.",
+        contextLine: ctxLine,
+      };
+    }
+    case "lowest_heart_rate": {
+      return {
+        title: label,
+        value,
+        body:
+          "Lowest heart rate during this sleep window from your Oura sleep period summary. " +
+          "Stored on your canonical sleep night when sync merges Oura wellness metrics.",
+        sourceLine: "Oura sleep period wellness fields, merged into SleepNight at sync.",
+        contextLine: ctxLine,
+      };
+    }
+    case "average_hrv": {
+      return {
+        title: label,
+        value,
+        body:
+          "Average HRV in milliseconds from your Oura sleep period summary when the API reports it.",
+        sourceLine: "Oura sleep `average_hrv`, surfaced via SleepNight.",
+        contextLine: ctxLine,
+      };
+    }
+    default:
+      return {
+        title: label,
+        value,
+        body: "Metric detail for this sleep night.",
+        contextLine: ctxLine,
+      };
+  }
+}
+
+function totalMinutesForDenominator(night: SleepNightDocumentDto): number | null {
+  const m = night.mainSleepMinutes ?? night.totalSleepMinutes;
+  if (typeof m === "number" && Number.isFinite(m) && m > 0) return m;
+  return null;
+}
+
+function remPercentFromNight(night: SleepNightDocumentDto): number | null {
+  if (typeof night.remPercent === "number" && Number.isFinite(night.remPercent)) return Math.round(night.remPercent);
+  const total = totalMinutesForDenominator(night);
+  const rem = night.remMinutes;
+  if (typeof rem !== "number" || !Number.isFinite(rem) || rem < 0 || total == null || total <= 0) return null;
+  return Math.round((rem / total) * 100);
+}
+
+function metricRowsFromSleepNight(
+  requestedCalendarDay: string,
+  night: SleepNightDocumentDto,
+): DailySleepMetricRow[] {
+  const anchorDay = night.anchorDay;
+  const deepM = typeof night.deepMinutes === "number" ? Math.round(night.deepMinutes) : undefined;
+  const remM = typeof night.remMinutes === "number" ? Math.round(night.remMinutes) : undefined;
+  const deepVal = deepM != null ? formatSleepDurationMinutes(deepM) : EMPTY;
+  const remVal = remM != null ? formatSleepDurationMinutes(remM) : EMPTY;
+  const effVal = formatEfficiencyRatio(night.efficiency);
+  const remPercent = remPercentFromNight(night);
+  const ctx: MetricDetailCtx = { requestedCalendarDay, anchorDay, remPercent };
+  const hrVal = formatLowestHeartRate(night);
+  const hrvVal = formatAverageHrv(night);
+  const specs = [
+    { id: "deep_sleep", label: "Deep sleep", value: deepVal },
+    { id: "rem_sleep", label: "REM sleep", value: remVal },
+    { id: "sleep_efficiency", label: "Sleep efficiency", value: effVal },
+    { id: "lowest_heart_rate", label: "Lowest heart rate", value: hrVal },
+    { id: "average_hrv", label: "Average HRV", value: hrvVal },
+  ] as const;
+  return specs.map((s) => ({
+    id: s.id,
+    label: s.label,
+    value: s.value,
+    detail: buildSleepMetricDetail(s.id, s.label, s.value, ctx),
+  }));
+}
+
+function emptyMetricRows(requestedCalendarDay: string, anchorDay: string): DailySleepMetricRow[] {
+  const ctx: MetricDetailCtx = { requestedCalendarDay, anchorDay, remPercent: null };
+  const specs = [
+    { id: "deep_sleep", label: "Deep sleep", value: EMPTY },
+    { id: "rem_sleep", label: "REM sleep", value: EMPTY },
+    { id: "sleep_efficiency", label: "Sleep efficiency", value: EMPTY },
+    { id: "lowest_heart_rate", label: "Lowest heart rate", value: EMPTY },
+    { id: "average_hrv", label: "Average HRV", value: EMPTY },
+  ] as const;
+  return specs.map((s) => ({
+    id: s.id,
+    label: s.label,
+    value: s.value,
+    detail: buildSleepMetricDetail(s.id, s.label, s.value, ctx),
+  }));
+}
+
+function efficiencyRatioForSummary(night: SleepNightDocumentDto): number | null {
+  const e = night.efficiency;
+  if (typeof e !== "number" || !Number.isFinite(e) || e < 0) return null;
+  return e;
+}
+
+function buildSleepSummarySentence(args: {
+  inputsSettled: boolean;
+  hasAnySignal: boolean;
+  shortSleep: boolean;
+  sleepGood: boolean;
+}): { summary: string; emptyTitle: string | null; emptySubtitle: string | null } {
+  if (!args.inputsSettled) {
+    return { summary: "", emptyTitle: null, emptySubtitle: null };
+  }
+  if (!args.hasAnySignal) {
+    return {
+      summary: "",
+      emptyTitle: "No sleep data yet",
+      emptySubtitle: "Sync Oura or check back after your next sleep.",
+    };
+  }
+  if (args.shortSleep) {
+    return {
+      summary: "Sleep was short, which may affect how you feel today.",
+      emptyTitle: null,
+      emptySubtitle: null,
+    };
+  }
+  if (args.sleepGood) {
+    return {
+      summary: "Sleep duration and efficiency look solid for this day.",
+      emptyTitle: null,
+      emptySubtitle: null,
+    };
+  }
+  return {
+    summary: "Key metrics below summarize last night\u2019s sleep.",
+    emptyTitle: null,
+    emptySubtitle: null,
+  };
+}
+
+export function buildDailySleepCardModel(input: {
+  day: string;
+  /** From `GET /users/me/sleep-night` when available. */
+  resolution?: SleepNightResolution;
+  sleepNight: SleepNightDocumentDto | undefined;
+  sleepNightSettled: boolean;
+}): DailySleepCardModel {
+  const { day, sleepNight, sleepNightSettled } = input;
+
+  const inputsSettled = sleepNightSettled;
+
+  let scoreValueText: string | null = null;
+  let ratingLabel: string | null = null;
+  let ratingTone: DailySleepRatingTone | null = null;
+  if (sleepNight != null && typeof sleepNight.score === "number") {
+    scoreValueText = String(Math.round(sleepNight.score));
+    const label = scoreToRatingLabel(sleepNight.score);
+    ratingLabel = label;
+    ratingTone = ouraLabelToTone(label);
+  }
+
+  const totalMin = sleepNight != null ? totalMinutesForDenominator(sleepNight) : null;
+  const headlineValueText =
+    sleepNight != null && totalMin != null ? formatSleepDurationMinutes(Math.round(totalMin)) : null;
+
+  const anchorDayForEmpty = sleepNight?.anchorDay ?? day;
+  const metricRows =
+    sleepNight != null ? metricRowsFromSleepNight(day, sleepNight) : emptyMetricRows(day, anchorDayForEmpty);
+
+  const rowHasSignal = (r: DailySleepMetricRow) => r.value !== EMPTY;
+  const hasRowSignal = metricRows.some(rowHasSignal);
+  const hasAnySignal =
+    headlineValueText != null ||
+    hasRowSignal ||
+    (sleepNight != null && typeof sleepNight.score === "number");
+
+  let totalMinutesForShort: number | null = null;
+  let efficiencyForGood: number | null = null;
+  if (sleepNight != null) {
+    totalMinutesForShort = totalMinutesForDenominator(sleepNight);
+    efficiencyForGood = efficiencyRatioForSummary(sleepNight);
+  }
+
+  const shortSleep = totalMinutesForShort != null && totalMinutesForShort < 360;
+  const sleepGood =
+    totalMinutesForShort != null &&
+    totalMinutesForShort >= 420 &&
+    (efficiencyForGood == null ||
+      (efficiencyForGood <= 1 && efficiencyForGood >= 0.82) ||
+      (efficiencyForGood > 1 && efficiencyForGood >= 82));
+
+  const { summary: summarySentence, emptyTitle, emptySubtitle } = buildSleepSummarySentence({
+    inputsSettled,
+    hasAnySignal,
+    shortSleep,
+    sleepGood,
+  });
+
+  const displaySummary = !inputsSettled ? "" : !hasAnySignal ? "" : summarySentence;
+  const emptyStateTitle = !hasAnySignal && inputsSettled ? emptyTitle : null;
+  const emptyStateSubtitle = !hasAnySignal && inputsSettled ? emptySubtitle : null;
+
+  const lastNightSubtitle = inputsSettled && hasAnySignal ? "Last night\u2019s sleep" : null;
+
+  return {
+    day,
+    headlineValueText,
+    scoreValueText,
+    ratingLabel,
+    ratingTone,
+    summarySentence: displaySummary,
+    metricRows,
+    hasAnySignal,
+    emptyStateTitle,
+    emptyStateSubtitle,
+    lastNightSubtitle,
+  };
+}
+
+export function emptyDailySleepCardModel(day: string): DailySleepCardModel {
+  return buildDailySleepCardModel({
+    day,
+    sleepNight: undefined,
+    sleepNightSettled: true,
+  });
+}

--- a/lib/data/dash/ouraSleepStageMinutes.ts
+++ b/lib/data/dash/ouraSleepStageMinutes.ts
@@ -1,0 +1,11 @@
+/** Raw Oura sleep stage payloads are usually seconds; values above the threshold are converted to minutes. */
+export const OURA_SLEEP_STAGE_SECONDS_THRESHOLD = 200;
+
+/**
+ * Vendor sleep stage payloads are usually seconds; values at or below the threshold are treated as already in minutes.
+ */
+export function normalizeOuraSleepStageToMinutes(raw: number | undefined): number | undefined {
+  if (typeof raw !== "number" || !Number.isFinite(raw) || raw < 0) return undefined;
+  if (raw > OURA_SLEEP_STAGE_SECONDS_THRESHOLD) return Math.round(raw / 60);
+  return Math.round(raw);
+}

--- a/lib/data/dash/useDashOuraCalendarSleepProbe.ts
+++ b/lib/data/dash/useDashOuraCalendarSleepProbe.ts
@@ -1,0 +1,76 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { getOuraSleepView, type TruthGetOptions } from "@/lib/api/usersMe";
+import { useAuth } from "@/lib/auth/AuthProvider";
+import { truthOutcomeFromApiResult } from "@/lib/data/truthOutcome";
+import type { SleepViewDto } from "@oli/contracts";
+
+function withUniqueCacheBust(opts: TruthGetOptions | undefined, seq: number): TruthGetOptions | undefined {
+  const cb = opts?.cacheBust;
+  if (!cb) return opts;
+  return { ...opts, cacheBust: `${cb}:${seq}` };
+}
+
+export type DashOuraCalendarSleepProbeState = {
+  view: SleepViewDto | undefined;
+  loading: boolean;
+  refetch: (opts?: TruthGetOptions) => void;
+};
+
+/**
+ * Oura sleep view for the **calendar** wake day only. Used to detect overnight physiology
+ * (requested calendar day, resolved previous sleep day) before choosing Dash sleep anchor.
+ */
+export function useDashOuraCalendarSleepProbe(calendarDay: string): DashOuraCalendarSleepProbeState {
+  const { user, initializing, getIdToken } = useAuth();
+  const dayRef = useRef(calendarDay);
+  dayRef.current = calendarDay;
+  const requestSeq = useRef(0);
+  const [view, setView] = useState<SleepViewDto | undefined>(undefined);
+  const [loading, setLoading] = useState(true);
+
+  const fetchOnce = useCallback(
+    async (opts?: TruthGetOptions) => {
+      const seq = ++requestSeq.current;
+      const dayKey = dayRef.current;
+
+      if (initializing || !user) {
+        if (seq === requestSeq.current) {
+          setView(undefined);
+          setLoading(false);
+        }
+        return;
+      }
+
+      const token = await getIdToken(false);
+      if (!token || seq !== requestSeq.current) {
+        if (seq === requestSeq.current) setLoading(false);
+        return;
+      }
+
+      if (seq !== requestSeq.current) return;
+      setLoading(true);
+
+      const bust = withUniqueCacheBust(opts, seq);
+      const sleepRes = await getOuraSleepView(dayKey, token, bust);
+      if (seq !== requestSeq.current) return;
+      const outcome = truthOutcomeFromApiResult(sleepRes);
+      setView(outcome.status === "ready" ? outcome.data : undefined);
+      setLoading(false);
+    },
+    [getIdToken, initializing, user?.uid],
+  );
+
+  useEffect(() => {
+    void fetchOnce();
+  }, [fetchOnce, calendarDay, user?.uid]);
+
+  return useMemo(
+    () => ({
+      view,
+      loading,
+      refetch: fetchOnce,
+    }),
+    [view, loading, fetchOnce],
+  );
+}

--- a/lib/data/dash/useDashOuraViews.ts
+++ b/lib/data/dash/useDashOuraViews.ts
@@ -1,0 +1,237 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { getOuraReadinessView, getOuraSleepView, type TruthGetOptions } from "@/lib/api/usersMe";
+import { useAuth } from "@/lib/auth/AuthProvider";
+import { truthOutcomeFromApiResult } from "@/lib/data/truthOutcome";
+import type { ReadinessViewDto, SleepViewDto } from "@oli/contracts";
+
+function withUniqueCacheBust(opts: TruthGetOptions | undefined, seq: number): TruthGetOptions | undefined {
+  const cb = opts?.cacheBust;
+  if (!cb) return opts;
+  return { ...opts, cacheBust: `${cb}:${seq}` };
+}
+
+export type DashOuraViewsState = {
+  sleepView: SleepViewDto | undefined;
+  readinessView: ReadinessViewDto | undefined;
+  /** True until the Oura sleep view request settles (ready, missing, or error). */
+  sleepViewLoading: boolean;
+  /** True until the Oura readiness view request settles. */
+  readinessViewLoading: boolean;
+  /**
+   * True until both Oura view requests have settled.
+   * Prefer `sleepViewLoading` for Daily Sleep so readiness latency does not block sleep score.
+   */
+  loading: boolean;
+  refetch: (opts?: TruthGetOptions) => void;
+};
+
+export type UseDashOuraViewsOptions = {
+  /** When false, skips network and clears views; loading flags are false (idle / disabled). */
+  enabled?: boolean;
+};
+
+/**
+ * Parallel Oura vendor views for Dash (sleep + readiness snapshots; Daily Sleep card uses sleep only).
+ * Sleep and readiness are fetched independently so a slow readiness call never blocks
+ * `GET /users/me/oura-sleep-view` or `sleepView` updates.
+ * Errors are non-fatal: views stay undefined so the card can still render DailyFacts-only.
+ */
+export function useDashOuraViews(day: string, options?: UseDashOuraViewsOptions): DashOuraViewsState {
+  const enabled = options?.enabled ?? true;
+  const { user, initializing, getIdToken } = useAuth();
+  const dayRef = useRef(day);
+  dayRef.current = day;
+  const enabledRef = useRef(enabled);
+  enabledRef.current = enabled;
+  const initializingRef = useRef(initializing);
+  initializingRef.current = initializing;
+  const hasUserRef = useRef(Boolean(user));
+  hasUserRef.current = Boolean(user);
+  const getIdTokenRef = useRef(getIdToken);
+  getIdTokenRef.current = getIdToken;
+
+  const generationRef = useRef(0);
+  const prevDayUidRef = useRef<{ day: string; uid: string | undefined } | null>(null);
+
+  const [sleepView, setSleepView] = useState<SleepViewDto | undefined>(undefined);
+  const [readinessView, setReadinessView] = useState<ReadinessViewDto | undefined>(undefined);
+  const [sleepViewLoading, setSleepViewLoading] = useState(true);
+  const [readinessViewLoading, setReadinessViewLoading] = useState(true);
+  const sleepErrorRef = useRef<string | undefined>(undefined);
+  const readinessErrorRef = useRef<string | undefined>(undefined);
+
+  const runFetch = useCallback(async (myGen: number, bustOpts?: TruthGetOptions) => {
+    if (!enabledRef.current) return;
+
+    const dayKey = dayRef.current;
+
+    if (initializingRef.current || !hasUserRef.current) {
+      if (myGen === generationRef.current) {
+        setSleepView(undefined);
+        setReadinessView(undefined);
+        setSleepViewLoading(false);
+        setReadinessViewLoading(false);
+      }
+      return;
+    }
+
+    const token = await getIdTokenRef.current(false);
+    if (!token) {
+      if (myGen === generationRef.current) {
+        setSleepViewLoading(false);
+        setReadinessViewLoading(false);
+      }
+      return;
+    }
+
+    if (myGen !== generationRef.current) return;
+
+    setSleepViewLoading(true);
+    setReadinessViewLoading(true);
+
+    const bust = withUniqueCacheBust(bustOpts, myGen);
+
+    if (__DEV__) {
+      // eslint-disable-next-line no-console -- Dash Oura sleep fetch audit (dev-only)
+      console.log("[DASH_OURA_SLEEP_FETCH_START]", { day: dayKey, enabled: enabledRef.current });
+    }
+
+    let devSleepDone: Record<string, unknown> | null = null;
+
+    void getOuraSleepView(dayKey, token, bust)
+      .then((sleepRes) => {
+        const sleepOutcome = truthOutcomeFromApiResult(sleepRes);
+        sleepErrorRef.current = sleepOutcome.status === "error" ? sleepOutcome.error : undefined;
+        const ready = sleepOutcome.status === "ready" ? sleepOutcome.data : undefined;
+        devSleepDone = {
+          ok: sleepRes.ok,
+          outcome: sleepOutcome.status,
+          requestedDay: ready?.requestedDay,
+          resolvedDay: ready?.resolvedDay,
+          score: ready?.score,
+          error: sleepOutcome.status === "error" ? sleepOutcome.error : undefined,
+        };
+        if (myGen !== generationRef.current) return;
+        setSleepView(sleepOutcome.status === "ready" ? sleepOutcome.data : undefined);
+      })
+      .catch((e: unknown) => {
+        devSleepDone = {
+          ok: false,
+          outcome: "error",
+          error: e instanceof Error ? e.message : String(e),
+        };
+        sleepErrorRef.current = typeof devSleepDone.error === "string" ? devSleepDone.error : undefined;
+        if (myGen === generationRef.current) setSleepView(undefined);
+      })
+      .finally(() => {
+        if (__DEV__) {
+          const stale = myGen !== generationRef.current;
+          const d = devSleepDone;
+          // eslint-disable-next-line no-console -- Dash Oura sleep fetch audit (dev-only)
+          console.log("[DASH_OURA_SLEEP_FETCH_DONE]", {
+            day: dayKey,
+            ok: Boolean(d?.ok),
+            outcome: typeof d?.outcome === "string" ? d.outcome : "incomplete",
+            requestedDay: d?.requestedDay,
+            resolvedDay: d?.resolvedDay,
+            score: d?.score,
+            error: d?.error,
+            cancelled: stale,
+            stale,
+          });
+        }
+        if (myGen === generationRef.current) setSleepViewLoading(false);
+      });
+
+    void getOuraReadinessView(dayKey, token, bust)
+      .then((readinessRes) => {
+        if (myGen !== generationRef.current) return;
+        const readinessOutcome = truthOutcomeFromApiResult(readinessRes);
+        readinessErrorRef.current =
+          readinessOutcome.status === "error" ? readinessOutcome.error : undefined;
+        setReadinessView(readinessOutcome.status === "ready" ? readinessOutcome.data : undefined);
+      })
+      .catch((e: unknown) => {
+        readinessErrorRef.current = e instanceof Error ? e.message : String(e);
+        if (myGen === generationRef.current) setReadinessView(undefined);
+      })
+      .finally(() => {
+        if (myGen === generationRef.current) setReadinessViewLoading(false);
+      });
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) {
+      generationRef.current += 1;
+      setSleepView(undefined);
+      setReadinessView(undefined);
+      setSleepViewLoading(false);
+      setReadinessViewLoading(false);
+      sleepErrorRef.current = undefined;
+      readinessErrorRef.current = undefined;
+      prevDayUidRef.current = null;
+      return;
+    }
+
+    const prev = prevDayUidRef.current;
+    const uid = user?.uid;
+    const dayUidChanged = prev == null || prev.day !== day || prev.uid !== uid;
+    if (dayUidChanged) {
+      prevDayUidRef.current = { day, uid };
+      setSleepView(undefined);
+      setReadinessView(undefined);
+      sleepErrorRef.current = undefined;
+      readinessErrorRef.current = undefined;
+    }
+
+    generationRef.current += 1;
+    const myGen = generationRef.current;
+    void runFetch(myGen);
+  }, [day, user?.uid, enabled, runFetch]);
+
+  const refetch = useCallback((opts?: TruthGetOptions) => {
+    if (!enabledRef.current) return;
+    generationRef.current += 1;
+    const myGen = generationRef.current;
+    void runFetch(myGen, opts);
+  }, [runFetch]);
+
+  const loading = sleepViewLoading || readinessViewLoading;
+
+  useEffect(() => {
+    if (!__DEV__) return;
+    // eslint-disable-next-line no-console -- Dash Oura views audit (dev-only)
+    console.log("[DASH_OURA_VIEWS_DEBUG]", {
+      day,
+      enabled,
+      sleepViewLoading,
+      readinessViewLoading,
+      sleepViewRequestedDay: sleepView?.requestedDay,
+      sleepViewResolvedDay: sleepView?.resolvedDay,
+      sleepViewScore: sleepView?.score,
+      sleepError: sleepErrorRef.current,
+      readinessError: readinessErrorRef.current,
+    });
+  }, [
+    day,
+    enabled,
+    sleepViewLoading,
+    readinessViewLoading,
+    sleepView?.requestedDay,
+    sleepView?.resolvedDay,
+    sleepView?.score,
+  ]);
+
+  return useMemo(
+    () => ({
+      sleepView,
+      readinessView,
+      sleepViewLoading,
+      readinessViewLoading,
+      loading,
+      refetch,
+    }),
+    [sleepView, readinessView, sleepViewLoading, readinessViewLoading, loading, refetch],
+  );
+}

--- a/lib/data/oura/isOuraViewAlignedToDay.ts
+++ b/lib/data/oura/isOuraViewAlignedToDay.ts
@@ -1,0 +1,21 @@
+import type { ReadinessViewDto, SleepViewDto } from "@oli/contracts";
+
+function normalizeDayKey(dayKey: string): string {
+  return typeof dayKey === "string" ? dayKey.trim() : dayKey;
+}
+
+/**
+ * True when an Oura vendor view DTO is for the **exact** calendar day requested.
+ * Reject last-resort / fallback rows where `resolvedDay` differs from the screen day.
+ */
+export function isOuraViewAlignedToDay(
+  view:
+    | Pick<SleepViewDto, "requestedDay" | "resolvedDay">
+    | Pick<ReadinessViewDto, "requestedDay" | "resolvedDay">
+    | undefined,
+  day: string,
+): boolean {
+  if (!view) return false;
+  const anchor = normalizeDayKey(day);
+  return normalizeDayKey(view.resolvedDay) === anchor && normalizeDayKey(view.requestedDay) === anchor;
+}

--- a/lib/data/oura/useOuraViewWeekSnapshotPresence.ts
+++ b/lib/data/oura/useOuraViewWeekSnapshotPresence.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { useAuth } from "@/lib/auth/AuthProvider";
 import { getOuraReadinessView, getOuraSleepView } from "@/lib/api/usersMe";
+import { isOuraViewAlignedToDay } from "@/lib/data/oura/isOuraViewAlignedToDay";
 import { truthOutcomeFromApiResult } from "@/lib/data/truthOutcome";
 import { getTodayDayKeyLocal } from "@/lib/ui/calendar/dateUtils";
 
@@ -99,7 +100,8 @@ export function useOuraViewWeekSnapshotPresence(
         const res =
           k === "sleep" ? await getOuraSleepView(day, token) : await getOuraReadinessView(day, token);
         const outcome = truthOutcomeFromApiResult(res);
-        return [day, outcome.status === "ready"] as const;
+        const has = outcome.status === "ready" && isOuraViewAlignedToDay(outcome.data, day);
+        return [day, has] as const;
       }),
     );
 

--- a/lib/data/sleep/__tests__/dashSleepAnchorLock.test.ts
+++ b/lib/data/sleep/__tests__/dashSleepAnchorLock.test.ts
@@ -1,0 +1,100 @@
+import type { DashSleepAnchorResolution } from "../resolveDashSleepAnchorDay";
+import { mergeDashSleepAnchorWithLock, reduceAnchorLock } from "../dashSleepAnchorLock";
+
+const cal = "2026-05-12";
+const prev = "2026-05-11";
+
+function res(overrides: Partial<DashSleepAnchorResolution>): DashSleepAnchorResolution {
+  return {
+    sleepAnchorDay: cal,
+    sleepAnchorSettled: false,
+    calendarDayHasSleep: false,
+    previousDayHasSleep: false,
+    selectedReason: "loading",
+    ...overrides,
+  };
+}
+
+describe("reduceAnchorLock", () => {
+  it("clears lock when calendar day changes", () => {
+    const settled = res({
+      sleepAnchorSettled: true,
+      sleepAnchorDay: prev,
+      selectedReason: "overnight_probe_previous_day",
+    });
+    let lock = reduceAnchorLock(null, cal, settled);
+    expect(lock?.resolution.sleepAnchorDay).toBe(prev);
+    lock = reduceAnchorLock(lock, "2026-05-13", res({ sleepAnchorSettled: false, selectedReason: "loading" }));
+    expect(lock).toBeNull();
+  });
+
+  it("does not replace previous-day overnight lock with wake-day calendar_empty", () => {
+    const overnight = res({
+      sleepAnchorSettled: true,
+      sleepAnchorDay: prev,
+      selectedReason: "overnight_probe_previous_day",
+    });
+    let lock = reduceAnchorLock(null, cal, overnight);
+    const wakeEmpty = res({
+      sleepAnchorSettled: true,
+      sleepAnchorDay: cal,
+      selectedReason: "calendar_empty",
+    });
+    lock = reduceAnchorLock(lock, cal, wakeEmpty);
+    expect(lock?.resolution.sleepAnchorDay).toBe(prev);
+    expect(lock?.resolution.selectedReason).toBe("overnight_probe_previous_day");
+  });
+
+  it("does not persist wake-day calendar_empty as a lock, but can upgrade to overnight when facts arrive", () => {
+    const wakeEmpty = res({
+      sleepAnchorSettled: true,
+      sleepAnchorDay: cal,
+      selectedReason: "calendar_empty",
+    });
+    let lock = reduceAnchorLock(null, cal, wakeEmpty);
+    expect(lock).toBeNull();
+    const overnight = res({
+      sleepAnchorSettled: true,
+      sleepAnchorDay: prev,
+      selectedReason: "overnight_probe_previous_day",
+    });
+    lock = reduceAnchorLock(lock, cal, overnight);
+    expect(lock?.resolution.sleepAnchorDay).toBe(prev);
+  });
+});
+
+describe("mergeDashSleepAnchorWithLock (log reproduction)", () => {
+  it("settled previousDay -> fresh loading -> merged previousDay with isUsingCachedSettledAnchor true", () => {
+    const overnight = res({
+      sleepAnchorSettled: true,
+      sleepAnchorDay: prev,
+      selectedReason: "overnight_probe_previous_day",
+    });
+    const lock = { calendarToday: cal, resolution: { ...overnight } };
+    const loading = res({ sleepAnchorSettled: false, selectedReason: "loading", sleepAnchorDay: cal });
+    const { merged, isUsingCachedSettledAnchor } = mergeDashSleepAnchorWithLock(cal, loading, lock);
+    expect(merged.sleepAnchorDay).toBe(prev);
+    expect(merged.sleepAnchorSettled).toBe(true);
+    expect(merged.selectedReason).toBe("overnight_probe_previous_day");
+    expect(isUsingCachedSettledAnchor).toBe(true);
+  });
+
+  it("settled previous-day lock -> fresh wake calendar_empty -> merged previousDay with isUsingCachedSettledAnchor true", () => {
+    const overnight = res({
+      sleepAnchorSettled: true,
+      sleepAnchorDay: prev,
+      selectedReason: "overnight_probe_previous_day",
+    });
+    const lock = { calendarToday: cal, resolution: { ...overnight } };
+    const wakeEmpty = res({
+      sleepAnchorSettled: true,
+      sleepAnchorDay: cal,
+      selectedReason: "calendar_empty",
+    });
+    const { merged, isUsingCachedSettledAnchor } = mergeDashSleepAnchorWithLock(cal, wakeEmpty, lock);
+    expect(merged.sleepAnchorDay).toBe(prev);
+    expect(merged.sleepAnchorSettled).toBe(true);
+    expect(merged.selectedReason).toBe("overnight_probe_previous_day");
+    expect(isUsingCachedSettledAnchor).toBe(true);
+  });
+});

--- a/lib/data/sleep/__tests__/pickPhysiologicalSleepAnchorFromVendorSleepView.test.ts
+++ b/lib/data/sleep/__tests__/pickPhysiologicalSleepAnchorFromVendorSleepView.test.ts
@@ -1,0 +1,67 @@
+import type { SleepViewDto } from "@oli/contracts";
+
+import { pickPhysiologicalSleepAnchorFromVendorSleepView } from "../pickPhysiologicalSleepAnchorFromVendorSleepView";
+
+const cal = "2026-05-13" as const;
+
+function view(over: Partial<SleepViewDto>): SleepViewDto {
+  return {
+    isFallback: false,
+    contributors: {},
+    ...over,
+  } as SleepViewDto;
+}
+
+describe("pickPhysiologicalSleepAnchorFromVendorSleepView", () => {
+  it("returns resolved day when requested anchor matches and resolved is within trust window", () => {
+    const out = pickPhysiologicalSleepAnchorFromVendorSleepView({
+      calendarToday: cal,
+      requestedSleepAnchorDay: "2026-05-12",
+      sleepView: view({
+        requestedDay: "2026-05-12",
+        resolvedDay: "2026-05-11",
+        day: "2026-05-11",
+      }),
+    });
+    expect(out).toBe("2026-05-11");
+  });
+
+  it("returns null when aligned (requested === resolved === anchor)", () => {
+    const out = pickPhysiologicalSleepAnchorFromVendorSleepView({
+      calendarToday: cal,
+      requestedSleepAnchorDay: "2026-05-11",
+      sleepView: view({
+        requestedDay: "2026-05-11",
+        resolvedDay: "2026-05-11",
+        day: "2026-05-11",
+      }),
+    });
+    expect(out).toBeNull();
+  });
+
+  it("returns null for unrelated old resolved day (stale fallback)", () => {
+    const out = pickPhysiologicalSleepAnchorFromVendorSleepView({
+      calendarToday: cal,
+      requestedSleepAnchorDay: "2026-05-12",
+      sleepView: view({
+        requestedDay: "2026-05-12",
+        resolvedDay: "2026-04-19",
+        day: "2026-04-19",
+      }),
+    });
+    expect(out).toBeNull();
+  });
+
+  it("returns null for fallback vendor rows", () => {
+    const out = pickPhysiologicalSleepAnchorFromVendorSleepView({
+      calendarToday: cal,
+      requestedSleepAnchorDay: "2026-05-12",
+      sleepView: view({
+        requestedDay: "2026-05-12",
+        resolvedDay: "2026-05-11",
+        isFallback: true,
+      }),
+    });
+    expect(out).toBeNull();
+  });
+});

--- a/lib/data/sleep/__tests__/pickVendorSleepScoreForAnchorDay.test.ts
+++ b/lib/data/sleep/__tests__/pickVendorSleepScoreForAnchorDay.test.ts
@@ -1,0 +1,72 @@
+import type { SleepViewDto } from "@oli/contracts";
+import { pickVendorSleepScoreForAnchorDay } from "../pickVendorSleepScoreForAnchorDay";
+
+const day = "2026-05-01";
+
+function sleepView(
+  over: Partial<SleepViewDto> & Pick<SleepViewDto, "requestedDay" | "resolvedDay" | "day">,
+): SleepViewDto {
+  return {
+    isFallback: false,
+    contributors: {},
+    ...over,
+  } as SleepViewDto;
+}
+
+describe("pickVendorSleepScoreForAnchorDay", () => {
+  it("returns score when view is exact-day and not fallback", () => {
+    expect(
+      pickVendorSleepScoreForAnchorDay(
+        sleepView({
+          requestedDay: day,
+          resolvedDay: day,
+          day,
+          score: 96,
+        }),
+        day,
+      ),
+    ).toBe(96);
+  });
+
+  it("returns null when isFallback (vendor row not for requested calendar day)", () => {
+    expect(
+      pickVendorSleepScoreForAnchorDay(
+        sleepView({
+          requestedDay: day,
+          resolvedDay: "2026-04-30",
+          day: "2026-04-30",
+          score: 99,
+          isFallback: true,
+        }),
+        day,
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null when requested/resolved days do not match anchor (trim-aware alignment)", () => {
+    expect(
+      pickVendorSleepScoreForAnchorDay(
+        sleepView({
+          requestedDay: day,
+          resolvedDay: day,
+          day,
+          score: 88,
+        }),
+        "2026-05-02",
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null when score is absent", () => {
+    expect(
+      pickVendorSleepScoreForAnchorDay(
+        sleepView({
+          requestedDay: day,
+          resolvedDay: day,
+          day,
+        }),
+        day,
+      ),
+    ).toBeNull();
+  });
+});

--- a/lib/data/sleep/__tests__/resolveDashSleepAnchorDay.test.ts
+++ b/lib/data/sleep/__tests__/resolveDashSleepAnchorDay.test.ts
@@ -1,0 +1,212 @@
+import type { DailyFactsDto, SleepViewDto } from "@oli/contracts";
+
+import { resolveDashSleepAnchorDay, type ResolveDashSleepAnchorDayInput } from "../resolveDashSleepAnchorDay";
+
+const cal = "2026-05-12";
+const prev = "2026-05-11";
+
+function base(overrides: Partial<ResolveDashSleepAnchorDayInput> = {}): ResolveDashSleepAnchorDayInput {
+  return {
+    calendarToday: cal,
+    previousDay: prev,
+    calendarFactsStatus: "ready",
+    calendarSleep: undefined,
+    previousFactsStatus: "ready",
+    previousSleep: undefined,
+    probeLoading: false,
+    probeView: undefined,
+    ...overrides,
+  };
+}
+
+function overnightProbe(score = 96, isFallback = false): SleepViewDto {
+  return {
+    requestedDay: cal,
+    resolvedDay: prev,
+    isFallback,
+    day: prev,
+    score,
+    contributors: {},
+  };
+}
+
+describe("resolveDashSleepAnchorDay", () => {
+  it("returns loading when probe still loading", () => {
+    const r = resolveDashSleepAnchorDay(
+      base({
+        calendarFactsStatus: "ready",
+        previousFactsStatus: "ready",
+        probeLoading: true,
+      }),
+    );
+    expect(r.sleepAnchorSettled).toBe(false);
+    expect(r.selectedReason).toBe("loading");
+    expect(r.sleepAnchorDay).toBe(cal);
+  });
+
+  it("overnight probe wins before calendar facts settle", () => {
+    const r = resolveDashSleepAnchorDay(
+      base({
+        calendarFactsStatus: "partial",
+        previousFactsStatus: "partial",
+        probeView: overnightProbe(),
+      }),
+    );
+    expect(r.sleepAnchorDay).toBe(prev);
+    expect(r.sleepAnchorSettled).toBe(true);
+    expect(r.selectedReason).toBe("overnight_probe_previous_day");
+  });
+
+  it("calendar DailyFacts sleep + probe resolves to previousDay -> previousDay wins", () => {
+    const calSleep: DailyFactsDto["sleep"] = { mainSleepMinutes: 300, totalMinutes: 320 };
+    const r = resolveDashSleepAnchorDay(
+      base({
+        calendarSleep: calSleep,
+        probeView: overnightProbe(96, true),
+      }),
+    );
+    expect(r.sleepAnchorDay).toBe(prev);
+    expect(r.selectedReason).toBe("overnight_probe_previous_day");
+    expect(r.calendarDayHasSleep).toBe(true);
+    expect(r.previousDayHasSleep).toBe(true);
+  });
+
+  it("calendar DailyFacts sleep + probe aligned to calendarDay -> calendarDay wins", () => {
+    const calSleep: DailyFactsDto["sleep"] = { mainSleepMinutes: 300, totalMinutes: 320 };
+    const aligned: SleepViewDto = {
+      requestedDay: cal,
+      resolvedDay: cal,
+      isFallback: false,
+      day: cal,
+      score: 88,
+      contributors: {},
+    };
+    const r = resolveDashSleepAnchorDay(
+      base({
+        calendarSleep: calSleep,
+        probeView: aligned,
+      }),
+    );
+    expect(r.sleepAnchorDay).toBe(cal);
+    expect(r.selectedReason).toBe("calendar_exact_sleep");
+  });
+
+  it("does not anchor on calendar facts sleep until probe has settled (may become overnight)", () => {
+    const calSleep: DailyFactsDto["sleep"] = { mainSleepMinutes: 200, totalMinutes: 210 };
+    const r = resolveDashSleepAnchorDay(
+      base({
+        calendarSleep: calSleep,
+        probeLoading: true,
+        probeView: undefined,
+      }),
+    );
+    expect(r.selectedReason).toBe("loading");
+    expect(r.sleepAnchorSettled).toBe(false);
+  });
+
+  it("no probe + calendar facts sleep -> calendarDay", () => {
+    const calSleep: DailyFactsDto["sleep"] = { mainSleepMinutes: 200, totalMinutes: 210 };
+    const r = resolveDashSleepAnchorDay(
+      base({
+        calendarSleep: calSleep,
+        probeView: undefined,
+      }),
+    );
+    expect(r.sleepAnchorDay).toBe(cal);
+    expect(r.selectedReason).toBe("calendar_exact_sleep");
+  });
+
+  it("calendar has no sleep, previous has DailyFacts sleep signal -> previousDay", () => {
+    const prevSleep: DailyFactsDto["sleep"] = { mainSleepMinutes: 420, totalMinutes: 450 };
+    const r = resolveDashSleepAnchorDay(
+      base({
+        calendarSleep: undefined,
+        previousSleep: prevSleep,
+        probeView: undefined,
+      }),
+    );
+    expect(r.sleepAnchorDay).toBe(prev);
+    expect(r.sleepAnchorSettled).toBe(true);
+    expect(r.selectedReason).toBe("previous_exact_sleep");
+    expect(r.previousDayHasSleep).toBe(true);
+    expect(r.calendarDayHasSleep).toBe(false);
+  });
+
+  it("calendar has only zeroed sleep minutes -> does not count as sleep", () => {
+    const r = resolveDashSleepAnchorDay(
+      base({
+        calendarSleep: { mainSleepMinutes: 0, totalMinutes: 0 },
+        previousSleep: undefined,
+        probeView: undefined,
+      }),
+    );
+    expect(r.calendarDayHasSleep).toBe(false);
+    expect(r.sleepAnchorDay).toBe(cal);
+    expect(r.selectedReason).toBe("calendar_empty");
+  });
+
+  it("Oura probe requested calendar but resolved previous -> overnight_probe_previous_day", () => {
+    const r = resolveDashSleepAnchorDay(
+      base({
+        calendarSleep: undefined,
+        previousSleep: undefined,
+        probeView: overnightProbe(96, false),
+      }),
+    );
+    expect(r.sleepAnchorDay).toBe(prev);
+    expect(r.sleepAnchorSettled).toBe(true);
+    expect(r.selectedReason).toBe("overnight_probe_previous_day");
+  });
+
+  it("misaligned probe to unrelated day is ignored for overnight (calendar_empty when nothing else)", () => {
+    const weird: SleepViewDto = {
+      requestedDay: cal,
+      resolvedDay: "2026-05-09",
+      isFallback: true,
+      day: "2026-05-09",
+      score: 50,
+      contributors: {},
+    };
+    const r = resolveDashSleepAnchorDay(
+      base({
+        calendarSleep: undefined,
+        previousSleep: undefined,
+        probeView: weird,
+      }),
+    );
+    expect(r.sleepAnchorDay).toBe(cal);
+    expect(r.selectedReason).toBe("calendar_empty");
+  });
+
+  it("aligned Oura on calendar with no overnight -> calendarDay without calendar facts sleep", () => {
+    const aligned: SleepViewDto = {
+      requestedDay: cal,
+      resolvedDay: cal,
+      isFallback: false,
+      day: cal,
+      score: 88,
+      contributors: {},
+    };
+    const r = resolveDashSleepAnchorDay(
+      base({
+        calendarSleep: undefined,
+        previousSleep: undefined,
+        probeView: aligned,
+      }),
+    );
+    expect(r.sleepAnchorDay).toBe(cal);
+    expect(r.selectedReason).toBe("calendar_exact_sleep");
+    expect(r.calendarDayHasSleep).toBe(true);
+  });
+
+  it("fallback overnight-shaped probe with previous facts still anchors previous via probe", () => {
+    const r = resolveDashSleepAnchorDay(
+      base({
+        previousSleep: { mainSleepMinutes: 400, totalMinutes: 400 },
+        probeView: overnightProbe(90, true),
+      }),
+    );
+    expect(r.sleepAnchorDay).toBe(prev);
+    expect(r.selectedReason).toBe("overnight_probe_previous_day");
+  });
+});

--- a/lib/data/sleep/__tests__/resolveSleepScreenStyleAnchorDay.test.ts
+++ b/lib/data/sleep/__tests__/resolveSleepScreenStyleAnchorDay.test.ts
@@ -1,0 +1,56 @@
+import { resolveSleepScreenStyleAnchorDay } from "../resolveSleepScreenStyleAnchorDay";
+
+const week = ["2026-05-10", "2026-05-11", "2026-05-12", "2026-05-13", "2026-05-14", "2026-05-15", "2026-05-16"] as const;
+
+describe("resolveSleepScreenStyleAnchorDay", () => {
+  it("returns calendar today when presence is still loading (conservative)", () => {
+    expect(
+      resolveSleepScreenStyleAnchorDay("2026-05-12", week, {
+        status: "partial",
+      }),
+    ).toBe("2026-05-12");
+  });
+
+  it("returns calendar today when that day has sleep data in the week", () => {
+    const map: Record<string, boolean> = {};
+    for (const k of week) map[k] = false;
+    map["2026-05-12"] = true;
+    expect(
+      resolveSleepScreenStyleAnchorDay("2026-05-12", week, {
+        status: "ready",
+        hasSleepDataByDay: map,
+      }),
+    ).toBe("2026-05-12");
+  });
+
+  it("overnight / wake-day: snaps to latest prior week day with sleep when calendar today has none (Sleep tab semantics)", () => {
+    const map: Record<string, boolean> = {};
+    for (const k of week) map[k] = false;
+    map["2026-05-11"] = true;
+    expect(
+      resolveSleepScreenStyleAnchorDay("2026-05-12", week, {
+        status: "ready",
+        hasSleepDataByDay: map,
+      }),
+    ).toBe("2026-05-11");
+  });
+
+  it("does not pick a day outside the week strip", () => {
+    const map: Record<string, boolean> = { "2026-05-09": true };
+    expect(
+      resolveSleepScreenStyleAnchorDay("2026-05-12", week, {
+        status: "ready",
+        hasSleepDataByDay: map,
+      }),
+    ).toBe("2026-05-12");
+  });
+
+  it("misaligned historical fallback: no presence in week falls back to calendar today", () => {
+    expect(
+      resolveSleepScreenStyleAnchorDay("2026-05-12", week, {
+        status: "ready",
+        hasSleepDataByDay: {},
+      }),
+    ).toBe("2026-05-12");
+  });
+});

--- a/lib/data/sleep/dashSleepAnchorLock.ts
+++ b/lib/data/sleep/dashSleepAnchorLock.ts
@@ -1,0 +1,108 @@
+import type { DashSleepAnchorResolution } from "@/lib/data/sleep/resolveDashSleepAnchorDay";
+import type { DashSleepAnchorReason } from "@/lib/data/sleep/resolveDashSleepAnchorDay";
+
+export type DashSleepAnchorLock = {
+  calendarToday: string;
+  resolution: DashSleepAnchorResolution;
+};
+
+const LOCKABLE_REASONS: ReadonlySet<DashSleepAnchorReason> = new Set([
+  "overnight_probe_previous_day",
+  "previous_exact_sleep",
+  "calendar_exact_sleep",
+]);
+
+function isWakeDayCalendarEmpty(cal: string, r: DashSleepAnchorResolution): boolean {
+  return r.selectedReason === "calendar_empty" && r.sleepAnchorDay === cal;
+}
+
+/** True when lock anchors sleep on a calendar day strictly before the Dash wake `calendarToday`. */
+function lockAnchorsStrictlyBeforeWakeDay(cal: string, r: DashSleepAnchorResolution): boolean {
+  return r.sleepAnchorSettled && r.sleepAnchorDay !== cal;
+}
+
+/**
+ * Updates the persisted Dash sleep anchor lock from resolver output.
+ * Never stores `loading`, `calendar_empty`, or other non-lockable settled rows as the persisted lock.
+ */
+export function reduceAnchorLock(
+  prev: DashSleepAnchorLock | null,
+  calendarToday: string,
+  fresh: DashSleepAnchorResolution,
+): DashSleepAnchorLock | null {
+  if (prev != null && prev.calendarToday !== calendarToday) {
+    return null;
+  }
+
+  if (!fresh.sleepAnchorSettled) {
+    return prev;
+  }
+
+  if (!LOCKABLE_REASONS.has(fresh.selectedReason)) {
+    return prev;
+  }
+
+  const incoming: DashSleepAnchorResolution = { ...fresh };
+  if (prev == null) {
+    return { calendarToday, resolution: incoming };
+  }
+
+  const p = prev.resolution;
+
+  if (lockAnchorsStrictlyBeforeWakeDay(calendarToday, p) && isWakeDayCalendarEmpty(calendarToday, incoming)) {
+    return prev;
+  }
+
+  if (p.sleepAnchorDay === calendarToday && incoming.sleepAnchorDay !== calendarToday) {
+    return { calendarToday, resolution: incoming };
+  }
+
+  return { calendarToday, resolution: incoming };
+}
+
+function mergeFromLock(
+  lock: DashSleepAnchorLock,
+  isUsingCachedSettledAnchor: boolean,
+): { merged: DashSleepAnchorResolution; isUsingCachedSettledAnchor: boolean } {
+  const r = lock.resolution;
+  return {
+    merged: {
+      ...r,
+      sleepAnchorDay: r.sleepAnchorDay,
+      sleepAnchorSettled: true,
+      selectedReason: r.selectedReason,
+      calendarDayHasSleep: r.calendarDayHasSleep,
+      previousDayHasSleep: r.previousDayHasSleep,
+    },
+    isUsingCachedSettledAnchor,
+  };
+}
+
+/**
+ * Prefer a persisted settled lock over transient resolver output (`loading` or wake-day `calendar_empty`)
+ * so probe / DailyFacts refetches cannot regress the Dash sleep anchor to the calendar wake day.
+ */
+export function mergeDashSleepAnchorWithLock(
+  calendarToday: string,
+  fresh: DashSleepAnchorResolution,
+  lock: DashSleepAnchorLock | null,
+): { merged: DashSleepAnchorResolution; isUsingCachedSettledAnchor: boolean } {
+  if (lock == null || lock.calendarToday !== calendarToday) {
+    return { merged: fresh, isUsingCachedSettledAnchor: false };
+  }
+
+  if (!fresh.sleepAnchorSettled && fresh.selectedReason === "loading") {
+    return mergeFromLock(lock, true);
+  }
+
+  if (
+    fresh.sleepAnchorSettled &&
+    fresh.selectedReason === "calendar_empty" &&
+    isWakeDayCalendarEmpty(calendarToday, fresh) &&
+    lockAnchorsStrictlyBeforeWakeDay(calendarToday, lock.resolution)
+  ) {
+    return mergeFromLock(lock, true);
+  }
+
+  return { merged: fresh, isUsingCachedSettledAnchor: false };
+}

--- a/lib/data/sleep/pickPhysiologicalSleepAnchorFromVendorSleepView.ts
+++ b/lib/data/sleep/pickPhysiologicalSleepAnchorFromVendorSleepView.ts
@@ -1,0 +1,37 @@
+import type { SleepViewDto } from "@oli/contracts";
+
+import { addCalendarDaysToDayKey } from "@/lib/ui/calendar/dateUtils";
+import type { DayKey } from "@/lib/ui/calendar/types";
+
+function normalizeDayKey(dayKey: string): string {
+  return typeof dayKey === "string" ? dayKey.trim() : dayKey;
+}
+
+/**
+ * When `GET /users/me/oura-sleep-view?day=D` returns `requestedDay === D` but `resolvedDay === R` with
+ * `R !== D`, the vendor row is physiologically keyed on `R`. Dash must anchor vendor reads + alignment
+ * on `R` without relaxing {@link isOuraViewAlignedToDay}.
+ *
+ * Rejects unrelated older `resolvedDay` rows (e.g. stale April fallback) using a tight window vs
+ * the Dash calendar wake day.
+ */
+export function pickPhysiologicalSleepAnchorFromVendorSleepView(args: {
+  calendarToday: DayKey;
+  requestedSleepAnchorDay: string;
+  sleepView: SleepViewDto | undefined;
+}): string | null {
+  const { calendarToday, requestedSleepAnchorDay, sleepView } = args;
+  if (!sleepView || sleepView.isFallback) return null;
+
+  const req = normalizeDayKey(sleepView.requestedDay);
+  const res = normalizeDayKey(sleepView.resolvedDay);
+  const anchor = normalizeDayKey(requestedSleepAnchorDay);
+
+  if (req !== anchor) return null;
+  if (res === anchor) return null;
+
+  const minTrust = addCalendarDaysToDayKey(calendarToday, -2);
+  if (res < minTrust || res > normalizeDayKey(calendarToday)) return null;
+
+  return res;
+}

--- a/lib/data/sleep/pickVendorSleepScoreForAnchorDay.ts
+++ b/lib/data/sleep/pickVendorSleepScoreForAnchorDay.ts
@@ -1,0 +1,19 @@
+import type { SleepViewDto } from "@oli/contracts";
+import { isOuraViewAlignedToDay } from "@/lib/data/oura/isOuraViewAlignedToDay";
+
+/**
+ * Vendor sleep score for a calendar anchor day: exact-day only (no Oura fallback rows).
+ * Matches the Sleep screen Oli path intent: use vendor snapshot score when the view is
+ * for this day, without mixing readiness or inventing values.
+ */
+export function pickVendorSleepScoreForAnchorDay(
+  view: SleepViewDto | undefined,
+  anchorDay: string,
+): number | null {
+  if (!view) return null;
+  if (view.isFallback) return null;
+  if (!isOuraViewAlignedToDay(view, anchorDay)) return null;
+  const raw = view.score;
+  if (typeof raw !== "number" || !Number.isFinite(raw) || raw < 0) return null;
+  return Math.round(Math.min(100, raw));
+}

--- a/lib/data/sleep/resolveDashSleepAnchorDay.ts
+++ b/lib/data/sleep/resolveDashSleepAnchorDay.ts
@@ -1,0 +1,135 @@
+import type { DailyFactsDto, SleepViewDto } from "@oli/contracts";
+
+import { dailyFactsHasSleepSignal } from "@/lib/data/sleep/sleepFactsSignal";
+import { isOuraViewAlignedToDay } from "@/lib/data/oura/isOuraViewAlignedToDay";
+
+export type DashSleepAnchorReason =
+  | "loading"
+  | "overnight_probe_previous_day"
+  | "calendar_exact_sleep"
+  | "previous_exact_sleep"
+  | "calendar_empty";
+
+export type ResolveDashSleepAnchorDayInput = {
+  calendarToday: string;
+  previousDay: string;
+  calendarFactsStatus: "partial" | "ready" | "missing" | "error";
+  calendarSleep: DailyFactsDto["sleep"] | undefined;
+  previousFactsStatus: "partial" | "ready" | "missing" | "error";
+  previousSleep: DailyFactsDto["sleep"] | undefined;
+  probeLoading: boolean;
+  probeView: SleepViewDto | undefined;
+};
+
+export type DashSleepAnchorResolution = {
+  sleepAnchorDay: string;
+  sleepAnchorSettled: boolean;
+  calendarDayHasSleep: boolean;
+  previousDayHasSleep: boolean;
+  selectedReason: DashSleepAnchorReason;
+};
+
+function normalizeDayKey(dayKey: string): string {
+  return typeof dayKey === "string" ? dayKey.trim() : dayKey;
+}
+
+/**
+ * Dash Daily Sleep anchor: choose the day key **before** strict Oura alignment so the main
+ * `useDashOuraViews` fetch targets the physiological sleep row.
+ *
+ * Priority:
+ * 1) Calendar Oura probe with `requestedDay === calendarToday` and `resolvedDay === previousDay`
+ *    (not aligned to calendar) → anchor previous, even when DailyFacts show sleep on the wake day.
+ * 2) Aligned non-fallback Oura sleep view on the calendar day.
+ * 3) DailyFacts sleep signal on the calendar day (only after the probe settles so overnight can win).
+ * 4) DailyFacts sleep signal on the previous calendar day.
+ * 5) Calendar day with empty card.
+ *
+ * Does not relax `isOuraViewAlignedToDay` on the **anchored** vendor fetch — only selects which day to request.
+ */
+export function resolveDashSleepAnchorDay(input: ResolveDashSleepAnchorDayInput): DashSleepAnchorResolution {
+  const { calendarToday, previousDay, probeView, probeLoading } = input;
+
+  const calFactsSettled = input.calendarFactsStatus !== "partial";
+  const prevFactsSettled = input.previousFactsStatus !== "partial";
+  const probeSettled = !probeLoading;
+
+  const calendarExactFromFacts =
+    input.calendarFactsStatus === "ready" && dailyFactsHasSleepSignal(input.calendarSleep);
+
+  const calendarAlignedOura =
+    probeView != null &&
+    !probeView.isFallback &&
+    isOuraViewAlignedToDay(probeView, calendarToday);
+
+  /** Physiological “wake calendar day” sleep lives on previous Oura sleep day (may be marked fallback). */
+  const probeOvernightToPrevious =
+    probeView != null &&
+    normalizeDayKey(probeView.requestedDay) === normalizeDayKey(calendarToday) &&
+    normalizeDayKey(probeView.resolvedDay) === normalizeDayKey(previousDay) &&
+    !isOuraViewAlignedToDay(probeView, calendarToday);
+
+  const previousExactFromFacts =
+    input.previousFactsStatus === "ready" && dailyFactsHasSleepSignal(input.previousSleep);
+
+  const calendarDayHasSleep = calendarExactFromFacts || calendarAlignedOura;
+  const previousDayHasSleep = previousExactFromFacts || probeOvernightToPrevious;
+
+  if (probeSettled && probeOvernightToPrevious) {
+    return {
+      sleepAnchorDay: previousDay,
+      sleepAnchorSettled: true,
+      calendarDayHasSleep,
+      previousDayHasSleep,
+      selectedReason: "overnight_probe_previous_day",
+    };
+  }
+
+  if (probeSettled && calendarAlignedOura) {
+    return {
+      sleepAnchorDay: calendarToday,
+      sleepAnchorSettled: true,
+      calendarDayHasSleep,
+      previousDayHasSleep,
+      selectedReason: "calendar_exact_sleep",
+    };
+  }
+
+  if (probeSettled && calFactsSettled && calendarExactFromFacts) {
+    return {
+      sleepAnchorDay: calendarToday,
+      sleepAnchorSettled: true,
+      calendarDayHasSleep,
+      previousDayHasSleep,
+      selectedReason: "calendar_exact_sleep",
+    };
+  }
+
+  if (calFactsSettled && probeSettled && prevFactsSettled && previousExactFromFacts) {
+    return {
+      sleepAnchorDay: previousDay,
+      sleepAnchorSettled: true,
+      calendarDayHasSleep,
+      previousDayHasSleep,
+      selectedReason: "previous_exact_sleep",
+    };
+  }
+
+  if (calFactsSettled && probeSettled && prevFactsSettled) {
+    return {
+      sleepAnchorDay: calendarToday,
+      sleepAnchorSettled: true,
+      calendarDayHasSleep,
+      previousDayHasSleep,
+      selectedReason: "calendar_empty",
+    };
+  }
+
+  return {
+    sleepAnchorDay: calendarToday,
+    sleepAnchorSettled: false,
+    calendarDayHasSleep,
+    previousDayHasSleep,
+    selectedReason: "loading",
+  };
+}

--- a/lib/data/sleep/resolveSleepScreenStyleAnchorDay.ts
+++ b/lib/data/sleep/resolveSleepScreenStyleAnchorDay.ts
@@ -1,0 +1,25 @@
+import { pickLatestSleepWeekDayWithPresence } from "@/lib/data/sleep/pickLatestSleepWeekDayWithPresence";
+
+export type SleepWeekPresenceForAnchor =
+  | { status: "partial" }
+  | { status: "ready"; hasSleepDataByDay: Record<string, boolean> };
+
+/**
+ * Un-pinned Sleep tab semantics: week strip is anchored on `calendarToday`, and the selected
+ * day snaps to the latest week day with sleep presence when the calendar day has none.
+ *
+ * Dash Daily Sleep uses this so `GET /users/me/oura-sleep-view?day=` and DailyFacts sleep rows
+ * target the same physiological sleep day as the Sleep screen default, without weakening
+ * `isOuraViewAlignedToDay` on the vendor view.
+ */
+export function resolveSleepScreenStyleAnchorDay(
+  calendarToday: string,
+  weekDayKeys: readonly string[],
+  presence: SleepWeekPresenceForAnchor,
+): string {
+  if (presence.status !== "ready") return calendarToday;
+  const map = presence.hasSleepDataByDay;
+  if (map[calendarToday] === true) return calendarToday;
+  const pivot = pickLatestSleepWeekDayWithPresence(weekDayKeys, map);
+  return pivot ?? calendarToday;
+}

--- a/lib/data/useSleepDayView.ts
+++ b/lib/data/useSleepDayView.ts
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
+// TODO: Migrate Sleep detail to consume GET /users/me/sleep-night (SleepNight) for headline/key metrics when safe.
+
 import { useAuth } from "@/lib/auth/AuthProvider";
 import {
   getDailyFacts,
@@ -8,6 +10,7 @@ import {
   type TruthGetOptions,
 } from "@/lib/api/usersMe";
 import type { DailyFactsDto, InsightsResponseDto, SleepViewDto } from "@oli/contracts";
+import { isOuraViewAlignedToDay } from "@/lib/data/oura/isOuraViewAlignedToDay";
 import { truthOutcomeFromApiResult } from "@/lib/data/truthOutcome";
 import { dailyFactsHasSleepSignal } from "@/lib/data/sleep/sleepFactsSignal";
 
@@ -135,7 +138,12 @@ export function useSleepDayView(
       }
 
       if (ouraParallelOutcome.status === "ready") {
-        safeSet({ status: "oura_fallback", data: ouraParallelOutcome.data });
+        const v = ouraParallelOutcome.data;
+        if (isOuraViewAlignedToDay(v, dayKey)) {
+          safeSet({ status: "oura_fallback", data: v });
+          return;
+        }
+        safeSet({ status: "missing" });
         return;
       }
 

--- a/lib/data/useSleepWeekDataPresence.ts
+++ b/lib/data/useSleepWeekDataPresence.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { useAuth } from "@/lib/auth/AuthProvider";
 import { getDailyFacts, getOuraSleepView } from "@/lib/api/usersMe";
+import { isOuraViewAlignedToDay } from "@/lib/data/oura/isOuraViewAlignedToDay";
 import { truthOutcomeFromApiResult } from "@/lib/data/truthOutcome";
 import { dailyFactsHasSleepSignal } from "@/lib/data/sleep/sleepFactsSignal";
 import { getTodayDayKeyLocal } from "@/lib/ui/calendar/dateUtils";
@@ -21,7 +22,9 @@ async function dayHasSleepData(day: string, token: string): Promise<boolean> {
     return true;
   }
   const ouraRes = await getOuraSleepView(day, token);
-  return truthOutcomeFromApiResult(ouraRes).status === "ready";
+  const ouraOutcome = truthOutcomeFromApiResult(ouraRes);
+  if (ouraOutcome.status !== "ready") return false;
+  return isOuraViewAlignedToDay(ouraOutcome.data, day);
 }
 
 type State =

--- a/lib/hooks/__tests__/useDashSleepAnchorDay.probeRefetchRegression.test.tsx
+++ b/lib/hooks/__tests__/useDashSleepAnchorDay.probeRefetchRegression.test.tsx
@@ -1,0 +1,168 @@
+import React from "react";
+import renderer, { act } from "react-test-renderer";
+
+import type { DailyFactsDto } from "@oli/contracts";
+import type { SleepViewDto } from "@oli/contracts";
+
+/** Mock reads this on every render of `useDashSleepAnchorDay`. */
+let mockProbeLoading = false;
+
+const mockOvernightProbeView: SleepViewDto = {
+  requestedDay: "2026-05-12",
+  resolvedDay: "2026-05-11",
+  isFallback: true,
+  day: "2026-05-11",
+  score: 72,
+  contributors: {},
+};
+
+const mockGetOuraSleepView = jest.fn();
+const mockGetOuraReadinessView = jest.fn();
+
+jest.mock("@/lib/api/usersMe", () => ({
+  getOuraSleepView: (...args: unknown[]) => mockGetOuraSleepView(...args),
+  getOuraReadinessView: (...args: unknown[]) => mockGetOuraReadinessView(...args),
+}));
+
+const mockAuthUser = { uid: "u1" };
+const mockGetIdToken = jest.fn().mockResolvedValue("id-token");
+
+jest.mock("@/lib/auth/AuthProvider", () => ({
+  useAuth: () => ({
+    user: mockAuthUser,
+    initializing: false,
+    getIdToken: mockGetIdToken,
+  }),
+}));
+
+const mockMinimalReadyFacts = {
+  status: "ready" as const,
+  data: { sleep: undefined } as unknown as DailyFactsDto,
+  refetch: jest.fn(),
+};
+
+jest.mock("@/lib/data/useDailyFacts", () => ({
+  useDailyFacts: () => mockMinimalReadyFacts,
+}));
+
+jest.mock("@/lib/data/dash/useDashOuraCalendarSleepProbe", () => ({
+  useDashOuraCalendarSleepProbe: () => ({
+    loading: mockProbeLoading,
+    view: mockOvernightProbeView,
+    refetch: jest.fn(),
+  }),
+}));
+
+import { useDashOuraViews } from "@/lib/data/dash/useDashOuraViews";
+import { useDashSleepAnchorDay } from "@/lib/hooks/useDashSleepAnchorDay";
+
+const CAL = "2026-05-12";
+const ANCHOR = "2026-05-11";
+
+type Sink = {
+  anchor: ReturnType<typeof useDashSleepAnchorDay>;
+  dashOuraEnabled: boolean;
+};
+
+function DashAnchorOuraHarness({
+  sink,
+}: {
+  sink: React.MutableRefObject<Sink | null>;
+}): null {
+  const anchor = useDashSleepAnchorDay(CAL);
+  const dashOuraEnabled = anchor.sleepAnchorSettled || anchor.isUsingCachedSettledAnchor;
+  useDashOuraViews(anchor.sleepAnchorDay, { enabled: dashOuraEnabled });
+  sink.current = { anchor, dashOuraEnabled };
+  return null;
+}
+
+describe("useDashSleepAnchorDay + useDashOuraViews (probe refetch regression)", () => {
+  beforeEach(() => {
+    mockProbeLoading = false;
+    mockGetOuraSleepView.mockReset();
+    mockGetOuraReadinessView.mockReset();
+    mockGetOuraReadinessView.mockResolvedValue({
+      ok: true,
+      status: 200,
+      requestId: null,
+      json: {
+        requestedDay: CAL,
+        resolvedDay: CAL,
+        isFallback: false,
+        day: CAL,
+        score: 80,
+        contributors: {},
+      },
+    });
+  });
+
+  it("settled overnight 2026-05-11 -> probeLoading -> anchor stays 2026-05-11, enabled stays true, sleep fetch not superseded", async () => {
+    let resolveMainSleep!: (v: unknown) => void;
+    const mainSleepPromise = new Promise((resolve) => {
+      resolveMainSleep = resolve;
+    });
+
+    mockGetOuraSleepView.mockImplementation((day: string) => {
+      if (day === CAL) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          requestId: null,
+          json: mockOvernightProbeView,
+        });
+      }
+      if (day === ANCHOR) {
+        return mainSleepPromise;
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        kind: "http" as const,
+        error: "nope",
+        requestId: null,
+      });
+    });
+
+    const sink: React.MutableRefObject<Sink | null> = { current: null };
+    let root: renderer.ReactTestRenderer;
+
+    await act(async () => {
+      root = renderer.create(<DashAnchorOuraHarness sink={sink} />);
+      await Promise.resolve();
+    });
+
+    expect(sink.current?.anchor.sleepAnchorDay).toBe(ANCHOR);
+    expect(sink.current?.anchor.sleepAnchorSettled).toBe(true);
+    expect(sink.current?.anchor.isUsingCachedSettledAnchor).toBe(false);
+    expect(sink.current?.dashOuraEnabled).toBe(true);
+    expect(mockGetOuraSleepView.mock.calls.some((c) => c[0] === ANCHOR && c[1] === "id-token")).toBe(true);
+
+    const callsAfterSettled = mockGetOuraSleepView.mock.calls.filter((c) => c[0] === ANCHOR).length;
+
+    mockProbeLoading = true;
+
+    await act(async () => {
+      root.update(<DashAnchorOuraHarness sink={sink} />);
+      await Promise.resolve();
+    });
+
+    expect(sink.current?.anchor.sleepAnchorDay).toBe(ANCHOR);
+    expect(sink.current?.anchor.sleepAnchorSettled).toBe(true);
+    expect(sink.current?.anchor.selectedReason).toBe("overnight_probe_previous_day");
+    expect(sink.current?.anchor.isUsingCachedSettledAnchor).toBe(true);
+    expect(sink.current?.dashOuraEnabled).toBe(true);
+
+    const callsDuringProbeLoading = mockGetOuraSleepView.mock.calls.filter((c) => c[0] === ANCHOR).length;
+    expect(callsDuringProbeLoading).toBe(callsAfterSettled);
+
+    await act(async () => {
+      resolveMainSleep({
+        ok: true,
+        status: 200,
+        requestId: null,
+        json: { ...mockOvernightProbeView, requestedDay: ANCHOR, resolvedDay: ANCHOR, isFallback: false },
+      });
+      await Promise.resolve();
+    });
+  });
+});

--- a/lib/hooks/__tests__/useSleepNight.resolution.test.tsx
+++ b/lib/hooks/__tests__/useSleepNight.resolution.test.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import renderer, { act } from "react-test-renderer";
+import { Text } from "react-native";
+
+import { getSleepNight } from "@/lib/api/usersMe";
+import { useSleepNight } from "../useSleepNight";
+
+jest.mock("@/lib/auth/AuthProvider", () => ({
+  useAuth: () => ({
+    user: { uid: "u1" },
+    initializing: false,
+    getIdToken: jest.fn(async () => "tok"),
+  }),
+}));
+
+jest.mock("@/lib/api/usersMe", () => ({
+  getSleepNight: jest.fn(),
+}));
+
+const getSleepNightMock = getSleepNight as jest.MockedFunction<typeof getSleepNight>;
+
+function Probe() {
+  const { view, settled } = useSleepNight("2026-05-13");
+  return (
+    <Text testID="out">
+      {settled && view ? `${view.requestedDay}|${view.anchorDay}|${view.resolution}` : "pending"}
+    </Text>
+  );
+}
+
+describe("useSleepNight", () => {
+  beforeEach(() => {
+    getSleepNightMock.mockReset();
+  });
+
+  it("surfaces API anchorDay when requested calendar day differs (prior night)", async () => {
+    getSleepNightMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      requestId: null,
+      json: {
+        requestedDay: "2026-05-13",
+        anchorDay: "2026-05-12",
+        wakeDay: "2026-05-13",
+        resolution: "latest_completed_prior_night",
+        isFallback: false,
+        sleepNight: {
+          anchorDay: "2026-05-12",
+          wakeDay: "2026-05-13",
+          provider: "oura",
+          source: "ouraVendorSleep",
+          sourceDocumentId: "s1",
+          isComplete: true,
+          score: 77,
+          updatedAt: "2026-05-13T12:00:00.000Z",
+        },
+      },
+    });
+
+    let root!: renderer.ReactTestRenderer;
+    await act(async () => {
+      root = renderer.create(<Probe />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const t = root.root.findByProps({ testID: "out" });
+    expect(t.props.children).toBe("2026-05-13|2026-05-12|latest_completed_prior_night");
+  });
+});

--- a/lib/hooks/useDashSleepAnchorDay.ts
+++ b/lib/hooks/useDashSleepAnchorDay.ts
@@ -1,0 +1,158 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { useDashOuraCalendarSleepProbe } from "@/lib/data/dash/useDashOuraCalendarSleepProbe";
+import {
+  mergeDashSleepAnchorWithLock,
+  reduceAnchorLock,
+  type DashSleepAnchorLock,
+} from "@/lib/data/sleep/dashSleepAnchorLock";
+import { resolveDashSleepAnchorDay, type DashSleepAnchorResolution } from "@/lib/data/sleep/resolveDashSleepAnchorDay";
+import { useDailyFacts } from "@/lib/data/useDailyFacts";
+import { addCalendarDaysToDayKey } from "@/lib/ui/calendar/dateUtils";
+import type { DayKey } from "@/lib/ui/calendar/types";
+
+export type UseDashSleepAnchorResult = DashSleepAnchorResolution & {
+  calendarToday: string;
+  previousDay: string;
+  refetchProbe: ReturnType<typeof useDashOuraCalendarSleepProbe>["refetch"];
+  isUsingCachedSettledAnchor: boolean;
+  invalidateSettledAnchor: () => void;
+};
+
+/**
+ * Dash Daily Sleep anchor: resolves `sleepAnchorDay`, then **locks** a settled choice in a ref
+ * so transient `loading` from probe refetch or `calendar_empty` wake-day snapshots cannot
+ * flip `sleepAnchorSettled` / `sleepAnchorDay` back to the calendar day or disable downstream Oura.
+ *
+ * The lock is reduced **during render** (before merge) so `mergeDashSleepAnchorWithLock` always
+ * reads the latest ref. Merge is **not** memoized on `fresh` identity — a stable `fresh` object
+ * during repeated `loading` renders must not resurrect a stale merged snapshot from before the lock
+ * existed (React `useMemo` footgun).
+ */
+export function useDashSleepAnchorDay(calendarToday: string): UseDashSleepAnchorResult {
+  const anchorLockRef = useRef<DashSleepAnchorLock | null>(null);
+  const [anchorLockEpoch, setAnchorLockEpoch] = useState(0);
+
+  const previousDay = useMemo(
+    () => addCalendarDaysToDayKey(calendarToday as DayKey, -1),
+    [calendarToday],
+  );
+
+  const factsCal = useDailyFacts(calendarToday);
+  const factsPrev = useDailyFacts(previousDay);
+  const probe = useDashOuraCalendarSleepProbe(calendarToday);
+
+  const fresh = useMemo(
+    () =>
+      resolveDashSleepAnchorDay({
+        calendarToday,
+        previousDay,
+        calendarFactsStatus: factsCal.status,
+        calendarSleep: factsCal.status === "ready" ? factsCal.data.sleep : undefined,
+        previousFactsStatus: factsPrev.status,
+        previousSleep: factsPrev.status === "ready" ? factsPrev.data.sleep : undefined,
+        probeLoading: probe.loading,
+        probeView: probe.view,
+      }),
+    [calendarToday, previousDay, factsCal, factsPrev, probe.loading, probe.view],
+  );
+
+  const lockBefore = anchorLockRef.current;
+  anchorLockRef.current = reduceAnchorLock(anchorLockRef.current, calendarToday, fresh);
+  const lockAfter = anchorLockRef.current;
+  const { merged, isUsingCachedSettledAnchor } = mergeDashSleepAnchorWithLock(
+    calendarToday,
+    fresh,
+    anchorLockRef.current,
+  );
+
+  useEffect(() => {
+    if (!__DEV__) return;
+    // eslint-disable-next-line no-console -- Dash sleep lock audit (dev-only)
+    console.log("[DASH_SLEEP_LOCK_DEBUG]", {
+      calendarDay: calendarToday,
+      freshReason: fresh.selectedReason,
+      freshAnchorDay: fresh.sleepAnchorDay,
+      freshSettled: fresh.sleepAnchorSettled,
+      lockBeforeDay: lockBefore?.resolution.sleepAnchorDay ?? null,
+      lockBeforeReason: lockBefore?.resolution.selectedReason ?? null,
+      lockBeforeSettled: lockBefore?.resolution.sleepAnchorSettled ?? null,
+      lockAfterDay: lockAfter?.resolution.sleepAnchorDay ?? null,
+      lockAfterReason: lockAfter?.resolution.selectedReason ?? null,
+      lockAfterSettled: lockAfter?.resolution.sleepAnchorSettled ?? null,
+      mergedDay: merged.sleepAnchorDay,
+      mergedReason: merged.selectedReason,
+      mergedSettled: merged.sleepAnchorSettled,
+      isUsingCachedSettledAnchor,
+      invalidatedThisRender: false,
+    });
+  }, [
+    calendarToday,
+    fresh.selectedReason,
+    fresh.sleepAnchorDay,
+    fresh.sleepAnchorSettled,
+    lockBefore?.resolution.sleepAnchorDay,
+    lockBefore?.resolution.selectedReason,
+    lockBefore?.resolution.sleepAnchorSettled,
+    lockAfter?.resolution.sleepAnchorDay,
+    lockAfter?.resolution.selectedReason,
+    lockAfter?.resolution.sleepAnchorSettled,
+    merged.sleepAnchorDay,
+    merged.selectedReason,
+    merged.sleepAnchorSettled,
+    isUsingCachedSettledAnchor,
+    anchorLockEpoch,
+  ]);
+
+  const invalidateSettledAnchor = useCallback(() => {
+    if (__DEV__) {
+      const stackHint = new Error("invalidateSettledAnchor").stack?.split("\n").slice(1, 4).join(" \u2192 ");
+      // eslint-disable-next-line no-console -- Dash sleep lock audit (dev-only)
+      console.log("[DASH_SLEEP_INVALIDATE_DEBUG]", {
+        calendarDay: calendarToday,
+        reason: "invalidateSettledAnchor",
+        stackHint: stackHint ?? null,
+      });
+    }
+    anchorLockRef.current = null;
+    setAnchorLockEpoch((n) => n + 1);
+  }, [calendarToday]);
+
+  useEffect(() => {
+    if (!__DEV__) return;
+    // eslint-disable-next-line no-console -- Dash sleep anchor audit (dev-only)
+    console.log("[DASH_SLEEP_ANCHOR_DEBUG]", {
+      calendarDay: calendarToday,
+      previousDay,
+      selectedReason: merged.selectedReason,
+      sleepAnchorDay: merged.sleepAnchorDay,
+      sleepAnchorSettled: merged.sleepAnchorSettled,
+      isUsingCachedSettledAnchor,
+      probeLoading: probe.loading,
+      calendarFactsPartial: factsCal.status === "partial",
+      previousFactsPartial: factsPrev.status === "partial",
+    });
+  }, [
+    calendarToday,
+    previousDay,
+    merged.selectedReason,
+    merged.sleepAnchorDay,
+    merged.sleepAnchorSettled,
+    isUsingCachedSettledAnchor,
+    probe.loading,
+    factsCal.status,
+    factsPrev.status,
+  ]);
+
+  return useMemo(
+    () => ({
+      ...merged,
+      calendarToday,
+      previousDay,
+      refetchProbe: probe.refetch,
+      isUsingCachedSettledAnchor,
+      invalidateSettledAnchor,
+    }),
+    [merged, calendarToday, previousDay, probe.refetch, isUsingCachedSettledAnchor, invalidateSettledAnchor],
+  );
+}

--- a/lib/hooks/useSleepNight.ts
+++ b/lib/hooks/useSleepNight.ts
@@ -1,0 +1,130 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { getSleepNight, type TruthGetOptions } from "@/lib/api/usersMe";
+import { useAuth } from "@/lib/auth/AuthProvider";
+import { truthOutcomeFromApiResult } from "@/lib/data/truthOutcome";
+import type { SleepNightViewDto } from "@oli/contracts";
+
+export type UseSleepNightOptions = {
+  enabled?: boolean;
+};
+
+export type UseSleepNightResult = {
+  /** Latest successful view; cleared on 404 missing; unchanged on transient errors. */
+  view: SleepNightViewDto | undefined;
+  loading: boolean;
+  settled: boolean;
+  error: string | null;
+  refetch: (opts?: TruthGetOptions) => void;
+};
+
+/**
+ * Canonical sleep night for a calendar day (`GET /users/me/sleep-night`).
+ * Server applies bounded physiological resolution (exact anchor, wake-day, then latest complete prior night).
+ * Keeps the prior successful `view` while `loading` is true so Dash does not flicker.
+ */
+export function useSleepNight(day: string, options?: UseSleepNightOptions): UseSleepNightResult {
+  const enabled = options?.enabled ?? true;
+  const { user, initializing, getIdToken } = useAuth();
+  const dayRef = useRef(day);
+  dayRef.current = day;
+  const enabledRef = useRef(enabled);
+  enabledRef.current = enabled;
+  const initializingRef = useRef(initializing);
+  initializingRef.current = initializing;
+  const hasUserRef = useRef(Boolean(user));
+  hasUserRef.current = Boolean(user);
+  const getIdTokenRef = useRef(getIdToken);
+  getIdTokenRef.current = getIdToken;
+
+  const generationRef = useRef(0);
+
+  const [view, setView] = useState<SleepNightViewDto | undefined>(undefined);
+  const [loading, setLoading] = useState(true);
+  const [settled, setSettled] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setView(undefined);
+    setSettled(false);
+    setLoading(true);
+    setError(null);
+  }, [day]);
+
+  const runFetch = useCallback(
+    async (myGen: number, bust?: TruthGetOptions) => {
+      if (!enabledRef.current) {
+        if (myGen === generationRef.current) {
+          setLoading(false);
+          setSettled(true);
+          setView(undefined);
+          setError(null);
+        }
+        return;
+      }
+
+      if (initializingRef.current || !hasUserRef.current) {
+        if (myGen === generationRef.current) {
+          setLoading(false);
+          setSettled(true);
+          setView(undefined);
+          setError(null);
+        }
+        return;
+      }
+
+      const token = await getIdTokenRef.current(false);
+      if (!token) {
+        if (myGen === generationRef.current) {
+          setLoading(false);
+          setSettled(true);
+          setError(null);
+        }
+        return;
+      }
+
+      if (myGen !== generationRef.current) return;
+
+      setLoading(true);
+
+      const res = await getSleepNight(dayRef.current, token, bust);
+      if (myGen !== generationRef.current) return;
+
+      const outcome = truthOutcomeFromApiResult(res);
+      if (outcome.status === "ready") {
+        setView(outcome.data);
+        setError(null);
+      } else if (outcome.status === "missing") {
+        setView(undefined);
+        setError(null);
+      } else {
+        setError(outcome.error);
+      }
+
+      setLoading(false);
+      setSettled(true);
+    },
+    [],
+  );
+
+  useEffect(() => {
+    const myGen = ++generationRef.current;
+    void runFetch(myGen);
+  }, [day, enabled, initializing, user, runFetch]);
+
+  const refetch = useCallback(
+    (opts?: TruthGetOptions) => {
+      const myGen = ++generationRef.current;
+      void runFetch(myGen, opts);
+    },
+    [runFetch],
+  );
+
+  return {
+    view,
+    loading,
+    settled,
+    error,
+    refetch,
+  };
+}

--- a/lib/hooks/useTodayHealthHero.ts
+++ b/lib/hooks/useTodayHealthHero.ts
@@ -1,31 +1,42 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import type { TruthGetOptions } from "@/lib/api/usersMe";
 import { useAuth } from "@/lib/auth/AuthProvider";
 import {
   buildTodayHealthHeroViewModel,
   type TodayHealthHeroViewModel,
 } from "@/lib/dashboard/todayHealthHero";
+import { buildDailySleepCardModel, type DailySleepCardModel } from "@/lib/data/dash/buildDailySleepCardModel";
 import type { DailyEnergyCardDto } from "@/lib/data/dash/useDailyEnergyCard";
 import { resolveUserProfileMainForUi } from "@/lib/data/profile/resolveUserProfileMainForUi";
 import { useUserProfileMain } from "@/lib/data/profile/useUserProfileMain";
 import { useDailyFacts } from "@/lib/data/useDailyFacts";
 import { useHealthScore } from "@/lib/data/useHealthScore";
+import { useSleepNight } from "@/lib/hooks/useSleepNight";
+import type { DayKey } from "@/lib/ui/calendar/types";
 
 export type UseTodayHealthHeroResult = {
   vm: TodayHealthHeroViewModel;
   energy: DailyEnergyCardDto | undefined;
   energyLoading: boolean;
   energyError: string | null;
+  sleepCard: DailySleepCardModel | undefined;
+  sleepCardLoading: boolean;
+  /** True while re-fetching but a prior stable model is still shown (no skeleton). */
+  sleepCardRefreshing: boolean;
+  sleepCardError: string | null;
   refetch: (opts?: TruthGetOptions) => void;
 };
 
 /**
- * Dash hero + shared Daily Energy payload from one `useDailyFacts` subscription.
+ * Dash hero plus shared truth payloads from `useDailyFacts`, `useHealthScore`, and `useSleepNight` (no API calls in screens).
+ *
+ * Daily Sleep uses canonical `GET /users/me/sleep-night` for the calendar day (bounded physiological resolution on the server).
  */
-export function useTodayHealthHero(day: string): UseTodayHealthHeroResult {
+export function useTodayHealthHero(day: DayKey): UseTodayHealthHeroResult {
   const { user, initializing } = useAuth();
   const facts = useDailyFacts(day);
   const health = useHealthScore(day);
+  const sleepNight = useSleepNight(day, { enabled: Boolean(user) && !initializing });
   const { state: profileState } = useUserProfileMain();
 
   const firstName = useMemo(() => {
@@ -37,6 +48,27 @@ export function useTodayHealthHero(day: string): UseTodayHealthHeroResult {
     if (facts.status !== "ready") return undefined;
     return facts.data.energy as DailyEnergyCardDto | undefined;
   }, [facts]);
+
+  const lastStableSleepCardRef = useRef<DailySleepCardModel | undefined>(undefined);
+  const prevDayForSleepStickyRef = useRef(day);
+  if (prevDayForSleepStickyRef.current !== day) {
+    prevDayForSleepStickyRef.current = day;
+    lastStableSleepCardRef.current = undefined;
+  }
+
+  const sleepCard = useMemo((): DailySleepCardModel | undefined => {
+    if (!sleepNight.settled) return undefined;
+    return buildDailySleepCardModel({
+      day,
+      ...(sleepNight.view?.resolution != null ? { resolution: sleepNight.view.resolution } : {}),
+      sleepNight: sleepNight.view?.sleepNight,
+      sleepNightSettled: sleepNight.settled,
+    });
+  }, [day, sleepNight.settled, sleepNight.view?.resolution, sleepNight.view?.sleepNight]);
+
+  useEffect(() => {
+    if (sleepCard) lastStableSleepCardRef.current = sleepCard;
+  }, [sleepCard]);
 
   const vm = useMemo(() => {
     const dailyFactsSettled = facts.status !== "partial";
@@ -66,13 +98,31 @@ export function useTodayHealthHero(day: string): UseTodayHealthHeroResult {
   const energyLoading = facts.status === "partial";
   const energyError = facts.status === "error" ? facts.error : null;
 
+  const sleepCardLoadingCore = !sleepNight.settled || sleepNight.loading;
+  const sleepCardError = sleepNight.error;
+
+  const sleepCardForUi = sleepCard ?? lastStableSleepCardRef.current;
+  const sleepCardLoading = sleepCardLoadingCore && sleepCardForUi == null;
+  const sleepCardRefreshing = sleepCardLoadingCore && sleepCardForUi != null;
+
   const refetch = useCallback(
     (opts?: TruthGetOptions) => {
       void facts.refetch(opts);
       void health.refetch(opts);
+      void sleepNight.refetch(opts);
     },
-    [facts.refetch, health.refetch],
+    [facts.refetch, health.refetch, sleepNight.refetch],
   );
 
-  return { vm, energy, energyLoading, energyError, refetch };
+  return {
+    vm,
+    energy,
+    energyLoading,
+    energyError,
+    sleepCard: sleepCardForUi,
+    sleepCardLoading,
+    sleepCardRefreshing,
+    sleepCardError,
+    refetch,
+  };
 }

--- a/lib/integrations/oura/buildSleepNightFromOuraDocument.d.ts
+++ b/lib/integrations/oura/buildSleepNightFromOuraDocument.d.ts
@@ -1,0 +1,20 @@
+/**
+ * Build Firestore merge payload for `users/{uid}/sleepNights/{anchorDay}` from an Oura sleep API doc.
+ */
+import { type OuraSleepWindowDocument } from "./resolveOuraSleepIngestBase";
+export type SleepNightBuildContext = {
+    /** Oura sleep document id (matches `users/{uid}/ouraVendorSleep/{id}` when present). */
+    sourceDocumentId: string;
+};
+/**
+ * Coerce Oura sleep score / composite_score (number or digit string) to 0–100 integer.
+ */
+export declare function coerceOuraSleepScore0to100(raw: unknown): number | null;
+/**
+ * Build Firestore merge payload for `users/{uid}/sleepNights/{anchorDay}`.
+ * Returns null when bed/wake cannot be resolved (same gate as ingest).
+ */
+export declare function buildSleepNightFromOuraSleepDocument(doc: OuraSleepWindowDocument, ctx: SleepNightBuildContext): {
+    anchorDay: string;
+    merge: Record<string, unknown>;
+} | null;

--- a/lib/integrations/oura/buildSleepNightFromOuraDocument.js
+++ b/lib/integrations/oura/buildSleepNightFromOuraDocument.js
@@ -1,0 +1,118 @@
+"use strict";
+/**
+ * Build Firestore merge payload for `users/{uid}/sleepNights/{anchorDay}` from an Oura sleep API doc.
+ */
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.coerceOuraSleepScore0to100 = coerceOuraSleepScore0to100;
+exports.buildSleepNightFromOuraSleepDocument = buildSleepNightFromOuraSleepDocument;
+const contracts_1 = require("@oli/contracts");
+const resolveOuraSleepIngestBase_1 = require("./resolveOuraSleepIngestBase");
+function stripUndefined(obj) {
+    const out = {};
+    for (const [k, v] of Object.entries(obj)) {
+        if (v === undefined)
+            continue;
+        if (v !== null && typeof v === "object" && !Array.isArray(v) && Object.getPrototypeOf(v) === Object.prototype) {
+            out[k] = stripUndefined(v);
+        }
+        else {
+            out[k] = v;
+        }
+    }
+    return out;
+}
+function toYmd(iso) {
+    return iso.slice(0, 10);
+}
+/**
+ * Coerce Oura sleep score / composite_score (number or digit string) to 0–100 integer.
+ */
+function coerceOuraSleepScore0to100(raw) {
+    if (typeof raw === "number" && Number.isFinite(raw)) {
+        return Math.round(Math.max(0, Math.min(100, raw)));
+    }
+    if (typeof raw === "string") {
+        const t = raw.trim();
+        if (t === "")
+            return null;
+        const n = Number(t);
+        if (!Number.isFinite(n))
+            return null;
+        return Math.round(Math.max(0, Math.min(100, n)));
+    }
+    return null;
+}
+/**
+ * Build Firestore merge payload for `users/{uid}/sleepNights/{anchorDay}`.
+ * Returns null when bed/wake cannot be resolved (same gate as ingest).
+ */
+function buildSleepNightFromOuraSleepDocument(doc, ctx) {
+    const resolved = (0, resolveOuraSleepIngestBase_1.resolveOuraSleepIngestBase)(doc);
+    if (!resolved)
+        return null;
+    const { start, end, rollupDay: anchorDay } = resolved;
+    const wakeDay = (0, contracts_1.localCalendarDayKeyFromIsoInTimeZone)(end, "UTC") ?? toYmd(end);
+    const totalSec = typeof doc.total_sleep_duration === "number" ? doc.total_sleep_duration : null;
+    const totalSleepMinutes = totalSec != null && totalSec >= 0 ? Math.round(totalSec / 60) : undefined;
+    const remSec = typeof doc.rem_sleep_duration === "number"
+        ? doc.rem_sleep_duration
+        : null;
+    const remMinutes = remSec != null && remSec >= 0 ? Math.round(remSec / 60) : undefined;
+    const deepSec = typeof doc.deep_sleep_duration === "number"
+        ? doc.deep_sleep_duration
+        : null;
+    const deepMinutes = deepSec != null && deepSec >= 0 ? Math.round(deepSec / 60) : undefined;
+    const efficiencyRaw = doc.efficiency;
+    const efficiency = typeof efficiencyRaw === "number" && Number.isFinite(efficiencyRaw) && efficiencyRaw >= 0 && efficiencyRaw <= 100
+        ? efficiencyRaw
+        : undefined;
+    const latencyRaw = doc.latency;
+    const latencyMinutes = typeof latencyRaw === "number" && Number.isFinite(latencyRaw) && latencyRaw >= 0
+        ? (0, resolveOuraSleepIngestBase_1.normalizeOuraLatencyRawToMinutes)(latencyRaw)
+        : undefined;
+    const score = coerceOuraSleepScore0to100(doc.score ?? doc.composite_score);
+    let remPercent;
+    let deepPercent;
+    if (typeof totalSleepMinutes === "number" && totalSleepMinutes > 0) {
+        if (typeof remMinutes === "number" && remMinutes >= 0) {
+            remPercent = Math.round((remMinutes / totalSleepMinutes) * 100);
+        }
+        if (typeof deepMinutes === "number" && deepMinutes >= 0) {
+            deepPercent = Math.round((deepMinutes / totalSleepMinutes) * 100);
+        }
+    }
+    const mainSleepMinutes = typeof totalSleepMinutes === "number" ? totalSleepMinutes : undefined;
+    const hasDuration = (typeof totalSleepMinutes === "number" && totalSleepMinutes > 0) ||
+        (typeof mainSleepMinutes === "number" && mainSleepMinutes > 0);
+    const hasWakeOrEnd = typeof wakeDay === "string" && wakeDay.length > 0 && typeof end === "string";
+    const isComplete = Boolean(anchorDay && hasWakeOrEnd && hasDuration);
+    const base = {
+        anchorDay,
+        wakeDay,
+        provider: "oura",
+        source: "ouraVendorSleep",
+        sourceDocumentId: ctx.sourceDocumentId,
+        isComplete,
+        startedAt: start,
+        endedAt: end,
+    };
+    if (typeof totalSleepMinutes === "number")
+        base.totalSleepMinutes = totalSleepMinutes;
+    if (typeof mainSleepMinutes === "number")
+        base.mainSleepMinutes = mainSleepMinutes;
+    if (efficiency !== undefined)
+        base.efficiency = efficiency;
+    if (typeof remMinutes === "number")
+        base.remMinutes = remMinutes;
+    if (typeof remPercent === "number")
+        base.remPercent = remPercent;
+    if (typeof deepMinutes === "number")
+        base.deepMinutes = deepMinutes;
+    if (typeof deepPercent === "number")
+        base.deepPercent = deepPercent;
+    if (typeof latencyMinutes === "number")
+        base.latencyMinutes = latencyMinutes;
+    if (score != null)
+        base.score = score;
+    return { anchorDay, merge: stripUndefined(base) };
+}

--- a/lib/integrations/oura/resolveOuraSleepIngestBase.d.ts
+++ b/lib/integrations/oura/resolveOuraSleepIngestBase.d.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared Oura sleep window + rollup day resolution.
+ * Used by API ingest, vendor snapshots, SleepNight build, and Cloud Functions post-raw.
+ */
+/** Minimal Oura v2 sleep document shape for resolution (matches services/api OuraSleepDocument fields used here). */
+export type OuraSleepWindowDocument = Record<string, unknown> & {
+    id?: string;
+    day?: string;
+    bed_time?: string;
+    wake_time?: string;
+    end_time?: string;
+    bedtime_start?: string;
+    bedtime_end?: string;
+    start?: string;
+    end?: string;
+    total_sleep_duration?: number;
+};
+/** Wake-time ISO for pull-now diagnostics (same field resolution as ingest). */
+export declare function ouraSleepWakeIsoForLog(doc: OuraSleepWindowDocument): string | null;
+/**
+ * Align with GET /users/me/oura-sleep-view: Oura may return latency as seconds (typically ≥ 60);
+ * smaller values are treated as minutes.
+ */
+export declare function normalizeOuraLatencyRawToMinutes(latencyRaw: number): number;
+/**
+ * Resolved sleep window + logical rollup day for Oura sleep docs.
+ * Shared by raw-event ingest, vendor snapshots, and canonical SleepNight anchor day.
+ */
+export declare function resolveOuraSleepIngestBase(doc: OuraSleepWindowDocument): {
+    start: string;
+    end: string;
+    rollupDay: string;
+} | null;

--- a/lib/integrations/oura/resolveOuraSleepIngestBase.js
+++ b/lib/integrations/oura/resolveOuraSleepIngestBase.js
@@ -1,0 +1,64 @@
+"use strict";
+/**
+ * Shared Oura sleep window + rollup day resolution.
+ * Used by API ingest, vendor snapshots, SleepNight build, and Cloud Functions post-raw.
+ */
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.ouraSleepWakeIsoForLog = ouraSleepWakeIsoForLog;
+exports.normalizeOuraLatencyRawToMinutes = normalizeOuraLatencyRawToMinutes;
+exports.resolveOuraSleepIngestBase = resolveOuraSleepIngestBase;
+const contracts_1 = require("@oli/contracts");
+function toYmd(iso) {
+    return iso.slice(0, 10);
+}
+function isYmdDateString(value) {
+    return /^\d{4}-\d{2}-\d{2}$/.test(value);
+}
+function getSleepStart(doc) {
+    const s = doc.bed_time ??
+        doc.bedtime_start ??
+        doc.start ??
+        doc.end_time ??
+        doc.end ??
+        null;
+    return typeof s === "string" && s.length > 0 ? s : null;
+}
+function getSleepEnd(doc) {
+    const e = doc.wake_time ??
+        doc.bedtime_end ??
+        doc.end ??
+        doc.end_time ??
+        null;
+    return typeof e === "string" && e.length > 0 ? e : null;
+}
+/** Wake-time ISO for pull-now diagnostics (same field resolution as ingest). */
+function ouraSleepWakeIsoForLog(doc) {
+    return getSleepEnd(doc);
+}
+/**
+ * Align with GET /users/me/oura-sleep-view: Oura may return latency as seconds (typically ≥ 60);
+ * smaller values are treated as minutes.
+ */
+function normalizeOuraLatencyRawToMinutes(latencyRaw) {
+    return latencyRaw >= 60 ? Math.round(latencyRaw / 60) : Math.round(latencyRaw);
+}
+/**
+ * Resolved sleep window + logical rollup day for Oura sleep docs.
+ * Shared by raw-event ingest, vendor snapshots, and canonical SleepNight anchor day.
+ */
+function resolveOuraSleepIngestBase(doc) {
+    const start = getSleepStart(doc);
+    let end = getSleepEnd(doc);
+    const totalSec = typeof doc.total_sleep_duration === "number" ? doc.total_sleep_duration : 0;
+    if (start && !end && totalSec > 0) {
+        const startMs = Date.parse(start);
+        if (!Number.isNaN(startMs)) {
+            end = new Date(startMs + totalSec * 1000).toISOString();
+        }
+    }
+    if (!start || !end)
+        return null;
+    const providerDay = typeof doc.day === "string" && isYmdDateString(doc.day) ? doc.day : null;
+    const rollupDay = providerDay ?? (0, contracts_1.localCalendarDayKeyFromIsoInTimeZone)(end, "UTC") ?? toYmd(end);
+    return { start, end, rollupDay };
+}

--- a/lib/modules/moduleReadiness.ts
+++ b/lib/modules/moduleReadiness.ts
@@ -55,11 +55,11 @@ export function getSectionReadiness(sectionId: ModuleSectionId): SectionReadines
 
     // RECOVERY
     case "recovery.overview":
-      return SOON("Soon");
+      return READY;
     case "recovery.sleep":
-      return SOON("Soon");
+      return READY;
     case "recovery.readiness":
-      return SOON("Soon");
+      return READY;
 
     // LABS
     case "labs.overview":

--- a/lib/ui/common/MetricDetailsSheet.tsx
+++ b/lib/ui/common/MetricDetailsSheet.tsx
@@ -1,0 +1,160 @@
+import React from "react";
+import {
+  Modal,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import {
+  UI_BORDER_STRONG,
+  UI_OVERLAY,
+  UI_PANEL_SURFACE,
+  UI_TEXT_MUTED,
+  UI_TEXT_PRIMARY,
+  UI_TEXT_SECONDARY,
+} from "@/lib/ui/theme/uiTokens";
+
+export type MetricDetailsSheetProps = {
+  visible: boolean;
+  onClose: () => void;
+  title: string;
+  value: string;
+  body: string;
+  sourceLine?: string;
+  contextLine?: string;
+};
+
+/**
+ * Bottom-sheet style metric explainer (dark theme, no new dependencies).
+ */
+export function MetricDetailsSheet({
+  visible,
+  onClose,
+  title,
+  value,
+  body,
+  sourceLine,
+  contextLine,
+}: MetricDetailsSheetProps): React.ReactElement {
+  const insets = useSafeAreaInsets();
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="slide"
+      onRequestClose={onClose}
+      testID="metric-details-sheet"
+    >
+      <View style={styles.root} accessibilityViewIsModal>
+        <Pressable
+          style={styles.backdrop}
+          onPress={onClose}
+          accessibilityLabel="Dismiss metric details"
+        />
+        <View
+          style={[styles.sheet, { paddingBottom: Math.max(insets.bottom, 20) }]}
+          onStartShouldSetResponder={() => true}
+        >
+          <View style={styles.handle} accessibilityElementsHidden />
+          <ScrollView
+            keyboardShouldPersistTaps="handled"
+            showsVerticalScrollIndicator={false}
+            contentContainerStyle={styles.scrollContent}
+          >
+            <Text style={styles.title}>{title}</Text>
+            <Text style={styles.value}>{value}</Text>
+            <Text style={styles.body}>{body}</Text>
+            {sourceLine ? <Text style={styles.meta}>{sourceLine}</Text> : null}
+            {contextLine ? <Text style={styles.meta}>{contextLine}</Text> : null}
+          </ScrollView>
+          <Pressable
+            onPress={onClose}
+            accessibilityRole="button"
+            accessibilityLabel="Done"
+            style={({ pressed }) => [styles.done, pressed && styles.donePressed]}
+          >
+            <Text style={styles.doneLabel}>Done</Text>
+          </Pressable>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    justifyContent: "flex-end",
+  },
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: UI_OVERLAY,
+  },
+  sheet: {
+    backgroundColor: UI_PANEL_SURFACE,
+    borderTopLeftRadius: 18,
+    borderTopRightRadius: 18,
+    paddingTop: 8,
+    paddingHorizontal: 20,
+    maxHeight: "88%",
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderColor: UI_BORDER_STRONG,
+  },
+  handle: {
+    alignSelf: "center",
+    width: 40,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: UI_TEXT_MUTED,
+    marginBottom: 12,
+    opacity: 0.85,
+  },
+  scrollContent: {
+    paddingBottom: 12,
+    gap: 10,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: "700",
+    color: UI_TEXT_PRIMARY,
+    letterSpacing: -0.3,
+  },
+  value: {
+    fontSize: 28,
+    fontWeight: "700",
+    color: UI_TEXT_PRIMARY,
+    letterSpacing: -0.35,
+  },
+  body: {
+    fontSize: 15,
+    lineHeight: 22,
+    color: UI_TEXT_SECONDARY,
+  },
+  meta: {
+    fontSize: 14,
+    lineHeight: 20,
+    color: UI_TEXT_MUTED,
+  },
+  done: {
+    marginTop: 4,
+    marginBottom: 4,
+    minHeight: 48,
+    borderRadius: 12,
+    backgroundColor: "rgba(255,255,255,0.08)",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  donePressed: {
+    opacity: 0.85,
+  },
+  doneLabel: {
+    fontSize: 17,
+    fontWeight: "600",
+    color: UI_TEXT_PRIMARY,
+  },
+});

--- a/lib/ui/dash/DailySleepCard.tsx
+++ b/lib/ui/dash/DailySleepCard.tsx
@@ -1,0 +1,267 @@
+import React, { useCallback, useMemo, useState } from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import { useRouter } from "expo-router";
+
+import type { DailySleepCardModel, DailySleepMetricDetail } from "@/lib/data/dash/buildDailySleepCardModel";
+import { MetricDetailsSheet } from "@/lib/ui/common/MetricDetailsSheet";
+import { elevatedCardSurfaceStyle } from "@/lib/ui/theme/elevatedCardSurface";
+import {
+  UI_BORDER_HAIRLINE,
+  UI_CARD_SURFACE,
+  UI_TEXT_MUTED,
+  UI_TEXT_PRIMARY,
+  UI_TEXT_SECONDARY,
+} from "@/lib/ui/theme/uiTokens";
+import { strengthMetricCardTitleTextStyle } from "@/lib/ui/workouts/strengthMetricCardTitleStyle";
+
+const SLEEP_DETAIL_HREF = "/(app)/recovery/sleep" as const;
+
+/** Match Daily Energy main result (`DailyEnergyCard` `rangeValue`). */
+const HEADLINE_VALUE_TEXT: React.ComponentProps<typeof Text>["style"] = {
+  fontSize: 34,
+  lineHeight: 40,
+  color: UI_TEXT_PRIMARY,
+  fontWeight: "700",
+  letterSpacing: -0.2,
+};
+
+type Props = {
+  model: DailySleepCardModel | undefined;
+  loading: boolean;
+  /** Shown when refreshing with a prior stable model (no skeleton takeover). */
+  isRefreshing?: boolean;
+  error: string | null;
+};
+
+export function DailySleepCard({
+  model,
+  loading,
+  isRefreshing = false,
+  error,
+}: Props): React.ReactElement {
+  const router = useRouter();
+  const [metricSheet, setMetricSheet] = useState<DailySleepMetricDetail | null>(null);
+
+  const onOpenSleep = useCallback(() => {
+    if (loading || error) return;
+    router.push(SLEEP_DETAIL_HREF);
+  }, [error, loading, router]);
+
+  const headerA11y = useMemo(() => {
+    if (loading) return "Daily Sleep header. Loading sleep summary.";
+    if (isRefreshing) return "Daily Sleep header. Refreshing.";
+    if (error) return "Daily Sleep header. Could not load data.";
+    if (!model) return "Daily Sleep header. Not enough data.";
+    const parts: string[] = [];
+    if (model.lastNightSubtitle) parts.push(model.lastNightSubtitle);
+    if (model.headlineValueText) parts.push(`Sleep duration ${model.headlineValueText}.`);
+    if (model.summarySentence) parts.push(model.summarySentence);
+    return `Daily Sleep header. ${parts.join(" ")} Opens Sleep details.`;
+  }, [loading, isRefreshing, error, model]);
+
+  const showEmptyBody = !loading && !error && model && !model.hasAnySignal;
+  const canOpenSleep = !loading && !error;
+
+  const showMetricSection = Boolean(model?.metricRows.length);
+
+  return (
+    <View style={styles.outer} accessibilityLabel="Daily Sleep card">
+      <View style={styles.card}>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={headerA11y}
+          accessibilityHint="Opens Sleep details"
+          disabled={!canOpenSleep}
+          onPress={onOpenSleep}
+          style={({ pressed }) => [styles.headerPressable, pressed && canOpenSleep && styles.headerPressed]}
+        >
+          <Text style={styles.title}>Daily Sleep</Text>
+          {!loading && !error && model?.lastNightSubtitle ? (
+            <Text style={styles.subtitle}>{model.lastNightSubtitle}</Text>
+          ) : null}
+          {!loading && !error && model?.headlineValueText ? (
+            <Text style={styles.headlineValue} accessibilityRole="text">
+              {model.headlineValueText}
+            </Text>
+          ) : null}
+          {!loading && isRefreshing ? (
+            <Text style={styles.mutedLine}>Refreshing daily sleep\u2026</Text>
+          ) : null}
+          {!loading && error ? <Text style={styles.mutedLine}>Could not load daily sleep</Text> : null}
+          {!loading && !error && !model ? (
+            <Text style={styles.mutedLine}>Not enough data yet for sleep summary.</Text>
+          ) : null}
+          {!loading && !error && model ? (
+            <>
+              {model.summarySentence ? <Text style={styles.summary}>{model.summarySentence}</Text> : null}
+              {showEmptyBody ? (
+                <>
+                  {model.emptyStateTitle ? <Text style={styles.emptyTitle}>{model.emptyStateTitle}</Text> : null}
+                  {model.emptyStateSubtitle ? (
+                    <Text style={styles.emptySubtitle}>{model.emptyStateSubtitle}</Text>
+                  ) : null}
+                </>
+              ) : null}
+            </>
+          ) : null}
+        </Pressable>
+
+        {!loading && !error && model && showMetricSection ? (
+          <View style={styles.metricSection} accessibilityRole="list">
+            {model.metricRows.map((row) => (
+              <Pressable
+                key={row.id}
+                testID={`sleep-metric-row-${row.id}`}
+                accessibilityRole="button"
+                accessibilityLabel={`${row.label}. ${row.value}. Open details`}
+                onPress={() => {
+                  setMetricSheet(row.detail);
+                }}
+                style={({ pressed }) => [styles.metricPressable, pressed && styles.metricPressablePressed]}
+              >
+                <View style={styles.metricRowInner}>
+                  <Text style={styles.label}>{row.label}</Text>
+                  <View style={styles.metricRight}>
+                    <Text style={styles.value}>{row.value}</Text>
+                    <Text
+                      style={styles.chevron}
+                      accessibilityElementsHidden
+                      importantForAccessibility="no"
+                    >
+                      {"\u203A"}
+                    </Text>
+                  </View>
+                </View>
+              </Pressable>
+            ))}
+          </View>
+        ) : null}
+
+        <MetricDetailsSheet
+          visible={metricSheet != null}
+          onClose={() => {
+            setMetricSheet(null);
+          }}
+          {...(metricSheet != null
+            ? {
+                title: metricSheet.title,
+                value: metricSheet.value,
+                body: metricSheet.body,
+                ...(metricSheet.sourceLine != null && metricSheet.sourceLine !== ""
+                  ? { sourceLine: metricSheet.sourceLine }
+                  : {}),
+                ...(metricSheet.contextLine != null && metricSheet.contextLine !== ""
+                  ? { contextLine: metricSheet.contextLine }
+                  : {}),
+              }
+            : {
+                title: "",
+                value: "",
+                body: "",
+              })}
+        />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  outer: {
+    marginTop: 12,
+  },
+  card: {
+    ...elevatedCardSurfaceStyle,
+    borderRadius: 12,
+    padding: 15,
+    gap: 8,
+    backgroundColor: UI_CARD_SURFACE,
+  },
+  headerPressable: {
+    borderRadius: 10,
+    marginHorizontal: -6,
+    paddingHorizontal: 6,
+    paddingVertical: 4,
+  },
+  headerPressed: {
+    opacity: 0.92,
+  },
+  title: strengthMetricCardTitleTextStyle,
+  subtitle: {
+    fontSize: 14,
+    lineHeight: 20,
+    color: UI_TEXT_SECONDARY,
+  },
+  headlineValue: HEADLINE_VALUE_TEXT,
+  summary: {
+    fontSize: 14,
+    lineHeight: 20,
+    color: UI_TEXT_SECONDARY,
+  },
+  mutedLine: {
+    fontSize: 14,
+    lineHeight: 20,
+    color: UI_TEXT_MUTED,
+  },
+  emptyTitle: {
+    fontSize: 15,
+    fontWeight: "600",
+    color: UI_TEXT_PRIMARY,
+    marginTop: 2,
+  },
+  emptySubtitle: {
+    fontSize: 14,
+    lineHeight: 20,
+    color: UI_TEXT_MUTED,
+  },
+  metricSection: {
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: UI_BORDER_HAIRLINE,
+    paddingTop: 8,
+    gap: 4,
+  },
+  metricPressable: {
+    borderRadius: 8,
+    marginHorizontal: -6,
+    paddingHorizontal: 6,
+    paddingVertical: 10,
+    minHeight: 44,
+    justifyContent: "center",
+  },
+  metricPressablePressed: {
+    opacity: 0.75,
+  },
+  metricRowInner: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 8,
+  },
+  metricRight: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "flex-end",
+    gap: 6,
+    flexShrink: 1,
+  },
+  chevron: {
+    fontSize: 16,
+    lineHeight: 20,
+    fontWeight: "500",
+    color: UI_TEXT_MUTED,
+    flexShrink: 0,
+  },
+  label: {
+    fontSize: 14,
+    lineHeight: 20,
+    color: UI_TEXT_SECONDARY,
+    fontWeight: "500",
+    flexShrink: 1,
+  },
+  value: {
+    fontSize: 15,
+    lineHeight: 20,
+    color: UI_TEXT_PRIMARY,
+    fontWeight: "600",
+    textAlign: "right",
+  },
+});

--- a/lib/ui/dash/__tests__/DailySleepCard.test.tsx
+++ b/lib/ui/dash/__tests__/DailySleepCard.test.tsx
@@ -1,0 +1,243 @@
+import React, { act } from "react";
+import { Image, Modal, Pressable, Text } from "react-native";
+import renderer, { type ReactTestInstance } from "react-test-renderer";
+
+import type { SleepNightDocumentDto } from "@oli/contracts";
+import { buildDailySleepCardModel } from "@/lib/data/dash/buildDailySleepCardModel";
+import { DailySleepCard } from "@/lib/ui/dash/DailySleepCard";
+
+const mockPush = jest.fn();
+
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 20, left: 0, right: 0 }),
+}));
+
+const day = "2026-05-01";
+
+function minimalNight(over: Partial<SleepNightDocumentDto> = {}): SleepNightDocumentDto {
+  return {
+    anchorDay: day,
+    wakeDay: day,
+    provider: "oura",
+    source: "ouraVendorSleep",
+    sourceDocumentId: "s1",
+    isComplete: true,
+    updatedAt: "2026-05-01T12:00:00.000Z",
+    totalSleepMinutes: 480,
+    ...over,
+  };
+}
+
+function allVisibleText(root: ReactTestInstance): string {
+  return root
+    .findAllByType(Text)
+    .map((t) => {
+      const ch = t.props.children;
+      if (typeof ch === "string") return ch;
+      if (Array.isArray(ch)) return ch.filter((x): x is string => typeof x === "string").join("");
+      return "";
+    })
+    .join("|");
+}
+
+describe("DailySleepCard", () => {
+  beforeEach(() => {
+    mockPush.mockReset();
+  });
+
+  it("renders large headline 9h 11m and Last night subtitle", () => {
+    const model = buildDailySleepCardModel({
+      day,
+      sleepNightSettled: true,
+      sleepNight: minimalNight({
+        mainSleepMinutes: 551,
+        efficiency: 0.92,
+        remMinutes: 124,
+        deepMinutes: 76,
+      }),
+    });
+
+    let root!: renderer.ReactTestRenderer;
+    act(() => {
+      root = renderer.create(<DailySleepCard model={model} loading={false} error={null} />);
+    });
+
+    const flat = allVisibleText(root.root);
+    expect(flat).toContain("Last night\u2019s sleep");
+    expect(flat).toContain("9h 11m");
+    expect(root.root.findAllByType(Image)).toHaveLength(0);
+  });
+
+  it("lists metric rows Deep sleep through Average HRV without Sleep duration row", () => {
+    const model = buildDailySleepCardModel({
+      day,
+      sleepNightSettled: true,
+      sleepNight: minimalNight({
+        mainSleepMinutes: 551,
+        deepMinutes: 76,
+        remMinutes: 124,
+        efficiency: 0.92,
+      }),
+    });
+
+    let root!: renderer.ReactTestRenderer;
+    act(() => {
+      root = renderer.create(<DailySleepCard model={model} loading={false} error={null} />);
+    });
+
+    expect(() => root.root.findByProps({ testID: "sleep-metric-row-sleep_duration" })).toThrow();
+    expect(root.root.findByProps({ testID: "sleep-metric-row-deep_sleep" })).toBeDefined();
+    expect(root.root.findByProps({ testID: "sleep-metric-row-rem_sleep" })).toBeDefined();
+    expect(root.root.findByProps({ testID: "sleep-metric-row-sleep_efficiency" })).toBeDefined();
+    expect(root.root.findByProps({ testID: "sleep-metric-row-lowest_heart_rate" })).toBeDefined();
+    expect(root.root.findByProps({ testID: "sleep-metric-row-average_hrv" })).toBeDefined();
+    const flat = allVisibleText(root.root);
+    expect(flat).toContain("Lowest heart rate");
+    expect(flat).toContain("Average HRV");
+    expect(flat).toContain("\u2014");
+    expect(root.root.findAllByType(Image)).toHaveLength(0);
+  });
+
+  it("shows Last night\u2019s sleep when model has prior-night resolution", () => {
+    const model = buildDailySleepCardModel({
+      day: "2026-05-13",
+      resolution: "wake_day",
+      sleepNightSettled: true,
+      sleepNight: minimalNight({
+        anchorDay: "2026-05-12",
+        wakeDay: "2026-05-13",
+        mainSleepMinutes: 530,
+        score: 77,
+      }),
+    });
+
+    let root!: renderer.ReactTestRenderer;
+    act(() => {
+      root = renderer.create(<DailySleepCard model={model} loading={false} error={null} />);
+    });
+
+    const flat = allVisibleText(root.root);
+    expect(flat).toContain("Last night\u2019s sleep");
+    expect(flat).toContain("8h 50m");
+  });
+
+  it("renders Daily Sleep title and does not show readiness copy", () => {
+    const model = buildDailySleepCardModel({
+      day,
+      sleepNightSettled: true,
+      sleepNight: minimalNight({ score: 82 }),
+    });
+
+    let root!: renderer.ReactTestRenderer;
+    act(() => {
+      root = renderer.create(<DailySleepCard model={model} loading={false} error={null} />);
+    });
+
+    const flat = allVisibleText(root.root);
+    expect(flat).toContain("Daily Sleep");
+    expect(flat).not.toMatch(/readiness/i);
+  });
+
+  it("renders chevron on metric rows", () => {
+    const model = buildDailySleepCardModel({
+      day,
+      sleepNightSettled: true,
+      sleepNight: minimalNight(),
+    });
+
+    let root!: renderer.ReactTestRenderer;
+    act(() => {
+      root = renderer.create(<DailySleepCard model={model} loading={false} error={null} />);
+    });
+
+    const flat = allVisibleText(root.root);
+    expect(flat).toContain("\u203A");
+  });
+
+  it("opens metric details sheet on deep_sleep row press without navigating", () => {
+    const model = buildDailySleepCardModel({
+      day,
+      sleepNightSettled: true,
+      sleepNight: minimalNight({ deepMinutes: 30 }),
+    });
+
+    let root!: renderer.ReactTestRenderer;
+    act(() => {
+      root = renderer.create(<DailySleepCard model={model} loading={false} error={null} />);
+    });
+
+    const row = root.root.findByProps({ testID: "sleep-metric-row-deep_sleep" });
+    act(() => {
+      row.props.onPress();
+    });
+
+    const modals = root.root.findAllByType(Modal);
+    const visibleModal = modals.find((m) => m.props.visible === true);
+    expect(visibleModal).toBeDefined();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("navigates to Sleep when header is pressed", () => {
+    const model = buildDailySleepCardModel({
+      day,
+      sleepNightSettled: true,
+      sleepNight: minimalNight({ score: 82 }),
+    });
+
+    let root!: renderer.ReactTestRenderer;
+    act(() => {
+      root = renderer.create(<DailySleepCard model={model} loading={false} error={null} />);
+    });
+
+    const header = root.root
+      .findAllByType(Pressable)
+      .find(
+        (p) =>
+          typeof p.props.accessibilityLabel === "string" &&
+          p.props.accessibilityLabel.startsWith("Daily Sleep header"),
+      );
+    expect(header).toBeDefined();
+    act(() => {
+      (header as ReactTestInstance).props.onPress();
+    });
+    expect(mockPush).toHaveBeenCalledWith("/(app)/recovery/sleep");
+  });
+
+  it("shows a muted refreshing line when isRefreshing without hiding headline", () => {
+    const model = buildDailySleepCardModel({
+      day,
+      sleepNightSettled: true,
+      sleepNight: minimalNight({ score: 96 }),
+    });
+
+    let root!: renderer.ReactTestRenderer;
+    act(() => {
+      root = renderer.create(
+        <DailySleepCard model={model} loading={false} isRefreshing error={null} />,
+      );
+    });
+
+    const flat = allVisibleText(root.root);
+    expect(flat).toContain("8h");
+    expect(flat).toContain("Refreshing daily sleep");
+  });
+
+  it("empty settled model still shows placeholder metric rows", () => {
+    const model = buildDailySleepCardModel({
+      day,
+      sleepNight: undefined,
+      sleepNightSettled: true,
+    });
+    let root!: renderer.ReactTestRenderer;
+    act(() => {
+      root = renderer.create(<DailySleepCard model={model} loading={false} error={null} />);
+    });
+    expect(root.root.findByProps({ testID: "sleep-metric-row-deep_sleep" })).toBeDefined();
+    const flat = allVisibleText(root.root);
+    expect(flat).toContain("No sleep data yet");
+  });
+});

--- a/scripts/admin/backfillOuraVendorSleepDay.cli.ts
+++ b/scripts/admin/backfillOuraVendorSleepDay.cli.ts
@@ -1,0 +1,379 @@
+#!/usr/bin/env npx tsx
+/**
+ * Admin-only: align `users/{uid}/ouraVendorSleep` document `day` with
+ * `resolveOuraSleepIngestBase` using the paired `rawEvents/{sameDocId}` Oura sleep row only.
+ *
+ * Default: dry-run (no writes). Mutations require `--write`.
+ * Require `--uid <uid>` unless `--all-users` is passed (collectionGroup scan).
+ *
+ * Usage:
+ *   npx tsx --tsconfig scripts/tsconfig.json scripts/admin/backfillOuraVendorSleepDay.cli.ts \
+ *     --project-id <firebaseProjectId> --uid <uid>
+ *   npx tsx --tsconfig scripts/tsconfig.json scripts/admin/backfillOuraVendorSleepDay.cli.ts \
+ *     --project-id <firebaseProjectId> --uid <uid> --write
+ *   npx tsx --tsconfig scripts/tsconfig.json scripts/admin/backfillOuraVendorSleepDay.cli.ts \
+ *     --project-id <firebaseProjectId> --all-users --write
+ *
+ * Environment: GOOGLE_APPLICATION_CREDENTIALS or gcloud auth application-default login
+ */
+
+import { initializeApp, getApps } from "firebase-admin/app";
+import type { DocumentReference, Firestore, QueryDocumentSnapshot, WriteBatch } from "firebase-admin/firestore";
+import { getFirestore, FieldPath, FieldValue } from "firebase-admin/firestore";
+
+import {
+  planOuraVendorSleepDayFromRaw,
+  buildVendorSleepDayMigrationWritePatch,
+  isOuraIngestedSleepRawEvent,
+} from "../../services/api/src/lib/ouraVendorSleepDayBackfill";
+
+const BATCH_MAX = 450;
+
+type Parsed =
+  | { mode: "help" }
+  | { mode: "usage" }
+  | {
+      mode: "run";
+      projectId: string;
+      uid: string | null;
+      allUsers: boolean;
+      write: boolean;
+      verbose: boolean;
+    };
+
+function parseArgs(argv: string[]): Parsed {
+  let projectId: string | null = null;
+  let uid: string | null = null;
+  let allUsers = false;
+  let write = false;
+  let verbose = false;
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--help" || a === "-h") return { mode: "help" };
+    if (a === "--project-id") projectId = argv[++i]?.trim() ?? null;
+    else if (a === "--uid") uid = argv[++i]?.trim() ?? null;
+    else if (a === "--all-users") allUsers = true;
+    else if (a === "--write") write = true;
+    else if (a === "--verbose") verbose = true;
+  }
+  if (!projectId) return { mode: "usage" };
+  if (allUsers && uid) return { mode: "usage" };
+  if (!allUsers && (!uid || uid.length === 0)) return { mode: "usage" };
+  return { mode: "run", projectId, uid, allUsers, write, verbose };
+}
+
+function printHelp(): void {
+  console.log(`backfillOuraVendorSleepDay.cli.ts
+
+Rewrites only users/{uid}/ouraVendorSleep docs where stored day ≠ rollup from paired rawEvents sleep
+(same document id; Oura ingest only). Adds migratedAt + migrationVersion. Does not touch rawEvents,
+canonical events, dailyFacts, or readiness.
+
+Required:
+  --project-id <firebaseProjectId>
+
+Exactly one of:
+  --uid <uid>
+  --all-users            (uses collectionGroup('ouraVendorSleep'); slower / needs index)
+
+Options:
+  --write                  perform batched writes (default: dry-run)
+  --verbose                log each skip/change line
+
+Dry-run is the default when --write is omitted.
+`);
+}
+
+type Counts = {
+  scanned: number;
+  aligned: number;
+  changed: number;
+  skipped: number;
+  errors: number;
+};
+
+function emptyCounts(): Counts {
+  return { scanned: 0, aligned: 0, changed: 0, skipped: 0, errors: 0 };
+}
+
+function extractUidFromVendorRef(refPath: string): string | null {
+  const m = /^users\/([^/]+)\/ouraVendorSleep\//.exec(refPath);
+  return m?.[1] ?? null;
+}
+
+type SingleWrite = { ref: DocumentReference; data: Record<string, unknown> };
+
+async function commitBatchOrSingles(db: Firestore, batch: WriteBatch, singles: SingleWrite[]): Promise<number> {
+  let errors = 0;
+  try {
+    await batch.commit();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error({ msg: "oura_vendor_sleep_day_batch_commit_failed", err: msg });
+    for (const { ref, data } of singles) {
+      try {
+        await ref.set(data, { merge: true });
+      } catch (e2) {
+        errors += 1;
+        const m2 = e2 instanceof Error ? e2.message : String(e2);
+        console.error({ msg: "oura_vendor_sleep_day_single_write_failed", path: ref.path, err: m2 });
+      }
+    }
+  }
+  return errors;
+}
+
+async function runForUser(db: Firestore, uid: string, write: boolean, verbose: boolean): Promise<Counts> {
+  const counts = emptyCounts();
+  const vendorCol = db.collection("users").doc(uid).collection("ouraVendorSleep");
+  const rawCol = db.collection("users").doc(uid).collection("rawEvents");
+
+  let batch: WriteBatch | null = null;
+  const singles: SingleWrite[] = [];
+  let batchOps = 0;
+
+  const enqueueWrite = async (ref: DocumentReference, patch: Record<string, unknown>) => {
+    if (!write) return;
+    if (!batch) batch = db.batch();
+    batch.set(ref, patch, { merge: true });
+    singles.push({ ref, data: patch });
+    batchOps += 1;
+    if (batchOps >= BATCH_MAX && batch) {
+      counts.errors += await commitBatchOrSingles(db, batch, singles);
+      singles.length = 0;
+      batchOps = 0;
+      batch = null;
+    }
+  };
+
+  const flushPending = async () => {
+    if (!write || !batch || batchOps === 0) return;
+    counts.errors += await commitBatchOrSingles(db, batch, singles);
+    singles.length = 0;
+    batchOps = 0;
+    batch = null;
+  };
+
+  let last: QueryDocumentSnapshot | undefined;
+  while (true) {
+    let q = vendorCol.orderBy(FieldPath.documentId()).limit(400);
+    if (last) q = q.startAfter(last);
+    const page = await q.get();
+    if (page.empty) break;
+
+    for (const vDoc of page.docs) {
+      counts.scanned += 1;
+      const vData = vDoc.data() as Record<string, unknown>;
+      const storedDay = typeof vData.day === "string" ? vData.day : undefined;
+
+      const rawSnap = await rawCol.doc(vDoc.id).get();
+      if (!rawSnap.exists) {
+        counts.skipped += 1;
+        if (verbose) console.log(`skip ${uid}/${vDoc.id} missing_raw_doc`);
+        continue;
+      }
+      const rawData = rawSnap.data() as Record<string, unknown>;
+      if (!isOuraIngestedSleepRawEvent(rawData)) {
+        counts.skipped += 1;
+        if (verbose) console.log(`skip ${uid}/${vDoc.id} raw_not_oura_sleep`);
+        continue;
+      }
+      const payload =
+        rawData.payload && typeof rawData.payload === "object"
+          ? (rawData.payload as Record<string, unknown>)
+          : undefined;
+
+      const plan = planOuraVendorSleepDayFromRaw(vDoc.id, storedDay, payload);
+      if (plan.status === "skip") {
+        counts.skipped += 1;
+        if (verbose) console.log(`skip ${uid}/${vDoc.id} ${plan.reason}`);
+        continue;
+      }
+      if (plan.status === "aligned") {
+        counts.aligned += 1;
+        continue;
+      }
+
+      counts.changed += 1;
+      const patch = buildVendorSleepDayMigrationWritePatch({
+        rollupDay: plan.rollupDay,
+        migratedAt: FieldValue.serverTimestamp(),
+      });
+
+      if (verbose) {
+        console.log(`change ${uid}/${vDoc.id} day ${plan.storedDay} -> ${plan.rollupDay}`);
+      }
+
+      await enqueueWrite(vDoc.ref, { ...patch });
+    }
+
+    await flushPending();
+
+    last = page.docs[page.docs.length - 1];
+    if (page.size < 400) break;
+  }
+
+  await flushPending();
+  return counts;
+}
+
+async function runAllUsers(db: Firestore, write: boolean, verbose: boolean): Promise<Counts> {
+  const counts = emptyCounts();
+
+  let batch: WriteBatch | null = null;
+  const singles: SingleWrite[] = [];
+  let batchOps = 0;
+
+  const enqueueWrite = async (ref: DocumentReference, patch: Record<string, unknown>) => {
+    if (!write) return;
+    if (!batch) batch = db.batch();
+    batch.set(ref, patch, { merge: true });
+    singles.push({ ref, data: patch });
+    batchOps += 1;
+    if (batchOps >= BATCH_MAX && batch) {
+      counts.errors += await commitBatchOrSingles(db, batch, singles);
+      singles.length = 0;
+      batchOps = 0;
+      batch = null;
+    }
+  };
+
+  const flushPending = async () => {
+    if (!write || !batch || batchOps === 0) return;
+    counts.errors += await commitBatchOrSingles(db, batch, singles);
+    singles.length = 0;
+    batchOps = 0;
+    batch = null;
+  };
+
+  let last: QueryDocumentSnapshot | undefined;
+  while (true) {
+    let q = db.collectionGroup("ouraVendorSleep").orderBy(FieldPath.documentId()).limit(300);
+    if (last) q = q.startAfter(last);
+    const page = await q.get();
+    if (page.empty) break;
+
+    for (const vDoc of page.docs) {
+      counts.scanned += 1;
+      const pathUid = extractUidFromVendorRef(vDoc.ref.path);
+      if (!pathUid) {
+        counts.skipped += 1;
+        if (verbose) console.log(`skip ${vDoc.ref.path} path_not_users_ouraVendorSleep`);
+        continue;
+      }
+
+      const vData = vDoc.data() as Record<string, unknown>;
+      const storedDay = typeof vData.day === "string" ? vData.day : undefined;
+
+      const rawSnap = await db.collection("users").doc(pathUid).collection("rawEvents").doc(vDoc.id).get();
+      if (!rawSnap.exists) {
+        counts.skipped += 1;
+        if (verbose) console.log(`skip ${pathUid}/${vDoc.id} missing_raw_doc`);
+        continue;
+      }
+      const rawData = rawSnap.data() as Record<string, unknown>;
+      if (!isOuraIngestedSleepRawEvent(rawData)) {
+        counts.skipped += 1;
+        if (verbose) console.log(`skip ${pathUid}/${vDoc.id} raw_not_oura_sleep`);
+        continue;
+      }
+      const payload =
+        rawData.payload && typeof rawData.payload === "object"
+          ? (rawData.payload as Record<string, unknown>)
+          : undefined;
+
+      const plan = planOuraVendorSleepDayFromRaw(vDoc.id, storedDay, payload);
+      if (plan.status === "skip") {
+        counts.skipped += 1;
+        if (verbose) console.log(`skip ${pathUid}/${vDoc.id} ${plan.reason}`);
+        continue;
+      }
+      if (plan.status === "aligned") {
+        counts.aligned += 1;
+        continue;
+      }
+
+      counts.changed += 1;
+      const patch = buildVendorSleepDayMigrationWritePatch({
+        rollupDay: plan.rollupDay,
+        migratedAt: FieldValue.serverTimestamp(),
+      });
+
+      if (verbose) {
+        console.log(`change ${pathUid}/${vDoc.id} day ${plan.storedDay} -> ${plan.rollupDay}`);
+      }
+
+      await enqueueWrite(vDoc.ref, { ...patch });
+    }
+
+    await flushPending();
+
+    last = page.docs[page.docs.length - 1];
+    if (page.size < 300) break;
+  }
+
+  await flushPending();
+  return counts;
+}
+
+async function main(): Promise<void> {
+  const parsed = parseArgs(process.argv);
+  if (parsed.mode === "help") {
+    printHelp();
+    process.exit(0);
+  }
+  if (parsed.mode === "usage") {
+    printHelp();
+    console.error("Invalid args: need --project-id and (--uid <uid> | --all-users), not both uid and --all-users.");
+    process.exit(1);
+  }
+
+  const { projectId, uid, allUsers, write, verbose } = parsed;
+  if (!getApps().length) {
+    initializeApp({ projectId });
+  }
+  const db = getFirestore();
+
+  console.log(
+    JSON.stringify(
+      {
+        msg: "oura_vendor_sleep_day_backfill_start",
+        dryRun: !write,
+        uid: uid ?? null,
+        allUsers,
+      },
+      null,
+      2,
+    ),
+  );
+
+  let totals = emptyCounts();
+  try {
+    if (allUsers) {
+      totals = await runAllUsers(db, write, verbose);
+    } else if (uid) {
+      totals = await runForUser(db, uid, write, verbose);
+    }
+  } catch (err) {
+    totals.errors += 1;
+    console.error(err);
+    process.exit(1);
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        msg: "oura_vendor_sleep_day_backfill_done",
+        dryRun: !write,
+        ...totals,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/admin/backfillSleepNightsFromOura.cli.ts
+++ b/scripts/admin/backfillSleepNightsFromOura.cli.ts
@@ -1,0 +1,455 @@
+#!/usr/bin/env npx tsx
+/**
+ * Admin: build `users/{uid}/sleepNights/{anchorDay}` from paired Oura vendor sleep + rawEvents rows.
+ * Never mutates rawEvents, events, or dailyFacts.
+ *
+ * Default: dry-run. Mutations require `--write`.
+ *
+ * Usage:
+ *   npx tsx --tsconfig scripts/tsconfig.json scripts/admin/backfillSleepNightsFromOura.cli.ts \
+ *     --project-id <firebaseProjectId> --uid <uid>
+ *   npx tsx --tsconfig scripts/tsconfig.json scripts/admin/backfillSleepNightsFromOura.cli.ts \
+ *     --project-id <firebaseProjectId> --uid <uid> --write
+ */
+
+import { initializeApp, getApps } from "firebase-admin/app";
+import type { DocumentReference, Firestore, QueryDocumentSnapshot, WriteBatch } from "firebase-admin/firestore";
+import { getFirestore, FieldValue } from "firebase-admin/firestore";
+
+import type { OuraSleepDocument } from "../../services/api/src/lib/ouraApi";
+import {
+  buildOuraSleepDocumentFromOuraIngestSleepPayload,
+  isOuraIngestedSleepRawEvent,
+} from "../../services/api/src/lib/ouraVendorSleepDayBackfill";
+import {
+  buildSleepNightFirestorePayloadWithOuraReadiness,
+  enrichReadinessRecordWithRawPayload,
+  readinessDayFromReadinessRecord,
+} from "../../services/api/src/lib/oura/readinessForSleepNightMerge";
+import {
+  pickOuraSleepAverageHrvMs,
+  pickOuraSleepLowestHeartRateBpm,
+} from "../../services/api/src/lib/oura/ouraSleepPhysiology";
+import { coerceOuraSleepScore0to100 } from "../../services/api/src/lib/sleepNight";
+
+const BATCH_MAX = 450;
+
+type Parsed =
+  | { mode: "help" }
+  | { mode: "usage" }
+  | {
+      mode: "run";
+      projectId: string;
+      uid: string | null;
+      allUsers: boolean;
+      write: boolean;
+      verbose: boolean;
+      targetDay: string | null;
+    };
+
+function parseArgs(argv: string[]): Parsed {
+  let projectId: string | null = null;
+  let uid: string | null = null;
+  let allUsers = false;
+  let write = false;
+  let verbose = false;
+  let targetDay: string | null = null;
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--help" || a === "-h") return { mode: "help" };
+    if (a === "--project-id") projectId = argv[++i]?.trim() ?? null;
+    else if (a === "--uid") uid = argv[++i]?.trim() ?? null;
+    else if (a === "--all-users") allUsers = true;
+    else if (a === "--write") write = true;
+    else if (a === "--verbose") verbose = true;
+    else if (a === "--day") targetDay = argv[++i]?.trim() ?? null;
+  }
+  if (!projectId) return { mode: "usage" };
+  if (allUsers && uid) return { mode: "usage" };
+  if (!allUsers && (!uid || uid.length === 0)) return { mode: "usage" };
+  if (targetDay != null && !/^\d{4}-\d{2}-\d{2}$/.test(targetDay)) return { mode: "usage" };
+  return { mode: "run", projectId, uid, allUsers, write, verbose, targetDay };
+}
+
+function printHelp(): void {
+  console.log(`backfillSleepNightsFromOura.cli.ts
+
+Builds users/{uid}/sleepNights/{anchorDay} merge docs from Oura vendor sleep + paired rawEvents/{sameId}.
+Dry-run by default; use --write to persist.
+
+Required:
+  --project-id <firebaseProjectId>
+
+Exactly one of:
+  --uid <uid>
+  --all-users            (collectionGroup on ouraVendorSleep)
+
+Options:
+  --write
+  --verbose
+  --day <YYYY-MM-DD>   verbose physiology audit for vendor docs on this day
+`);
+}
+
+function sleepPhysiologyCandidateKeys(vendor: Record<string, unknown>): string[] {
+  const keys = new Set<string>(Object.keys(vendor));
+  const payload = vendor.payload;
+  if (payload != null && typeof payload === "object" && !Array.isArray(payload)) {
+    for (const k of Object.keys(payload as Record<string, unknown>)) {
+      keys.add(`payload.${k}`);
+    }
+  }
+  return [...keys]
+    .filter((k) => /heart|hrv|hr_/i.test(k) || /lowest|average/i.test(k))
+    .sort();
+}
+
+function reportSleepPhysiologyGap(
+  vendorId: string,
+  vendor: Record<string, unknown>,
+  merged: OuraSleepDocument,
+): void {
+  const lhr = pickOuraSleepLowestHeartRateBpm(merged);
+  const hrv = pickOuraSleepAverageHrvMs(merged);
+  if (lhr !== undefined && hrv !== undefined) return;
+  const fromVendor = pickOuraSleepLowestHeartRateBpm(vendor);
+  const fromVendorHrv = pickOuraSleepAverageHrvMs(vendor);
+  console.log({
+    msg: "sleep_doc_lacks_physiology_repull_required",
+    vendorId,
+    vendorDay: vendor.day,
+    missingLowestHeartRate: lhr === undefined,
+    missingAverageHrv: hrv === undefined,
+    vendorHasLowest: fromVendor !== undefined,
+    vendorHasHrv: fromVendorHrv !== undefined,
+    rawCandidateKeys: sleepPhysiologyCandidateKeys(vendor),
+    note:
+      "sleep doc lacks lowest_heart_rate / average_hrv on vendor snapshot and raw payload; re-pull Oura required",
+  });
+}
+
+type Counts = { scanned: number; changed: number; skipped: number; errors: number };
+
+function emptyCounts(): Counts {
+  return { scanned: 0, changed: 0, skipped: 0, errors: 0 };
+}
+
+function extractUidFromVendorRef(refPath: string): string | null {
+  const m = /^users\/([^/]+)\/ouraVendorSleep\//.exec(refPath);
+  return m?.[1] ?? null;
+}
+
+function enrichOuraDocFromVendorSnapshot(
+  vendorId: string,
+  vendor: Record<string, unknown>,
+  base: OuraSleepDocument,
+): OuraSleepDocument {
+  const payload =
+    vendor.payload != null && typeof vendor.payload === "object" && !Array.isArray(vendor.payload)
+      ? (vendor.payload as Record<string, unknown>)
+      : null;
+  const v: OuraSleepDocument = {
+    ...base,
+    ...(payload ?? {}),
+    id: vendorId,
+  };
+  if (typeof vendor.totalSleepDuration === "number") {
+    v.total_sleep_duration = vendor.totalSleepDuration as number;
+  }
+  if (typeof vendor.efficiency === "number") {
+    v.efficiency = vendor.efficiency as number;
+  }
+  if (typeof vendor.remSleep === "number") {
+    (v as { rem_sleep_duration?: number }).rem_sleep_duration = vendor.remSleep as number;
+  }
+  if (typeof vendor.deepSleep === "number") {
+    (v as { deep_sleep_duration?: number }).deep_sleep_duration = vendor.deepSleep as number;
+  }
+  if (typeof vendor.latency === "number") {
+    v.latency = vendor.latency as number;
+  }
+  const s = coerceOuraSleepScore0to100(vendor.score ?? vendor.composite_score);
+  if (s != null) (v as { score?: number }).score = s;
+  const day = typeof vendor.day === "string" ? vendor.day.trim() : "";
+  if (/^\d{4}-\d{2}-\d{2}$/.test(day)) {
+    v.day = day;
+  }
+  const lhr = vendor.lowestHeartRateBpm ?? vendor.lowest_heart_rate;
+  const hrv = vendor.averageHrvMs ?? vendor.average_hrv;
+  if (typeof lhr === "number") (v as { lowest_heart_rate?: number }).lowest_heart_rate = lhr;
+  if (typeof hrv === "number") (v as { average_hrv?: number }).average_hrv = hrv;
+  return v;
+}
+
+type SingleWrite = { ref: DocumentReference; data: Record<string, unknown> };
+
+async function commitBatchOrSingles(db: Firestore, batch: WriteBatch, singles: SingleWrite[]): Promise<number> {
+  let errors = 0;
+  try {
+    await batch.commit();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error({ msg: "sleep_night_backfill_batch_failed", err: msg });
+    for (const { ref, data } of singles) {
+      try {
+        await ref.set(data, { merge: true });
+      } catch (e2) {
+        errors += 1;
+        console.error({
+          msg: "sleep_night_backfill_single_failed",
+          path: ref.path,
+          err: e2 instanceof Error ? e2.message : String(e2),
+        });
+      }
+    }
+  }
+  return errors;
+}
+
+async function loadAllOuraVendorReadinessByDay(
+  db: Firestore,
+  uid: string,
+): Promise<Map<string, Record<string, unknown>>> {
+  const map = new Map<string, Record<string, unknown>>();
+  const userRef = db.collection("users").doc(uid);
+  const snaps = await userRef.collection("ouraVendorReadiness").get();
+  for (const docSnap of snaps.docs) {
+    let raw = docSnap.data() as Record<string, unknown>;
+    const linkedId =
+      (typeof raw.id === "string" && raw.id.trim().length > 0 ? raw.id.trim() : null) ?? docSnap.id;
+    const rawSnap = await userRef.collection("rawEvents").doc(linkedId).get();
+    if (rawSnap.exists) {
+      const rawRow = rawSnap.data() as Record<string, unknown>;
+      const payload =
+        rawRow.payload && typeof rawRow.payload === "object" && !Array.isArray(rawRow.payload)
+          ? (rawRow.payload as Record<string, unknown>)
+          : null;
+      raw = enrichReadinessRecordWithRawPayload(raw, payload);
+    }
+    const day = readinessDayFromReadinessRecord(raw, docSnap.id);
+    if (day) map.set(day, raw);
+  }
+  return map;
+}
+
+async function processVendorDoc(
+  db: Firestore,
+  uid: string,
+  vendorSnap: QueryDocumentSnapshot,
+  write: boolean,
+  verbose: boolean,
+  targetDay: string | null,
+  pending: SingleWrite[],
+  persistedReadinessByDay: Map<string, Record<string, unknown>>,
+): Promise<{ skipped: number; changed: number }> {
+  const out = { skipped: 0, changed: 0 };
+  const vendorId = vendorSnap.id;
+  const vendor = vendorSnap.data() as Record<string, unknown>;
+
+  const rawSnap = await db.collection("users").doc(uid).collection("rawEvents").doc(vendorId).get();
+  const raw = rawSnap.data() as Record<string, unknown> | undefined;
+  const payload =
+    raw && typeof raw.payload === "object" && raw.payload ? (raw.payload as Record<string, unknown>) : undefined;
+
+  if (!raw || !isOuraIngestedSleepRawEvent(raw)) {
+    if (verbose) console.log({ msg: "skip_no_oura_raw", uid, vendorId });
+    out.skipped += 1;
+    return out;
+  }
+
+  const base = buildOuraSleepDocumentFromOuraIngestSleepPayload(vendorId, payload ?? {});
+  if (!base) {
+    if (verbose) console.log({ msg: "skip_unbuildable_raw", uid, vendorId });
+    out.skipped += 1;
+    return out;
+  }
+
+  let merged = enrichOuraDocFromVendorSnapshot(vendorId, vendor, base);
+
+  if (
+    pickOuraSleepLowestHeartRateBpm(merged) === undefined ||
+    pickOuraSleepAverageHrvMs(merged) === undefined
+  ) {
+    const ouraRawSnap = await db.collection("users").doc(uid).collection("rawEvents").doc(vendorId).get();
+    if (ouraRawSnap.exists) {
+      const rawRow = ouraRawSnap.data() as Record<string, unknown>;
+      const pl = rawRow.payload as Record<string, unknown> | undefined;
+      if (pl?.dataset === "sleep" && pl.data != null && typeof pl.data === "object" && !Array.isArray(pl.data)) {
+        merged = enrichOuraDocFromVendorSnapshot(vendorId, vendor, {
+          ...merged,
+          ...(pl.data as Record<string, unknown>),
+        } as OuraSleepDocument);
+      }
+    }
+  }
+
+  const vendorDay = typeof vendor.day === "string" ? vendor.day.trim() : "";
+  if (targetDay && vendorDay === targetDay) {
+    console.log({
+      msg: "sleep_physiology_target_day_audit",
+      uid,
+      vendorId,
+      anchorDay: targetDay,
+      rawCandidateKeys: sleepPhysiologyCandidateKeys(vendor),
+      pickedLowestHeartRateBpm: pickOuraSleepLowestHeartRateBpm(merged),
+      pickedAverageHrvMs: pickOuraSleepAverageHrvMs(merged),
+    });
+  }
+
+  reportSleepPhysiologyGap(vendorId, vendor, merged);
+
+  const built = buildSleepNightFirestorePayloadWithOuraReadiness(
+    merged,
+    vendorId,
+    [],
+    persistedReadinessByDay,
+  );
+  if (!built) {
+    if (verbose) console.log({ msg: "skip_sleep_night_builder", uid, vendorId });
+    out.skipped += 1;
+    return out;
+  }
+
+  const ref = db.collection("users").doc(uid).collection("sleepNights").doc(built.anchorDay);
+  const data = { ...built.payload, updatedAt: FieldValue.serverTimestamp() };
+
+  if (verbose) {
+    console.log({
+      msg: write ? "write_sleep_night" : "dry_run_sleep_night",
+      uid,
+      anchorDay: built.anchorDay,
+      vendorId,
+      lowestHeartRateBpm: built.payload.lowestHeartRateBpm,
+      averageHrvMs: built.payload.averageHrvMs,
+      physiologySource: built.payload.physiologySource,
+    });
+  }
+
+  out.changed += 1;
+  if (write) {
+    pending.push({ ref, data });
+  }
+  return out;
+}
+
+async function backfillForUid(
+  db: Firestore,
+  uid: string,
+  write: boolean,
+  verbose: boolean,
+  targetDay: string | null,
+): Promise<Counts> {
+  const c = emptyCounts();
+  const vendorCol = db.collection("users").doc(uid).collection("ouraVendorSleep");
+  const snaps = await vendorCol.get();
+  const pending: SingleWrite[] = [];
+  const persistedReadinessByDay = await loadAllOuraVendorReadinessByDay(db, uid);
+
+  for (const docSnap of snaps.docs as QueryDocumentSnapshot[]) {
+    c.scanned += 1;
+    const r = await processVendorDoc(
+      db,
+      uid,
+      docSnap,
+      write,
+      verbose,
+      targetDay,
+      pending,
+      persistedReadinessByDay,
+    );
+    c.skipped += r.skipped;
+    c.changed += r.changed;
+  }
+
+  if (write && pending.length > 0) {
+    for (let i = 0; i < pending.length; i += BATCH_MAX) {
+      const chunk = pending.slice(i, i + BATCH_MAX);
+      const batch = db.batch();
+      for (const { ref, data } of chunk) {
+        batch.set(ref, data, { merge: true });
+      }
+      c.errors += await commitBatchOrSingles(db, batch, chunk);
+    }
+  }
+
+  return c;
+}
+
+async function main(): Promise<void> {
+  const parsed = parseArgs(process.argv);
+  if (parsed.mode === "help") {
+    printHelp();
+    return;
+  }
+  if (parsed.mode === "usage") {
+    console.error("Usage: --project-id <id> and (--uid <uid> | --all-users) [--write] [--verbose]");
+    process.exitCode = 2;
+    return;
+  }
+
+  const { projectId, uid, allUsers, write, verbose, targetDay } = parsed;
+  if (getApps().length === 0) {
+    initializeApp({ projectId });
+  }
+  const db = getFirestore();
+
+  console.log({
+    msg: "sleep_night_backfill_start",
+    projectId,
+    uid: uid ?? "ALL",
+    allUsers,
+    write,
+  });
+
+  if (!allUsers && uid) {
+    const c = await backfillForUid(db, uid, write, verbose, targetDay);
+    console.log({ msg: "sleep_night_backfill_done", uid, ...c });
+    return;
+  }
+
+  const cg = await db.collectionGroup("ouraVendorSleep").get();
+  const totals = emptyCounts();
+  const pending: SingleWrite[] = [];
+  const readinessByUid = new Map<string, Map<string, Record<string, unknown>>>();
+
+  for (const docSnap of cg.docs as QueryDocumentSnapshot[]) {
+    totals.scanned += 1;
+    const u = extractUidFromVendorRef(docSnap.ref.path);
+    if (!u) {
+      totals.skipped += 1;
+      continue;
+    }
+    let persistedReadinessByDay = readinessByUid.get(u);
+    if (!persistedReadinessByDay) {
+      persistedReadinessByDay = await loadAllOuraVendorReadinessByDay(db, u);
+      readinessByUid.set(u, persistedReadinessByDay);
+    }
+    const r = await processVendorDoc(
+      db,
+      u,
+      docSnap,
+      write,
+      verbose,
+      targetDay,
+      pending,
+      persistedReadinessByDay,
+    );
+    totals.skipped += r.skipped;
+    totals.changed += r.changed;
+  }
+
+  if (write && pending.length > 0) {
+    for (let i = 0; i < pending.length; i += BATCH_MAX) {
+      const chunk = pending.slice(i, i + BATCH_MAX);
+      const batch = db.batch();
+      for (const { ref, data } of chunk) {
+        batch.set(ref, data, { merge: true });
+      }
+      totals.errors += await commitBatchOrSingles(db, batch, chunk);
+    }
+  }
+
+  console.log({ msg: "sleep_night_backfill_all_done", ...totals });
+}
+
+void main();

--- a/scripts/admin/verifyOuraUserTruth.cli.ts
+++ b/scripts/admin/verifyOuraUserTruth.cli.ts
@@ -1,0 +1,368 @@
+#!/usr/bin/env npx tsx
+/**
+ * Firestore admin: verify Oura → rawEvents → events → dailyFacts → vendor snapshots → sleepNights → sleep-night resolution.
+ *
+ * Usage (repo root, ADC or GOOGLE_APPLICATION_CREDENTIALS):
+ *
+ *   npx tsx --tsconfig scripts/tsconfig.json scripts/admin/verifyOuraUserTruth.cli.ts \
+ *     --project-id <firebaseProjectId> --uid <uid> --day 2026-05-11 [--window-days 2]
+ *
+ * Notes:
+ * - Raw Oura rows use `sourceId: "oura"` and `provider: "manual"` (ingest schema).
+ * - Readiness from Oura is stored as raw `kind: "hrv"`, not `readiness`.
+ * - Vendor sleep `day` matches ingest rollup (Oura `day` field or wake UTC).
+ *
+ *   gcloud logging read 'jsonPayload.msg="[OURA_SLEEP_LATEST_AUDIT]" AND jsonPayload.uid="UID"' --project=PROJECT --limit=5
+ *   gcloud logging read 'jsonPayload.msg="[OURA_SLEEP_SNAPSHOT_WRITE_AUDIT]" AND jsonPayload.uid="UID"' --project=PROJECT --limit=20
+ *   gcloud logging read 'jsonPayload.msg="[SLEEP_NIGHT_READ_DEBUG]" AND jsonPayload.uid="UID"' --project=PROJECT --limit=10
+ */
+
+import { initializeApp, getApps } from "firebase-admin/app";
+import { getFirestore, Timestamp } from "firebase-admin/firestore";
+
+function parseArgs(argv: string[]): { projectId: string; uid: string; day: string; windowDays: number } | "help" | "usage" {
+  let projectId: string | null = null;
+  let uid: string | null = null;
+  let day: string | null = null;
+  let windowDays = 2;
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--help" || a === "-h") return "help";
+    if (a === "--project-id") projectId = argv[++i]?.trim() ?? null;
+    else if (a === "--uid") uid = argv[++i]?.trim() ?? null;
+    else if (a === "--day") day = argv[++i]?.trim() ?? null;
+    else if (a === "--window-days") windowDays = Math.max(0, Number.parseInt(argv[++i] ?? "2", 10) || 2);
+  }
+  if (!projectId || !uid || !day) return "usage";
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(day)) return "usage";
+  return { projectId, uid, day, windowDays };
+}
+
+function printHelp(): void {
+  console.log(`verifyOuraUserTruth.cli.ts — dump Firestore truth for Oura pipeline verification.
+
+Required:
+  --project-id <firebaseProjectId>
+  --uid <userId>
+  --day <YYYY-MM-DD>   anchor local/calendar day (UTC window expansion uses calendar math on this string)
+
+Optional:
+  --window-days <n>    include raw rows whose payload.day or observedAt day is within ±n of anchor (default 2)
+`);
+}
+
+function ymdFromIso(iso: string): string | null {
+  if (typeof iso !== "string" || iso.length < 10) return null;
+  const head = iso.slice(0, 10);
+  return /^\d{4}-\d{2}-\d{2}$/.test(head) ? head : null;
+}
+
+function dayMinus(ymd: string, days: number): string {
+  const d = new Date(ymd + "T12:00:00.000Z");
+  d.setUTCDate(d.getUTCDate() - days);
+  return d.toISOString().slice(0, 10);
+}
+
+function dayPlus(ymd: string, days: number): string {
+  const d = new Date(ymd + "T12:00:00.000Z");
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+function inYmdWindow(ymd: string | null, anchor: string, windowDays: number): boolean {
+  if (!ymd) return false;
+  const lo = dayMinus(anchor, windowDays);
+  const hi = dayPlus(anchor, windowDays);
+  return ymd >= lo && ymd <= hi;
+}
+
+function sleepPhysiologyCandidateKeys(data: Record<string, unknown>): string[] {
+  const keys = new Set<string>(Object.keys(data));
+  const payload = data.payload;
+  if (payload != null && typeof payload === "object" && !Array.isArray(payload)) {
+    for (const k of Object.keys(payload as Record<string, unknown>)) {
+      keys.add(`payload.${k}`);
+    }
+  }
+  return [...keys]
+    .filter((k) => /heart|hrv|hr_/i.test(k) || /lowest|average/i.test(k))
+    .sort();
+}
+
+function serializeFirestoreValue(v: unknown): unknown {
+  if (v instanceof Timestamp) return v.toDate().toISOString();
+  if (v && typeof v === "object" && !Array.isArray(v)) {
+    const o = v as Record<string, unknown>;
+    const out: Record<string, unknown> = {};
+    for (const [k, val] of Object.entries(o)) {
+      out[k] = serializeFirestoreValue(val);
+    }
+    return out;
+  }
+  if (Array.isArray(v)) return v.map(serializeFirestoreValue);
+  return v;
+}
+
+async function main(): Promise<void> {
+  const parsed = parseArgs(process.argv);
+  if (parsed === "help") {
+    printHelp();
+    process.exit(0);
+  }
+  if (parsed === "usage") {
+    printHelp();
+    console.error("Missing or invalid --project-id / --uid / --day.");
+    process.exit(1);
+  }
+  const { projectId, uid, day, windowDays } = parsed;
+
+  if (!getApps().length) {
+    initializeApp({ projectId });
+  }
+  const db = getFirestore();
+
+  const userRef = db.collection("users").doc(uid);
+
+  console.log("\n=== 1) integrations/oura ===\n");
+  const integSnap = await userRef.collection("integrations").doc("oura").get();
+  if (!integSnap.exists) {
+    console.log("(no document)");
+  } else {
+    console.log(JSON.stringify(serializeFirestoreValue(integSnap.data()), null, 2));
+  }
+
+  const windowLo = dayMinus(day, windowDays);
+  const windowHi = dayPlus(day, windowDays);
+  console.log(`\n=== 2) rawEvents (sourceId==oura, kind sleep|hrv, window ${windowLo}..${windowHi} via payload.day or observedAt) ===\n`);
+
+  const rawCol = userRef.collection("rawEvents");
+  const [sleepSnap, hrvSnap] = await Promise.all([
+    rawCol.where("kind", "==", "sleep").where("sourceId", "==", "oura").limit(120).get(),
+    rawCol.where("kind", "==", "hrv").where("sourceId", "==", "oura").limit(120).get(),
+  ]);
+
+  type RawRow = {
+    id: string;
+    kind: string;
+    provider?: unknown;
+    sourceId?: unknown;
+    observedAt?: unknown;
+    receivedAt?: unknown;
+    payloadDay?: unknown;
+  };
+
+  const rawRows: RawRow[] = [];
+  for (const snap of [sleepSnap, hrvSnap]) {
+    for (const d of snap.docs) {
+      const data = d.data() as Record<string, unknown>;
+      const payload = data.payload && typeof data.payload === "object" ? (data.payload as Record<string, unknown>) : {};
+      const payloadDay = typeof payload.day === "string" ? payload.day : null;
+      const obs = typeof data.observedAt === "string" ? data.observedAt : null;
+      const obsDay = obs ? ymdFromIso(obs) : null;
+      const matchDay = inYmdWindow(payloadDay, day, windowDays) || inYmdWindow(obsDay, day, windowDays);
+      if (!matchDay) continue;
+      rawRows.push({
+        id: d.id,
+        kind: String(data.kind ?? ""),
+        provider: data.provider,
+        sourceId: data.sourceId,
+        observedAt: data.observedAt,
+        receivedAt: data.receivedAt,
+        payloadDay: payload.day,
+      });
+    }
+  }
+  rawRows.sort((a, b) => String(b.receivedAt).localeCompare(String(a.receivedAt)));
+  console.log(JSON.stringify(rawRows, null, 2));
+  console.log(`(matched ${rawRows.length} raw row(s) in ±${windowDays}d window)`);
+
+  console.log(`\n=== 3) canonical events (day == ${day}, kind sleep|hrv) ===\n`);
+  const eventsSnap = await userRef.collection("events").where("day", "==", day).get();
+  const canonical = eventsSnap.docs
+    .map((d) => {
+      const data = d.data() as Record<string, unknown>;
+      const k = data.kind;
+      if (k !== "sleep" && k !== "hrv") return null;
+      return {
+        id: d.id,
+        kind: k,
+        day: data.day,
+        timezone: data.timezone,
+        start: data.start,
+        end: data.end,
+        time: data.time,
+        sourceId: data.sourceId,
+      };
+    })
+    .filter(Boolean);
+  console.log(JSON.stringify(canonical, null, 2));
+
+  console.log("\n=== 4) dailyFacts/" + day + " ===\n");
+  const factsSnap = await userRef.collection("dailyFacts").doc(day).get();
+  if (!factsSnap.exists) {
+    console.log("(no document)");
+  } else {
+    const data = factsSnap.data() as Record<string, unknown>;
+    const sleep = data.sleep && typeof data.sleep === "object" ? (data.sleep as Record<string, unknown>) : {};
+    const recovery = data.recovery && typeof data.recovery === "object" ? (data.recovery as Record<string, unknown>) : {};
+    const energy =
+      data.energyInfluencers && typeof data.energyInfluencers === "object"
+        ? (data.energyInfluencers as Record<string, unknown>)
+        : {};
+    const physiology =
+      energy.physiology && typeof energy.physiology === "object" ? (energy.physiology as Record<string, unknown>) : {};
+    const activity = data.activity && typeof data.activity === "object" ? (data.activity as Record<string, unknown>) : {};
+    const slice = {
+      sleep: {
+        totalMinutes: sleep.totalMinutes,
+        deepSleepMinutes: sleep.deepSleepMinutes,
+        remSleepMinutes: sleep.remSleepMinutes,
+        efficiency: sleep.efficiency,
+      },
+      recovery: {
+        hrvRmssd: recovery.hrvRmssd,
+        hrvRmssdBaseline: recovery.hrvRmssdBaseline,
+        hrvRmssdDeviation: recovery.hrvRmssdDeviation,
+      },
+      energyInfluencers: {
+        physiology: { restingHeartRateBpm: physiology.restingHeartRateBpm },
+      },
+      activity: { trainingLoad: activity.trainingLoad },
+    };
+    console.log(JSON.stringify(serializeFirestoreValue(slice), null, 2));
+  }
+
+  console.log("\n=== 5) Vendor snapshots (exact day " + day + ") ===\n");
+  const [exactSleep, exactReadiness] = await Promise.all([
+    userRef.collection("ouraVendorSleep").where("day", "==", day).limit(5).get(),
+    userRef.collection("ouraVendorReadiness").where("day", "==", day).limit(5).get(),
+  ]);
+  console.log("ouraVendorSleep (day match):", exactSleep.size);
+  for (const d of exactSleep.docs) {
+    const data = d.data() as Record<string, unknown>;
+    const payload =
+      data.payload && typeof data.payload === "object" ? (data.payload as Record<string, unknown>) : null;
+    console.log(
+      JSON.stringify(
+        {
+          id: d.id,
+          day: data.day,
+          score: data.score,
+          lowestHeartRateBpm: data.lowestHeartRateBpm,
+          averageHrvMs: data.averageHrvMs,
+          lowest_heart_rate: data.lowest_heart_rate,
+          average_hrv: data.average_hrv,
+          payloadLowestHeartRate: payload?.lowest_heart_rate ?? payload?.lowestHeartRateBpm,
+          payloadAverageHrv: payload?.average_hrv ?? payload?.averageHrvMs,
+          rawCandidateKeys: sleepPhysiologyCandidateKeys(data),
+          fetchedAt: data.fetchedAt,
+          updatedAt: data.updatedAt,
+        },
+        null,
+        2,
+      ),
+    );
+  }
+  console.log("ouraVendorReadiness (day match):", exactReadiness.size);
+  for (const d of exactReadiness.docs) {
+    const data = d.data() as Record<string, unknown>;
+    const payload =
+      data.payload && typeof data.payload === "object" ? (data.payload as Record<string, unknown>) : null;
+    const rawCandidateKeys = [
+      ...Object.keys(data),
+      ...(payload ? Object.keys(payload).map((k) => `payload.${k}`) : []),
+    ].sort();
+    console.log(
+      JSON.stringify(
+        {
+          id: d.id,
+          day: data.day,
+          score: data.score,
+          lowestHeartRateBpm: data.lowestHeartRateBpm,
+          averageHrvMs: data.averageHrvMs,
+          lowest_heart_rate: data.lowest_heart_rate,
+          average_hrv: data.average_hrv,
+          rmssd_5min: data.rmssd_5min,
+          payloadLowestHeartRate: payload?.lowest_heart_rate ?? payload?.lowestHeartRateBpm,
+          payloadAverageHrv: payload?.average_hrv ?? payload?.averageHrvMs ?? payload?.rmssd_5min,
+          rawCandidateKeys,
+          fetchedAt: data.fetchedAt,
+          updatedAt: data.updatedAt,
+        },
+        null,
+        2,
+      ),
+    );
+  }
+
+  const latestSleep = await userRef.collection("ouraVendorSleep").orderBy("day", "desc").limit(5).get();
+  console.log("\nLatest ouraVendorSleep docs by field 'day' (desc, max 5):");
+  for (const d of latestSleep.docs) {
+    const data = d.data() as Record<string, unknown>;
+    console.log(JSON.stringify({ id: d.id, day: data.day, fetchedAt: data.fetchedAt }, null, 2));
+  }
+
+  console.log("\n=== 6) sleepNights (requested day + D-1 + D-2) ===\n");
+  const anchorMinus1 = dayMinus(day, 1);
+  const anchorMinus2 = dayMinus(day, 2);
+  for (const anchor of [day, anchorMinus1, anchorMinus2]) {
+    const sn = await userRef.collection("sleepNights").doc(anchor).get();
+    if (!sn.exists) {
+      console.log(`sleepNights/${anchor}: (no document)`);
+      continue;
+    }
+    const data = sn.data() as Record<string, unknown>;
+    console.log(
+      JSON.stringify(
+        {
+          path: sn.ref.path,
+          anchorDay: data.anchorDay,
+          wakeDay: data.wakeDay,
+          isComplete: data.isComplete,
+          score: data.score,
+          totalSleepMinutes: data.totalSleepMinutes,
+          remMinutes: data.remMinutes,
+          deepMinutes: data.deepMinutes,
+          efficiency: data.efficiency,
+          lowestHeartRateBpm: data.lowestHeartRateBpm,
+          averageHrvMs: data.averageHrvMs,
+          physiologySource: data.physiologySource,
+          rawCandidateKeys: sleepPhysiologyCandidateKeys(data),
+          startedAt: data.startedAt,
+          endedAt: data.endedAt,
+        },
+        null,
+        2,
+      ),
+    );
+  }
+
+  console.log("\n=== 7) GET /users/me/sleep-night resolution (loadSleepNightView) ===\n");
+  try {
+    const { loadSleepNightView } = await import("../../services/api/src/lib/sleepNightRead");
+    const view = await loadSleepNightView(uid, day);
+    console.log(JSON.stringify(serializeFirestoreValue(view ?? null), null, 2));
+  } catch (e) {
+    console.log("(loadSleepNightView failed — check ADC and that services/api can initialize Firestore)", e);
+  }
+
+  console.log(
+    [
+      "",
+      "=== 8) Log search hints (run locally with gcloud) ===",
+      "  oura_pull_sleep_latest_wake",
+      "  oura_sleep_docs_dropped",
+      "  oura_sleep_snapshot_docs_dropped",
+      "  oura_pull_now_token_refresh_failed",
+      "  oura_pull_now_fetch_skipped (dataset: daily_readiness)",
+      "  onRawEventCreated / normalization (search jsonPayload.msg in your sink)",
+      "  dailyFacts recompute (jsonPayload.msg ~ sch_dailyFacts or recompute)",
+      "",
+    ].join("\n"),
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/services/api/src/lib/__tests__/ouraApi.sleep.test.ts
+++ b/services/api/src/lib/__tests__/ouraApi.sleep.test.ts
@@ -3,11 +3,54 @@
  * Regression: Oura API v2 can return bedtime_start/bedtime_end or start/end instead of bed_time/wake_time.
  */
 import {
+  mapOuraReadinessToHrvItem,
   mapOuraSleepToIngestItem,
   normalizeOuraLatencyRawToMinutes,
   type OuraSleepDocument,
   type OuraSleepIngestItem,
 } from "../ouraApi";
+
+describe("mapOuraReadinessToHrvItem", () => {
+  it("maps average_hrv to rmssdMs when rmssd_5min fields are absent (Oura v2 daily_readiness)", () => {
+    const doc = {
+      id: "readiness_1",
+      day: "2026-05-11",
+      timestamp: "2026-05-11T08:15:00.000Z",
+      average_hrv: 51,
+    };
+    const item = mapOuraReadinessToHrvItem(doc);
+    expect(item).toMatchObject({
+      idempotencyKey: "readiness_1",
+      day: "2026-05-11",
+      rmssdMs: 51,
+      measurementType: "nightly",
+    });
+  });
+
+  it("prefers rmssd_5min over average_hrv when both exist", () => {
+    const doc = {
+      id: "r2",
+      day: "2026-05-10",
+      timestamp: "2026-05-10T07:00:00.000Z",
+      rmssd_5min: 60,
+      average_hrv: 40,
+    };
+    const item = mapOuraReadinessToHrvItem(doc);
+    expect(item?.rmssdMs).toBe(60);
+  });
+
+  it("maps average_heart_rate to restingHeartRateBpm when in plausible range", () => {
+    const doc = {
+      id: "r3",
+      day: "2026-05-09",
+      timestamp: "2026-05-09T06:00:00.000Z",
+      average_hrv: 45,
+      average_heart_rate: 58,
+    };
+    const item = mapOuraReadinessToHrvItem(doc);
+    expect(item?.restingHeartRateBpm).toBe(58);
+  });
+});
 
 describe("normalizeOuraLatencyRawToMinutes", () => {
   it("treats values >= 60 as seconds (matches oura-sleep-view read path)", () => {

--- a/services/api/src/lib/__tests__/ouraVendorSleepDayBackfill.test.ts
+++ b/services/api/src/lib/__tests__/ouraVendorSleepDayBackfill.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Oura vendor sleep day backfill — planning + write patch (no Firestore).
+ */
+import {
+  buildOuraSleepDocumentFromOuraIngestSleepPayload,
+  buildVendorSleepDayMigrationWritePatch,
+  isOuraIngestedSleepRawEvent,
+  OURA_VENDOR_SLEEP_DAY_MIGRATION_VERSION,
+  planOuraVendorSleepDayFromRaw,
+} from "../ouraVendorSleepDayBackfill";
+
+describe("buildOuraSleepDocumentFromOuraIngestSleepPayload", () => {
+  it("returns null when start or end is missing", () => {
+    expect(buildOuraSleepDocumentFromOuraIngestSleepPayload("id1", {})).toBeNull();
+    expect(
+      buildOuraSleepDocumentFromOuraIngestSleepPayload("id1", { start: "2025-03-14T22:00:00.000Z" }),
+    ).toBeNull();
+  });
+
+  it("maps start/end/totalMinutes and optional api day", () => {
+    const doc = buildOuraSleepDocumentFromOuraIngestSleepPayload("sleep_abc", {
+      start: "2025-03-14T22:00:00.000Z",
+      end: "2025-03-15T06:00:00.000Z",
+      totalMinutes: 480,
+      day: "2025-03-15",
+    });
+    expect(doc).toMatchObject({
+      id: "sleep_abc",
+      start: "2025-03-14T22:00:00.000Z",
+      end: "2025-03-15T06:00:00.000Z",
+      day: "2025-03-15",
+      total_sleep_duration: 480 * 60,
+    });
+  });
+});
+
+describe("planOuraVendorSleepDayFromRaw", () => {
+  it("returns aligned when stored day matches rollup", () => {
+    const plan = planOuraVendorSleepDayFromRaw("s1", "2025-03-15", {
+      start: "2025-03-14T22:00:00.000Z",
+      end: "2025-03-15T06:00:00.000Z",
+      totalMinutes: 480,
+    });
+    expect(plan).toEqual({ status: "aligned", storedDay: "2025-03-15", rollupDay: "2025-03-15" });
+  });
+
+  it("returns change when stored day was legacy bed-UTC key (dry-run scenario)", () => {
+    const plan = planOuraVendorSleepDayFromRaw("s1", "2025-03-14", {
+      start: "2025-03-14T22:00:00.000Z",
+      end: "2025-03-15T06:00:00.000Z",
+      totalMinutes: 480,
+    });
+    expect(plan).toEqual({
+      status: "change",
+      storedDay: "2025-03-14",
+      rollupDay: "2025-03-15",
+      vendorDocId: "s1",
+    });
+  });
+
+  it("prefers Oura api day on raw payload over wake-only rollup (doc.day override)", () => {
+    const plan = planOuraVendorSleepDayFromRaw("s_api", "2026-04-19", {
+      start: "2026-04-18T22:00:00.000Z",
+      end: "2026-04-19T11:00:00.000Z",
+      day: "2026-04-19",
+      totalMinutes: 486,
+    });
+    expect(plan).toEqual({ status: "aligned", storedDay: "2026-04-19", rollupDay: "2026-04-19" });
+  });
+
+  it("uses api day for change detection when stored day disagrees with payload.day", () => {
+    const plan = planOuraVendorSleepDayFromRaw("s_api2", "2026-04-18", {
+      start: "2026-04-18T22:00:00.000Z",
+      end: "2026-04-19T11:00:00.000Z",
+      day: "2026-04-19",
+      totalMinutes: 486,
+    });
+    expect(plan).toEqual({
+      status: "change",
+      storedDay: "2026-04-18",
+      rollupDay: "2026-04-19",
+      vendorDocId: "s_api2",
+    });
+  });
+
+  it("wake-day fallback when payload has no day", () => {
+    const plan = planOuraVendorSleepDayFromRaw("s_wake", "2025-03-11", {
+      start: "2025-03-10T21:30:00.000Z",
+      end: "2025-03-11T05:45:00.000Z",
+      totalMinutes: 495,
+    });
+    expect(plan).toEqual({ status: "aligned", storedDay: "2025-03-11", rollupDay: "2025-03-11" });
+  });
+
+  it("skips when raw payload is missing", () => {
+    const plan = planOuraVendorSleepDayFromRaw("s1", "2025-03-15", undefined);
+    expect(plan).toEqual({
+      status: "skip",
+      vendorDocId: "s1",
+      reason: "missing_raw_payload",
+      storedDay: "2025-03-15",
+    });
+  });
+
+  it("skips when stored day is invalid", () => {
+    const plan = planOuraVendorSleepDayFromRaw("s1", "not-a-day", {
+      start: "2025-03-14T22:00:00.000Z",
+      end: "2025-03-15T06:00:00.000Z",
+    });
+    expect(plan).toEqual({
+      status: "skip",
+      vendorDocId: "s1",
+      reason: "invalid_or_missing_stored_day",
+      storedDay: "not-a-day",
+    });
+  });
+});
+
+describe("isOuraIngestedSleepRawEvent", () => {
+  it("returns true only for Oura-ingested sleep raw rows", () => {
+    expect(
+      isOuraIngestedSleepRawEvent({
+        kind: "sleep",
+        sourceId: "oura",
+        provider: "manual",
+        payload: {},
+      }),
+    ).toBe(true);
+    expect(isOuraIngestedSleepRawEvent({ kind: "hrv", sourceId: "oura", provider: "manual" })).toBe(false);
+    expect(isOuraIngestedSleepRawEvent({ kind: "sleep", sourceId: "oura", provider: "apple_health" })).toBe(false);
+    expect(isOuraIngestedSleepRawEvent(undefined)).toBe(false);
+  });
+});
+
+describe("buildVendorSleepDayMigrationWritePatch (write mode fields)", () => {
+  it("includes day, migratedAt sentinel, and migrationVersion", () => {
+    const migratedAt = { __test: "serverTimestamp" };
+    const patch = buildVendorSleepDayMigrationWritePatch({ rollupDay: "2025-03-15", migratedAt });
+    expect(patch).toEqual({
+      day: "2025-03-15",
+      migratedAt,
+      migrationVersion: OURA_VENDOR_SLEEP_DAY_MIGRATION_VERSION,
+    });
+  });
+});

--- a/services/api/src/lib/__tests__/ouraVendorSnapshot.test.ts
+++ b/services/api/src/lib/__tests__/ouraVendorSnapshot.test.ts
@@ -10,22 +10,51 @@ import {
 
 jest.mock("../../db", () => ({
   userCollection: jest.fn(),
+  FieldValue: {
+    serverTimestamp: jest.fn(() => ({ __: "ServerTimestamp" })),
+  },
 }));
 
 const mockSet = jest.fn().mockResolvedValue(undefined);
 const mockBatchSet = jest.fn();
 const mockBatchCommit = jest.fn().mockResolvedValue(undefined);
 
+function mockReadinessCollection() {
+  return {
+    doc: jest.fn(() => ({
+      set: mockSet,
+      get: jest.fn().mockResolvedValue({ exists: false }),
+    })),
+    where: jest.fn(() => ({
+      limit: jest.fn(() => ({ get: jest.fn().mockResolvedValue({ docs: [] }) })),
+    })),
+    firestore: {
+      batch: () => ({ set: mockBatchSet, commit: mockBatchCommit }),
+    },
+  };
+}
+
 describe("ouraVendorSnapshot", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    (userCollection as jest.Mock).mockReturnValue({
-      doc: () => ({ set: mockSet }),
-      firestore: {
-        batch: () => ({ set: mockBatchSet, commit: mockBatchCommit }),
-      },
+    (userCollection as jest.Mock).mockImplementation((_uid: string, name: string) => {
+      if (name === "ouraVendorReadiness") return mockReadinessCollection();
+      return {
+        doc: () => ({ set: mockSet }),
+        firestore: {
+          batch: () => ({ set: mockBatchSet, commit: mockBatchCommit }),
+        },
+      };
     });
   });
+
+  function vendorSnapshotWrites(): unknown[][] {
+    return mockBatchSet.mock.calls.filter((c) => (c[1] as { source?: string }).source === "oura");
+  }
+
+  function sleepNightWrites(): unknown[][] {
+    return mockBatchSet.mock.calls.filter((c) => (c[1] as { source?: string }).source === "ouraVendorSleep");
+  }
 
   describe("writeOuraVendorSleepSnapshots", () => {
     it("writes snapshot with id, day, score, contributors, source, fetchedAt", async () => {
@@ -45,19 +74,31 @@ describe("ouraVendorSnapshot", () => {
       await writeOuraVendorSleepSnapshots("uid1", docs, "req-1");
 
       expect(userCollection).toHaveBeenCalledWith("uid1", "ouraVendorSleep");
-      expect(mockBatchSet).toHaveBeenCalledTimes(1);
-      expect(mockBatchCommit).toHaveBeenCalledTimes(1);
-      const payload = mockBatchSet.mock.calls[0][1];
+      expect(userCollection).toHaveBeenCalledWith("uid1", "sleepNights");
+      expect(mockBatchSet).toHaveBeenCalledTimes(2);
+      expect(mockBatchCommit).toHaveBeenCalledTimes(2);
+      const vendorCalls = vendorSnapshotWrites();
+      expect(vendorCalls).toHaveLength(1);
+      const payload = vendorCalls[0]![1] as Record<string, unknown>;
       expect(payload.id).toBe("oura_sleep_1");
-      expect(payload.day).toBe("2025-03-14");
+      expect(payload.day).toBe("2025-03-15");
       expect(payload.score).toBe(85);
       expect(payload.contributors).toMatchObject({ total_sleep: 90, efficiency: 88, restfulness: 82 });
-      expect(Object.keys(payload.contributors)).toContain("total_sleep");
-      expect(Object.keys(payload.contributors)).toContain("efficiency");
-      expect(Object.keys(payload.contributors)).toContain("restfulness");
-      expect(Object.values(payload.contributors).every((v) => typeof v === "number")).toBe(true);
+      expect(Object.keys(payload.contributors as object)).toContain("total_sleep");
+      expect(Object.keys(payload.contributors as object)).toContain("efficiency");
+      expect(Object.keys(payload.contributors as object)).toContain("restfulness");
+      expect(Object.values(payload.contributors as Record<string, number>).every((v) => typeof v === "number")).toBe(
+        true,
+      );
       expect(payload.source).toBe("oura");
       expect(typeof payload.fetchedAt).toBe("string");
+
+      const nightCalls = sleepNightWrites();
+      expect(nightCalls).toHaveLength(1);
+      const nightPayload = nightCalls[0]![1] as Record<string, unknown>;
+      expect(nightPayload.anchorDay).toBe("2025-03-15");
+      expect(nightPayload.source).toBe("ouraVendorSleep");
+      expect(nightPayload.updatedAt).toEqual({ __: "ServerTimestamp" });
     });
 
     it("skips doc when day cannot be derived", async () => {
@@ -77,10 +118,10 @@ describe("ouraVendorSnapshot", () => {
         } as unknown as import("../ouraApi").OuraSleepDocument,
       ];
       await writeOuraVendorSleepSnapshots("uid1", docs, "req-1");
-      expect(mockBatchSet).toHaveBeenCalledTimes(1);
-      const payload = mockBatchSet.mock.calls[0][1];
+      expect(mockBatchSet).toHaveBeenCalledTimes(2);
+      const payload = vendorSnapshotWrites()[0]![1] as Record<string, unknown>;
       expect(payload.id).toBe("oura_sleep_v2_1");
-      expect(payload.day).toBe("2025-03-14");
+      expect(payload.day).toBe("2025-03-15");
       expect(payload.score).toBe(82);
       expect(payload.source).toBe("oura");
     });
@@ -95,9 +136,9 @@ describe("ouraVendorSnapshot", () => {
         } as unknown as import("../ouraApi").OuraSleepDocument,
       ];
       await writeOuraVendorSleepSnapshots("uid1", docs, "req-1");
-      expect(mockBatchSet).toHaveBeenCalledTimes(1);
-      const payload = mockBatchSet.mock.calls[0][1];
-      expect(payload.day).toBe("2025-03-10");
+      expect(mockBatchSet).toHaveBeenCalledTimes(2);
+      const payload = vendorSnapshotWrites()[0]![1] as Record<string, unknown>;
+      expect(payload.day).toBe("2025-03-11");
       expect(payload.source).toBe("oura");
     });
 
@@ -111,10 +152,11 @@ describe("ouraVendorSnapshot", () => {
         } as unknown as import("../ouraApi").OuraSleepDocument,
       ];
       await writeOuraVendorSleepSnapshots("uid1", docs, "req-1");
-      expect(mockBatchCommit).toHaveBeenCalledTimes(1);
-      const payload = mockBatchSet.mock.calls[0][1];
+      expect(mockBatchSet).toHaveBeenCalledTimes(2);
+      expect(mockBatchCommit).toHaveBeenCalledTimes(2);
+      const payload = vendorSnapshotWrites()[0]![1] as Record<string, unknown>;
       expect(payload.id).toBe("oura_sleep_no_score");
-      expect(payload.day).toBe("2025-03-14");
+      expect(payload.day).toBe("2025-03-15");
       expect(payload.source).toBe("oura");
       expect(Object.prototype.hasOwnProperty.call(payload, "score")).toBe(false);
       expect(Object.values(payload).every((v) => v !== undefined)).toBe(true);
@@ -130,11 +172,148 @@ describe("ouraVendorSnapshot", () => {
         } as unknown as import("../ouraApi").OuraSleepDocument,
       ];
       await writeOuraVendorSleepSnapshots("uid1", docs, "req-1");
-      expect(mockBatchSet).toHaveBeenCalledTimes(1);
-      expect(mockBatchCommit).toHaveBeenCalledTimes(1);
-      const payload = mockBatchSet.mock.calls[0][1];
+      expect(mockBatchSet).toHaveBeenCalledTimes(2);
+      expect(mockBatchCommit).toHaveBeenCalledTimes(2);
+      const payload = vendorSnapshotWrites()[0]![1] as Record<string, unknown>;
       expect(payload.id).toBe("valid_1");
-      expect(payload.day).toBe("2025-03-14");
+      expect(payload.day).toBe("2025-03-15");
+    });
+
+    it("prefers Oura API day on vendor snapshot when present (matches ingest rollup)", async () => {
+      const docs = [
+        {
+          id: "oura_sleep_api_day",
+          day: "2026-04-19",
+          bed_time: "2026-04-18T22:00:00Z",
+          wake_time: "2026-04-19T11:00:00Z",
+          total_sleep_duration: 29160,
+          score: 88,
+        } as unknown as import("../ouraApi").OuraSleepDocument,
+      ];
+      await writeOuraVendorSleepSnapshots("uid1", docs, "req-1");
+      expect(mockBatchSet).toHaveBeenCalledTimes(2);
+      const payload = vendorSnapshotWrites()[0]![1] as Record<string, unknown>;
+      expect(payload.day).toBe("2026-04-19");
+    });
+
+  it("preserves lowestHeartRateBpm, averageHrvMs, and payload on vendor sleep snapshot", async () => {
+      const docs = [
+        {
+          id: "s_phys",
+          day: "2026-05-15",
+          bedtime_start: "2026-05-14T23:00:00.000Z",
+          bedtime_end: "2026-05-15T07:50:00.000Z",
+          total_sleep_duration: 24600,
+          lowest_heart_rate: 50,
+          average_hrv: 21,
+        } as unknown as import("../ouraApi").OuraSleepDocument,
+      ];
+      await writeOuraVendorSleepSnapshots("uid1", docs, "req-vendor-phys");
+      const vendorPayload = vendorSnapshotWrites()[0]![1] as Record<string, unknown>;
+      expect(vendorPayload.lowestHeartRateBpm).toBe(50);
+      expect(vendorPayload.averageHrvMs).toBe(21);
+      expect(vendorPayload.payload).toBeDefined();
+      expect((vendorPayload.payload as Record<string, unknown>).lowest_heart_rate).toBe(50);
+    });
+
+  it("2026-05-15: sleep document physiology (50 bpm / 21 ms) wins over readiness", async () => {
+      const docs = [
+        {
+          id: "s_2026_05_15",
+          day: "2026-05-15",
+          bedtime_start: "2026-05-14T23:00:00.000Z",
+          bedtime_end: "2026-05-15T07:50:00.000Z",
+          total_sleep_duration: 24600,
+          score: 81,
+          lowest_heart_rate: 50,
+          average_hrv: 21,
+        } as unknown as import("../ouraApi").OuraSleepDocument,
+      ];
+      const readiness = [
+        { day: "2026-05-15", lowest_heart_rate: 48, average_hrv: 23 },
+      ] as import("../ouraApi").OuraDailyReadinessDocument[];
+      await writeOuraVendorSleepSnapshots("uid1", docs, "req-dash-515", readiness);
+      const nightPayload = sleepNightWrites()[0]![1] as Record<string, unknown>;
+      expect(nightPayload.anchorDay).toBe("2026-05-15");
+      expect(nightPayload.lowestHeartRateBpm).toBe(50);
+      expect(nightPayload.averageHrvMs).toBe(21);
+    });
+
+  it("2026-05-14: Oura day + inferred end writes vendor + sleepNight headline metrics + readiness physiology", async () => {
+      const docs = [
+        {
+          id: "s_2026_05_14",
+          day: "2026-05-14",
+          bedtime_start: "2026-05-13T23:00:00.000Z",
+          total_sleep_duration: 24600,
+          score: 81,
+          efficiency: 91,
+          rem_sleep_duration: 4800,
+          deep_sleep_duration: 3120,
+        } as unknown as import("../ouraApi").OuraSleepDocument,
+      ];
+      const readiness = [
+        { day: "2026-05-14", lowest_heart_rate: 50, average_hrv: 23 },
+      ] as import("../ouraApi").OuraDailyReadinessDocument[];
+      await writeOuraVendorSleepSnapshots("uid1", docs, "req-dash-514", readiness);
+      expect(userCollection).toHaveBeenCalledWith("uid1", "sleepNights");
+      const vendorPayload = vendorSnapshotWrites()[0]![1] as Record<string, unknown>;
+      expect(vendorPayload.day).toBe("2026-05-14");
+      const nightPayload = sleepNightWrites()[0]![1] as Record<string, unknown>;
+      expect(nightPayload.anchorDay).toBe("2026-05-14");
+      expect(nightPayload.score).toBe(81);
+      expect(nightPayload.totalSleepMinutes).toBe(410);
+      expect(nightPayload.efficiency).toBe(91);
+      expect(nightPayload.remMinutes).toBe(80);
+      expect(nightPayload.deepMinutes).toBe(52);
+      expect(nightPayload.isComplete).toBe(true);
+      expect(nightPayload.lowestHeartRateBpm).toBe(50);
+      expect(nightPayload.averageHrvMs).toBe(23);
+    });
+
+    it("merges physiology from persisted ouraVendorReadiness when API readiness array is omitted", async () => {
+      const docs = [
+        {
+          id: "s_2026_05_14",
+          day: "2026-05-14",
+          bedtime_start: "2026-05-13T23:00:00.000Z",
+          total_sleep_duration: 24600,
+          score: 81,
+        } as unknown as import("../ouraApi").OuraSleepDocument,
+      ];
+      (userCollection as jest.Mock).mockImplementation((_uid: string, name: string) => {
+        if (name === "ouraVendorReadiness") {
+          return {
+            doc: jest.fn((day: string) => ({
+              get: jest.fn().mockResolvedValue({
+                exists: day === "2026-05-14",
+                data: () =>
+                  day === "2026-05-14"
+                    ? { day: "2026-05-14", lowestHeartRateBpm: 50, averageHrvMs: 23 }
+                    : undefined,
+              }),
+            })),
+            where: jest.fn(() => ({
+              limit: jest.fn(() => ({ get: jest.fn().mockResolvedValue({ docs: [] }) })),
+            })),
+            firestore: {
+              batch: () => ({ set: mockBatchSet, commit: mockBatchCommit }),
+            },
+          };
+        }
+        return {
+          doc: () => ({ set: mockSet }),
+          firestore: {
+            batch: () => ({ set: mockBatchSet, commit: mockBatchCommit }),
+          },
+        };
+      });
+
+      await writeOuraVendorSleepSnapshots("uid1", docs, "req-persisted-readiness");
+
+      const nightPayload = sleepNightWrites()[0]![1] as Record<string, unknown>;
+      expect(nightPayload.lowestHeartRateBpm).toBe(50);
+      expect(nightPayload.averageHrvMs).toBe(23);
     });
 
     it("writes contributors derived from doc when API does not send contributors", async () => {
@@ -152,8 +331,8 @@ describe("ouraVendorSnapshot", () => {
         } as unknown as import("../ouraApi").OuraSleepDocument,
       ];
       await writeOuraVendorSleepSnapshots("uid1", docs, "req-1");
-      expect(mockBatchSet).toHaveBeenCalledTimes(1);
-      const payload = mockBatchSet.mock.calls[0][1];
+      expect(mockBatchSet).toHaveBeenCalledTimes(2);
+      const payload = vendorSnapshotWrites()[0]![1] as Record<string, unknown>;
       expect(payload.contributors).toBeDefined();
       expect(typeof payload.contributors).toBe("object");
       expect(payload.contributors.total_sleep).toBeDefined();
@@ -177,8 +356,8 @@ describe("ouraVendorSnapshot", () => {
         } as unknown as import("../ouraApi").OuraSleepDocument,
       ];
       await writeOuraVendorSleepSnapshots("uid1", docs, "req-1");
-      expect(mockBatchSet).toHaveBeenCalledTimes(1);
-      const payload = mockBatchSet.mock.calls[0][1];
+      expect(mockBatchSet).toHaveBeenCalledTimes(2);
+      const payload = vendorSnapshotWrites()[0]![1] as Record<string, unknown>;
       expect(payload.contributors?.total_sleep).toBeDefined();
       expect(typeof payload.contributors?.total_sleep).toBe("number");
       expect(payload.contributors.total_sleep).toBeGreaterThanOrEqual(0);
@@ -196,8 +375,8 @@ describe("ouraVendorSnapshot", () => {
         } as unknown as import("../ouraApi").OuraSleepDocument,
       ];
       await writeOuraVendorSleepSnapshots("uid1", docs, "req-1");
-      expect(mockBatchSet).toHaveBeenCalledTimes(1);
-      const payload = mockBatchSet.mock.calls[0][1];
+      expect(mockBatchSet).toHaveBeenCalledTimes(2);
+      const payload = vendorSnapshotWrites()[0]![1] as Record<string, unknown>;
       expect(payload.contributors).toBeDefined();
       expect(Object.keys(payload.contributors)).toContain("total_sleep");
       expect(Object.keys(payload.contributors)).toContain("restfulness");

--- a/services/api/src/lib/__tests__/sleepNight.test.ts
+++ b/services/api/src/lib/__tests__/sleepNight.test.ts
@@ -1,0 +1,90 @@
+import {
+  buildSleepNightFromOuraSleepDocument,
+  coerceOuraSleepScore0to100,
+} from "../sleepNight";
+import type { OuraSleepDocument } from "../ouraApi";
+
+describe("coerceOuraSleepScore0to100", () => {
+  it("maps string digits to number", () => {
+    expect(coerceOuraSleepScore0to100("96")).toBe(96);
+    expect(coerceOuraSleepScore0to100(" 82 ")).toBe(82);
+  });
+
+  it("returns null for invalid strings", () => {
+    expect(coerceOuraSleepScore0to100("x")).toBeNull();
+    expect(coerceOuraSleepScore0to100("")).toBeNull();
+  });
+
+  it("clamps to 0–100", () => {
+    expect(coerceOuraSleepScore0to100(150)).toBe(100);
+    expect(coerceOuraSleepScore0to100(-3)).toBe(0);
+  });
+});
+
+describe("buildSleepNightFromOuraSleepDocument", () => {
+  const baseDoc: OuraSleepDocument = {
+    id: "s1",
+    day: "2026-04-19",
+    bed_time: "2026-04-18T22:00:00Z",
+    wake_time: "2026-04-19T11:00:00Z",
+    total_sleep_duration: 29160,
+    type: "long_sleep",
+    rem_sleep_duration: 7200,
+    deep_sleep_duration: 3600,
+    efficiency: 94,
+    latency: 1020,
+  };
+
+  it("prefers Oura API day as anchorDay when present", () => {
+    const r = buildSleepNightFromOuraSleepDocument(
+      { ...baseDoc, score: "88" } as OuraSleepDocument,
+      { sourceDocumentId: "s1" },
+    );
+    expect(r).not.toBeNull();
+    expect(r?.anchorDay).toBe("2026-04-19");
+    expect(r?.merge.wakeDay).toBe("2026-04-19");
+  });
+
+  it("derives wakeDay from endedAt when Oura day is absent", () => {
+    const rest = { ...baseDoc };
+    delete (rest as { day?: string }).day;
+    const r = buildSleepNightFromOuraSleepDocument(rest, { sourceDocumentId: "s1" });
+    expect(r).not.toBeNull();
+    expect(r?.merge.wakeDay).toBe("2026-04-19");
+  });
+
+  it("maps score string to number in merge payload", () => {
+    const r = buildSleepNightFromOuraSleepDocument(
+      { ...baseDoc, score: "88" } as OuraSleepDocument,
+      { sourceDocumentId: "s1" },
+    );
+    expect(r?.merge.score).toBe(88);
+  });
+
+  it("produces metrics without score when score absent", () => {
+    const r = buildSleepNightFromOuraSleepDocument(baseDoc, { sourceDocumentId: "s1" });
+    expect(r?.merge.score).toBeUndefined();
+    expect(r?.merge.totalSleepMinutes).toBe(486);
+  });
+
+  it("returns null when bed/wake cannot be resolved", () => {
+    const r = buildSleepNightFromOuraSleepDocument({ id: "x", total_sleep_duration: 100 } as OuraSleepDocument, {
+      sourceDocumentId: "x",
+    });
+    expect(r).toBeNull();
+  });
+
+  it("persists lowestHeartRateBpm and averageHrvMs from Oura sleep document", () => {
+    const r = buildSleepNightFromOuraSleepDocument(
+      {
+        ...baseDoc,
+        lowest_heart_rate: 50,
+        average_hrv: 21,
+      } as OuraSleepDocument,
+      { sourceDocumentId: "s1" },
+    );
+    expect(r?.merge.lowestHeartRateBpm).toBe(50);
+    expect(r?.merge.averageHrvMs).toBe(21);
+    expect(r?.merge.physiologySource).toBe("oura_sleep_doc");
+  });
+});

--- a/services/api/src/lib/__tests__/sleepNightRead.coerce.test.ts
+++ b/services/api/src/lib/__tests__/sleepNightRead.coerce.test.ts
@@ -1,0 +1,80 @@
+import { sleepNightDocumentSchema } from "@oli/contracts/sleepNight";
+
+import { coerceRawSleepNightForRead } from "../sleepNightReadCoerce";
+
+describe("coerceRawSleepNightForRead", () => {
+  const base = {
+    provider: "oura",
+    source: "ouraVendorSleep",
+    sourceDocumentId: "s1",
+    anchorDay: "2026-05-12",
+    totalSleepMinutes: 530,
+    mainSleepMinutes: 530,
+    endedAt: "2026-05-13T14:30:00.000Z",
+  };
+
+  it("derives wakeDay from endedAt when wakeDay is absent", () => {
+    const merged = coerceRawSleepNightForRead({ ...base }, "2026-05-12");
+    const parsed = sleepNightDocumentSchema.safeParse(merged);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.wakeDay).toBe("2026-05-13");
+      expect(parsed.data.isComplete).toBe(true);
+    }
+  });
+
+  it("upgrades isComplete false to true when duration and endedAt support Dash semantics", () => {
+    const merged = coerceRawSleepNightForRead(
+      {
+        ...base,
+        isComplete: false,
+      },
+      "2026-05-12",
+    );
+    const parsed = sleepNightDocumentSchema.safeParse(merged);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.isComplete).toBe(true);
+    }
+  });
+
+  it("infers endedAt from startedAt + duration so exact-anchor doc can become complete", () => {
+    const merged = coerceRawSleepNightForRead(
+      {
+        provider: "oura",
+        source: "ouraVendorSleep",
+        sourceDocumentId: "s1",
+        anchorDay: "2026-05-13",
+        startedAt: "2026-05-13T01:00:00.000Z",
+        mainSleepMinutes: 551,
+        isComplete: false,
+      },
+      "2026-05-13",
+    );
+    const parsed = sleepNightDocumentSchema.safeParse(merged);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.isComplete).toBe(true);
+      expect(typeof parsed.data.endedAt).toBe("string");
+      expect(parsed.data.wakeDay.length).toBe(10);
+    }
+  });
+
+  it("fills anchorDay from doc id when anchor field is missing", () => {
+    const merged = coerceRawSleepNightForRead(
+      {
+        provider: "oura",
+        source: "ouraVendorSleep",
+        sourceDocumentId: "s1",
+        totalSleepMinutes: 400,
+        endedAt: "2026-05-13T08:00:00.000Z",
+      },
+      "2026-05-12",
+    );
+    const parsed = sleepNightDocumentSchema.safeParse(merged);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.anchorDay).toBe("2026-05-12");
+    }
+  });
+});

--- a/services/api/src/lib/__tests__/sleepNightRead.hydrate.test.ts
+++ b/services/api/src/lib/__tests__/sleepNightRead.hydrate.test.ts
@@ -1,0 +1,178 @@
+jest.mock("../../db", () => ({
+  userCollection: jest.fn(),
+}));
+
+import type { SleepNightViewDto } from "@oli/contracts/sleepNight";
+import { hydrateSleepNightPhysiologyMetrics } from "../sleepNightRead";
+
+const userCollection = jest.requireMock("../../db").userCollection as jest.Mock;
+
+function baseView(over: Partial<SleepNightViewDto["sleepNight"]> = {}): SleepNightViewDto {
+  return {
+    requestedDay: "2026-05-14",
+    anchorDay: "2026-05-13",
+    wakeDay: "2026-05-14",
+    resolution: "wake_day",
+    isFallback: false,
+    sleepNight: {
+      anchorDay: "2026-05-13",
+      wakeDay: "2026-05-14",
+      provider: "oura",
+      source: "ouraVendorSleep",
+      sourceDocumentId: "s1",
+      isComplete: true,
+      endedAt: "2026-05-14T07:00:00.000Z",
+      mainSleepMinutes: 400,
+      ...over,
+    },
+  };
+}
+
+describe("hydrateSleepNightPhysiologyMetrics", () => {
+  beforeEach(() => {
+    userCollection.mockReset();
+  });
+
+  it("fills lowest HR and HRV from ouraVendorReadiness when absent on sleepNight", async () => {
+    const readinessGet = jest.fn().mockResolvedValue({
+      docs: [{ data: () => ({ lowestHeartRateBpm: 50, averageHrvMs: 23 }) }],
+    });
+    const directGet = jest.fn().mockResolvedValue({ exists: false });
+    const factsGet = jest.fn().mockResolvedValue({ exists: false });
+
+    userCollection.mockImplementation((_uid: string, name: string) => {
+      if (name === "ouraVendorReadiness") {
+        return {
+          doc: jest.fn(() => ({ get: directGet })),
+          where: jest.fn(() => ({
+            limit: jest.fn(() => ({ get: readinessGet })),
+          })),
+        };
+      }
+      if (name === "dailyFacts") {
+        return { doc: jest.fn(() => ({ get: factsGet })) };
+      }
+      return {};
+    });
+
+    const out = await hydrateSleepNightPhysiologyMetrics("u1", baseView());
+    expect(out.sleepNight.lowestHeartRateBpm).toBe(50);
+    expect(out.sleepNight.averageHrvMs).toBe(23);
+    expect(readinessGet).toHaveBeenCalled();
+  });
+
+  it("fills only average HRV from dailyFacts when readiness lacks HRV", async () => {
+    const readinessGet = jest.fn().mockResolvedValue({
+      docs: [{ data: () => ({ lowestHeartRateBpm: 48 }) }],
+    });
+    const directGet = jest.fn().mockResolvedValue({ exists: false });
+    const factsGet = jest.fn().mockResolvedValue({
+      exists: true,
+      data: () => ({
+        energyInfluencers: { physiology: { hrvRmssdMs: 31 } },
+      }),
+    });
+
+    userCollection.mockImplementation((_uid: string, name: string) => {
+      if (name === "ouraVendorReadiness") {
+        return {
+          doc: jest.fn(() => ({ get: directGet })),
+          where: jest.fn(() => ({
+            limit: jest.fn(() => ({ get: readinessGet })),
+          })),
+        };
+      }
+      if (name === "dailyFacts") {
+        return { doc: jest.fn(() => ({ get: factsGet })) };
+      }
+      return {};
+    });
+
+    const out = await hydrateSleepNightPhysiologyMetrics("u1", baseView());
+    expect(out.sleepNight.lowestHeartRateBpm).toBe(48);
+    expect(out.sleepNight.averageHrvMs).toBe(31);
+  });
+
+  it("returns unchanged when both metrics already on sleepNight", async () => {
+    const view = baseView({ lowestHeartRateBpm: 40, averageHrvMs: 20 });
+    const out = await hydrateSleepNightPhysiologyMetrics("u1", view);
+    expect(out).toEqual(view);
+    expect(userCollection).not.toHaveBeenCalled();
+  });
+
+  it("hydrates from linked rawEvents payload when vendor readiness omits physiology", async () => {
+    const directGet = jest.fn().mockResolvedValue({
+      exists: true,
+      id: "readiness-1",
+      data: () => ({ id: "readiness-1", day: "2026-05-14", score: 78 }),
+    });
+    const rawGet = jest.fn().mockResolvedValue({
+      exists: true,
+      data: () => ({
+        payload: { lowest_heart_rate: 50, average_hrv: 23 },
+      }),
+    });
+    const readinessGet = jest.fn().mockResolvedValue({ docs: [] });
+    const factsGet = jest.fn().mockResolvedValue({ exists: false });
+
+    userCollection.mockImplementation((_uid: string, name: string) => {
+      if (name === "ouraVendorReadiness") {
+        return {
+          doc: jest.fn(() => ({ get: directGet })),
+          where: jest.fn(() => ({
+            limit: jest.fn(() => ({ get: readinessGet })),
+          })),
+        };
+      }
+      if (name === "rawEvents") {
+        return { doc: jest.fn(() => ({ get: rawGet })) };
+      }
+      if (name === "dailyFacts") {
+        return { doc: jest.fn(() => ({ get: factsGet })) };
+      }
+      return {};
+    });
+
+    const out = await hydrateSleepNightPhysiologyMetrics("u1", baseView());
+    expect(out.sleepNight.lowestHeartRateBpm).toBe(50);
+    expect(out.sleepNight.averageHrvMs).toBe(23);
+    expect(rawGet).toHaveBeenCalled();
+  });
+
+  it("hydrates from nested payload on direct ouraVendorReadiness doc", async () => {
+    const directGet = jest.fn().mockImplementation((id: string) => {
+      if (id === "2026-05-14") {
+        return Promise.resolve({
+          exists: true,
+          id: "2026-05-14",
+          data: () => ({
+            day: "2026-05-14",
+            payload: { lowest_heart_rate: 50, average_hrv: 23 },
+          }),
+        });
+      }
+      return Promise.resolve({ exists: false });
+    });
+    const readinessGet = jest.fn().mockResolvedValue({ docs: [] });
+    const factsGet = jest.fn().mockResolvedValue({ exists: false });
+
+    userCollection.mockImplementation((_uid: string, name: string) => {
+      if (name === "ouraVendorReadiness") {
+        return {
+          doc: jest.fn((id: string) => ({ get: () => directGet(id) })),
+          where: jest.fn(() => ({
+            limit: jest.fn(() => ({ get: readinessGet })),
+          })),
+        };
+      }
+      if (name === "dailyFacts") {
+        return { doc: jest.fn(() => ({ get: factsGet })) };
+      }
+      return {};
+    });
+
+    const out = await hydrateSleepNightPhysiologyMetrics("u1", baseView());
+    expect(out.sleepNight.lowestHeartRateBpm).toBe(50);
+    expect(out.sleepNight.averageHrvMs).toBe(23);
+  });
+});

--- a/services/api/src/lib/__tests__/sleepNightRead.resolve.test.ts
+++ b/services/api/src/lib/__tests__/sleepNightRead.resolve.test.ts
@@ -1,0 +1,236 @@
+jest.mock("../../db", () => ({
+  userCollection: jest.fn(),
+  documentIdPath: { _: "documentId" },
+}));
+
+import { sleepNightDocumentSchema, type SleepNightDocumentDto } from "@oli/contracts/sleepNight";
+import { dayMinus, resolveSleepNightViewFromBoundedReads } from "../sleepNightRead";
+import { coerceRawSleepNightForRead } from "../sleepNightReadCoerce";
+
+function night(over: Partial<SleepNightDocumentDto> & Pick<SleepNightDocumentDto, "anchorDay" | "wakeDay">): SleepNightDocumentDto {
+  return {
+    provider: "oura",
+    source: "ouraVendorSleep",
+    sourceDocumentId: "x",
+    isComplete: true,
+    updatedAt: "2026-05-01T12:00:00.000Z",
+    ...over,
+  };
+}
+
+describe("resolveSleepNightViewFromBoundedReads", () => {
+  it("prefers exact anchor for D when endedAt was missing but inferrable, over D−1 wake_day", () => {
+    const rawExact: Record<string, unknown> = {
+      provider: "oura",
+      source: "ouraVendorSleep",
+      sourceDocumentId: "s13",
+      anchorDay: "2026-05-13",
+      isComplete: false,
+      startedAt: "2026-05-13T01:00:00.000Z",
+      mainSleepMinutes: 551,
+      totalSleepMinutes: 551,
+      efficiency: 0.92,
+      remMinutes: 124,
+      deepMinutes: 76,
+      score: 77,
+    };
+    const exactDto = sleepNightDocumentSchema.parse(coerceRawSleepNightForRead(rawExact, "2026-05-13"));
+    const minus1 = night({
+      anchorDay: "2026-05-12",
+      wakeDay: "2026-05-13",
+      endedAt: "2026-05-13T08:00:00.000Z",
+      mainSleepMinutes: 522,
+      score: 70,
+    });
+    const r = resolveSleepNightViewFromBoundedReads("2026-05-13", exactDto, minus1, null);
+    expect(r?.resolution).toBe("exact_anchor");
+    expect(r?.sleepNight.mainSleepMinutes).toBe(551);
+  });
+
+  it("returns exact_anchor when exact doc is complete", () => {
+    const exact = night({
+      anchorDay: "2026-05-10",
+      wakeDay: "2026-05-11",
+      endedAt: "2026-05-11T08:00:00.000Z",
+      score: 90,
+    });
+    const r = resolveSleepNightViewFromBoundedReads("2026-05-10", exact, null, null);
+    expect(r?.resolution).toBe("exact_anchor");
+    expect(r?.anchorDay).toBe("2026-05-10");
+    expect(r?.sleepNight.anchorDay).toBe("2026-05-10");
+  });
+
+  it("2026-05-14: complete exact anchor wins over older complete nights (no two-nights-ago fallback)", () => {
+    const exact = night({
+      anchorDay: "2026-05-14",
+      wakeDay: "2026-05-15",
+      endedAt: "2026-05-15T07:00:00.000Z",
+      score: 81,
+      mainSleepMinutes: 410,
+      totalSleepMinutes: 410,
+      remMinutes: 80,
+      deepMinutes: 52,
+      efficiency: 91,
+    });
+    const minus1 = night({
+      anchorDay: "2026-05-13",
+      wakeDay: "2026-05-14",
+      endedAt: "2026-05-14T06:00:00.000Z",
+      score: 40,
+      mainSleepMinutes: 300,
+    });
+    const minus2 = night({
+      anchorDay: "2026-05-12",
+      wakeDay: "2026-05-13",
+      endedAt: "2026-05-13T08:00:00.000Z",
+      score: 99,
+      mainSleepMinutes: 500,
+    });
+    const r = resolveSleepNightViewFromBoundedReads("2026-05-14", exact, minus1, minus2);
+    expect(r?.resolution).toBe("exact_anchor");
+    expect(r?.anchorDay).toBe("2026-05-14");
+    expect(r?.sleepNight.score).toBe(81);
+    expect(r?.sleepNight.totalSleepMinutes).toBe(410);
+    expect(r?.sleepNight.remMinutes).toBe(80);
+    expect(r?.sleepNight.deepMinutes).toBe(52);
+    expect(r?.sleepNight.efficiency).toBe(91);
+  });
+
+  it("for requested 2026-05-13 returns anchor 2026-05-12 when that night woke on the requested calendar day (wake_day)", () => {
+    const exact = night({ anchorDay: "2026-05-13", wakeDay: "2026-05-14", isComplete: false });
+    const d12 = night({
+      anchorDay: "2026-05-12",
+      wakeDay: "2026-05-13",
+      endedAt: "2026-05-13T07:00:00.000Z",
+      score: 77,
+      mainSleepMinutes: 530,
+    });
+    const r = resolveSleepNightViewFromBoundedReads("2026-05-13", exact, d12, null);
+    expect(r?.resolution).toBe("wake_day");
+    expect(r?.anchorDay).toBe("2026-05-12");
+    expect(r?.sleepNight.score).toBe(77);
+  });
+
+  it("2026-05-13 resolves wake_day when minus1 coerced from raw lacked wakeDay but has endedAt", () => {
+    const raw: Record<string, unknown> = {
+      provider: "oura",
+      source: "ouraVendorSleep",
+      sourceDocumentId: "s1",
+      totalSleepMinutes: 530,
+      mainSleepMinutes: 530,
+      endedAt: "2026-05-13T07:00:00.000Z",
+      isComplete: false,
+    };
+    const minus1 = sleepNightDocumentSchema.parse(coerceRawSleepNightForRead(raw, "2026-05-12"));
+    const exact = night({ anchorDay: "2026-05-13", wakeDay: "2026-05-14", isComplete: false });
+    const r = resolveSleepNightViewFromBoundedReads("2026-05-13", exact, minus1, null);
+    expect(r?.resolution).toBe("wake_day");
+    expect(r?.anchorDay).toBe("2026-05-12");
+  });
+
+  it("2026-05-13 resolves latest_completed_prior_night when wakeDay does not match but night is complete", () => {
+    const exact = night({ anchorDay: "2026-05-13", wakeDay: "2026-05-14", isComplete: false });
+    const d12 = night({
+      anchorDay: "2026-05-12",
+      wakeDay: "2026-05-14",
+      endedAt: "2026-05-14T05:00:00.000Z",
+      score: 77,
+      mainSleepMinutes: 530,
+    });
+    const r = resolveSleepNightViewFromBoundedReads("2026-05-13", exact, d12, null);
+    expect(r?.resolution).toBe("latest_completed_prior_night");
+    expect(r?.anchorDay).toBe("2026-05-12");
+  });
+
+  it("prefers wake_day over a complete prior night whose wakeDay does not match requested", () => {
+    const exact = night({ anchorDay: "2026-05-13", wakeDay: "2026-05-14", isComplete: false });
+    const d12 = night({
+      anchorDay: "2026-05-12",
+      wakeDay: "2026-05-13",
+      endedAt: "2026-05-13T07:00:00.000Z",
+      score: 55,
+    });
+    const d11 = night({
+      anchorDay: "2026-05-11",
+      wakeDay: "2026-05-12",
+      endedAt: "2026-05-13T22:00:00.000Z",
+      score: 99,
+    });
+    const r = resolveSleepNightViewFromBoundedReads("2026-05-13", exact, d12, d11);
+    expect(r?.resolution).toBe("wake_day");
+    expect(r?.anchorDay).toBe("2026-05-12");
+    expect(r?.sleepNight.score).toBe(55);
+  });
+
+  it("when multiple wake_day candidates exist, picks latest by endedAt", () => {
+    const exact = night({ anchorDay: "2026-05-13", wakeDay: "2026-05-14", isComplete: false });
+    const d12 = night({
+      anchorDay: "2026-05-12",
+      wakeDay: "2026-05-13",
+      endedAt: "2026-05-13T06:00:00.000Z",
+      score: 50,
+    });
+    const d11 = night({
+      anchorDay: "2026-05-11",
+      wakeDay: "2026-05-13",
+      endedAt: "2026-05-13T08:00:00.000Z",
+      score: 88,
+    });
+    const r = resolveSleepNightViewFromBoundedReads("2026-05-13", exact, d12, d11);
+    expect(r?.resolution).toBe("wake_day");
+    expect(r?.anchorDay).toBe("2026-05-11");
+    expect(r?.sleepNight.score).toBe(88);
+  });
+
+  it("when both day-1 and day-2 are generic candidates, picks latest by endedAt", () => {
+    const exact = night({ anchorDay: "2026-05-13", wakeDay: "2026-05-14", isComplete: false });
+    const d12 = night({
+      anchorDay: "2026-05-12",
+      wakeDay: "2026-05-14",
+      endedAt: "2026-05-14T05:00:00.000Z",
+      score: 60,
+    });
+    const d11 = night({
+      anchorDay: "2026-05-11",
+      wakeDay: "2026-05-14",
+      endedAt: "2026-05-14T09:00:00.000Z",
+      score: 70,
+    });
+    const r = resolveSleepNightViewFromBoundedReads("2026-05-13", exact, d12, d11);
+    expect(r?.resolution).toBe("latest_completed_prior_night");
+    expect(r?.anchorDay).toBe("2026-05-11");
+  });
+
+  it("does not look beyond day-2 (unrelated older row is not returned)", () => {
+    const exact = night({ anchorDay: "2026-05-13", wakeDay: "2026-05-14", isComplete: false });
+    const d12 = night({ anchorDay: "2026-05-12", wakeDay: "2026-05-13", isComplete: false });
+    const d11 = night({ anchorDay: "2026-05-11", wakeDay: "2026-05-12", isComplete: false });
+    const r = resolveSleepNightViewFromBoundedReads("2026-05-13", exact, d12, d11);
+    expect(r).toBeNull();
+  });
+
+  it("incomplete exact doc does not block complete prior-night doc", () => {
+    const exact = night({ anchorDay: "2026-05-13", wakeDay: "2026-05-14", isComplete: false, score: 99 });
+    const d12 = night({ anchorDay: "2026-05-12", wakeDay: "2026-05-13", score: 77, isComplete: true });
+    const r = resolveSleepNightViewFromBoundedReads("2026-05-13", exact, d12, null);
+    expect(r?.anchorDay).toBe("2026-05-12");
+    expect(r?.sleepNight.score).toBe(77);
+  });
+
+  it("returns null when bounded lookback has no complete night", () => {
+    const r = resolveSleepNightViewFromBoundedReads(
+      "2026-05-13",
+      night({ anchorDay: "2026-05-13", wakeDay: "2026-05-14", isComplete: false }),
+      night({ anchorDay: "2026-05-12", wakeDay: "2026-05-13", isComplete: false }),
+      null,
+    );
+    expect(r).toBeNull();
+  });
+});
+
+describe("dayMinus", () => {
+  it("subtracts UTC calendar days", () => {
+    expect(dayMinus("2026-05-13", 1)).toBe("2026-05-12");
+    expect(dayMinus("2026-05-13", 2)).toBe("2026-05-11");
+  });
+});

--- a/services/api/src/lib/oura/__tests__/ouraSleepPhysiology.test.ts
+++ b/services/api/src/lib/oura/__tests__/ouraSleepPhysiology.test.ts
@@ -1,0 +1,45 @@
+import {
+  pickOuraSleepAverageHrvMs,
+  pickOuraSleepLowestHeartRateBpm,
+  sleepRecordsForPick,
+} from "../ouraSleepPhysiology";
+
+describe("ouraSleepPhysiology", () => {
+  it("reads lowest_heart_rate and average_hrv from Oura sleep API snake_case", () => {
+    expect(pickOuraSleepLowestHeartRateBpm({ lowest_heart_rate: 50 })).toBe(50);
+    expect(pickOuraSleepAverageHrvMs({ average_hrv: 21 })).toBe(21);
+  });
+
+  it("reads camelCase fields", () => {
+    expect(pickOuraSleepLowestHeartRateBpm({ lowestHeartRateBpm: 50 })).toBe(50);
+    expect(pickOuraSleepAverageHrvMs({ averageHrvMs: 21 })).toBe(21);
+  });
+
+  it("reads nested payload fields", () => {
+    const doc = {
+      id: "s1",
+      payload: { lowest_heart_rate: 50, average_hrv: 21 },
+    };
+    expect(sleepRecordsForPick(doc)).toHaveLength(2);
+    expect(pickOuraSleepLowestHeartRateBpm(doc)).toBe(50);
+    expect(pickOuraSleepAverageHrvMs(doc)).toBe(21);
+  });
+
+  it("coerces numeric strings and ignores null", () => {
+    expect(pickOuraSleepLowestHeartRateBpm({ lowest_heart_rate: "50" })).toBe(50);
+    expect(pickOuraSleepAverageHrvMs({ average_hrv: "21" })).toBe(21);
+    expect(pickOuraSleepLowestHeartRateBpm({ lowest_heart_rate: null })).toBeUndefined();
+    expect(pickOuraSleepAverageHrvMs({ average_hrv: undefined })).toBeUndefined();
+  });
+
+  it("does not infer HRV from rmssd fields on sleep doc", () => {
+    expect(
+      pickOuraSleepAverageHrvMs({ rmssd_5min: 99 } as Record<string, unknown>),
+    ).toBeUndefined();
+  });
+
+  it("rejects out-of-range lowest HR", () => {
+    expect(pickOuraSleepLowestHeartRateBpm({ lowest_heart_rate: 10 })).toBeUndefined();
+    expect(pickOuraSleepLowestHeartRateBpm({ lowest_heart_rate: 300 })).toBeUndefined();
+  });
+});

--- a/services/api/src/lib/oura/__tests__/readinessForSleepNightMerge.test.ts
+++ b/services/api/src/lib/oura/__tests__/readinessForSleepNightMerge.test.ts
@@ -1,0 +1,174 @@
+import type { OuraSleepDocument } from "../../ouraApi";
+import {
+  buildSleepNightFirestorePayloadWithOuraReadiness,
+  enrichReadinessRecordWithRawPayload,
+  pickAverageHrvMsFromReadinessRecord,
+  pickLowestHeartRateBpmFromReadinessRecord,
+  readinessRecordsForPick,
+} from "../readinessForSleepNightMerge";
+
+describe("readinessForSleepNightMerge", () => {
+  it("reads physiology from Oura API snake_case", () => {
+    expect(
+      pickLowestHeartRateBpmFromReadinessRecord({ lowest_heart_rate: 50 }),
+    ).toBe(50);
+    expect(pickAverageHrvMsFromReadinessRecord({ average_hrv: 23 })).toBe(23);
+  });
+
+  it("reads physiology from vendor snapshot camelCase", () => {
+    expect(
+      pickLowestHeartRateBpmFromReadinessRecord({ lowestHeartRateBpm: 50 }),
+    ).toBe(50);
+    expect(pickAverageHrvMsFromReadinessRecord({ averageHrvMs: 23 })).toBe(23);
+  });
+
+  it("reads physiology from nested payload and numeric strings", () => {
+    const nested = {
+      day: "2026-05-15",
+      payload: { lowest_heart_rate: "50", average_hrv: "23" },
+    };
+    expect(readinessRecordsForPick(nested)).toHaveLength(2);
+    expect(pickLowestHeartRateBpmFromReadinessRecord(nested)).toBe(50);
+    expect(pickAverageHrvMsFromReadinessRecord(nested)).toBe(23);
+  });
+
+  it("reads HRV from rmssd_5min in nested payload when average_hrv absent", () => {
+    expect(
+      pickAverageHrvMsFromReadinessRecord({
+        payload: { rmssd_5min: 31 },
+      }),
+    ).toBe(31);
+  });
+
+  it("reads HRV from ingest rmssdMs on readiness or nested payload", () => {
+    expect(pickAverageHrvMsFromReadinessRecord({ rmssdMs: 23 })).toBe(23);
+    expect(
+      pickAverageHrvMsFromReadinessRecord({
+        payload: { rmssdMs: "31" },
+      }),
+    ).toBe(31);
+  });
+
+  it("merges readiness from persisted map when API docs are empty", () => {
+    const sleepDoc = {
+      id: "s_2026_05_14",
+      day: "2026-05-14",
+      bedtime_start: "2026-05-13T23:00:00.000Z",
+      total_sleep_duration: 24600,
+      score: 81,
+    } as unknown as OuraSleepDocument;
+
+    const persisted = new Map<string, Record<string, unknown>>([
+      [
+        "2026-05-14",
+        { day: "2026-05-14", lowestHeartRateBpm: 50, averageHrvMs: 23 },
+      ],
+    ]);
+
+    const built = buildSleepNightFirestorePayloadWithOuraReadiness(
+      sleepDoc,
+      "s_2026_05_14",
+      [],
+      persisted,
+    );
+    expect(built?.anchorDay).toBe("2026-05-14");
+    expect(built?.payload.lowestHeartRateBpm).toBe(50);
+    expect(built?.payload.averageHrvMs).toBe(23);
+  });
+
+  it("enriches vendor readiness with linked raw payload for picking", () => {
+    const vendor = { id: "r1", day: "2026-05-15", score: 78 };
+    const enriched = enrichReadinessRecordWithRawPayload(vendor, {
+      lowest_heart_rate: 50,
+      average_hrv: 23,
+    });
+    expect(pickLowestHeartRateBpmFromReadinessRecord(enriched)).toBe(50);
+    expect(pickAverageHrvMsFromReadinessRecord(enriched)).toBe(23);
+  });
+
+  it("merges physiology from persisted map with nested payload readiness", () => {
+    const sleepDoc = {
+      id: "s_2026_05_15",
+      day: "2026-05-15",
+      bedtime_start: "2026-05-14T23:00:00.000Z",
+      total_sleep_duration: 24600,
+      score: 81,
+    } as unknown as OuraSleepDocument;
+
+    const persisted = new Map<string, Record<string, unknown>>([
+      [
+        "2026-05-15",
+        {
+          day: "2026-05-15",
+          payload: { lowest_heart_rate: 50, average_hrv: 23 },
+        },
+      ],
+    ]);
+
+    const built = buildSleepNightFirestorePayloadWithOuraReadiness(
+      sleepDoc,
+      "s_2026_05_15",
+      [],
+      persisted,
+    );
+    expect(built?.payload.lowestHeartRateBpm).toBe(50);
+    expect(built?.payload.averageHrvMs).toBe(23);
+  });
+
+  it("2026-05-15: prefers Oura sleep document physiology over daily_readiness", () => {
+    const sleepDoc = {
+      id: "s_2026_05_15",
+      day: "2026-05-15",
+      bedtime_start: "2026-05-14T23:00:00.000Z",
+      bedtime_end: "2026-05-15T07:50:00.000Z",
+      total_sleep_duration: 24600,
+      score: 81,
+      lowest_heart_rate: 50,
+      average_hrv: 21,
+    } as unknown as OuraSleepDocument;
+
+    const apiDocs = [{ day: "2026-05-15", lowest_heart_rate: 48, average_hrv: 23 }];
+
+    const built = buildSleepNightFirestorePayloadWithOuraReadiness(
+      sleepDoc,
+      "s_2026_05_15",
+      apiDocs,
+    );
+    expect(built?.anchorDay).toBe("2026-05-15");
+    expect(built?.payload.lowestHeartRateBpm).toBe(50);
+    expect(built?.payload.averageHrvMs).toBe(21);
+    expect(built?.payload.physiologySource).toBe("oura_sleep_doc");
+  });
+
+  it("readiness fills gaps only when sleep doc lacks physiology fields", () => {
+    const sleepDoc = {
+      id: "s_no_phys",
+      day: "2026-05-15",
+      bedtime_start: "2026-05-14T23:00:00.000Z",
+      total_sleep_duration: 24600,
+    } as unknown as OuraSleepDocument;
+    const apiDocs = [{ day: "2026-05-15", lowest_heart_rate: 50, average_hrv: 21 }];
+    const built = buildSleepNightFirestorePayloadWithOuraReadiness(sleepDoc, "s_no_phys", apiDocs);
+    expect(built?.payload.lowestHeartRateBpm).toBe(50);
+    expect(built?.payload.averageHrvMs).toBe(21);
+    expect(built?.payload.physiologySource).toBe("oura_readiness");
+  });
+
+  it("prefers wake-day readiness row over anchor when both exist", () => {
+    const sleepDoc = {
+      id: "s1",
+      bed_time: "2026-05-13T22:00:00Z",
+      wake_time: "2026-05-14T07:00:00Z",
+      total_sleep_duration: 28800,
+    } as unknown as OuraSleepDocument;
+
+    const apiDocs = [
+      { day: "2026-05-14", lowest_heart_rate: 50, average_hrv: 23 },
+      { day: "2026-05-13", lowest_heart_rate: 99, average_hrv: 99 },
+    ];
+
+    const built = buildSleepNightFirestorePayloadWithOuraReadiness(sleepDoc, "s1", apiDocs);
+    expect(built?.payload.lowestHeartRateBpm).toBe(50);
+    expect(built?.payload.averageHrvMs).toBe(23);
+  });
+});

--- a/services/api/src/lib/oura/buildSleepNightFromOuraDocument.ts
+++ b/services/api/src/lib/oura/buildSleepNightFromOuraDocument.ts
@@ -1,0 +1,150 @@
+/**
+ * Build Firestore merge payload for `users/{uid}/sleepNights/{anchorDay}` from an Oura sleep API doc.
+ */
+
+import { localCalendarDayKeyFromIsoInTimeZone } from "@oli/contracts";
+
+import {
+  pickOuraSleepAverageHrvMs,
+  pickOuraSleepLowestHeartRateBpm,
+} from "./ouraSleepPhysiology";
+import {
+  normalizeOuraLatencyRawToMinutes,
+  resolveOuraSleepIngestBase,
+  type OuraSleepWindowDocument,
+} from "./resolveOuraSleepIngestBase";
+
+export type SleepNightBuildContext = {
+  /** Oura sleep document id (matches `users/{uid}/ouraVendorSleep/{id}` when present). */
+  sourceDocumentId: string;
+};
+
+function stripUndefined<T extends Record<string, unknown>>(obj: T): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v === undefined) continue;
+    if (v !== null && typeof v === "object" && !Array.isArray(v) && Object.getPrototypeOf(v) === Object.prototype) {
+      out[k] = stripUndefined(v as Record<string, unknown>);
+    } else {
+      out[k] = v;
+    }
+  }
+  return out;
+}
+
+function toYmd(iso: string): string {
+  return iso.slice(0, 10);
+}
+
+/**
+ * Coerce Oura sleep score / composite_score (number or digit string) to 0–100 integer.
+ */
+export function coerceOuraSleepScore0to100(raw: unknown): number | null {
+  if (typeof raw === "number" && Number.isFinite(raw)) {
+    return Math.round(Math.max(0, Math.min(100, raw)));
+  }
+  if (typeof raw === "string") {
+    const t = raw.trim();
+    if (t === "") return null;
+    const n = Number(t);
+    if (!Number.isFinite(n)) return null;
+    return Math.round(Math.max(0, Math.min(100, n)));
+  }
+  return null;
+}
+
+/**
+ * Build Firestore merge payload for `users/{uid}/sleepNights/{anchorDay}`.
+ * Returns null when bed/wake cannot be resolved (same gate as ingest).
+ */
+export function buildSleepNightFromOuraSleepDocument(
+  doc: OuraSleepWindowDocument,
+  ctx: SleepNightBuildContext,
+): { anchorDay: string; merge: Record<string, unknown> } | null {
+  const resolved = resolveOuraSleepIngestBase(doc);
+  if (!resolved) return null;
+
+  const { start, end, rollupDay: anchorDay } = resolved;
+  const wakeDay = localCalendarDayKeyFromIsoInTimeZone(end, "UTC") ?? toYmd(end);
+
+  const totalSec = typeof doc.total_sleep_duration === "number" ? doc.total_sleep_duration : null;
+  const totalSleepMinutes = totalSec != null && totalSec >= 0 ? Math.round(totalSec / 60) : undefined;
+
+  const remSec =
+    typeof (doc as { rem_sleep_duration?: number }).rem_sleep_duration === "number"
+      ? (doc as { rem_sleep_duration: number }).rem_sleep_duration
+      : null;
+  const remMinutes = remSec != null && remSec >= 0 ? Math.round(remSec / 60) : undefined;
+
+  const deepSec =
+    typeof (doc as { deep_sleep_duration?: number }).deep_sleep_duration === "number"
+      ? (doc as { deep_sleep_duration: number }).deep_sleep_duration
+      : null;
+  const deepMinutes = deepSec != null && deepSec >= 0 ? Math.round(deepSec / 60) : undefined;
+
+  const efficiencyRaw = doc.efficiency;
+  const efficiency =
+    typeof efficiencyRaw === "number" && Number.isFinite(efficiencyRaw) && efficiencyRaw >= 0 && efficiencyRaw <= 100
+      ? efficiencyRaw
+      : undefined;
+
+  const latencyRaw = doc.latency;
+  const latencyMinutes =
+    typeof latencyRaw === "number" && Number.isFinite(latencyRaw) && latencyRaw >= 0
+      ? normalizeOuraLatencyRawToMinutes(latencyRaw)
+      : undefined;
+
+  const score = coerceOuraSleepScore0to100(
+    (doc as { score?: unknown }).score ?? (doc as { composite_score?: unknown }).composite_score,
+  );
+
+  let remPercent: number | undefined;
+  let deepPercent: number | undefined;
+  if (typeof totalSleepMinutes === "number" && totalSleepMinutes > 0) {
+    if (typeof remMinutes === "number" && remMinutes >= 0) {
+      remPercent = Math.round((remMinutes / totalSleepMinutes) * 100);
+    }
+    if (typeof deepMinutes === "number" && deepMinutes >= 0) {
+      deepPercent = Math.round((deepMinutes / totalSleepMinutes) * 100);
+    }
+  }
+
+  const mainSleepMinutes = typeof totalSleepMinutes === "number" ? totalSleepMinutes : undefined;
+
+  const hasDuration =
+    (typeof totalSleepMinutes === "number" && totalSleepMinutes > 0) ||
+    (typeof mainSleepMinutes === "number" && mainSleepMinutes > 0);
+  const hasWakeOrEnd = typeof wakeDay === "string" && wakeDay.length > 0 && typeof end === "string";
+  const isComplete = Boolean(anchorDay && hasWakeOrEnd && hasDuration);
+
+  const base: Record<string, unknown> = {
+    anchorDay,
+    wakeDay,
+    provider: "oura",
+    source: "ouraVendorSleep",
+    sourceDocumentId: ctx.sourceDocumentId,
+    isComplete,
+    startedAt: start,
+    endedAt: end,
+  };
+
+  if (typeof totalSleepMinutes === "number") base.totalSleepMinutes = totalSleepMinutes;
+  if (typeof mainSleepMinutes === "number") base.mainSleepMinutes = mainSleepMinutes;
+  if (efficiency !== undefined) base.efficiency = efficiency;
+  if (typeof remMinutes === "number") base.remMinutes = remMinutes;
+  if (typeof remPercent === "number") base.remPercent = remPercent;
+  if (typeof deepMinutes === "number") base.deepMinutes = deepMinutes;
+  if (typeof deepPercent === "number") base.deepPercent = deepPercent;
+  if (typeof latencyMinutes === "number") base.latencyMinutes = latencyMinutes;
+  if (score != null) base.score = score;
+
+  const lowestHeartRateBpm = pickOuraSleepLowestHeartRateBpm(doc);
+  const averageHrvMs = pickOuraSleepAverageHrvMs(doc);
+  if (lowestHeartRateBpm !== undefined) base.lowestHeartRateBpm = lowestHeartRateBpm;
+  if (averageHrvMs !== undefined) base.averageHrvMs = averageHrvMs;
+  if (lowestHeartRateBpm !== undefined || averageHrvMs !== undefined) {
+    base.physiologySource = "oura_sleep_doc";
+  }
+
+  return { anchorDay, merge: stripUndefined(base) };
+}

--- a/services/api/src/lib/oura/ouraSleepPhysiology.ts
+++ b/services/api/src/lib/oura/ouraSleepPhysiology.ts
@@ -1,0 +1,127 @@
+/**
+ * Nightly lowest HR and average HRV from Oura API v2 sleep documents
+ * (`GET /v2/usercollection/sleep` — `lowest_heart_rate`, `average_hrv`).
+ * Matches Oura app sleep summary; not derived from heartrate/HRV time series.
+ */
+
+import { logger } from "../logger";
+import type { OuraSleepWindowDocument } from "./resolveOuraSleepIngestBase";
+
+function coerceOptionalNumber(val: unknown): number | undefined {
+  if (typeof val === "number" && Number.isFinite(val)) return val;
+  if (typeof val === "string") {
+    const t = val.trim();
+    if (t === "") return undefined;
+    const n = Number(t);
+    return Number.isFinite(n) ? n : undefined;
+  }
+  return undefined;
+}
+
+/** Top-level vendor/API row, then nested `payload` when present. */
+export function sleepRecordsForPick(raw: Record<string, unknown>): Record<string, unknown>[] {
+  const out: Record<string, unknown>[] = [raw];
+  const payload = raw.payload;
+  if (
+    payload != null &&
+    typeof payload === "object" &&
+    !Array.isArray(payload) &&
+    Object.getPrototypeOf(payload) === Object.prototype
+  ) {
+    out.push(payload as Record<string, unknown>);
+  }
+  return out;
+}
+
+/** Lowest heart rate (bpm) from Oura sleep period document only. */
+export function pickOuraSleepLowestHeartRateBpm(
+  doc: OuraSleepWindowDocument | Record<string, unknown>,
+): number | undefined {
+  for (const src of sleepRecordsForPick(doc as Record<string, unknown>)) {
+    for (const key of ["lowest_heart_rate", "lowestHeartRateBpm"] as const) {
+      const n = coerceOptionalNumber(src[key]);
+      if (n != null && n >= 30 && n <= 220) return Math.round(n);
+    }
+  }
+  return undefined;
+}
+
+/** Average HRV (ms) from Oura sleep `average_hrv` / `averageHrvMs` only — no RMSSD inference. */
+export function pickOuraSleepAverageHrvMs(
+  doc: OuraSleepWindowDocument | Record<string, unknown>,
+): number | undefined {
+  for (const src of sleepRecordsForPick(doc as Record<string, unknown>)) {
+    for (const key of ["average_hrv", "averageHrvMs"] as const) {
+      const n = coerceOptionalNumber(src[key]);
+      if (n != null && n >= 0) return Math.round(n);
+    }
+  }
+  return undefined;
+}
+
+/** @deprecated Use pickOuraSleepLowestHeartRateBpm */
+export const pickLowestHeartRateBpmFromOuraSleepDoc = pickOuraSleepLowestHeartRateBpm;
+
+/** @deprecated Use pickOuraSleepAverageHrvMs */
+export const pickAverageHrvMsFromOuraSleepDoc = pickOuraSleepAverageHrvMs;
+
+export type OuraSleepPhysiologyDebug = {
+  uid?: string;
+  day: string;
+  sourceEndpoint: string;
+  sleepDocId: string;
+  sleepDocKeys: string[];
+  hasLowestHeartRate: boolean;
+  lowestHeartRateRaw: unknown;
+  hasAverageHrv: boolean;
+  averageHrvRaw: unknown;
+  start: string | null;
+  end: string | null;
+};
+
+export function logOuraSleepPhysiologyDebugIfEnabled(debug: OuraSleepPhysiologyDebug): void {
+  if (
+    process.env.OURA_SLEEP_PHYSIOLOGY_DEBUG !== "1" &&
+    process.env.OURA_SLEEP_PHYSIOLOGY_DEBUG !== "true"
+  ) {
+    return;
+  }
+  logger.info({
+    msg: "[OURA_SLEEP_PHYSIOLOGY_DEBUG]",
+    ...debug,
+  });
+}
+
+/** Emit debug line for one Oura sleep API document (pull-now / snapshot write). */
+export function logOuraSleepPhysiologyDebugForDoc(
+  doc: OuraSleepWindowDocument | Record<string, unknown>,
+  ctx: {
+    uid?: string;
+    day: string;
+    sourceEndpoint?: string;
+    sleepDocId: string;
+    start?: string | null;
+    end?: string | null;
+  },
+): void {
+  const rec = doc as Record<string, unknown>;
+  const payload =
+    rec.payload != null && typeof rec.payload === "object" && !Array.isArray(rec.payload)
+      ? (rec.payload as Record<string, unknown>)
+      : null;
+  const lowestRaw = rec.lowest_heart_rate ?? rec.lowestHeartRateBpm ?? payload?.lowest_heart_rate ?? payload?.lowestHeartRateBpm;
+  const hrvRaw = rec.average_hrv ?? rec.averageHrvMs ?? payload?.average_hrv ?? payload?.averageHrvMs;
+  logOuraSleepPhysiologyDebugIfEnabled({
+    ...(ctx.uid != null ? { uid: ctx.uid } : {}),
+    day: ctx.day,
+    sourceEndpoint: ctx.sourceEndpoint ?? "GET /v2/usercollection/sleep",
+    sleepDocId: ctx.sleepDocId,
+    sleepDocKeys: Object.keys(rec).sort(),
+    hasLowestHeartRate: pickOuraSleepLowestHeartRateBpm(doc) !== undefined,
+    lowestHeartRateRaw: lowestRaw ?? null,
+    hasAverageHrv: pickOuraSleepAverageHrvMs(doc) !== undefined,
+    averageHrvRaw: hrvRaw ?? null,
+    start: ctx.start ?? null,
+    end: ctx.end ?? null,
+  });
+}

--- a/services/api/src/lib/oura/readinessForSleepNightMerge.ts
+++ b/services/api/src/lib/oura/readinessForSleepNightMerge.ts
@@ -1,0 +1,369 @@
+/**
+ * Match Oura daily_readiness rows to a sleep night and merge persisted HRV / lowest HR fields.
+ */
+
+import { buildSleepNightFromOuraSleepDocument } from "./buildSleepNightFromOuraDocument";
+import {
+  pickOuraReadinessAverageHrvMs,
+  pickOuraReadinessLowestHeartRateBpm,
+  type OuraDailyReadinessDocument,
+} from "../ouraApi";
+import { logger } from "../logger";
+import type { OuraSleepWindowDocument } from "./resolveOuraSleepIngestBase";
+
+function toYmd(iso: string): string {
+  return iso.slice(0, 10);
+}
+
+function coerceOptionalNumber(val: unknown): number | null {
+  if (typeof val === "number" && Number.isFinite(val)) return val;
+  if (typeof val === "string") {
+    const t = val.trim();
+    if (t === "") return null;
+    const n = Number(t);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
+/** Coerce snake_case API numeric fields (incl. digit strings) before Oura API pickers run. */
+function readinessDocWithCoercedApiNumbers(raw: Record<string, unknown>): OuraDailyReadinessDocument {
+  const out: Record<string, unknown> = { ...raw };
+  for (const key of [
+    "lowest_heart_rate",
+    "average_hrv",
+    "rmssd_5min",
+    "rmssd_5min_balance",
+    "average_heart_rate",
+  ] as const) {
+    const n = coerceOptionalNumber(raw[key]);
+    if (n != null) out[key] = n;
+  }
+  return out as OuraDailyReadinessDocument;
+}
+
+/**
+ * Records to scan for physiology: top-level vendor/API row, then nested raw `payload` when present.
+ */
+export function readinessRecordsForPick(raw: Record<string, unknown>): Record<string, unknown>[] {
+  const out: Record<string, unknown>[] = [raw];
+  const payload = raw.payload;
+  if (
+    payload != null &&
+    typeof payload === "object" &&
+    !Array.isArray(payload) &&
+    Object.getPrototypeOf(payload) === Object.prototype
+  ) {
+    out.push(payload as Record<string, unknown>);
+  }
+  return out;
+}
+
+/**
+ * Attach linked Oura ingest `rawEvents.payload` when vendor snapshot omitted nested/raw fields.
+ * Does not invent values — only exposes payload already stored on the raw row.
+ */
+export function enrichReadinessRecordWithRawPayload(
+  vendor: Record<string, unknown>,
+  rawPayload: Record<string, unknown> | null | undefined,
+): Record<string, unknown> {
+  if (!rawPayload || typeof rawPayload !== "object" || Array.isArray(rawPayload)) {
+    return vendor;
+  }
+  const existing = vendor.payload;
+  if (
+    existing != null &&
+    typeof existing === "object" &&
+    !Array.isArray(existing) &&
+    Object.getPrototypeOf(existing) === Object.prototype
+  ) {
+    return vendor;
+  }
+  return { ...vendor, payload: rawPayload };
+}
+
+/** Top-level + nested payload keys (for debug / verify scripts). */
+export function listReadinessRecordKeysForDebug(raw: Record<string, unknown>): string[] {
+  const keys = new Set<string>();
+  for (const rec of readinessRecordsForPick(raw)) {
+    for (const k of Object.keys(rec)) keys.add(k);
+  }
+  return [...keys].sort();
+}
+
+export function readinessDayFromOuraReadinessDoc(doc: OuraDailyReadinessDocument): string | null {
+  if (typeof doc.day === "string" && /^\d{4}-\d{2}-\d{2}$/.test(doc.day)) return doc.day;
+  if (typeof doc.timestamp === "string" && doc.timestamp.length >= 10) return toYmd(doc.timestamp);
+  return null;
+}
+
+/** Day key from API doc, vendor snapshot (`day` / `id`), or Firestore doc id. */
+export function readinessDayFromReadinessRecord(
+  raw: Record<string, unknown>,
+  docId?: string,
+): string | null {
+  const fromApi = readinessDayFromOuraReadinessDoc(raw as OuraDailyReadinessDocument);
+  if (fromApi) return fromApi;
+  const dayField = typeof raw.day === "string" ? raw.day.trim() : "";
+  if (/^\d{4}-\d{2}-\d{2}$/.test(dayField)) return dayField;
+  const id = typeof raw.id === "string" ? raw.id.trim() : docId?.trim() ?? "";
+  if (/^\d{4}-\d{2}-\d{2}$/.test(id)) return id;
+  const m = /^oura_readiness_(\d{4}-\d{2}-\d{2})$/.exec(id);
+  return m?.[1] ?? null;
+}
+
+/** Prefer readiness row for wake calendar day, then rollup anchor day (Oura daily_readiness `day`). */
+export function findReadinessDocumentForSleepNight(
+  anchorDay: string,
+  wakeDay: string | undefined | null,
+  readinessDocs: OuraDailyReadinessDocument[],
+): OuraDailyReadinessDocument | null {
+  if (readinessDocs.length === 0) return null;
+  const wake = typeof wakeDay === "string" && wakeDay.length > 0 ? wakeDay : null;
+  if (wake) {
+    const byWake = readinessDocs.find((d) => readinessDayFromOuraReadinessDoc(d) === wake);
+    if (byWake) return byWake;
+  }
+  return readinessDocs.find((d) => readinessDayFromOuraReadinessDoc(d) === anchorDay) ?? null;
+}
+
+export function findPersistedReadinessRecord(
+  anchorDay: string,
+  wakeDay: string | null,
+  byDay: Map<string, Record<string, unknown>>,
+): Record<string, unknown> | null {
+  const keys = wakeDay ? [wakeDay, anchorDay] : [anchorDay];
+  for (const k of keys) {
+    const r = byDay.get(k);
+    if (r) return r;
+  }
+  return null;
+}
+
+/** Oura API snake_case + vendor camelCase + nested payload + numeric strings. */
+export function pickAverageHrvMsFromReadinessRecord(raw: Record<string, unknown>): number | null {
+  for (const src of readinessRecordsForPick(raw)) {
+    const fromApi = pickOuraReadinessAverageHrvMs(readinessDocWithCoercedApiNumbers(src));
+    if (fromApi != null) return fromApi;
+    const camel = coerceOptionalNumber(src.averageHrvMs);
+    if (camel != null && camel >= 0) return Math.round(camel);
+    /** Oura ingest / canonical HRV raw payload (ms). */
+    const ingestRmssd = coerceOptionalNumber(src.rmssdMs);
+    if (ingestRmssd != null && ingestRmssd >= 0) return Math.round(ingestRmssd);
+  }
+  return null;
+}
+
+export function pickLowestHeartRateBpmFromReadinessRecord(raw: Record<string, unknown>): number | null {
+  for (const src of readinessRecordsForPick(raw)) {
+    const fromApi = pickOuraReadinessLowestHeartRateBpm(readinessDocWithCoercedApiNumbers(src));
+    if (fromApi != null) return fromApi;
+    const camel = coerceOptionalNumber(src.lowestHeartRateBpm);
+    if (camel != null && camel >= 30 && camel <= 220) return Math.round(camel);
+  }
+  return null;
+}
+
+/** Mutates `merge` with first non-null physiology values from each source (in order). Readiness is fallback only. */
+export function mergePhysiologySourcesIntoSleepNightPayload(
+  merge: Record<string, unknown>,
+  sources: (Record<string, unknown> | null | undefined)[],
+): void {
+  for (const src of sources) {
+    if (!src) continue;
+    let filled = false;
+    if (merge.averageHrvMs == null) {
+      const hrv = pickAverageHrvMsFromReadinessRecord(src);
+      if (hrv != null) {
+        merge.averageHrvMs = hrv;
+        filled = true;
+      }
+    }
+    if (merge.lowestHeartRateBpm == null) {
+      const lhr = pickLowestHeartRateBpmFromReadinessRecord(src);
+      if (lhr != null) {
+        merge.lowestHeartRateBpm = lhr;
+        filled = true;
+      }
+    }
+    if (filled && merge.physiologySource !== "oura_sleep_doc") {
+      merge.physiologySource = "oura_readiness";
+    }
+    if (merge.averageHrvMs != null && merge.lowestHeartRateBpm != null) break;
+  }
+}
+
+/** @deprecated Use mergePhysiologySourcesIntoSleepNightPayload */
+export function mergeOuraReadinessMetricsIntoSleepNightPayload(
+  merge: Record<string, unknown>,
+  readiness: OuraDailyReadinessDocument | null,
+): void {
+  mergePhysiologySourcesIntoSleepNightPayload(merge, readiness ? [readiness as Record<string, unknown>] : []);
+}
+
+export type SleepNightReadinessMergeDebug = {
+  sleepAnchorDay: string;
+  readinessDay: string | null;
+  matched: boolean;
+  lowestHeartRateCandidate: number | null;
+  averageHrvCandidate: number | null;
+  mergedPayloadKeys: string[];
+  source: "api" | "persisted" | "none";
+};
+
+export function logSleepNightReadinessMergeDebugIfEnabled(debug: SleepNightReadinessMergeDebug): void {
+  if (
+    process.env.SLEEP_NIGHT_READINESS_MERGE_DEBUG !== "1" &&
+    process.env.SLEEP_NIGHT_READINESS_MERGE_DEBUG !== "true"
+  ) {
+    return;
+  }
+  logger.info({
+    msg: "[SLEEP_NIGHT_READINESS_MERGE_DEBUG]",
+    ...debug,
+  });
+}
+
+export type SleepNightPhysiologyDebug = {
+  uid?: string;
+  requestedDay?: string;
+  sleepAnchorDay: string;
+  wakeDay: string | null;
+  readinessDocFound: boolean;
+  readinessDay: string | null;
+  readinessKeys: string[];
+  pickedLowestHeartRateBpm: number | null;
+  pickedAverageHrvMs: number | null;
+  writePayloadKeys: string[];
+  readHydrationSource: "sleep_night" | "readiness" | "daily_facts" | "write" | "none";
+};
+
+export function logSleepNightPhysiologyDebugIfEnabled(debug: SleepNightPhysiologyDebug): void {
+  if (
+    process.env.SLEEP_NIGHT_PHYSIOLOGY_DEBUG !== "1" &&
+    process.env.SLEEP_NIGHT_PHYSIOLOGY_DEBUG !== "true"
+  ) {
+    return;
+  }
+  logger.info({
+    msg: "[SLEEP_NIGHT_PHYSIOLOGY_DEBUG]",
+    ...debug,
+  });
+}
+
+export function collectReadinessLookupDaysForSleepPairs(
+  pairs: { doc: OuraSleepWindowDocument; snapshot: { id: string } }[],
+): string[] {
+  const days = new Set<string>();
+  for (const { doc, snapshot } of pairs) {
+    const built = buildSleepNightFromOuraSleepDocument(doc, { sourceDocumentId: snapshot.id });
+    if (!built) continue;
+    days.add(built.anchorDay);
+    const wake = typeof built.merge.wakeDay === "string" ? built.merge.wakeDay : null;
+    if (wake) days.add(wake);
+  }
+  return [...days];
+}
+
+/** Load `ouraVendorReadiness` by calendar day (doc id `YYYY-MM-DD` or `day` field). */
+export async function loadPersistedOuraVendorReadinessByDaysFromCollection(
+  col: FirebaseFirestore.CollectionReference,
+  days: string[],
+): Promise<Map<string, Record<string, unknown>>> {
+  const map = new Map<string, Record<string, unknown>>();
+  const unique = [...new Set(days.filter((d) => /^\d{4}-\d{2}-\d{2}$/.test(d)))];
+  await Promise.all(
+    unique.map(async (day) => {
+      const byId = await col.doc(day).get();
+      if (byId.exists) {
+        map.set(day, byId.data() as Record<string, unknown>);
+        return;
+      }
+      const byOuraId = await col.doc(`oura_readiness_${day}`).get();
+      if (byOuraId.exists) {
+        map.set(day, byOuraId.data() as Record<string, unknown>);
+        return;
+      }
+      const q = await col.where("day", "==", day).limit(5).get();
+      for (const doc of q.docs) {
+        const raw = doc.data() as Record<string, unknown>;
+        const key = readinessDayFromReadinessRecord(raw, doc.id) ?? day;
+        if (/^\d{4}-\d{2}-\d{2}$/.test(key) && !map.has(key)) {
+          map.set(key, raw);
+        }
+      }
+    }),
+  );
+  return map;
+}
+
+export type BuildSleepNightPhysiologyDebugContext = {
+  uid?: string;
+  requestedDay?: string;
+};
+
+/**
+ * Merge payload for `users/{uid}/sleepNights/{anchorDay}` from Oura sleep + readiness (API + persisted).
+ * Sleep-period `lowest_heart_rate` / `average_hrv` are set in `buildSleepNightFromOuraSleepDocument`;
+ * readiness fills only missing fields.
+ */
+export function buildSleepNightFirestorePayloadWithOuraReadiness(
+  doc: OuraSleepWindowDocument,
+  sourceDocumentId: string,
+  readinessDocs: OuraDailyReadinessDocument[] | undefined,
+  persistedReadinessByDay?: Map<string, Record<string, unknown>>,
+  physiologyDebug?: BuildSleepNightPhysiologyDebugContext,
+): { anchorDay: string; payload: Record<string, unknown> } | null {
+  const built = buildSleepNightFromOuraSleepDocument(doc, { sourceDocumentId });
+  if (!built) return null;
+  const merge: Record<string, unknown> = { ...built.merge };
+  const wake = typeof merge.wakeDay === "string" ? merge.wakeDay : null;
+  const apiRd = findReadinessDocumentForSleepNight(built.anchorDay, wake, readinessDocs ?? []);
+  const persistedRd = findPersistedReadinessRecord(
+    built.anchorDay,
+    wake,
+    persistedReadinessByDay ?? new Map(),
+  );
+  mergePhysiologySourcesIntoSleepNightPayload(merge, [
+    apiRd as Record<string, unknown> | null,
+    persistedRd,
+  ]);
+
+  const matchedRecord = apiRd ?? persistedRd;
+  const readinessDay =
+    matchedRecord != null
+      ? readinessDayFromReadinessRecord(matchedRecord as Record<string, unknown>)
+      : null;
+
+  logSleepNightReadinessMergeDebugIfEnabled({
+    sleepAnchorDay: built.anchorDay,
+    readinessDay,
+    matched: matchedRecord != null,
+    lowestHeartRateCandidate: pickLowestHeartRateBpmFromReadinessRecord(
+      (matchedRecord ?? {}) as Record<string, unknown>,
+    ),
+    averageHrvCandidate: pickAverageHrvMsFromReadinessRecord(
+      (matchedRecord ?? {}) as Record<string, unknown>,
+    ),
+    mergedPayloadKeys: ["lowestHeartRateBpm", "averageHrvMs"].filter((k) => merge[k] != null),
+    source: apiRd ? "api" : persistedRd ? "persisted" : "none",
+  });
+
+  const writePayloadKeys = ["lowestHeartRateBpm", "averageHrvMs"].filter((k) => merge[k] != null);
+  logSleepNightPhysiologyDebugIfEnabled({
+    ...(physiologyDebug?.uid != null ? { uid: physiologyDebug.uid } : {}),
+    requestedDay: physiologyDebug?.requestedDay ?? built.anchorDay,
+    sleepAnchorDay: built.anchorDay,
+    wakeDay: wake,
+    readinessDocFound: matchedRecord != null,
+    readinessDay,
+    readinessKeys: matchedRecord != null ? listReadinessRecordKeysForDebug(matchedRecord as Record<string, unknown>) : [],
+    pickedLowestHeartRateBpm:
+      typeof merge.lowestHeartRateBpm === "number" ? (merge.lowestHeartRateBpm as number) : null,
+    pickedAverageHrvMs: typeof merge.averageHrvMs === "number" ? (merge.averageHrvMs as number) : null,
+    writePayloadKeys,
+    readHydrationSource: writePayloadKeys.length > 0 ? "write" : "none",
+  });
+
+  return { anchorDay: built.anchorDay, payload: merge };
+}

--- a/services/api/src/lib/oura/resolveOuraSleepIngestBase.ts
+++ b/services/api/src/lib/oura/resolveOuraSleepIngestBase.ts
@@ -1,0 +1,87 @@
+/**
+ * Shared Oura sleep window + rollup day resolution.
+ * Used by API ingest, vendor snapshots, SleepNight build, and Cloud Functions post-raw.
+ */
+
+import { localCalendarDayKeyFromIsoInTimeZone } from "@oli/contracts";
+
+/** Minimal Oura v2 sleep document shape for resolution (matches services/api OuraSleepDocument fields used here). */
+export type OuraSleepWindowDocument = Record<string, unknown> & {
+  id?: string;
+  day?: string;
+  bed_time?: string;
+  wake_time?: string;
+  end_time?: string;
+  bedtime_start?: string;
+  bedtime_end?: string;
+  start?: string;
+  end?: string;
+  total_sleep_duration?: number;
+};
+
+function toYmd(iso: string): string {
+  return iso.slice(0, 10);
+}
+
+function isYmdDateString(value: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}$/.test(value);
+}
+
+function getSleepStart(doc: OuraSleepWindowDocument): string | null {
+  const s =
+    doc.bed_time ??
+    doc.bedtime_start ??
+    doc.start ??
+    doc.end_time ??
+    doc.end ??
+    null;
+  return typeof s === "string" && s.length > 0 ? s : null;
+}
+
+function getSleepEnd(doc: OuraSleepWindowDocument): string | null {
+  const e =
+    doc.wake_time ??
+    doc.bedtime_end ??
+    doc.end ??
+    doc.end_time ??
+    null;
+  return typeof e === "string" && e.length > 0 ? e : null;
+}
+
+/** Wake-time ISO for pull-now diagnostics (same field resolution as ingest). */
+export function ouraSleepWakeIsoForLog(doc: OuraSleepWindowDocument): string | null {
+  return getSleepEnd(doc);
+}
+
+/**
+ * Align with GET /users/me/oura-sleep-view: Oura may return latency as seconds (typically ≥ 60);
+ * smaller values are treated as minutes.
+ */
+export function normalizeOuraLatencyRawToMinutes(latencyRaw: number): number {
+  return latencyRaw >= 60 ? Math.round(latencyRaw / 60) : Math.round(latencyRaw);
+}
+
+/**
+ * Resolved sleep window + logical rollup day for Oura sleep docs.
+ * Shared by raw-event ingest, vendor snapshots, and canonical SleepNight anchor day.
+ */
+export function resolveOuraSleepIngestBase(
+  doc: OuraSleepWindowDocument,
+): { start: string; end: string; rollupDay: string } | null {
+  const start = getSleepStart(doc);
+  let end = getSleepEnd(doc);
+  const totalSec = typeof doc.total_sleep_duration === "number" ? doc.total_sleep_duration : 0;
+  if (start && !end && totalSec > 0) {
+    const startMs = Date.parse(start);
+    if (!Number.isNaN(startMs)) {
+      end = new Date(startMs + totalSec * 1000).toISOString();
+    }
+  }
+  if (!start || !end) return null;
+
+  const providerDay = typeof doc.day === "string" && isYmdDateString(doc.day) ? doc.day : null;
+  const rollupDay =
+    providerDay ?? localCalendarDayKeyFromIsoInTimeZone(end, "UTC") ?? toYmd(end);
+
+  return { start, end, rollupDay };
+}

--- a/services/api/src/lib/ouraApi.ts
+++ b/services/api/src/lib/ouraApi.ts
@@ -3,8 +3,14 @@
  * Used by POST /integrations/oura/pull-now. OAuth token URL and scopes match integrations.ts.
  */
 
-import { localCalendarDayKeyFromIsoInTimeZone } from "@oli/contracts";
 import { logger } from "./logger";
+import {
+  normalizeOuraLatencyRawToMinutes,
+  ouraSleepWakeIsoForLog,
+  resolveOuraSleepIngestBase,
+} from "./oura/resolveOuraSleepIngestBase";
+
+export { normalizeOuraLatencyRawToMinutes, ouraSleepWakeIsoForLog, resolveOuraSleepIngestBase };
 
 const OURA_TOKEN_URL = "https://api.ouraring.com/oauth/token";
 const OURA_API_BASE = "https://api.ouraring.com/v2/usercollection";
@@ -41,6 +47,10 @@ export type OuraSleepDocument = {
   restful_sleep?: number | null;
   awake_time?: number | null;
   type?: string;
+  /** Lowest HR during this sleep period (bpm) — matches Oura app sleep summary. */
+  lowest_heart_rate?: number | null;
+  /** Average HRV during this sleep period (ms). */
+  average_hrv?: number | null;
   [key: string]: unknown;
 };
 
@@ -50,8 +60,14 @@ export type OuraDailyReadinessDocument = {
   day?: string;
   timestamp?: string;
   score?: number | null;
+  /** Legacy / alternate HRV fields (ms) when present. */
   rmssd_5min?: number | null;
   rmssd_5min_balance?: number | null;
+  /** Public daily_readiness model: nightly HRV aggregate in ms (see Oura API v2 docs). */
+  average_hrv?: number | null;
+  /** Nightly average heart rate (bpm) — used for resting HR proxy when present. */
+  average_heart_rate?: number | null;
+  lowest_heart_rate?: number | null;
   [key: string]: unknown;
 };
 
@@ -439,6 +455,8 @@ export type OuraHrvIngestItem = {
   rmssdMs?: number | null;
   sdnnMs?: number | null;
   measurementType?: "nightly" | "spot";
+  /** From daily_readiness `average_heart_rate` / `lowest_heart_rate` when present (bpm). */
+  restingHeartRateBpm?: number | null;
 };
 
 /** Steps-like item from Oura daily_activity (maps to canonical steps). */
@@ -477,65 +495,11 @@ function toYmd(iso: string): string {
   return iso.slice(0, 10);
 }
 
-function isYmdDateString(value: string): boolean {
-  return /^\d{4}-\d{2}-\d{2}$/.test(value);
-}
-
-/**
- * Normalize sleep window start from Oura sleep doc (supports bed_time, bedtime_start, start, end_time).
- * Oura API v2 can return bed_time/wake_time or bedtime_start/bedtime_end or start/end.
- */
-function getSleepStart(doc: OuraSleepDocument): string | null {
-  const s =
-    doc.bed_time ??
-    doc.bedtime_start ??
-    (doc as { start?: string }).start ??
-    doc.end_time ??
-    (doc as { end?: string }).end ??
-    null;
-  return typeof s === "string" && s.length > 0 ? s : null;
-}
-
-/**
- * Normalize sleep window end from Oura sleep doc (supports wake_time, bedtime_end, end, end_time).
- */
-function getSleepEnd(doc: OuraSleepDocument): string | null {
-  const e =
-    doc.wake_time ??
-    doc.bedtime_end ??
-    (doc as { end?: string }).end ??
-    doc.end_time ??
-    null;
-  return typeof e === "string" && e.length > 0 ? e : null;
-}
-
-/**
- * Wake-time ISO for pull-now diagnostics (same field resolution as ingest).
- */
-export function ouraSleepWakeIsoForLog(doc: OuraSleepDocument): string | null {
-  return getSleepEnd(doc);
-}
-
-/**
- * Align with GET /users/me/oura-sleep-view (`usersMe.ts`): Oura may return latency as seconds
- * (typically ≥ 60); smaller values are treated as minutes.
- */
-export function normalizeOuraLatencyRawToMinutes(latencyRaw: number): number {
-  return latencyRaw >= 60 ? Math.round(latencyRaw / 60) : Math.round(latencyRaw);
-}
-
 export function mapOuraSleepToIngestItem(doc: OuraSleepDocument): OuraSleepIngestItem | null {
-  const start = getSleepStart(doc);
-  let end = getSleepEnd(doc);
+  const resolved = resolveOuraSleepIngestBase(doc);
+  if (!resolved) return null;
+  const { start, end, rollupDay } = resolved;
   const totalSec = typeof doc.total_sleep_duration === "number" ? doc.total_sleep_duration : 0;
-  // When Oura omits wake/bedtime_end but provides duration, infer end so we still write a sleep rawEvent.
-  if (start && !end && totalSec > 0) {
-    const startMs = Date.parse(start);
-    if (!Number.isNaN(startMs)) {
-      end = new Date(startMs + totalSec * 1000).toISOString();
-    }
-  }
-  if (!start || !end) return null;
 
   const totalMinutes = Math.round(totalSec / 60);
   const efficiencyRaw = doc.efficiency;
@@ -568,14 +532,6 @@ export function mapOuraSleepToIngestItem(doc: OuraSleepDocument): OuraSleepInges
   const id = doc.id ?? `oura_sleep_${start}`;
   const isMainSleep = doc.type === "long_sleep" || doc.type === "sleep";
 
-  const providerDay =
-    typeof doc.day === "string" && isYmdDateString(doc.day) ? doc.day : null;
-  /** Prefer Oura `day`; else wake calendar day in UTC (matches normalization fallback without API day). */
-  const rollupDay =
-    providerDay ??
-    localCalendarDayKeyFromIsoInTimeZone(end, "UTC") ??
-    toYmd(end);
-
   return {
     idempotencyKey: String(id),
     start,
@@ -592,6 +548,41 @@ export function mapOuraSleepToIngestItem(doc: OuraSleepDocument): OuraSleepInges
   };
 }
 
+/** RMSSD / balance first, then `average_hrv` — matches canonical HRV ingest expectations. */
+function pickOuraReadinessRmssdMsForHrvIngest(doc: OuraDailyReadinessDocument): number | null {
+  const candidates = [doc.rmssd_5min, doc.rmssd_5min_balance, doc.average_hrv];
+  for (const c of candidates) {
+    if (typeof c === "number" && Number.isFinite(c) && c >= 0) return c;
+  }
+  return null;
+}
+
+export function pickOuraReadinessAverageHrvMs(doc: OuraDailyReadinessDocument): number | null {
+  if (typeof doc.average_hrv === "number" && Number.isFinite(doc.average_hrv) && doc.average_hrv >= 0) {
+    return doc.average_hrv;
+  }
+  const cands = [doc.rmssd_5min, doc.rmssd_5min_balance];
+  for (const c of cands) {
+    if (typeof c === "number" && Number.isFinite(c) && c >= 0) return c;
+  }
+  return null;
+}
+
+/** Lowest heart rate (bpm) from Oura daily_readiness only — not average HR. */
+export function pickOuraReadinessLowestHeartRateBpm(doc: OuraDailyReadinessDocument): number | null {
+  const low = doc.lowest_heart_rate;
+  if (typeof low === "number" && Number.isFinite(low) && low >= 30 && low <= 220) return Math.round(low);
+  return null;
+}
+
+function pickOuraReadinessRestingHeartRateBpm(doc: OuraDailyReadinessDocument): number | null {
+  const avg = doc.average_heart_rate;
+  if (typeof avg === "number" && Number.isFinite(avg) && avg >= 30 && avg <= 220) return avg;
+  const low = doc.lowest_heart_rate;
+  if (typeof low === "number" && Number.isFinite(low) && low >= 30 && low <= 220) return low;
+  return null;
+}
+
 export function mapOuraReadinessToHrvItem(
   doc: OuraDailyReadinessDocument,
 ): OuraHrvIngestItem | null {
@@ -600,8 +591,8 @@ export function mapOuraReadinessToHrvItem(
   if (!day || !time) return null;
 
   const id = doc.id ?? `oura_hrv_${day}`;
-  const rmssd = doc.rmssd_5min ?? doc.rmssd_5min_balance;
-  const rmssdMs = typeof rmssd === "number" && rmssd >= 0 ? rmssd : null;
+  const rmssdMs = pickOuraReadinessRmssdMsForHrvIngest(doc);
+  const restingHeartRateBpm = pickOuraReadinessRestingHeartRateBpm(doc);
 
   return {
     idempotencyKey: String(id),
@@ -609,6 +600,7 @@ export function mapOuraReadinessToHrvItem(
     timezone: "UTC",
     day,
     ...(rmssdMs != null ? { rmssdMs } : {}),
+    ...(restingHeartRateBpm != null ? { restingHeartRateBpm } : {}),
     measurementType: "nightly",
   };
 }

--- a/services/api/src/lib/ouraIngestWrite.ts
+++ b/services/api/src/lib/ouraIngestWrite.ts
@@ -202,6 +202,7 @@ async function writeHrvLoop(
       ...(item.rmssdMs != null ? { rmssdMs: item.rmssdMs } : {}),
       ...(item.sdnnMs != null ? { sdnnMs: item.sdnnMs } : {}),
       ...(item.measurementType != null ? { measurementType: item.measurementType } : {}),
+      ...(item.restingHeartRateBpm != null ? { restingHeartRateBpm: item.restingHeartRateBpm } : {}),
     };
     const doc = {
       id: item.idempotencyKey,

--- a/services/api/src/lib/ouraVendorSleepDayBackfill.ts
+++ b/services/api/src/lib/ouraVendorSleepDayBackfill.ts
@@ -1,0 +1,108 @@
+/**
+ * Plan Oura vendor sleep snapshot `day` alignment against ingest rollup
+ * (`resolveOuraSleepIngestBase`). Uses only the paired `rawEvents` sleep row
+ * (same document id as vendor snapshot); does not invent bed/wake times.
+ */
+
+import type { OuraSleepDocument } from "./ouraApi";
+import { resolveOuraSleepIngestBase } from "./ouraApi";
+
+export const OURA_VENDOR_SLEEP_DAY_MIGRATION_VERSION = 1;
+
+export type VendorSleepDayPlan =
+  | { status: "aligned"; storedDay: string; rollupDay: string }
+  | { status: "change"; storedDay: string; rollupDay: string; vendorDocId: string }
+  | { status: "skip"; vendorDocId: string; reason: string; storedDay?: string };
+
+function isYmd(value: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}$/.test(value);
+}
+
+/**
+ * Build a minimal Oura API-shaped sleep doc from an Oura-ingested raw sleep `payload`
+ * (see `ouraIngestWrite` sleep shape). Returns null if start/end are missing.
+ */
+export function buildOuraSleepDocumentFromOuraIngestSleepPayload(
+  rawEventId: string,
+  payload: Record<string, unknown>,
+): OuraSleepDocument | null {
+  const start = typeof payload.start === "string" && payload.start.length > 0 ? payload.start : null;
+  const end = typeof payload.end === "string" && payload.end.length > 0 ? payload.end : null;
+  if (!start || !end) return null;
+
+  const apiDay = typeof payload.day === "string" && isYmd(payload.day) ? payload.day : undefined;
+  const totalMinutes = typeof payload.totalMinutes === "number" && Number.isFinite(payload.totalMinutes)
+    ? payload.totalMinutes
+    : 0;
+  const total_sleep_duration = Math.max(0, Math.round(totalMinutes * 60));
+
+  const doc: OuraSleepDocument = {
+    id: rawEventId,
+    start,
+    end,
+    total_sleep_duration,
+  };
+  if (apiDay) {
+    doc.day = apiDay;
+  }
+  return doc;
+}
+
+/**
+ * Raw Firestore `rawEvents` document data for an Oura sleep row (caller verifies kind/sourceId).
+ */
+export function planOuraVendorSleepDayFromRaw(
+  vendorDocId: string,
+  storedDay: string | null | undefined,
+  rawPayload: Record<string, unknown> | null | undefined,
+): VendorSleepDayPlan {
+  if (typeof storedDay !== "string" || !isYmd(storedDay)) {
+    if (typeof storedDay === "string") {
+      return { status: "skip", vendorDocId, reason: "invalid_or_missing_stored_day", storedDay };
+    }
+    return { status: "skip", vendorDocId, reason: "invalid_or_missing_stored_day" };
+  }
+
+  if (!rawPayload || typeof rawPayload !== "object") {
+    return { status: "skip", vendorDocId, reason: "missing_raw_payload", storedDay };
+  }
+
+  const doc = buildOuraSleepDocumentFromOuraIngestSleepPayload(vendorDocId, rawPayload);
+  if (!doc) {
+    return { status: "skip", vendorDocId, reason: "insufficient_raw_payload", storedDay };
+  }
+
+  const resolved = resolveOuraSleepIngestBase(doc);
+  if (!resolved) {
+    return { status: "skip", vendorDocId, reason: "unresolvable_sleep_window", storedDay };
+  }
+
+  const { rollupDay } = resolved;
+  if (rollupDay === storedDay) {
+    return { status: "aligned", storedDay, rollupDay };
+  }
+  return { status: "change", storedDay, rollupDay, vendorDocId };
+}
+
+export type VendorSleepDayMigrationWriteFields = {
+  day: string;
+  migratedAt: unknown;
+  migrationVersion: typeof OURA_VENDOR_SLEEP_DAY_MIGRATION_VERSION;
+};
+
+export function buildVendorSleepDayMigrationWritePatch(input: {
+  rollupDay: string;
+  migratedAt: unknown;
+}): VendorSleepDayMigrationWriteFields {
+  return {
+    day: input.rollupDay,
+    migratedAt: input.migratedAt,
+    migrationVersion: OURA_VENDOR_SLEEP_DAY_MIGRATION_VERSION,
+  };
+}
+
+/** Caller should skip vendor doc if raw row is not Oura-ingested sleep (same id). */
+export function isOuraIngestedSleepRawEvent(raw: Record<string, unknown> | undefined): boolean {
+  if (!raw || typeof raw !== "object") return false;
+  return raw.kind === "sleep" && raw.sourceId === "oura" && raw.provider === "manual";
+}

--- a/services/api/src/lib/ouraVendorSnapshot.ts
+++ b/services/api/src/lib/ouraVendorSnapshot.ts
@@ -4,7 +4,27 @@
  * Called from performOuraPullNowCore after fetch; does not replace canonical sleep/HRV writes.
  */
 
-import type { OuraSleepDocument, OuraDailyReadinessDocument } from "./ouraApi";
+import {
+  resolveOuraSleepIngestBase,
+  type OuraDailyReadinessDocument,
+  type OuraSleepDocument,
+} from "./ouraApi";
+import {
+  buildSleepNightFirestorePayloadWithOuraReadiness,
+  collectReadinessLookupDaysForSleepPairs,
+  loadPersistedOuraVendorReadinessByDaysFromCollection,
+  pickAverageHrvMsFromReadinessRecord,
+  pickLowestHeartRateBpmFromReadinessRecord,
+} from "./oura/readinessForSleepNightMerge";
+import {
+  logOuraSleepPhysiologyDebugForDoc,
+  pickOuraSleepAverageHrvMs,
+  pickOuraSleepLowestHeartRateBpm,
+} from "./oura/ouraSleepPhysiology";
+import { coerceOuraSleepScore0to100 } from "./sleepNight";
+import { FieldValue, userCollection } from "../db";
+import type { OuraSleepSnapshot, OuraReadinessSnapshot } from "@oli/contracts";
+import { logger } from "./logger";
 
 export type OuraSnapshotWriteResult = {
   attempted: number;
@@ -12,9 +32,6 @@ export type OuraSnapshotWriteResult = {
   skippedMissingDay: number;
   errors: number;
 };
-import type { OuraSleepSnapshot, OuraReadinessSnapshot } from "@oli/contracts";
-import { userCollection } from "../db";
-import { logger } from "./logger";
 
 /** Firestore batch limit is 500; use a smaller chunk to stay safe. */
 const BATCH_CHUNK_SIZE = 450;
@@ -194,26 +211,19 @@ function buildSleepContributors(doc: OuraSleepDocument): Record<string, number> 
   return out;
 }
 
-/** Derive sleep window start from doc (Oura v2 can use bed_time, bedtime_start, start, or end_time). */
-function getSleepStartForSnapshot(doc: OuraSleepDocument): string | null {
-  const s =
-    doc.bed_time ??
-    (doc as { bedtime_start?: string }).bedtime_start ??
-    (doc as { start?: string }).start ??
-    doc.end_time ??
-    (doc as { end?: string }).end ??
-    null;
-  return typeof s === "string" && s.length > 0 ? s : null;
-}
-
-function extractSleepSnapshot(doc: OuraSleepDocument, fetchedAt: string): OuraSleepSnapshot | null {
-  const start = getSleepStartForSnapshot(doc);
-  const day = start ? toYmd(start) : null;
-  if (!day) return null;
+function extractSleepSnapshot(
+  doc: OuraSleepDocument,
+  fetchedAt: string,
+  debugCtx?: { uid?: string },
+): OuraSleepSnapshot | null {
+  const resolved = resolveOuraSleepIngestBase(doc);
+  if (!resolved) return null;
+  const { start, end, rollupDay: day } = resolved;
 
   const id = doc.id ?? `oura_sleep_${start}`;
-  const scoreRaw = (doc as { score?: number }).score ?? (doc as { composite_score?: number }).composite_score;
-  const score = typeof scoreRaw === "number" && !Number.isNaN(scoreRaw) ? scoreRaw : null;
+  const score = coerceOuraSleepScore0to100(
+    (doc as { score?: unknown }).score ?? (doc as { composite_score?: unknown }).composite_score,
+  );
   const contributors = buildSleepContributors(doc);
 
   const out: Record<string, unknown> = {
@@ -223,7 +233,7 @@ function extractSleepSnapshot(doc: OuraSleepDocument, fetchedAt: string): OuraSl
     fetchedAt,
     updatedAt: fetchedAt,
   };
-  if (typeof score === "number") out.score = score;
+  if (score != null) out.score = score;
   if (Object.keys(contributors).length > 0) {
     out.contributors = stripUndefined(contributors as unknown as Record<string, unknown>);
   }
@@ -237,6 +247,20 @@ function extractSleepSnapshot(doc: OuraSleepDocument, fetchedAt: string): OuraSl
   if (typeof (doc as { deep_sleep_duration?: number }).deep_sleep_duration === "number") {
     out.deepSleep = (doc as { deep_sleep_duration: number }).deep_sleep_duration;
   }
+  const lhr = pickOuraSleepLowestHeartRateBpm(doc);
+  const hrv = pickOuraSleepAverageHrvMs(doc);
+  if (lhr !== undefined) out.lowestHeartRateBpm = lhr;
+  if (hrv !== undefined) out.averageHrvMs = hrv;
+  out.payload = stripUndefined(doc as Record<string, unknown>);
+
+  logOuraSleepPhysiologyDebugForDoc(doc, {
+    ...(debugCtx?.uid != null ? { uid: debugCtx.uid } : {}),
+    day,
+    sleepDocId: String(id),
+    start,
+    end,
+  });
+
   return out as OuraSleepSnapshot;
 }
 
@@ -261,6 +285,13 @@ function extractReadinessSnapshot(
   };
   if (typeof score === "number") out.score = score;
   if (contributors && typeof contributors === "object") out.contributors = contributors;
+  const asRecord = doc as Record<string, unknown>;
+  const hrv = pickAverageHrvMsFromReadinessRecord(asRecord);
+  const lhr = pickLowestHeartRateBpmFromReadinessRecord(asRecord);
+  if (hrv != null) out.averageHrvMs = hrv;
+  if (lhr != null) out.lowestHeartRateBpm = lhr;
+  /** Preserve full Oura API document for read-time / backfill picks when field names vary by API version. */
+  out.payload = stripUndefined(asRecord);
   return out as OuraReadinessSnapshot;
 }
 
@@ -272,6 +303,7 @@ export async function writeOuraVendorSleepSnapshots(
   uid: string,
   docs: OuraSleepDocument[],
   requestId: string,
+  readinessDocs?: OuraDailyReadinessDocument[],
 ): Promise<OuraSnapshotWriteResult> {
   logger.info({
     msg: "oura_sleep_snapshot_docs_received",
@@ -281,15 +313,16 @@ export async function writeOuraVendorSleepSnapshots(
   });
 
   const col = userCollection(uid, "ouraVendorSleep");
+  const sleepNightsCol = userCollection(uid, "sleepNights");
   const fetchedAt = new Date().toISOString();
   let written = 0;
   let skippedMissingDay = 0;
   let errors = 0;
 
-  const snapshots: OuraSleepSnapshot[] = [];
+  const pairs: { doc: OuraSleepDocument; snapshot: OuraSleepSnapshot }[] = [];
   let droppedSampleKeys: string[] | undefined;
   for (const doc of docs) {
-    const snapshot = extractSleepSnapshot(doc, fetchedAt);
+    const snapshot = extractSleepSnapshot(doc, fetchedAt, { uid });
     if (!snapshot) {
       skippedMissingDay += 1;
       if (!droppedSampleKeys && doc && typeof doc === "object") {
@@ -297,8 +330,10 @@ export async function writeOuraVendorSleepSnapshots(
       }
       continue;
     }
-    snapshots.push(snapshot);
+    pairs.push({ doc, snapshot });
   }
+
+  const snapshots = pairs.map((p) => p.snapshot);
 
   if (droppedSampleKeys !== undefined && skippedMissingDay > 0) {
     logger.info({
@@ -318,7 +353,43 @@ export async function writeOuraVendorSleepSnapshots(
     requestId,
     sleepDocsReceived: docs.length,
     sleepSnapshotsExtracted: snapshots.length,
+    readinessDocsForMerge: readinessDocs?.length ?? 0,
   });
+
+  const readinessCol = userCollection(uid, "ouraVendorReadiness");
+  const lookupDays = collectReadinessLookupDaysForSleepPairs(pairs);
+  const persistedReadinessByDay = await loadPersistedOuraVendorReadinessByDaysFromCollection(
+    readinessCol as FirebaseFirestore.CollectionReference,
+    lookupDays,
+  );
+
+  if (process.env.OURA_SLEEP_SNAPSHOT_WRITE_AUDIT === "1" || process.env.OURA_SLEEP_SNAPSHOT_WRITE_AUDIT === "true") {
+    for (const { doc, snapshot } of pairs) {
+      const merged = buildSleepNightFirestorePayloadWithOuraReadiness(
+        doc,
+        snapshot.id,
+        readinessDocs,
+        persistedReadinessByDay,
+        { uid, requestedDay: snapshot.day },
+      );
+      const merge = merged?.payload;
+      logger.info({
+        msg: "[OURA_SLEEP_SNAPSHOT_WRITE_AUDIT]",
+        uid,
+        sourceDocumentId: snapshot.id,
+        vendorDay: snapshot.day,
+        anchorDay: merged?.anchorDay ?? null,
+        wakeDay: typeof merge?.wakeDay === "string" ? merge.wakeDay : null,
+        score: typeof merge?.score === "number" ? merge.score : null,
+        totalSleepMinutes: typeof merge?.totalSleepMinutes === "number" ? merge.totalSleepMinutes : null,
+        lowestHeartRateBpm: typeof merge?.lowestHeartRateBpm === "number" ? merge.lowestHeartRateBpm : null,
+        averageHrvMs: typeof merge?.averageHrvMs === "number" ? merge.averageHrvMs : null,
+        wroteVendorSleep: true,
+        wroteSleepNight: merged != null,
+        skippedReason: merged == null ? "sleep_night_build_failed" : null,
+      });
+    }
+  }
 
   for (let i = 0; i < snapshots.length; i += BATCH_CHUNK_SIZE) {
     const chunk = snapshots.slice(i, i + BATCH_CHUNK_SIZE);
@@ -365,11 +436,89 @@ export async function writeOuraVendorSleepSnapshots(
     sleepSnapshotsErrors: errors,
   });
 
+  let sleepNightsWritten = 0;
+  let sleepNightsErrors = 0;
+  for (let i = 0; i < pairs.length; i += BATCH_CHUNK_SIZE) {
+    const chunk = pairs.slice(i, i + BATCH_CHUNK_SIZE);
+    const batch = (col as FirebaseFirestore.CollectionReference).firestore.batch();
+    let ops = 0;
+    for (const { doc, snapshot } of chunk) {
+      const merged = buildSleepNightFirestorePayloadWithOuraReadiness(
+        doc,
+        snapshot.id,
+        readinessDocs,
+        persistedReadinessByDay,
+        { uid, requestedDay: snapshot.day },
+      );
+      if (!merged) continue;
+      batch.set(
+        sleepNightsCol.doc(merged.anchorDay),
+        stripUndefined({
+          ...merged.payload,
+          updatedAt: FieldValue.serverTimestamp(),
+        } as Record<string, unknown>),
+        { merge: true },
+      );
+      ops += 1;
+    }
+    if (ops === 0) continue;
+    try {
+      await batch.commit();
+      sleepNightsWritten += ops;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error({
+        msg: "sleep_night_batch_error",
+        uid,
+        requestId,
+        chunkSize: chunk.length,
+        err: message,
+      });
+      for (const { doc, snapshot } of chunk) {
+        const merged = buildSleepNightFirestorePayloadWithOuraReadiness(
+          doc,
+          snapshot.id,
+          readinessDocs,
+          persistedReadinessByDay,
+          { uid, requestedDay: snapshot.day },
+        );
+        if (!merged) continue;
+        try {
+          await sleepNightsCol.doc(merged.anchorDay).set(
+            stripUndefined({
+              ...merged.payload,
+              updatedAt: FieldValue.serverTimestamp(),
+            } as Record<string, unknown>),
+            { merge: true },
+          );
+          sleepNightsWritten += 1;
+        } catch (singleErr) {
+          sleepNightsErrors += 1;
+          logger.error({
+            msg: "sleep_night_write_error",
+            uid,
+            requestId,
+            anchorDay: merged.anchorDay,
+            err: singleErr instanceof Error ? singleErr.message : String(singleErr),
+          });
+        }
+      }
+    }
+  }
+
+  logger.info({
+    msg: "sleep_night_written_after_vendor_sleep",
+    uid,
+    requestId,
+    sleepNightsWritten,
+    sleepNightsErrors,
+  });
+
   return {
     attempted: docs.length,
     written,
     skippedMissingDay,
-    errors,
+    errors: errors + sleepNightsErrors,
   };
 }
 

--- a/services/api/src/lib/sleepNight.ts
+++ b/services/api/src/lib/sleepNight.ts
@@ -1,0 +1,10 @@
+/**
+ * Canonical SleepNight read model from Oura sleep API / ingest-shaped documents.
+ * Anchor day matches `resolveOuraSleepIngestBase` rollup semantics (same as vendor snapshot `day`).
+ */
+
+export type { SleepNightBuildContext } from "./oura/buildSleepNightFromOuraDocument";
+export {
+  buildSleepNightFromOuraSleepDocument,
+  coerceOuraSleepScore0to100,
+} from "./oura/buildSleepNightFromOuraDocument";

--- a/services/api/src/lib/sleepNightFirestore.ts
+++ b/services/api/src/lib/sleepNightFirestore.ts
@@ -1,0 +1,20 @@
+/** Convert Firestore Timestamp-like fields to ISO strings for JSON + Zod parsing. */
+function isFirestoreTimestampLike(v: unknown): v is { toDate: () => Date } {
+  return (
+    v != null &&
+    typeof v === "object" &&
+    typeof (v as { toDate?: unknown }).toDate === "function"
+  );
+}
+
+export function firestoreDocToPlainJson(obj: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (isFirestoreTimestampLike(v)) {
+      out[k] = v.toDate().toISOString();
+    } else {
+      out[k] = v;
+    }
+  }
+  return out;
+}

--- a/services/api/src/lib/sleepNightRead.ts
+++ b/services/api/src/lib/sleepNightRead.ts
@@ -1,0 +1,347 @@
+import {
+  sleepNightDocumentSchema,
+  type SleepNightDocumentDto,
+  type SleepNightViewDto,
+} from "@oli/contracts/sleepNight";
+
+import { userCollection } from "../db";
+import { firestoreDocToPlainJson } from "./sleepNightFirestore";
+import { logger } from "./logger";
+import {
+  enrichReadinessRecordWithRawPayload,
+  listReadinessRecordKeysForDebug,
+  logSleepNightPhysiologyDebugIfEnabled,
+  pickAverageHrvMsFromReadinessRecord,
+  pickLowestHeartRateBpmFromReadinessRecord,
+  readinessDayFromReadinessRecord,
+} from "./oura/readinessForSleepNightMerge";
+import { coerceRawSleepNightForRead } from "./sleepNightReadCoerce";
+
+/** Minimal snapshot surface (avoids runtime firebase-admin resolution in Jest). */
+type SleepNightDocSnapshot = {
+  exists: boolean;
+  id: string;
+  data: () => Record<string, unknown> | undefined;
+};
+
+export function dayMinus(day: string, days: number): string {
+  const d = new Date(day + "T12:00:00.000Z");
+  d.setUTCDate(d.getUTCDate() - days);
+  return d.toISOString().slice(0, 10);
+}
+
+function parseSleepNightSnapshot(snap: SleepNightDocSnapshot): SleepNightDocumentDto | null {
+  if (!snap.exists) return null;
+  const raw = snap.data() as Record<string, unknown> | undefined;
+  if (!raw) return null;
+  const flat = firestoreDocToPlainJson(raw);
+  const merged = coerceRawSleepNightForRead(flat, snap.id);
+  const parsed = sleepNightDocumentSchema.safeParse(merged);
+  return parsed.success ? parsed.data : null;
+}
+
+function notFoundReason(args: {
+  exactExists: boolean;
+  exact: SleepNightDocumentDto | null;
+  minus1Exists: boolean;
+  minus1: SleepNightDocumentDto | null;
+  minus2Exists: boolean;
+  minus2: SleepNightDocumentDto | null;
+}): string {
+  const parts: string[] = [];
+  if (args.exactExists && args.exact == null) parts.push("exact_parse_failed");
+  if (args.minus1Exists && args.minus1 == null) parts.push("minus1_parse_failed");
+  if (args.minus2Exists && args.minus2 == null) parts.push("minus2_parse_failed");
+  const anyParsed = args.exact != null || args.minus1 != null || args.minus2 != null;
+  const anyComplete =
+    args.exact?.isComplete === true ||
+    args.minus1?.isComplete === true ||
+    args.minus2?.isComplete === true;
+  if (anyParsed && !anyComplete) parts.push("no_complete_doc_in_window");
+  if (!args.exactExists && !args.minus1Exists && !args.minus2Exists) parts.push("no_docs_in_window");
+  if (parts.length === 0) parts.push("no_complete_match");
+  return parts.join(",");
+}
+
+/** Latest by `endedAt`, then by `anchorDay` (ascending sort → take last). */
+export function pickLatestCompleteSleepNight(nights: SleepNightDocumentDto[]): SleepNightDocumentDto | null {
+  const complete = nights.filter((n) => n.isComplete);
+  if (complete.length === 0) return null;
+  complete.sort((a, b) => {
+    const endA = a.endedAt ?? "";
+    const endB = b.endedAt ?? "";
+    if (endA !== endB) return endA.localeCompare(endB);
+    return a.anchorDay.localeCompare(b.anchorDay);
+  });
+  return complete[complete.length - 1] ?? null;
+}
+
+function dedupeDayKeys(days: (string | undefined)[]): string[] {
+  const out: string[] = [];
+  for (const d of days) {
+    if (typeof d !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(d)) continue;
+    if (!out.includes(d)) out.push(d);
+  }
+  return out;
+}
+
+/**
+ * When `sleepNights` predates readiness merge, fill lowest HR / average HRV from persisted
+ * `ouraVendorReadiness` (same-day order: wake → anchor → requested), then `dailyFacts` HRV only.
+ */
+export async function hydrateSleepNightPhysiologyMetrics(
+  uid: string,
+  view: SleepNightViewDto,
+): Promise<SleepNightViewDto> {
+  const night = view.sleepNight;
+  const hasLowest = typeof night.lowestHeartRateBpm === "number" && Number.isFinite(night.lowestHeartRateBpm);
+  const hasHrv = typeof night.averageHrvMs === "number" && Number.isFinite(night.averageHrvMs);
+  if (hasLowest && hasHrv) return view;
+
+  let lowest: number | null = hasLowest ? night.lowestHeartRateBpm! : null;
+  let hrv: number | null = hasHrv ? night.averageHrvMs! : null;
+
+  let readinessDocFound = false;
+  let readinessDay: string | null = null;
+  let readinessKeys: string[] = [];
+  let readHydrationSource: "sleep_night" | "readiness" | "daily_facts" | "none" = hasLowest && hasHrv
+    ? "sleep_night"
+    : "none";
+
+  const readinessCol = userCollection(uid, "ouraVendorReadiness");
+  const rawEventsCol = userCollection(uid, "rawEvents");
+
+  const tryReadinessRecord = async (raw: Record<string, unknown>, docId?: string) => {
+    readinessDocFound = true;
+    const rd = readinessDayFromReadinessRecord(raw, docId) ?? null;
+    if (rd) readinessDay = rd;
+    readinessKeys = listReadinessRecordKeysForDebug(raw);
+
+    const applyPick = (rec: Record<string, unknown>) => {
+      if (lowest == null) {
+        const l = pickLowestHeartRateBpmFromReadinessRecord(rec);
+        if (l != null) {
+          lowest = l;
+          if (!hasLowest) readHydrationSource = "readiness";
+        }
+      }
+      if (hrv == null) {
+        const h = pickAverageHrvMsFromReadinessRecord(rec);
+        if (h != null) {
+          hrv = h;
+          if (!hasHrv) readHydrationSource = "readiness";
+        }
+      }
+    };
+
+    applyPick(raw);
+    if (lowest != null && hrv != null) return;
+
+    const linkedId =
+      (typeof raw.id === "string" && raw.id.trim().length > 0 ? raw.id.trim() : null) ??
+      (typeof docId === "string" && docId.trim().length > 0 ? docId.trim() : null);
+    if (!linkedId) return;
+
+    const rawSnap = await rawEventsCol.doc(linkedId).get();
+    if (!rawSnap.exists) return;
+    const rawRow = rawSnap.data() as Record<string, unknown>;
+    const payload =
+      rawRow.payload && typeof rawRow.payload === "object" && !Array.isArray(rawRow.payload)
+        ? (rawRow.payload as Record<string, unknown>)
+        : null;
+    if (!payload) return;
+    const enriched = enrichReadinessRecordWithRawPayload(raw, payload);
+    readinessKeys = listReadinessRecordKeysForDebug(enriched);
+    applyPick(enriched);
+    if (hrv == null && linkedId) {
+      const evSnap = await userCollection(uid, "events").doc(linkedId).get();
+      if (evSnap.exists) {
+        const ev = evSnap.data() as Record<string, unknown>;
+        const rmssd = ev.rmssdMs;
+        if (typeof rmssd === "number" && Number.isFinite(rmssd) && rmssd >= 0) {
+          hrv = Math.round(rmssd);
+          if (!hasHrv) readHydrationSource = "daily_facts";
+        }
+      }
+    }
+  };
+
+  for (const day of dedupeDayKeys([night.wakeDay, night.anchorDay, view.requestedDay])) {
+    if (lowest != null && hrv != null) break;
+    const direct = await readinessCol.doc(day).get();
+    if (direct.exists) {
+      await tryReadinessRecord(direct.data() as Record<string, unknown>, direct.id);
+    } else {
+      const alt = await readinessCol.doc(`oura_readiness_${day}`).get();
+      if (alt.exists) {
+        await tryReadinessRecord(alt.data() as Record<string, unknown>, alt.id);
+      }
+    }
+    if (lowest != null && hrv != null) break;
+    const snap = await readinessCol.where("day", "==", day).limit(10).get();
+    for (const doc of snap.docs) {
+      if (lowest != null && hrv != null) break;
+      await tryReadinessRecord(doc.data() as Record<string, unknown>, doc.id);
+    }
+  }
+
+  if (hrv == null) {
+    const factsSnap = await userCollection(uid, "dailyFacts").doc(view.requestedDay).get();
+    if (factsSnap.exists) {
+      const data = factsSnap.data() as Record<string, unknown>;
+      const energy = data.energyInfluencers as Record<string, unknown> | undefined;
+      const phys = energy?.physiology as Record<string, unknown> | undefined;
+      const recovery = data.recovery as Record<string, unknown> | undefined;
+      const physMs = phys?.hrvRmssdMs;
+      const recMs = recovery?.hrvRmssd;
+      const pick =
+        typeof physMs === "number" && Number.isFinite(physMs) && physMs >= 0
+          ? physMs
+          : typeof recMs === "number" && Number.isFinite(recMs) && recMs >= 0
+            ? recMs
+            : null;
+      if (pick != null) {
+        hrv = Math.round(pick);
+        if (!hasHrv) readHydrationSource = "daily_facts";
+      }
+    }
+  }
+
+  const patch: Partial<SleepNightDocumentDto> = {};
+  if (!hasLowest && lowest != null) patch.lowestHeartRateBpm = lowest;
+  if (!hasHrv && hrv != null) patch.averageHrvMs = hrv;
+
+  logSleepNightPhysiologyDebugIfEnabled({
+    uid,
+    requestedDay: view.requestedDay,
+    sleepAnchorDay: night.anchorDay,
+    wakeDay: night.wakeDay ?? null,
+    readinessDocFound,
+    readinessDay,
+    readinessKeys,
+    pickedLowestHeartRateBpm: !hasLowest && lowest != null ? lowest : hasLowest ? night.lowestHeartRateBpm ?? null : null,
+    pickedAverageHrvMs: !hasHrv && hrv != null ? hrv : hasHrv ? night.averageHrvMs ?? null : null,
+    writePayloadKeys: [],
+    readHydrationSource: Object.keys(patch).length > 0 ? readHydrationSource : "none",
+  });
+
+  if (Object.keys(patch).length === 0) return view;
+
+  const candidate = { ...night, ...patch };
+  const parsed = sleepNightDocumentSchema.safeParse(candidate);
+  if (!parsed.success) return view;
+  return { ...view, sleepNight: parsed.data };
+}
+
+/**
+ * Bounded resolution for `GET /users/me/sleep-night` (max lookback: anchors `day-1`, `day-2` only).
+ * Complete nights only. Caller supplies reads for exact path + two prior anchors.
+ *
+ * Order (matches Sleep “Today” when `sleepNights/{D}` is complete after read coercion):
+ * 1. `sleepNights/{requestedDay}` when **complete** (Oura rollup / anchor day = calendar day).
+ * 2. Latest complete night among `day−1` / `day−2` with **`wakeDay === requestedDay`** (prior physiological night that woke on D).
+ * 3. Otherwise latest complete among `day−1` / `day−2` by `endedAt` (bounded fallback).
+ */
+export function resolveSleepNightViewFromBoundedReads(
+  requestedDay: string,
+  exact: SleepNightDocumentDto | null,
+  minus1: SleepNightDocumentDto | null,
+  minus2: SleepNightDocumentDto | null,
+): SleepNightViewDto | null {
+  const priorAnchors = [minus1, minus2].filter((n): n is SleepNightDocumentDto => n != null);
+
+  if (exact?.isComplete === true) {
+    return {
+      requestedDay,
+      anchorDay: exact.anchorDay,
+      wakeDay: exact.wakeDay,
+      resolution: "exact_anchor",
+      isFallback: false,
+      sleepNight: exact,
+    };
+  }
+
+  const wakeMatches = priorAnchors.filter((n) => n.isComplete && n.wakeDay === requestedDay);
+  const bestWake = pickLatestCompleteSleepNight(wakeMatches);
+  if (bestWake != null) {
+    return {
+      requestedDay,
+      anchorDay: bestWake.anchorDay,
+      wakeDay: bestWake.wakeDay,
+      resolution: "wake_day",
+      isFallback: false,
+      sleepNight: bestWake,
+    };
+  }
+
+  const bestPrior = pickLatestCompleteSleepNight(priorAnchors);
+  if (bestPrior != null) {
+    return {
+      requestedDay,
+      anchorDay: bestPrior.anchorDay,
+      wakeDay: bestPrior.wakeDay,
+      resolution: "latest_completed_prior_night",
+      isFallback: false,
+      sleepNight: bestPrior,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Resolve canonical SleepNight for calendar `requestedDay` (Dash: show latest completed prior night when needed).
+ *
+ * Set `SLEEP_NIGHT_READ_DEBUG=1` to emit one structured `[SLEEP_NIGHT_READ_DEBUG]` log line per request (Cloud Run).
+ */
+export async function loadSleepNightView(uid: string, requestedDay: string): Promise<SleepNightViewDto | null> {
+  const col = userCollection(uid, "sleepNights");
+  const d1 = dayMinus(requestedDay, 1);
+  const d2 = dayMinus(requestedDay, 2);
+
+  const [exactSnap, s1, s2] = await Promise.all([
+    col.doc(requestedDay).get(),
+    col.doc(d1).get(),
+    col.doc(d2).get(),
+  ]);
+
+  const exact = parseSleepNightSnapshot(exactSnap);
+  const minus1 = parseSleepNightSnapshot(s1);
+  const minus2 = parseSleepNightSnapshot(s2);
+
+  let view = resolveSleepNightViewFromBoundedReads(requestedDay, exact, minus1, minus2);
+  if (view) {
+    view = await hydrateSleepNightPhysiologyMetrics(uid, view);
+  }
+
+  if (process.env.SLEEP_NIGHT_READ_DEBUG === "1" || process.env.SLEEP_NIGHT_READ_DEBUG === "true") {
+    logger.info({
+      msg: "[SLEEP_NIGHT_READ_DEBUG]",
+      uid,
+      requestedDay,
+      exactExists: exactSnap.exists,
+      exactComplete: exact?.isComplete ?? null,
+      exactScore: exact?.score ?? null,
+      exactWakeDay: exact?.wakeDay ?? null,
+      minus1Exists: s1.exists,
+      minus1Complete: minus1?.isComplete ?? null,
+      minus1Score: minus1?.score ?? null,
+      minus1WakeDay: minus1?.wakeDay ?? null,
+      selectedResolution: view?.resolution ?? null,
+      selectedAnchorDay: view?.anchorDay ?? null,
+      reasonIfNotFound:
+        view == null
+          ? notFoundReason({
+              exactExists: exactSnap.exists,
+              exact,
+              minus1Exists: s1.exists,
+              minus1,
+              minus2Exists: s2.exists,
+              minus2,
+            })
+          : null,
+    });
+  }
+
+  return view;
+}

--- a/services/api/src/lib/sleepNightReadCoerce.ts
+++ b/services/api/src/lib/sleepNightReadCoerce.ts
@@ -1,0 +1,62 @@
+import { localCalendarDayKeyFromIsoInTimeZone } from "@oli/contracts";
+
+/** YYYY-MM-DD from ISO start (UTC slice). */
+function toYmdUtc(iso: string): string {
+  return iso.slice(0, 10);
+}
+
+/**
+ * Repair legacy / partial `sleepNights` payloads before Zod parse so GET /sleep-night can resolve.
+ * - Ensures `anchorDay` matches doc id when absent or invalid.
+ * - Derives `wakeDay` from `endedAt` when missing (same semantics as `buildSleepNightFromOuraSleepDocument`).
+ * - Upgrades `isComplete` when duration + end + wake are present (score not required).
+ */
+export function coerceRawSleepNightForRead(flat: Record<string, unknown>, docId: string): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...flat };
+
+  const anchorFromFlat = typeof out.anchorDay === "string" ? out.anchorDay.trim() : "";
+  out.anchorDay = /^\d{4}-\d{2}-\d{2}$/.test(anchorFromFlat) ? anchorFromFlat : docId;
+
+  const main = out.mainSleepMinutes;
+  const total = out.totalSleepMinutes;
+  const durationMinutes =
+    typeof main === "number" && Number.isFinite(main) && main > 0
+      ? main
+      : typeof total === "number" && Number.isFinite(total) && total > 0
+        ? total
+        : null;
+
+  let endedRaw = typeof out.endedAt === "string" ? out.endedAt.trim() : "";
+  const startedRaw = typeof out.startedAt === "string" ? out.startedAt.trim() : "";
+  /** Legacy rows sometimes omit `endedAt`; infer from Oura window semantics so exact-anchor beats D−1 wake_day. */
+  if (!endedRaw && startedRaw && durationMinutes != null) {
+    const startMs = Date.parse(startedRaw);
+    if (!Number.isNaN(startMs)) {
+      endedRaw = new Date(startMs + durationMinutes * 60_000).toISOString();
+      out.endedAt = endedRaw;
+    }
+  }
+
+  const endedOk = endedRaw.length > 0;
+
+  let wake = typeof out.wakeDay === "string" ? out.wakeDay.trim() : "";
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(wake) && endedOk) {
+    wake = localCalendarDayKeyFromIsoInTimeZone(endedRaw, "UTC") ?? toYmdUtc(endedRaw);
+    out.wakeDay = wake;
+  }
+
+  const hasDuration =
+    (typeof main === "number" && Number.isFinite(main) && main > 0) ||
+    (typeof total === "number" && Number.isFinite(total) && total > 0);
+  const wakeFinal = typeof out.wakeDay === "string" ? out.wakeDay.trim() : "";
+  const wakeOk = /^\d{4}-\d{2}-\d{2}$/.test(wakeFinal);
+  const derivedComplete = Boolean(out.anchorDay && hasDuration && endedOk && wakeOk);
+
+  if (typeof out.isComplete !== "boolean") {
+    out.isComplete = derivedComplete;
+  } else if (out.isComplete === false && derivedComplete) {
+    out.isComplete = true;
+  }
+
+  return out;
+}

--- a/services/api/src/routes/__tests__/gateway-openapi-sleep-night.contract.test.ts
+++ b/services/api/src/routes/__tests__/gateway-openapi-sleep-night.contract.test.ts
@@ -1,0 +1,21 @@
+// Ensures canonical SleepNight route stays registered for API Gateway (deploy drift guard).
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const repoRoot = join(__dirname, "..", "..", "..", "..", "..");
+const openApiPath = join(repoRoot, "infra", "gateway", "openapi.yaml");
+
+describe("infra/gateway/openapi.yaml — GET /users/me/sleep-night", () => {
+  let yaml: string;
+
+  beforeAll(() => {
+    yaml = readFileSync(openApiPath, "utf8");
+  });
+
+  it("includes GET /users/me/sleep-night with required day query", () => {
+    expect(yaml).toContain("/users/me/sleep-night:");
+    expect(yaml).toContain("operationId: sleepNightGet");
+    expect(yaml).toContain("name: day");
+    expect(yaml).toContain("required: true");
+  });
+});

--- a/services/api/src/routes/__tests__/usersMe.ouraView.test.ts
+++ b/services/api/src/routes/__tests__/usersMe.ouraView.test.ts
@@ -372,6 +372,32 @@ describe("GET /users/me/oura-sleep-view and oura-readiness-view", () => {
     expect(body.score).toBe(72);
   });
 
+  it("oura-sleep-view coerces string score from Firestore to a JSON number", async () => {
+    const snapshotData = {
+      id: "s1",
+      day: "2025-03-15",
+      score: "96",
+      contributors: {},
+      source: "oura",
+      fetchedAt: "2025-03-15T10:00:00Z",
+    };
+
+    (userCollection as jest.Mock).mockReturnValue({
+      where: () => ({
+        limit: () => ({
+          get: async () => ({
+            docs: [{ exists: true, data: () => snapshotData }],
+          }),
+        }),
+      }),
+    });
+
+    const res = await fetch(`${baseUrl}/users/me/oura-sleep-view?day=2025-03-15`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.score).toBe(96);
+  });
+
   it("oura-sleep-view does not invent score when neither score nor composite_score exists", async () => {
     const snapshotData = {
       id: "s1",

--- a/services/api/src/routes/__tests__/usersMe.sleepNight.test.ts
+++ b/services/api/src/routes/__tests__/usersMe.sleepNight.test.ts
@@ -1,0 +1,186 @@
+/**
+ * GET /users/me/sleep-night — canonical SleepNight read model.
+ */
+import express from "express";
+import type http from "http";
+import { AddressInfo } from "net";
+
+jest.mock("../../lib/sleepNightRead", () => ({
+  loadSleepNightView: jest.fn(),
+}));
+
+jest.mock("../../db", () => ({
+  userCollection: jest.fn(),
+  documentIdPath: { _: "documentId" },
+}));
+
+import { loadSleepNightView } from "../../lib/sleepNightRead";
+import usersMeRoutes from "../usersMe";
+
+const mockLoadSleepNightView = loadSleepNightView as jest.MockedFunction<typeof loadSleepNightView>;
+
+describe("GET /users/me/sleep-night", () => {
+  let server: http.Server;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    const app = express();
+    app.use((req, _res, next) => {
+      (req as unknown as { uid: string }).uid = "user_sleep_night";
+      next();
+    });
+    app.use("/users/me", usersMeRoutes);
+    server = app.listen(0);
+    const addr = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${addr.port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  beforeEach(() => {
+    mockLoadSleepNightView.mockReset();
+  });
+
+  it("returns 400 when day query is missing", async () => {
+    const res = await fetch(`${baseUrl}/users/me/sleep-night`);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when no SleepNight", async () => {
+    mockLoadSleepNightView.mockResolvedValue(null);
+    const res = await fetch(`${baseUrl}/users/me/sleep-night?day=2026-05-10`);
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error?.code).toBe("NOT_FOUND");
+    expect(body.error?.resource).toBe("sleepNight");
+  });
+
+  it("returns 200 with sleepNight when exact anchor exists", async () => {
+    mockLoadSleepNightView.mockResolvedValue({
+      requestedDay: "2026-05-10",
+      anchorDay: "2026-05-10",
+      wakeDay: "2026-05-11",
+      resolution: "exact_anchor",
+      isFallback: false,
+      sleepNight: {
+        anchorDay: "2026-05-10",
+        wakeDay: "2026-05-11",
+        provider: "oura",
+        source: "ouraVendorSleep",
+        sourceDocumentId: "abc",
+        score: 96,
+        isComplete: true,
+        totalSleepMinutes: 522,
+        mainSleepMinutes: 522,
+        efficiency: 94,
+        remMinutes: 131,
+        deepMinutes: 75,
+        updatedAt: "2026-05-11T12:00:00.000Z",
+      },
+    });
+
+    const res = await fetch(`${baseUrl}/users/me/sleep-night?day=2026-05-10`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.requestedDay).toBe("2026-05-10");
+    expect(body.anchorDay).toBe("2026-05-10");
+    expect(body.resolution).toBe("exact_anchor");
+    expect(body.sleepNight.score).toBe(96);
+  });
+
+  it("parses string score from Firestore-shaped payload", async () => {
+    const view = {
+      requestedDay: "2026-05-10",
+      anchorDay: "2026-05-10",
+      wakeDay: "2026-05-10",
+      resolution: "exact_anchor",
+      isFallback: false,
+      sleepNight: {
+        anchorDay: "2026-05-10",
+        wakeDay: "2026-05-10",
+        provider: "oura",
+        source: "ouraVendorSleep",
+        sourceDocumentId: "abc",
+        score: "82",
+        isComplete: true,
+        updatedAt: "2026-05-11T12:00:00.000Z",
+      },
+    };
+    mockLoadSleepNightView.mockResolvedValue(view as never);
+
+    const res = await fetch(`${baseUrl}/users/me/sleep-night?day=2026-05-10`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sleepNight.score).toBe(82);
+  });
+
+  it("returns 200 exact_anchor for 2026-05-14 with Oura headline metrics when SleepNight exists", async () => {
+    mockLoadSleepNightView.mockResolvedValue({
+      requestedDay: "2026-05-14",
+      anchorDay: "2026-05-14",
+      wakeDay: "2026-05-15",
+      resolution: "exact_anchor",
+      isFallback: false,
+      sleepNight: {
+        anchorDay: "2026-05-14",
+        wakeDay: "2026-05-15",
+        provider: "oura",
+        source: "ouraVendorSleep",
+        sourceDocumentId: "oura_sleep_1",
+        score: 81,
+        isComplete: true,
+        totalSleepMinutes: 410,
+        mainSleepMinutes: 410,
+        efficiency: 91,
+        remMinutes: 80,
+        deepMinutes: 52,
+        startedAt: "2026-05-14T01:00:00.000Z",
+        endedAt: "2026-05-15T07:50:00.000Z",
+        updatedAt: "2026-05-15T12:00:00.000Z",
+      },
+    });
+
+    const res = await fetch(`${baseUrl}/users/me/sleep-night?day=2026-05-14`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.resolution).toBe("exact_anchor");
+    expect(body.anchorDay).toBe("2026-05-14");
+    expect(body.sleepNight.score).toBe(81);
+    expect(body.sleepNight.totalSleepMinutes).toBe(410);
+    expect(body.sleepNight.efficiency).toBe(91);
+    expect(body.sleepNight.remMinutes).toBe(80);
+    expect(body.sleepNight.deepMinutes).toBe(52);
+  });
+
+  it("returns 200 with lowest HR and average HRV for 2026-05-15 Dash physiology", async () => {
+    mockLoadSleepNightView.mockResolvedValue({
+      requestedDay: "2026-05-15",
+      anchorDay: "2026-05-15",
+      wakeDay: "2026-05-15",
+      resolution: "exact_anchor",
+      isFallback: false,
+      sleepNight: {
+        anchorDay: "2026-05-15",
+        wakeDay: "2026-05-15",
+        provider: "oura",
+        source: "ouraVendorSleep",
+        sourceDocumentId: "s_2026_05_15",
+        score: 81,
+        isComplete: true,
+        totalSleepMinutes: 410,
+        lowestHeartRateBpm: 50,
+        averageHrvMs: 21,
+        updatedAt: "2026-05-15T12:00:00.000Z",
+      },
+    });
+
+    const res = await fetch(`${baseUrl}/users/me/sleep-night?day=2026-05-15`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sleepNight.lowestHeartRateBpm).toBe(50);
+    expect(body.sleepNight.averageHrvMs).toBe(21);
+  });
+});

--- a/services/api/src/routes/integrations/__tests__/ouraPullNow.test.ts
+++ b/services/api/src/routes/integrations/__tests__/ouraPullNow.test.ts
@@ -58,6 +58,7 @@ jest.mock("../../../lib/ouraApi", () => ({
   ouraSleepWakeIsoForLog: jest.fn((d: { wake_time?: string }) =>
     typeof d?.wake_time === "string" ? d.wake_time : null,
   ),
+  resolveOuraSleepIngestBase: jest.fn(() => null),
   fetchOuraDailyReadiness: jest.fn(),
   fetchOuraPersonalInfo: jest.fn().mockResolvedValue(null),
   fetchOuraDailyActivity: jest.fn().mockResolvedValue([]),
@@ -261,6 +262,10 @@ describe("POST /integrations/oura/pull-now", () => {
     expect(res.body.eventsAlreadyExists).toBe(0);
     expect(res.body.windowDays).toBe(30);
     expect(ouraSecrets.setRefreshToken).toHaveBeenCalledWith("user_oura_1", "rt_new");
+    const sleepCall = (ouraApi.fetchOuraSleep as jest.Mock).mock.calls[0];
+    const readinessCall = (ouraApi.fetchOuraDailyReadiness as jest.Mock).mock.calls[0];
+    expect(readinessCall[1]).toBe(sleepCall[1]);
+    expect(readinessCall[2]).toBe(sleepCall[2]);
     expect(ouraIngestWrite.writeOuraRawEvents).toHaveBeenCalledWith(
       "user_oura_1",
       expect.any(Array),
@@ -288,6 +293,7 @@ describe("POST /integrations/oura/pull-now", () => {
       "user_oura_1",
       expect.any(Array),
       "req-oura-pull",
+      expect.any(Array),
     );
     expect(ouraVendorSnapshot.writeOuraVendorReadinessSnapshots).toHaveBeenCalledWith(
       "user_oura_1",
@@ -361,6 +367,10 @@ describe("POST /integrations/oura/pull-now", () => {
     const [, , sleepDocs, readinessDocs] = (ouraPostRawJob.publishOuraPostRawJob as jest.Mock).mock.calls[0];
     expect(sleepDocs).toHaveLength(1);
     expect(readinessDocs).toHaveLength(1);
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+    expect(ouraVendorSnapshot.writeOuraVendorSleepSnapshots).toHaveBeenCalled();
+    expect(ouraVendorSnapshot.writeOuraVendorReadinessSnapshots).toHaveBeenCalled();
   });
 
   it("falls back to in-process post-raw when enqueue fails", async () => {
@@ -457,6 +467,7 @@ describe("performOuraPostRawPersistence", () => {
       "uid-post-raw",
       sleepDocs,
       "req-post-raw",
+      readinessDocs,
     );
     expect(ouraVendorSnapshot.writeOuraVendorReadinessSnapshots).toHaveBeenCalledWith(
       "uid-post-raw",

--- a/services/api/src/routes/integrations/ouraIngest.ts
+++ b/services/api/src/routes/integrations/ouraIngest.ts
@@ -37,6 +37,7 @@ const hrvItemSchema = z.object({
   rmssdMs: z.number().finite().nonnegative().nullable().optional(),
   sdnnMs: z.number().finite().nonnegative().nullable().optional(),
   measurementType: z.enum(["nightly", "spot"]).optional(),
+  restingHeartRateBpm: z.number().finite().min(1).max(250).nullable().optional(),
 });
 
 const ouraIngestBodySchema = z.object({
@@ -110,6 +111,9 @@ router.post("/", async (req: Request, res: Response) => {
     ...(item.rmssdMs !== undefined ? { rmssdMs: item.rmssdMs ?? null } : {}),
     ...(item.sdnnMs !== undefined ? { sdnnMs: item.sdnnMs ?? null } : {}),
     ...(item.measurementType !== undefined ? { measurementType: item.measurementType } : {}),
+    ...(item.restingHeartRateBpm !== undefined
+      ? { restingHeartRateBpm: item.restingHeartRateBpm ?? null }
+      : {}),
   }));
   const { eventsCreated, eventsAlreadyExists } = await writeOuraRawEvents(
     uid,

--- a/services/api/src/routes/integrations/ouraPullNow.ts
+++ b/services/api/src/routes/integrations/ouraPullNow.ts
@@ -35,6 +35,7 @@ import {
   type OuraDailyReadinessDocument,
   OuraApiError,
   ouraSleepWakeIsoForLog,
+  resolveOuraSleepIngestBase,
 } from "../../lib/ouraApi";
 import { writeOuraRawEvents } from "../../lib/ouraIngestWrite";
 import {
@@ -334,7 +335,8 @@ export async function performOuraPullNowCore(
       heartrateDocs,
     ] = await Promise.all([
       fetchOuraSleep(accessToken, sleepStartStr, sleepEndStr, { requestId, uid }),
-      fetchOuraDailyReadiness(accessToken, startStr, endStr),
+      /** Same inclusive window as sleep so readiness/HRV rows near rolling boundaries are not dropped. */
+      fetchOuraDailyReadiness(accessToken, sleepStartStr, sleepEndStr),
       safeFetch("personal_info", () => fetchOuraPersonalInfo(accessToken)),
       safeFetch("daily_activity", () => fetchOuraDailyActivity(accessToken, startStr, endStr)),
       safeFetch("workout", () => fetchOuraWorkouts(accessToken, startStr, endStr)),
@@ -367,6 +369,49 @@ export async function performOuraPullNowCore(
       latestSleepId,
       sleepDocCount: sleepDocs.length,
     });
+
+    if (process.env.OURA_SLEEP_LATEST_AUDIT === "1" || process.env.OURA_SLEEP_LATEST_AUDIT === "true") {
+      let latestDoc: OuraSleepDocument | null = null;
+      let latestWakeMs = -1;
+      for (const d of sleepDocs) {
+        const w = ouraSleepWakeIsoForLog(d);
+        if (!w) continue;
+        const t = Date.parse(w);
+        if (Number.isNaN(t)) continue;
+        if (!latestDoc || t > latestWakeMs) {
+          latestWakeMs = t;
+          latestDoc = d;
+        }
+      }
+      const r = latestDoc ? resolveOuraSleepIngestBase(latestDoc) : null;
+      const totalSec =
+        latestDoc && typeof latestDoc.total_sleep_duration === "number" ? latestDoc.total_sleep_duration : null;
+      const scoreRaw = latestDoc
+        ? ((latestDoc as { score?: unknown }).score ?? (latestDoc as { composite_score?: unknown }).composite_score)
+        : undefined;
+      const latestScore =
+        typeof scoreRaw === "number" && Number.isFinite(scoreRaw)
+          ? Math.round(Math.max(0, Math.min(100, scoreRaw)))
+          : typeof scoreRaw === "string"
+            ? (() => {
+                const n = Number(scoreRaw.trim());
+                return Number.isFinite(n) ? Math.round(Math.max(0, Math.min(100, n))) : null;
+              })()
+            : null;
+      logger.info({
+        msg: "[OURA_SLEEP_LATEST_AUDIT]",
+        uid,
+        requestedStart: sleepStartStr,
+        requestedEnd: sleepEndStr,
+        docsFetched: sleepDocs.length,
+        latestOuraDay: typeof latestDoc?.day === "string" ? latestDoc.day : null,
+        latestStart: r?.start ?? null,
+        latestEnd: r?.end ?? null,
+        latestScore,
+        latestTotalSleep: totalSec != null && totalSec >= 0 ? Math.round(totalSec / 60) : null,
+        latestEfficiency: typeof latestDoc?.efficiency === "number" ? latestDoc.efficiency : null,
+      });
+    }
 
     logger.info({
       msg: "oura_fetch_counts",
@@ -427,6 +472,18 @@ export async function performOuraPullNowCore(
       const id = (doc as { id?: string }).id ?? `oura_heartrate_${startStr}_${i}`;
       ouraRawItems.push(toOuraRawIngestItem("heartrate", id, doc as Record<string, unknown>));
     });
+    for (const doc of sleepDocs) {
+      const id =
+        typeof doc.id === "string" && doc.id.trim().length > 0
+          ? doc.id.trim()
+          : (() => {
+              const r = resolveOuraSleepIngestBase(doc);
+              return r ? `oura_sleep_${r.start}` : null;
+            })();
+      if (id) {
+        ouraRawItems.push(toOuraRawIngestItem("sleep", id, doc as Record<string, unknown>));
+      }
+    }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     const code = err instanceof OuraApiError ? err.code : "OURA_FETCH_FAILED";
@@ -502,6 +559,16 @@ export async function performOuraPullNowCore(
         sleepDocCount: sleepDocsToUse.length,
         readinessDocCount: readinessDocsToUse.length,
       });
+      void performOuraPostRawPersistence(uid, requestId, sleepDocsToUse, readinessDocsToUse).catch(
+        (persistErr: unknown) => {
+          logger.error({
+            msg: "oura_post_raw_persistence_after_enqueue_error",
+            uid,
+            requestId,
+            err: persistErr instanceof Error ? persistErr.message : String(persistErr),
+          });
+        },
+      );
     } catch (err) {
       logger.error({
         msg: "oura_post_raw_job_enqueue_error",
@@ -569,7 +636,7 @@ export async function performOuraPostRawPersistence(
   let readinessResult = { attempted: 0, written: 0, skippedMissingDay: 0, errors: 0 };
   try {
     const [sleepRes, readinessRes] = await Promise.all([
-      writeOuraVendorSleepSnapshots(uid, sleepDocs, requestId),
+      writeOuraVendorSleepSnapshots(uid, sleepDocs, requestId, readinessDocs),
       writeOuraVendorReadinessSnapshots(uid, readinessDocs, requestId),
     ]);
     sleepResult = sleepRes;
@@ -739,7 +806,7 @@ export async function triggerOuraBackfill(uid: string, requestId: string): Promi
 
       await writeOuraRawEvents(uid, sleepItems, hrvItems, requestId, {});
       const [sleepRes, readinessRes] = await Promise.all([
-        writeOuraVendorSleepSnapshots(uid, sleepDocs, requestId),
+        writeOuraVendorSleepSnapshots(uid, sleepDocs, requestId, readinessDocs),
         writeOuraVendorReadinessSnapshots(uid, readinessDocs, requestId),
       ]);
       totalSleepWritten += sleepRes.written;

--- a/services/api/src/routes/usersMe.ts
+++ b/services/api/src/routes/usersMe.ts
@@ -56,6 +56,7 @@ import {
   healthSignalDocSchema,
   sleepViewDtoSchema,
   readinessViewDtoSchema,
+  sleepNightViewDtoSchema,
   nutritionFoodSearchResponseDtoSchema,
   nutritionFoodDetailResponseDtoSchema,
   type InsightDto,
@@ -64,6 +65,7 @@ import {
 
 import { db, userCollection, documentIdPath } from "../db";
 import { fillSleepContributorsFromStored } from "../lib/ouraVendorSnapshot";
+import { loadSleepNightView } from "../lib/sleepNightRead";
 import {
   isAppleHealthWorkoutIngestSuppressionDocId,
   shouldLogSuppressionAuditForId,
@@ -1951,6 +1953,25 @@ router.get(
 
 const OURA_VIEW_FALLBACK_DAYS = 7;
 
+/** Firestore may store Oura sleep score as number or digit string (legacy / import paths). */
+function readOuraVendorSleepNumericScoreFromDoc(data: Record<string, unknown> | undefined): number | undefined {
+  if (!data) return undefined;
+  const read = (v: unknown): number | undefined => {
+    if (typeof v === "number" && Number.isFinite(v)) return v;
+    if (typeof v === "string") {
+      const t = v.trim();
+      if (t === "") return undefined;
+      const n = Number(t);
+      return Number.isFinite(n) ? n : undefined;
+    }
+    return undefined;
+  };
+  const primary = read(data.score);
+  if (primary != null) return primary;
+  const composite = read((data as { composite_score?: unknown }).composite_score);
+  return composite ?? undefined;
+}
+
 /** Return YYYY-MM-DD for (day - days). */
 function dayMinus(day: string, days: number): string {
   const d = new Date(day + "T12:00:00.000Z");
@@ -1999,7 +2020,8 @@ router.get(
     }
 
     const data = doc.data() as Record<string, unknown> | undefined;
-    const resolvedDay = typeof data?.day === "string" ? data.day : requestedDay;
+    const resolvedDay =
+      typeof data?.day === "string" && data.day.trim().length > 0 ? data.day.trim() : requestedDay;
     const isFallback = resolvedDay !== requestedDay;
     const totalSleepDuration = typeof data?.totalSleepDuration === "number" ? data.totalSleepDuration : undefined;
     const latencyRaw = typeof data?.latency === "number" ? data.latency : undefined;
@@ -2020,22 +2042,12 @@ router.get(
     if (typeof data?.remSleep === "number") storedData.remSleep = data.remSleep;
     if (typeof data?.deepSleep === "number") storedData.deepSleep = data.deepSleep;
     if (typeof data?.latency === "number") storedData.latency = data.latency;
-    if (typeof data?.score === "number") storedData.score = data.score;
-    if (typeof (data as { composite_score?: number })?.composite_score === "number") {
-      storedData.composite_score = (data as { composite_score: number }).composite_score;
-    }
+    const coercedSleepScore = readOuraVendorSleepNumericScoreFromDoc(data);
+    if (coercedSleepScore != null) storedData.score = coercedSleepScore;
     const mergedContributors = fillSleepContributorsFromStored(storedData);
     const responseContributorKeys = Object.keys(mergedContributors);
-    const scoreOnDoc = typeof data?.score === "number" ? data.score : undefined;
-    const compositeScoreOnDoc = typeof (data as { composite_score?: number })?.composite_score === "number"
-      ? (data as { composite_score: number }).composite_score
-      : undefined;
-    const responseScore =
-      typeof scoreOnDoc === "number"
-        ? scoreOnDoc
-        : typeof compositeScoreOnDoc === "number"
-          ? compositeScoreOnDoc
-          : undefined;
+    const responseScore = coercedSleepScore;
+    const compositeRaw = (data as { composite_score?: unknown }).composite_score;
 
     logger.info({
       msg: "oura_sleep_view_proof",
@@ -2043,9 +2055,13 @@ router.get(
       resolvedDay,
       storedContributorKeys,
       responseContributorKeys,
-      scoreOnDoc: scoreOnDoc != null,
+      scoreOnDoc: coercedSleepScore != null,
       scoreOnResponse: responseScore != null,
-      compositeScoreOnDoc: compositeScoreOnDoc != null,
+      compositeScoreOnDoc:
+        compositeRaw !== undefined &&
+        compositeRaw !== null &&
+        compositeRaw !== "" &&
+        (typeof compositeRaw === "number" || typeof compositeRaw === "string"),
     });
 
     const view = {
@@ -2130,6 +2146,37 @@ router.get(
     const parsed = readinessViewDtoSchema.safeParse(view);
     if (!parsed.success) {
       invalidDoc500(req, res, "ouraReadinessView", parsed.error.flatten());
+      return;
+    }
+    res.status(200).json(parsed.data);
+  }),
+);
+
+router.get(
+  "/sleep-night",
+  asyncHandler(async (req: AuthedRequest, res: Response) => {
+    const uid = requireUid(req, res);
+    if (!uid) return;
+
+    const requestedDay = parseDay(req, res);
+    if (!requestedDay) return;
+
+    logger.info({
+      msg: "[SLEEP_NIGHT_ROUTE_VERSION]",
+      version: "sleep-night-resolution-v2",
+      requestedDay,
+      uid,
+    });
+
+    const view = await loadSleepNightView(uid, requestedDay);
+    if (!view) {
+      res.status(404).json({ ok: false, error: { code: "NOT_FOUND", resource: "sleepNight", day: requestedDay } });
+      return;
+    }
+
+    const parsed = sleepNightViewDtoSchema.safeParse(view);
+    if (!parsed.success) {
+      invalidDoc500(req, res, "sleepNight", parsed.error.flatten());
       return;
     }
     res.status(200).json(parsed.data);

--- a/services/api/src/types/dtos.ts
+++ b/services/api/src/types/dtos.ts
@@ -68,6 +68,10 @@ export {
 } from "@oli/contracts/ouraVendor";
 export type { SleepViewDto, ReadinessViewDto } from "@oli/contracts/ouraVendor";
 
+// Canonical SleepNight read surface (GET /users/me/sleep-night)
+export { sleepNightViewDtoSchema, sleepNightDocumentSchema } from "@oli/contracts/sleepNight";
+export type { SleepNightViewDto, SleepNightDocumentDto, SleepNightResolution } from "@oli/contracts/sleepNight";
+
 // Nutrition — dev food catalog read surface (GET /users/me/nutrition/*)
 export {
   nutritionFoodSearchResponseDtoSchema,

--- a/services/functions/src/dailyFacts/__tests__/aggregateDailyFacts.test.ts
+++ b/services/functions/src/dailyFacts/__tests__/aggregateDailyFacts.test.ts
@@ -178,6 +178,45 @@ describe('aggregateDailyFactsForDay', () => {
     expect(recovery.hrvRmssd).toBe(70);
   });
 
+  it("aggregates Oura-style HRV rmssd + resting HR into recovery and physiology", () => {
+    const events: CanonicalEvent[] = [
+      makeHrv({
+        id: "hrv_oura_1",
+        rmssdMs: 48,
+        restingHeartRateBpm: 55,
+      }),
+    ];
+    const result = aggregateDailyFactsForDay({
+      userId: "user_123",
+      date: "2025-01-01",
+      computedAt: "2025-01-02T03:00:00.000Z",
+      events,
+    });
+    expect(result.recovery?.hrvRmssd).toBe(48);
+    expect(result.recovery?.restingHeartRate).toBe(55);
+    expect(result.energyInfluencers?.physiology?.hrvRmssdMs).toBe(48);
+    expect(result.energyInfluencers?.physiology?.restingHeartRateBpm).toBe(55);
+  });
+
+  it("returns undefined recovery when HRV events have no numeric rmssd or resting HR", () => {
+    const events: CanonicalEvent[] = [
+      makeHrv({
+        id: "hrv_no_signal",
+        rmssdMs: null,
+        restingHeartRateBpm: null,
+        sdnnMs: 100,
+      }),
+    ];
+    const result = aggregateDailyFactsForDay({
+      userId: "user_123",
+      date: "2025-01-01",
+      computedAt: "2025-01-02T03:00:00.000Z",
+      events,
+    });
+    expect(result.recovery).toBeUndefined();
+    expect(result.energyInfluencers?.physiology).toBeUndefined();
+  });
+
   it("aggregates REM/deep minutes from main sleep episodes only", () => {
     const events: CanonicalEvent[] = [
       makeSleep({

--- a/services/functions/src/dailyFacts/__tests__/enrichDailyFacts.test.ts
+++ b/services/functions/src/dailyFacts/__tests__/enrichDailyFacts.test.ts
@@ -61,6 +61,23 @@ describe('enrichDailyFactsWithBaselinesAndAverages', () => {
     expect(recovery.hrvRmssdDeviation).toBeCloseTo(-0.4);
   });
 
+  it('preserves restingHeartRate when computing HRV baseline and deviation', () => {
+    const history: DailyFacts[] = [
+      makeFacts({ date: '2025-01-01', recovery: { hrvRmssd: 100 } }),
+    ];
+
+    const today: DailyFacts = makeFacts({
+      date: '2025-01-02',
+      recovery: { hrvRmssd: 80, restingHeartRate: 54 },
+    });
+
+    const enriched = enrichDailyFactsWithBaselinesAndAverages({ today, history });
+
+    expect(enriched.recovery?.restingHeartRate).toBe(54);
+    expect(enriched.recovery?.hrvRmssdBaseline).toBeCloseTo(100);
+    expect(enriched.recovery?.hrvRmssdDeviation).toBeCloseTo(-0.2);
+  });
+
   it('leaves derived averages undefined when there is no history', () => {
     const today: DailyFacts = makeFacts({
       date: '2025-01-01',

--- a/services/functions/src/dailyFacts/aggregateDailyFacts.ts
+++ b/services/functions/src/dailyFacts/aggregateDailyFacts.ts
@@ -253,8 +253,14 @@ const buildRecoveryFacts = (events: CanonicalEvent[]): DailyRecoveryFacts | unde
     facts.hrvRmssd = avgRmssd;
   }
 
+  const resting = hrvEvents.map((e) => e.restingHeartRateBpm).filter(isNumber);
+  const avgResting = average(resting);
+  if (avgResting !== undefined) {
+    facts.restingHeartRate = avgResting;
+  }
+
   // sdnnMs not promoted to DailyFacts in v1 (reserved)
-  // restingHeartRate/readinessScore reserved for future sources/rules.
+  // readinessScore reserved for future sources/rules.
 
   return Object.keys(facts).length > 0 ? facts : undefined;
 };

--- a/services/functions/src/normalization/__tests__/mapRawEventToCanonical.test.ts
+++ b/services/functions/src/normalization/__tests__/mapRawEventToCanonical.test.ts
@@ -132,6 +132,34 @@ describe("mapRawEventToCanonical", () => {
     expect(result.canonical.day).toBe(expectedEndDay);
   });
 
+  it("Oura-ingested HRV uses payload.day when valid and maps restingHeartRateBpm", () => {
+    const raw: RawEvent = {
+      ...baseRawEvent,
+      id: "raw_oura_hrv_1",
+      sourceId: "oura",
+      sourceType: "wearable",
+      provider: "manual",
+      kind: "hrv",
+      payload: {
+        time: "2026-05-11T08:00:00.000Z",
+        timezone: "UTC",
+        day: "2026-05-11",
+        rmssdMs: 52,
+        restingHeartRateBpm: 54,
+        measurementType: "nightly",
+      } as unknown,
+    };
+
+    const result = mapRawEventToCanonical(raw);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected mapping success");
+    expect(result.canonical.kind).toBe("hrv");
+    if (result.canonical.kind !== "hrv") throw new Error("Expected hrv");
+    expect(result.canonical.day).toBe("2026-05-11");
+    expect(result.canonical.rmssdMs).toBe(52);
+    expect(result.canonical.restingHeartRateBpm).toBe(54);
+  });
+
   it("maps optional REM/deep stage minutes on manual sleep", () => {
     const raw: RawEvent = {
       ...baseRawEvent,

--- a/services/functions/src/normalization/mapRawEventToCanonical.ts
+++ b/services/functions/src/normalization/mapRawEventToCanonical.ts
@@ -107,9 +107,12 @@ type ManualWorkoutPayload = ManualWindowBase & {
 type ManualHrvPayload = {
   time: IsoDateTimeString;
   timezone: string;
+  /** Oura readiness logical day (YYYY-MM-DD) when present. */
+  day?: string;
   rmssdMs?: number | null;
   sdnnMs?: number | null;
   measurementType?: "nightly" | "spot";
+  restingHeartRateBpm?: number | null;
 };
 
 type ManualStrengthWorkoutSetPayload = {
@@ -460,8 +463,29 @@ const mapManualHrv = (
   raw: RawEvent,
   payload: ManualHrvPayload,
 ): HrvCanonicalEvent | null => {
-  const day = localCalendarDayKeyFromIsoInTimeZone(payload.time, payload.timezone);
+  /**
+   * Oura nightly readiness: align canonical `day` with Oura `payload.day` when valid (same as sleep),
+   * so DailyFacts rollups match GET /users/me/oura-readiness-view and sleep rows for the same ring day.
+   * Otherwise attribute to local calendar day of `time` + timezone.
+   */
+  let day: YmdDateString | null = null;
+  if (raw.sourceId === "oura") {
+    const apiDay =
+      typeof payload.day === "string" && isYmdDateString(payload.day) ? payload.day : null;
+    day =
+      apiDay ?? localCalendarDayKeyFromIsoInTimeZone(payload.time, payload.timezone) ?? null;
+  } else {
+    day = localCalendarDayKeyFromIsoInTimeZone(payload.time, payload.timezone);
+  }
   if (!day) return null;
+
+  const resting =
+    typeof payload.restingHeartRateBpm === "number" &&
+    Number.isFinite(payload.restingHeartRateBpm) &&
+    payload.restingHeartRateBpm >= 1 &&
+    payload.restingHeartRateBpm <= 250
+      ? payload.restingHeartRateBpm
+      : null;
 
   const base: HrvCanonicalEvent = {
     id: raw.id,
@@ -478,6 +502,10 @@ const mapManualHrv = (
     rmssdMs: payload.rmssdMs ?? null,
     sdnnMs: payload.sdnnMs ?? null,
   };
+
+  if (resting != null) {
+    base.restingHeartRateBpm = resting;
+  }
 
   if (payload.measurementType) {
     base.measurementType = payload.measurementType;

--- a/services/functions/src/oura/__tests__/ouraPostRawHandler.test.ts
+++ b/services/functions/src/oura/__tests__/ouraPostRawHandler.test.ts
@@ -7,12 +7,21 @@ const mockSet = jest.fn().mockResolvedValue(undefined);
 const mockCommit = jest.fn().mockResolvedValue(undefined);
 const mockBatchSet = jest.fn().mockReturnThis();
 
+const mockReadinessDocGet = jest.fn().mockResolvedValue({ exists: false });
+const mockReadinessQueryGet = jest.fn().mockResolvedValue({ docs: [] });
+
 jest.mock("firebase-admin/firestore", () => ({
   getFirestore: jest.fn(() => ({
     collection: jest.fn(() => ({
       doc: jest.fn(() => ({
         collection: jest.fn(() => ({
-          doc: jest.fn(() => ({ set: mockSet })),
+          doc: jest.fn(() => ({
+            set: mockSet,
+            get: mockReadinessDocGet,
+          })),
+          where: jest.fn(() => ({
+            limit: jest.fn(() => ({ get: mockReadinessQueryGet })),
+          })),
         })),
         set: mockSet,
       })),
@@ -41,6 +50,7 @@ describe("runOuraPostRaw", () => {
 
     expect(result.metadataWritten).toBe(true);
     expect(result.sleepWritten).toBe(0);
+    expect(result.sleepNightsWritten).toBe(0);
     expect(result.readinessWritten).toBe(0);
     expect(mockSet).toHaveBeenCalled();
     const setCalls = mockSet.mock.calls;
@@ -62,6 +72,7 @@ describe("runOuraPostRaw", () => {
     const result = await runOuraPostRaw("uid2", "req2", sleepDocs, readinessDocs);
 
     expect(result.sleepWritten).toBeGreaterThanOrEqual(1);
+    expect(result.sleepNightsWritten).toBeGreaterThanOrEqual(1);
     expect(result.readinessWritten).toBeGreaterThanOrEqual(1);
     expect(result.metadataWritten).toBe(true);
     const setCalls = mockSet.mock.calls;
@@ -80,6 +91,7 @@ describe("runOuraPostRaw", () => {
     const result = await runOuraPostRaw("uid3", "req3", sleepDocsNoDay, readinessDocs);
 
     expect(result.sleepWritten).toBe(0);
+    expect(result.sleepNightsWritten).toBe(0);
     expect(result.readinessWritten).toBeGreaterThanOrEqual(1);
     expect(result.metadataWritten).toBe(true);
   });
@@ -93,6 +105,7 @@ describe("runOuraPostRaw", () => {
     const result = await runOuraPostRaw("uid4", "req4", sleepDocs, readinessDocs);
 
     expect(result.sleepWritten).toBeGreaterThanOrEqual(1);
+    expect(result.sleepNightsWritten).toBeGreaterThanOrEqual(1);
     expect(result.readinessWritten).toBeGreaterThanOrEqual(1);
     expect(result.metadataWritten).toBe(true);
     const setCalls = mockSet.mock.calls;
@@ -111,6 +124,7 @@ describe("runOuraPostRaw", () => {
     const result = await runOuraPostRaw("uid5", "req5", sleepDocs, readinessDocs);
 
     expect(result.sleepWritten).toBeGreaterThanOrEqual(1);
+    expect(result.sleepNightsWritten).toBeGreaterThanOrEqual(1);
     expect(result.readinessWritten).toBe(0);
     expect(result.metadataWritten).toBe(true);
   });
@@ -134,14 +148,49 @@ describe("runOuraPostRaw", () => {
     const result = await runOuraPostRaw("uid6", "req6", sleepDocs, readinessDocs);
 
     expect(result.sleepWritten).toBeGreaterThanOrEqual(1);
+    expect(result.sleepNightsWritten).toBeGreaterThanOrEqual(1);
     const batchSetCalls = mockBatchSet.mock.calls as [unknown, Record<string, unknown>, unknown][];
-    const sleepPayload = batchSetCalls.find((c) => c[1]?.source === "oura" && c[1]?.day === "2025-03-13")?.[1];
+    /** Rollup day = wake UTC (2025-03-14), not bedtime UTC (2025-03-13). */
+    const sleepPayload = batchSetCalls.find((c) => c[1]?.source === "oura" && c[1]?.day === "2025-03-14")?.[1];
     expect(sleepPayload).toBeDefined();
+    const sleepNightPayload = batchSetCalls.find((c) => c[1]?.source === "ouraVendorSleep")?.[1];
+    expect(sleepNightPayload).toBeDefined();
+    expect(sleepNightPayload?.anchorDay).toBe("2025-03-14");
+    expect(sleepNightPayload?.isComplete).toBe(true);
     expect(sleepPayload?.contributors).toBeDefined();
     expect(typeof sleepPayload?.contributors).toBe("object");
     const contrib = sleepPayload?.contributors as Record<string, unknown>;
     expect(Object.keys(contrib).length).toBeGreaterThan(0);
     expect(Object.values(contrib).every((v) => typeof v === "number")).toBe(true);
     expect(Object.values(sleepPayload!).every((v) => v !== undefined)).toBe(true);
+  });
+
+  it("infers end from start + total_sleep_duration and writes sleepNight on rollup day", async () => {
+    const sleepDocs = [
+      {
+        id: "s_infer",
+        day: "2026-05-14",
+        bedtime_start: "2026-05-13T23:00:00.000Z",
+        total_sleep_duration: 24600,
+        efficiency: 91,
+        rem_sleep_duration: 4800,
+        deep_sleep_duration: 3120,
+        score: 81,
+      },
+    ];
+    const readinessDocs = [{ id: "r1", day: "2026-05-14", timestamp: "2026-05-14T08:00:00Z" }];
+
+    const result = await runOuraPostRaw("uid7", "req7", sleepDocs, readinessDocs);
+
+    expect(result.sleepWritten).toBeGreaterThanOrEqual(1);
+    expect(result.sleepNightsWritten).toBeGreaterThanOrEqual(1);
+    const batchSetCalls = mockBatchSet.mock.calls as [unknown, Record<string, unknown>, unknown][];
+    const sleepPayload = batchSetCalls.find((c) => c[1]?.source === "oura" && c[1]?.day === "2026-05-14")?.[1];
+    expect(sleepPayload).toBeDefined();
+    const sleepNightPayload = batchSetCalls.find(
+      (c) => c[1]?.source === "ouraVendorSleep" && c[1]?.anchorDay === "2026-05-14",
+    )?.[1];
+    expect(sleepNightPayload?.isComplete).toBe(true);
+    expect(sleepNightPayload?.score).toBe(81);
   });
 });

--- a/services/functions/src/oura/ouraPostRawHandler.ts
+++ b/services/functions/src/oura/ouraPostRawHandler.ts
@@ -6,6 +6,24 @@
 import { getFirestore, FieldValue } from "firebase-admin/firestore";
 import { logger } from "firebase-functions";
 
+import { coerceOuraSleepScore0to100 } from "../../../api/src/lib/oura/buildSleepNightFromOuraDocument";
+import { resolveOuraSleepIngestBase } from "../../../api/src/lib/oura/resolveOuraSleepIngestBase";
+import {
+  buildSleepNightFirestorePayloadWithOuraReadiness,
+  collectReadinessLookupDaysForSleepPairs,
+  loadPersistedOuraVendorReadinessByDaysFromCollection,
+} from "../../../api/src/lib/oura/readinessForSleepNightMerge";
+import type { OuraDailyReadinessDocument } from "../../../api/src/lib/ouraApi";
+import {
+  logOuraSleepPhysiologyDebugForDoc,
+  pickOuraSleepAverageHrvMs,
+  pickOuraSleepLowestHeartRateBpm,
+} from "../../../api/src/lib/oura/ouraSleepPhysiology";
+import {
+  pickAverageHrvMsFromReadinessRecord,
+  pickLowestHeartRateBpmFromReadinessRecord,
+} from "../../../api/src/lib/oura/readinessForSleepNightMerge";
+
 const BATCH_CHUNK_SIZE = 450;
 const SOURCE = "oura";
 
@@ -90,7 +108,7 @@ function buildSleepContributors(doc: SleepDoc): Record<string, number> {
 
   const lat = doc.latency;
   if (typeof lat === "number" && !Number.isNaN(lat) && lat >= 0 && !Object.prototype.hasOwnProperty.call(out, "latency")) {
-    const latMinutes = lat > 120 ? lat / 60 : lat;
+    const latMinutes = lat >= 60 ? lat / 60 : lat;
     out.latency = clampScore(Math.max(0, 100 - latMinutes * 2));
   }
 
@@ -104,6 +122,9 @@ function buildSleepContributors(doc: SleepDoc): Record<string, number> {
 
 export type SleepDoc = Record<string, unknown> & {
   id?: string;
+  day?: string;
+  wake_time?: string;
+  bedtime_end?: string;
   bed_time?: string;
   bedtime_start?: string;
   start?: string;
@@ -141,6 +162,9 @@ type SleepSnapshot = {
   restfulSleep?: number;
   remSleep?: number;
   deepSleep?: number;
+  lowestHeartRateBpm?: number;
+  averageHrvMs?: number;
+  payload?: Record<string, unknown>;
 };
 
 type ReadinessSnapshot = {
@@ -151,31 +175,28 @@ type ReadinessSnapshot = {
   source: string;
   fetchedAt: string;
   updatedAt: string;
+  lowestHeartRateBpm?: number;
+  averageHrvMs?: number;
+  payload?: Record<string, unknown>;
 };
 
 function toYmd(iso: string): string {
   return iso.slice(0, 10);
 }
 
-function getSleepStartForSnapshot(doc: SleepDoc): string | null {
-  const s =
-    doc.bed_time ??
-    doc.bedtime_start ??
-    doc.start ??
-    doc.end_time ??
-    doc.end ??
-    null;
-  return typeof s === "string" && s.length > 0 ? s : null;
-}
-
-function extractSleepSnapshot(doc: SleepDoc, fetchedAt: string): SleepSnapshot | null {
-  const start = getSleepStartForSnapshot(doc);
-  const day = start ? toYmd(start) : null;
-  if (!day) return null;
+function extractSleepSnapshot(
+  doc: SleepDoc,
+  fetchedAt: string,
+  debugCtx?: { uid?: string },
+): SleepSnapshot | null {
+  const resolved = resolveOuraSleepIngestBase(doc);
+  if (!resolved) return null;
+  const { start, end, rollupDay: day } = resolved;
 
   const id = doc.id ?? `oura_sleep_${start}`;
-  const scoreRaw = doc.score ?? (doc as { composite_score?: number }).composite_score;
-  const score = typeof scoreRaw === "number" && !Number.isNaN(scoreRaw) ? scoreRaw : null;
+  const score = coerceOuraSleepScore0to100(
+    (doc as { score?: unknown }).score ?? (doc as { composite_score?: unknown }).composite_score,
+  );
   const contributors = buildSleepContributors(doc);
 
   const out: SleepSnapshot = {
@@ -195,6 +216,20 @@ function extractSleepSnapshot(doc: SleepDoc, fetchedAt: string): SleepSnapshot |
   if (typeof doc.restful_sleep === "number") out.restfulSleep = doc.restful_sleep;
   if (typeof doc.rem_sleep_duration === "number") out.remSleep = doc.rem_sleep_duration;
   if (typeof doc.deep_sleep_duration === "number") out.deepSleep = doc.deep_sleep_duration;
+  const lhr = pickOuraSleepLowestHeartRateBpm(doc);
+  const hrv = pickOuraSleepAverageHrvMs(doc);
+  if (lhr !== undefined) out.lowestHeartRateBpm = lhr;
+  if (hrv !== undefined) out.averageHrvMs = hrv;
+  out.payload = stripUndefined(doc as Record<string, unknown>);
+
+  logOuraSleepPhysiologyDebugForDoc(doc, {
+    ...(debugCtx?.uid != null ? { uid: debugCtx.uid } : {}),
+    day,
+    sleepDocId: String(id),
+    start,
+    end,
+  });
+
   return out;
 }
 
@@ -215,12 +250,19 @@ function extractReadinessSnapshot(doc: ReadinessDoc, fetchedAt: string): Readine
   };
   if (score != null) out.score = score;
   if (contributors != null) out.contributors = contributors;
+  const asRecord = doc as Record<string, unknown>;
+  const hrv = pickAverageHrvMsFromReadinessRecord(asRecord);
+  const lhr = pickLowestHeartRateBpmFromReadinessRecord(asRecord);
+  if (hrv != null) out.averageHrvMs = hrv;
+  if (lhr != null) out.lowestHeartRateBpm = lhr;
+  out.payload = stripUndefined(asRecord);
   return out;
 }
 
 export type RunOuraPostRawResult = {
   sleepWritten: number;
   readinessWritten: number;
+  sleepNightsWritten: number;
   metadataWritten: boolean;
 };
 
@@ -232,19 +274,28 @@ async function writeSleepSnapshots(
   uid: string,
   docs: SleepDoc[],
   requestId: string,
-): Promise<{ written: number; attempted: number; skippedMissingDay: number; errors: number }> {
+  readinessDocs: ReadinessDoc[],
+): Promise<{
+  written: number;
+  attempted: number;
+  skippedMissingDay: number;
+  errors: number;
+  sleepNightsWritten: number;
+  sleepNightsErrors: number;
+}> {
   logger.info("oura_post_raw: sleep docs received", { uid, requestId, sleepDocCount: docs.length });
 
   const fetchedAt = new Date().toISOString();
   const col = db.collection("users").doc(uid).collection("ouraVendorSleep");
+  const sleepNightsCol = db.collection("users").doc(uid).collection("sleepNights");
   let written = 0;
   let skippedMissingDay = 0;
   let errors = 0;
 
-  const snapshots: SleepSnapshot[] = [];
+  const pairs: { doc: SleepDoc; snapshot: SleepSnapshot }[] = [];
   let droppedSampleKeys: string[] | undefined;
   for (const doc of docs) {
-    const snapshot = extractSleepSnapshot(doc, fetchedAt);
+    const snapshot = extractSleepSnapshot(doc, fetchedAt, { uid });
     if (!snapshot) {
       skippedMissingDay += 1;
       if (!droppedSampleKeys && doc && typeof doc === "object") {
@@ -252,8 +303,10 @@ async function writeSleepSnapshots(
       }
       continue;
     }
-    snapshots.push(snapshot);
+    pairs.push({ doc, snapshot });
   }
+
+  const snapshots = pairs.map((p) => p.snapshot);
 
   if (droppedSampleKeys !== undefined && skippedMissingDay > 0) {
     logger.info("oura_post_raw: sleep docs dropped", {
@@ -310,7 +363,82 @@ async function writeSleepSnapshots(
     sleepSnapshotsErrors: errors,
   });
 
-  return { written, attempted: docs.length, skippedMissingDay, errors };
+  const readinessCol = db.collection("users").doc(uid).collection("ouraVendorReadiness");
+  const lookupDays = collectReadinessLookupDaysForSleepPairs(pairs);
+  const persistedReadinessByDay = await loadPersistedOuraVendorReadinessByDaysFromCollection(
+    readinessCol,
+    lookupDays,
+  );
+
+  let sleepNightsWritten = 0;
+  let sleepNightsErrors = 0;
+  for (let i = 0; i < pairs.length; i += BATCH_CHUNK_SIZE) {
+    const chunk = pairs.slice(i, i + BATCH_CHUNK_SIZE);
+    const batch = db.batch();
+    let ops = 0;
+    for (const { doc, snapshot } of chunk) {
+      const merged = buildSleepNightFirestorePayloadWithOuraReadiness(
+        doc,
+        snapshot.id,
+        readinessDocs as OuraDailyReadinessDocument[],
+        persistedReadinessByDay,
+      );
+      if (!merged) continue;
+      batch.set(
+        sleepNightsCol.doc(merged.anchorDay),
+        stripUndefined({
+          ...merged.payload,
+          updatedAt: FieldValue.serverTimestamp(),
+        } as Record<string, unknown>),
+        { merge: true },
+      );
+      ops += 1;
+    }
+    if (ops === 0) continue;
+    try {
+      await batch.commit();
+      sleepNightsWritten += ops;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error("oura_post_raw: sleep_night_batch_error", { uid, requestId, chunkSize: chunk.length, err: message });
+      for (const { doc, snapshot } of chunk) {
+        const merged = buildSleepNightFirestorePayloadWithOuraReadiness(
+          doc,
+          snapshot.id,
+          readinessDocs as OuraDailyReadinessDocument[],
+          persistedReadinessByDay,
+        );
+        if (!merged) continue;
+        try {
+          await sleepNightsCol.doc(merged.anchorDay).set(
+            stripUndefined({
+              ...merged.payload,
+              updatedAt: FieldValue.serverTimestamp(),
+            } as Record<string, unknown>),
+            { merge: true },
+          );
+          sleepNightsWritten += 1;
+        } catch (singleErr) {
+          sleepNightsErrors += 1;
+          logger.error("oura_post_raw: sleep_night_write_error", {
+            uid,
+            requestId,
+            anchorDay: merged.anchorDay,
+            err: singleErr instanceof Error ? singleErr.message : String(singleErr),
+          });
+        }
+      }
+    }
+  }
+
+  logger.info("oura_post_raw: sleep_nights_written", {
+    uid,
+    requestId,
+    sleepNightsWritten,
+    sleepNightsErrors,
+  });
+
+  return { written, attempted: docs.length, skippedMissingDay, errors, sleepNightsWritten, sleepNightsErrors };
 }
 
 async function writeReadinessSnapshots(
@@ -401,7 +529,7 @@ export async function runOuraPostRaw(
   });
 
   const [sleepResult, readinessResult] = await Promise.all([
-    writeSleepSnapshots(db, uid, sleepDocs, requestId),
+    writeSleepSnapshots(db, uid, sleepDocs, requestId, readinessDocs),
     writeReadinessSnapshots(db, uid, readinessDocs, requestId),
   ]);
 
@@ -434,12 +562,14 @@ export async function runOuraPostRaw(
     requestId,
     sleepWritten: sleepResult.written,
     readinessWritten: readinessResult.written,
+    sleepNightsWritten: sleepResult.sleepNightsWritten,
     metadataWritten,
   });
 
   return {
     sleepWritten: sleepResult.written,
     readinessWritten: readinessResult.written,
+    sleepNightsWritten: sleepResult.sleepNightsWritten,
     metadataWritten,
   };
 }

--- a/services/functions/src/types/health.ts
+++ b/services/functions/src/types/health.ts
@@ -288,6 +288,9 @@ export interface HrvCanonicalEvent extends BaseCanonicalEvent {
   /** Standard deviation of NN intervals (ms) */
   sdnnMs?: number | null;
 
+  /** Nightly resting / average HR from vendor readiness when mapped (bpm). */
+  restingHeartRateBpm?: number | null;
+
   /** Whether this was a nightly aggregated measurement or spot check */
   measurementType?: "nightly" | "spot";
 }

--- a/services/functions/src/workouts/recomputeWorkoutDaySummary.ts
+++ b/services/functions/src/workouts/recomputeWorkoutDaySummary.ts
@@ -127,7 +127,7 @@ export async function recomputeAndWriteWorkoutDaySummary(args: {
   await db.collection("users").doc(userId).collection("workoutDaySummaries").doc(uiDay).set(payload);
 
   try {
-    const mod = await import("./recomputeWorkoutMonthSummary");
+    const mod = await import("./recomputeWorkoutMonthSummary.js");
     await mod.maybeRecomputeWorkoutMonthSummaryForUiDay({ db, userId, uiDay });
   } catch (err) {
     logger.error("workout_month_summary_after_day_failed", {

--- a/services/functions/tsconfig.json
+++ b/services/functions/tsconfig.json
@@ -6,7 +6,10 @@
     "composite": true,
     "tsBuildInfoFile": "../../node_modules/.cache/tsbuildinfo/functions.tsbuildinfo"
   },
-  "references": [{ "path": "../../lib/tsconfig.build.json" }],
+  "references": [
+    { "path": "../../lib/tsconfig.build.json" },
+    { "path": "../api/tsconfig.json" }
+  ],
   "include": ["src/**/*"],
   "exclude": ["lib", "dist", "node_modules", "**/*.spec.*"]
 }


### PR DESCRIPTION
## Summary

Implements the canonical SleepNight pipeline end-to-end:

Oura API → rawEvents → canonical sleep/HRV → sleepNights → /users/me/sleep-night → Dash Daily Sleep

## Includes

- Canonical SleepNight read model
- Daily Sleep Dash card
- Correct wake-day/latest-night resolution
- Oura physiology ingestion:
  - lowest heart rate
  - average HRV
- Sleep vendor snapshot persistence
- SleepNight backfill + verification tooling
- Oura pull-now integration fixes
- Robust alignment/day resolution logic
- Hydration fallbacks for older rows
- Extensive test coverage

## Verification

- npm run typecheck ✅
- npm run lint ✅
- CI=1 npm test ✅

## Result

Dash Daily Sleep now correctly shows:
- Latest completed sleep
- Sleep duration
- REM/deep sleep
- Efficiency
- Lowest heart rate
- Average HRV

from canonical persisted Oura sleep data.