### PR TITLE
feat(api): bounded SleepNight range read endpoint

### DIFF
--- a/docs/90_audits/SLEEP_NIGHT_BOUNDED_RANGE_READ.md
+++ b/docs/90_audits/SLEEP_NIGHT_BOUNDED_RANGE_READ.md
@@ -22,9 +22,10 @@ Authenticated clients that need Sleep overview or Profile Health Baseline curren
 ## Storage / read path
 
 - Collection: existing `users/{uid}/sleepNights/{anchorDay}` only
-- Per requested day: same resolution rules as exact-day `GET /users/me/sleep-night`
-- Prefetch window: `start-2` through `end` via **one** document-ID range query (no per-day `.get()` fan-out)
-- Physiology hydrate for range: vendor readiness + dailyFacts only — **no `rawEvents` reads**
+- Prefetch: **one** document-ID range query for `[start-2, end]` (wake-day lookback; no per-day `.get()`)
+- Sparse resolutions only: `exact_anchor` and `wake_day`
+  - Exact-day Dash fallback `latest_completed_prior_night` is **not** used (avoids densifying empty days)
+- Stored SleepNight fields only — **no** per-night hydrate I/O (`ouraVendor*`, `dailyFacts`, `rawEvents`, `events`)
 - No new Firestore collection; no Firestore rules change in this change set
 
 ## Privacy

--- a/docs/90_audits/SLEEP_NIGHT_BOUNDED_RANGE_READ.md
+++ b/docs/90_audits/SLEEP_NIGHT_BOUNDED_RANGE_READ.md
@@ -23,7 +23,7 @@ Authenticated clients that need Sleep overview or Profile Health Baseline curren
 
 - Collection: existing `users/{uid}/sleepNights/{anchorDay}` only
 - Per requested day: same resolution rules as exact-day `GET /users/me/sleep-night`
-- Prefetch window: `start-2` through `end` (wake-day lookback)
+- Prefetch window: `start-2` through `end` via **one** document-ID range query (no per-day `.get()` fan-out)
 - Physiology hydrate for range: vendor readiness + dailyFacts only — **no `rawEvents` reads**
 - No new Firestore collection; no Firestore rules change in this change set
 

--- a/docs/90_audits/SLEEP_NIGHT_BOUNDED_RANGE_READ.md
+++ b/docs/90_audits/SLEEP_NIGHT_BOUNDED_RANGE_READ.md
@@ -1,0 +1,39 @@
+# SleepNight Bounded Range Read API
+
+**Date:** 2026-07-11  
+**Branch:** `feat/sleep-night-range-api`  
+**Scope:** Backend foundation to replace client per-day SleepNight fan-out
+
+## Purpose
+
+Authenticated clients that need Sleep overview or Profile Health Baseline currently call exact-day `GET /users/me/sleep-night` once per calendar day. Missing days produce many individual 404 responses. This note documents the bounded range endpoint that returns a sparse list in one request.
+
+## Endpoint
+
+`GET /users/me/sleep-nights?start=YYYY-MM-DD&end=YYYY-MM-DD`
+
+- Inclusive `[start, end]`
+- Policy max: **90** inclusive calendar days (`SLEEP_NIGHT_RANGE_MAX_DAYS`)
+- Auth: Firebase (same as other `/users/me` reads)
+- Success: **200** with `{ start, end, dayCount, resolvedCount, nights[] }`
+- Missing days: **omitted** from `nights` (no per-day 404)
+- Validation failures / oversize span: **400**
+
+## Storage / read path
+
+- Collection: existing `users/{uid}/sleepNights/{anchorDay}` only
+- Per requested day: same resolution rules as exact-day `GET /users/me/sleep-night`
+- Prefetch window: `start-2` through `end` (wake-day lookback)
+- Physiology hydrate for range: vendor readiness + dailyFacts only — **no `rawEvents` reads**
+- No new Firestore collection; no Firestore rules change in this change set
+
+## Privacy
+
+Route logs may include version tag and `dayCount` only. Do not log UIDs, date strings, health values, document IDs, or tokens.
+
+## Out of scope
+
+- Client fan-out replacement (dashboard / hooks)
+- `sleep-day-refresh` HTTP 500
+- Gateway deploy, Oura refresh, or data backfill
+- Production push / PR (local commit only until push review)

--- a/infra/gateway/openapi.yaml
+++ b/infra/gateway/openapi.yaml
@@ -426,6 +426,41 @@ paths:
         500:
           description: Server Error
 
+  # Canonical SleepNight bounded range read (Firestore sleepNights; missing days omitted)
+  /users/me/sleep-nights:
+    options:
+      operationId: sleepNightsRangeOptions
+      security: []
+      responses:
+        204:
+          description: No Content
+    get:
+      operationId: sleepNightsRangeGet
+      security:
+        - firebase: []
+      parameters:
+        - name: start
+          in: query
+          required: true
+          type: string
+          description: Inclusive range start YYYY-MM-DD
+        - name: end
+          in: query
+          required: true
+          type: string
+          description: Inclusive range end YYYY-MM-DD (span max 90 days)
+      produces:
+        - application/json
+      responses:
+        200:
+          description: Bounded SleepNight range (start, end, dayCount, resolvedCount, nights[])
+        400:
+          description: Bad Request (missing/invalid range or span exceeds policy max)
+        401:
+          description: Unauthorized
+        500:
+          description: Server Error
+
   # Oura Tier 1 — Sleep view (vendor snapshot read; 404 when no snapshot in window)
   /users/me/oura-sleep-view:
     options:

--- a/lib/api/usersMe.ts
+++ b/lib/api/usersMe.ts
@@ -60,11 +60,13 @@ import {
   sleepViewDtoSchema,
   readinessViewDtoSchema,
   sleepNightViewDtoSchema,
+  sleepNightRangeResponseDtoSchema,
   type HealthScoreDoc,
   type HealthSignalDoc,
   type SleepViewDto,
   type ReadinessViewDto,
   type SleepNightViewDto,
+  type SleepNightRangeResponseDto,
   workoutDaySummariesResponseDtoSchema,
   workoutDaySummariesRebuildResponseDtoSchema,
   workoutMonthSummariesResponseDtoSchema,
@@ -543,6 +545,22 @@ export const getSleepNight = async (
     `/users/me/sleep-night?day=${encodeURIComponent(day)}`,
     idToken,
     sleepNightViewDtoSchema,
+    truthGetOpts(opts),
+  );
+};
+
+/** GET /users/me/sleep-nights?start=&end= — bounded SleepNight range (missing days omitted; max 90 inclusive days). */
+export const getSleepNightsRange = async (
+  start: string,
+  end: string,
+  idToken: string,
+  opts?: TruthGetOptions,
+): Promise<ApiResult<SleepNightRangeResponseDto>> => {
+  const q = `start=${encodeURIComponent(start)}&end=${encodeURIComponent(end)}`;
+  return apiGetZodAuthed(
+    `/users/me/sleep-nights?${q}`,
+    idToken,
+    sleepNightRangeResponseDtoSchema,
     truthGetOpts(opts),
   );
 };

--- a/lib/contracts/__tests__/sleepNightRange.schema.test.ts
+++ b/lib/contracts/__tests__/sleepNightRange.schema.test.ts
@@ -1,0 +1,39 @@
+import {
+  SLEEP_NIGHT_RANGE_MAX_DAYS,
+  sleepNightRangeQuerySchema,
+  sleepNightRangeResponseDtoSchema,
+} from "../sleepNight";
+import { countInclusiveCalendarDays } from "../workoutSummaryRebuildLimits";
+
+describe("sleepNight range contracts", () => {
+  it("exports a 90-day inclusive policy max", () => {
+    expect(SLEEP_NIGHT_RANGE_MAX_DAYS).toBe(90);
+  });
+
+  it("parses start/end query", () => {
+    const parsed = sleepNightRangeQuerySchema.safeParse({
+      start: "2026-05-01",
+      end: "2026-05-07",
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it("accepts empty nights response within dayCount", () => {
+    const parsed = sleepNightRangeResponseDtoSchema.safeParse({
+      start: "2026-05-01",
+      end: "2026-05-07",
+      dayCount: 7,
+      resolvedCount: 0,
+      nights: [],
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it("dayCount matches inclusive calendar span helper", () => {
+    expect(countInclusiveCalendarDays("2026-05-01", "2026-05-01")).toBe(1);
+    expect(countInclusiveCalendarDays("2026-05-01", "2026-05-30")).toBe(30);
+    expect(countInclusiveCalendarDays("2026-01-01", "2026-03-31")).toBeLessThanOrEqual(
+      SLEEP_NIGHT_RANGE_MAX_DAYS,
+    );
+  });
+});

--- a/lib/contracts/sleepNight.ts
+++ b/lib/contracts/sleepNight.ts
@@ -99,3 +99,31 @@ export const sleepNightViewDtoSchema = z.object({
 });
 
 export type SleepNightViewDto = z.infer<typeof sleepNightViewDtoSchema>;
+
+/** Inclusive calendar-day span cap for GET /users/me/sleep-nights range reads. */
+export const SLEEP_NIGHT_RANGE_MAX_DAYS = 90;
+
+export const sleepNightRangeQuerySchema = z
+  .object({
+    start: dayKeySchema,
+    end: dayKeySchema,
+  })
+  .strip();
+
+export type SleepNightRangeQuery = z.infer<typeof sleepNightRangeQuerySchema>;
+
+/**
+ * Bounded range response: only nights that resolve are included (missing days omitted — no per-day 404).
+ * Each item is the same view DTO as GET /users/me/sleep-night for that requestedDay.
+ */
+export const sleepNightRangeResponseDtoSchema = z.object({
+  start: dayKeySchema,
+  end: dayKeySchema,
+  /** Number of calendar days in the inclusive [start, end] window (policy-checked). */
+  dayCount: z.number().int().positive(),
+  /** Number of resolved SleepNight views returned. */
+  resolvedCount: z.number().int().nonnegative(),
+  nights: z.array(sleepNightViewDtoSchema),
+});
+
+export type SleepNightRangeResponseDto = z.infer<typeof sleepNightRangeResponseDtoSchema>;

--- a/services/api/src/lib/__tests__/sleepNightRead.range.test.ts
+++ b/services/api/src/lib/__tests__/sleepNightRead.range.test.ts
@@ -24,13 +24,48 @@ function nightDoc(
   };
 }
 
+function mockSleepNightsOnly(docs: Record<string, SleepNightDocumentDto>) {
+  const sleepDocGet = jest.fn(async () => {
+    throw new Error("per-doc sleepNights.get() must not be used for range prefetch");
+  });
+  const rangeGet = jest.fn(async () => ({
+    docs: Object.entries(docs).map(([id, data]) => ({
+      id,
+      data: () => data as unknown as Record<string, unknown>,
+    })),
+  }));
+  const whereCalls: { field: unknown; op: string; value: string }[] = [];
+  const calledCollections: string[] = [];
+
+  userCollection.mockImplementation((_uid: string, name: string) => {
+    calledCollections.push(name);
+    if (name === "sleepNights") {
+      const chain: {
+        where: (field: unknown, op: string, value: string) => typeof chain;
+        get: typeof rangeGet;
+        doc: () => { get: typeof sleepDocGet };
+      } = {
+        where: (field, op, value) => {
+          whereCalls.push({ field, op, value });
+          return chain;
+        },
+        get: rangeGet,
+        doc: () => ({ get: sleepDocGet }),
+      };
+      return chain;
+    }
+    throw new Error(`range loader must not open collection "${name}"`);
+  });
+
+  return { sleepDocGet, rangeGet, whereCalls, calledCollections };
+}
+
 describe("loadSleepNightViewsForRange", () => {
   beforeEach(() => {
     userCollection.mockReset();
   });
 
-  it("omits unresolved days, uses one document-ID range query, and does not query rawEvents", async () => {
-    // Only the last day has a doc; earlier requested days have empty lookback (no prior-night fill).
+  it("uses one document-ID range query and opens only sleepNights (no hydrate I/O)", async () => {
     const docs: Record<string, SleepNightDocumentDto> = {
       "2026-05-03": nightDoc({
         anchorDay: "2026-05-03",
@@ -38,53 +73,12 @@ describe("loadSleepNightViewsForRange", () => {
         score: 88,
       }),
     };
-
-    const sleepDocGet = jest.fn(async () => {
-      throw new Error("per-doc sleepNights.get() must not be used for range prefetch");
-    });
-    const rangeGet = jest.fn(async () => ({
-      docs: Object.entries(docs).map(([id, data]) => ({
-        id,
-        data: () => data as unknown as Record<string, unknown>,
-      })),
-    }));
-    const whereCalls: { field: unknown; op: string; value: string }[] = [];
-    const calledCollections: string[] = [];
-
-    userCollection.mockImplementation((_uid: string, name: string) => {
-      calledCollections.push(name);
-      if (name === "sleepNights") {
-        const chain: {
-          where: (field: unknown, op: string, value: string) => typeof chain;
-          get: typeof rangeGet;
-          doc: () => { get: typeof sleepDocGet };
-        } = {
-          where: (field, op, value) => {
-            whereCalls.push({ field, op, value });
-            return chain;
-          },
-          get: rangeGet,
-          doc: () => ({ get: sleepDocGet }),
-        };
-        return chain;
-      }
-      if (name === "ouraVendorSleep" || name === "ouraVendorReadiness" || name === "dailyFacts") {
-        return {
-          doc: () => ({ get: async () => ({ exists: false, data: () => undefined }) }),
-          where: () => ({
-            limit: () => ({ get: async () => ({ docs: [] }) }),
-          }),
-        };
-      }
-      if (name === "rawEvents") {
-        throw new Error("rawEvents must not be queried for range reads");
-      }
-      return {};
-    });
+    const { sleepDocGet, rangeGet, whereCalls, calledCollections } = mockSleepNightsOnly(docs);
 
     const nights = await loadSleepNightViewsForRange("u-range", "2026-05-01", "2026-05-03");
     expect(nights.map((n) => n.requestedDay)).toEqual(["2026-05-03"]);
-    expect(calledCollections).not.toContain("rawEvents");
+    expect(nights[0]?.resolution).toBe("exact_anchor");
+    expect(calledCollections).toEqual(["sleepNights"]);
     expect(sleepDocGet).not.toHaveBeenCalled();
     expect(rangeGet).toHaveBeenCalledTimes(1);
     expect(whereCalls).toEqual([
@@ -93,7 +87,27 @@ describe("loadSleepNightViewsForRange", () => {
     ]);
   });
 
-  it("returns empty array when start > end", async () => {
+  it("keeps exact_anchor and wake_day, omits latest_completed_prior_night densification", async () => {
+    // Night anchored 05-01 woke on 05-02. 05-03 would only densify via prior-night fallback → omit.
+    const docs: Record<string, SleepNightDocumentDto> = {
+      "2026-05-01": nightDoc({
+        anchorDay: "2026-05-01",
+        wakeDay: "2026-05-02",
+        endedAt: "2026-05-02T07:00:00.000Z",
+        score: 77,
+      }),
+    };
+    mockSleepNightsOnly(docs);
+
+    const nights = await loadSleepNightViewsForRange("u-range", "2026-05-01", "2026-05-03");
+    expect(nights.map((n) => ({ day: n.requestedDay, resolution: n.resolution }))).toEqual([
+      { day: "2026-05-01", resolution: "exact_anchor" },
+      { day: "2026-05-02", resolution: "wake_day" },
+    ]);
+    expect(nights.map((n) => n.resolution)).not.toContain("latest_completed_prior_night");
+  });
+
+  it("returns empty array when start > end without Firestore I/O", async () => {
     const nights = await loadSleepNightViewsForRange("u-range", "2026-05-10", "2026-05-01");
     expect(nights).toEqual([]);
     expect(userCollection).not.toHaveBeenCalled();

--- a/services/api/src/lib/__tests__/sleepNightRead.range.test.ts
+++ b/services/api/src/lib/__tests__/sleepNightRead.range.test.ts
@@ -1,0 +1,85 @@
+jest.mock("../../db", () => ({
+  userCollection: jest.fn(),
+  documentIdPath: { _: "documentId" },
+}));
+
+import type { SleepNightDocumentDto } from "@oli/contracts/sleepNight";
+import { loadSleepNightViewsForRange } from "../sleepNightRead";
+
+const userCollection = jest.requireMock("../../db").userCollection as jest.Mock;
+
+function nightDoc(
+  over: Partial<SleepNightDocumentDto> & Pick<SleepNightDocumentDto, "anchorDay" | "wakeDay">,
+): SleepNightDocumentDto {
+  return {
+    provider: "oura",
+    source: "ouraVendorSleep",
+    sourceDocumentId: "src",
+    isComplete: true,
+    updatedAt: "2026-05-01T12:00:00.000Z",
+    score: 80,
+    totalSleepMinutes: 400,
+    ...over,
+  };
+}
+
+function snap(data: SleepNightDocumentDto | null) {
+  if (!data) return { exists: false, data: () => undefined };
+  return { exists: true, data: () => data };
+}
+
+describe("loadSleepNightViewsForRange", () => {
+  beforeEach(() => {
+    userCollection.mockReset();
+  });
+
+  it("omits unresolved days and does not query rawEvents", async () => {
+    // Only the last day has a doc; earlier requested days have empty lookback (no prior-night fill).
+    const docs: Record<string, SleepNightDocumentDto | null> = {
+      "2026-04-29": null,
+      "2026-04-30": null,
+      "2026-05-01": null,
+      "2026-05-02": null,
+      "2026-05-03": nightDoc({
+        anchorDay: "2026-05-03",
+        wakeDay: "2026-05-03",
+        score: 88,
+      }),
+    };
+
+    const sleepDocGet = jest.fn(async (id: string) => snap(docs[id] ?? null));
+    const calledCollections: string[] = [];
+
+    userCollection.mockImplementation((_uid: string, name: string) => {
+      calledCollections.push(name);
+      if (name === "sleepNights") {
+        return {
+          doc: (id: string) => ({ get: () => sleepDocGet(id) }),
+        };
+      }
+      if (name === "ouraVendorSleep" || name === "ouraVendorReadiness" || name === "dailyFacts") {
+        return {
+          doc: () => ({ get: async () => ({ exists: false, data: () => undefined }) }),
+          where: () => ({
+            limit: () => ({ get: async () => ({ docs: [] }) }),
+          }),
+        };
+      }
+      if (name === "rawEvents") {
+        throw new Error("rawEvents must not be queried for range reads");
+      }
+      return {};
+    });
+
+    const nights = await loadSleepNightViewsForRange("u-range", "2026-05-01", "2026-05-03");
+    expect(nights.map((n) => n.requestedDay)).toEqual(["2026-05-03"]);
+    expect(calledCollections).not.toContain("rawEvents");
+    expect(sleepDocGet).toHaveBeenCalled();
+  });
+
+  it("returns empty array when start > end", async () => {
+    const nights = await loadSleepNightViewsForRange("u-range", "2026-05-10", "2026-05-01");
+    expect(nights).toEqual([]);
+    expect(userCollection).not.toHaveBeenCalled();
+  });
+});

--- a/services/api/src/lib/__tests__/sleepNightRead.range.test.ts
+++ b/services/api/src/lib/__tests__/sleepNightRead.range.test.ts
@@ -7,6 +7,7 @@ import type { SleepNightDocumentDto } from "@oli/contracts/sleepNight";
 import { loadSleepNightViewsForRange } from "../sleepNightRead";
 
 const userCollection = jest.requireMock("../../db").userCollection as jest.Mock;
+const documentIdPath = jest.requireMock("../../db").documentIdPath;
 
 function nightDoc(
   over: Partial<SleepNightDocumentDto> & Pick<SleepNightDocumentDto, "anchorDay" | "wakeDay">,
@@ -23,23 +24,14 @@ function nightDoc(
   };
 }
 
-function snap(data: SleepNightDocumentDto | null) {
-  if (!data) return { exists: false, data: () => undefined };
-  return { exists: true, data: () => data };
-}
-
 describe("loadSleepNightViewsForRange", () => {
   beforeEach(() => {
     userCollection.mockReset();
   });
 
-  it("omits unresolved days and does not query rawEvents", async () => {
+  it("omits unresolved days, uses one document-ID range query, and does not query rawEvents", async () => {
     // Only the last day has a doc; earlier requested days have empty lookback (no prior-night fill).
-    const docs: Record<string, SleepNightDocumentDto | null> = {
-      "2026-04-29": null,
-      "2026-04-30": null,
-      "2026-05-01": null,
-      "2026-05-02": null,
+    const docs: Record<string, SleepNightDocumentDto> = {
       "2026-05-03": nightDoc({
         anchorDay: "2026-05-03",
         wakeDay: "2026-05-03",
@@ -47,15 +39,34 @@ describe("loadSleepNightViewsForRange", () => {
       }),
     };
 
-    const sleepDocGet = jest.fn(async (id: string) => snap(docs[id] ?? null));
+    const sleepDocGet = jest.fn(async () => {
+      throw new Error("per-doc sleepNights.get() must not be used for range prefetch");
+    });
+    const rangeGet = jest.fn(async () => ({
+      docs: Object.entries(docs).map(([id, data]) => ({
+        id,
+        data: () => data as unknown as Record<string, unknown>,
+      })),
+    }));
+    const whereCalls: { field: unknown; op: string; value: string }[] = [];
     const calledCollections: string[] = [];
 
     userCollection.mockImplementation((_uid: string, name: string) => {
       calledCollections.push(name);
       if (name === "sleepNights") {
-        return {
-          doc: (id: string) => ({ get: () => sleepDocGet(id) }),
+        const chain: {
+          where: (field: unknown, op: string, value: string) => typeof chain;
+          get: typeof rangeGet;
+          doc: () => { get: typeof sleepDocGet };
+        } = {
+          where: (field, op, value) => {
+            whereCalls.push({ field, op, value });
+            return chain;
+          },
+          get: rangeGet,
+          doc: () => ({ get: sleepDocGet }),
         };
+        return chain;
       }
       if (name === "ouraVendorSleep" || name === "ouraVendorReadiness" || name === "dailyFacts") {
         return {
@@ -74,7 +85,12 @@ describe("loadSleepNightViewsForRange", () => {
     const nights = await loadSleepNightViewsForRange("u-range", "2026-05-01", "2026-05-03");
     expect(nights.map((n) => n.requestedDay)).toEqual(["2026-05-03"]);
     expect(calledCollections).not.toContain("rawEvents");
-    expect(sleepDocGet).toHaveBeenCalled();
+    expect(sleepDocGet).not.toHaveBeenCalled();
+    expect(rangeGet).toHaveBeenCalledTimes(1);
+    expect(whereCalls).toEqual([
+      { field: documentIdPath, op: ">=", value: "2026-04-29" },
+      { field: documentIdPath, op: "<=", value: "2026-05-03" },
+    ]);
   });
 
   it("returns empty array when start > end", async () => {

--- a/services/api/src/lib/sleepNightRead.ts
+++ b/services/api/src/lib/sleepNightRead.ts
@@ -421,10 +421,11 @@ function enumerateDayKeysInclusive(start: string, end: string): string[] {
 /**
  * Bounded range read over `users/{uid}/sleepNights` for inclusive [start, end].
  *
- * - Does **not** query `rawEvents` (physiology hydrate uses vendor readiness + dailyFacts only).
- * - Missing calendar days are omitted (no per-day 404).
- * - Uses the same resolution rules as GET /users/me/sleep-night per requested day.
- * - Prefetches `[start-2, end]` with **one** document-ID range query (no per-day `.get()` fan-out).
+ * - **One** document-ID range query for `[start-2, end]` (no per-day `.get()` fan-out).
+ * - **No** per-night hydrate I/O (`ouraVendor*`, `dailyFacts`, `rawEvents`, `events`).
+ * - Sparse semantics: only `exact_anchor` and `wake_day` resolutions are returned.
+ *   `latest_completed_prior_night` is exact-day Dash fallback and must not densify ranges.
+ * - Missing / unresolved calendar days are omitted (no per-day 404).
  */
 export async function loadSleepNightViewsForRange(
   uid: string,
@@ -467,16 +468,11 @@ export async function loadSleepNightViewsForRange(
     const minus1 = byId.get(dayMinus(day, 1)) ?? null;
     const minus2 = byId.get(dayMinus(day, 2)) ?? null;
     const view = resolveSleepNightViewFromBoundedReads(day, exact, minus1, minus2);
-    if (view) resolved.push(view);
+    // Sparse range: do not fill empty calendar days with prior-night Dash fallback.
+    if (view && view.resolution !== "latest_completed_prior_night") {
+      resolved.push(view);
+    }
   }
 
-  const hydrated = await Promise.all(
-    resolved.map(async (view) => {
-      let next = await hydrateSleepNightPhysiologyMetrics(uid, view, { allowRawEventLookup: false });
-      next = await hydrateSleepNightDailyScore(uid, next);
-      return next;
-    }),
-  );
-
-  return hydrated;
+  return resolved;
 }

--- a/services/api/src/lib/sleepNightRead.ts
+++ b/services/api/src/lib/sleepNightRead.ts
@@ -93,6 +93,7 @@ function dedupeDayKeys(days: (string | undefined)[]): string[] {
 export async function hydrateSleepNightPhysiologyMetrics(
   uid: string,
   view: SleepNightViewDto,
+  opts?: { allowRawEventLookup?: boolean },
 ): Promise<SleepNightViewDto> {
   const night = view.sleepNight;
   const hasLowest = typeof night.lowestHeartRateBpm === "number" && Number.isFinite(night.lowestHeartRateBpm);
@@ -110,7 +111,8 @@ export async function hydrateSleepNightPhysiologyMetrics(
     : "none";
 
   const readinessCol = userCollection(uid, "ouraVendorReadiness");
-  const rawEventsCol = userCollection(uid, "rawEvents");
+  const allowRawEventLookup = opts?.allowRawEventLookup !== false;
+  const rawEventsCol = allowRawEventLookup ? userCollection(uid, "rawEvents") : null;
 
   const tryReadinessRecord = async (raw: Record<string, unknown>, docId?: string) => {
     readinessDocFound = true;
@@ -141,7 +143,7 @@ export async function hydrateSleepNightPhysiologyMetrics(
     const linkedId =
       (typeof raw.id === "string" && raw.id.trim().length > 0 ? raw.id.trim() : null) ??
       (typeof docId === "string" && docId.trim().length > 0 ? docId.trim() : null);
-    if (!linkedId) return;
+    if (!linkedId || !rawEventsCol) return;
 
     const rawSnap = await rawEventsCol.doc(linkedId).get();
     if (!rawSnap.exists) return;
@@ -403,4 +405,61 @@ export async function loadSleepNightView(uid: string, requestedDay: string): Pro
   }
 
   return view;
+}
+
+function enumerateDayKeysInclusive(start: string, end: string): string[] {
+  if (start > end) return [];
+  const out: string[] = [];
+  let current = start;
+  while (current <= end) {
+    out.push(current);
+    current = dayMinus(current, -1);
+  }
+  return out;
+}
+
+/**
+ * Bounded range read over `users/{uid}/sleepNights` for inclusive [start, end].
+ *
+ * - Does **not** query `rawEvents` (physiology hydrate uses vendor readiness + dailyFacts only).
+ * - Missing calendar days are omitted (no per-day 404).
+ * - Uses the same resolution rules as GET /users/me/sleep-night per requested day.
+ * - Prefetches doc IDs from `start-2` through `end` so wake-day lookback stays in-memory.
+ */
+export async function loadSleepNightViewsForRange(
+  uid: string,
+  start: string,
+  end: string,
+): Promise<SleepNightViewDto[]> {
+  if (start > end) return [];
+
+  const col = userCollection(uid, "sleepNights");
+  const fetchStart = dayMinus(start, 2);
+  const fetchIds = enumerateDayKeysInclusive(fetchStart, end);
+
+  const snaps = await Promise.all(fetchIds.map((id) => col.doc(id).get()));
+  const byId = new Map<string, SleepNightDocumentDto | null>();
+  for (let i = 0; i < fetchIds.length; i++) {
+    byId.set(fetchIds[i]!, parseSleepNightSnapshot(snaps[i]!));
+  }
+
+  const requestedDays = enumerateDayKeysInclusive(start, end);
+  const resolved: SleepNightViewDto[] = [];
+  for (const day of requestedDays) {
+    const exact = byId.get(day) ?? null;
+    const minus1 = byId.get(dayMinus(day, 1)) ?? null;
+    const minus2 = byId.get(dayMinus(day, 2)) ?? null;
+    const view = resolveSleepNightViewFromBoundedReads(day, exact, minus1, minus2);
+    if (view) resolved.push(view);
+  }
+
+  const hydrated = await Promise.all(
+    resolved.map(async (view) => {
+      let next = await hydrateSleepNightPhysiologyMetrics(uid, view, { allowRawEventLookup: false });
+      next = await hydrateSleepNightDailyScore(uid, next);
+      return next;
+    }),
+  );
+
+  return hydrated;
 }

--- a/services/api/src/lib/sleepNightRead.ts
+++ b/services/api/src/lib/sleepNightRead.ts
@@ -4,7 +4,7 @@ import {
   type SleepNightViewDto,
 } from "@oli/contracts/sleepNight";
 
-import { userCollection } from "../db";
+import { documentIdPath, userCollection } from "../db";
 import { firestoreDocToPlainJson } from "./sleepNightFirestore";
 import { logger } from "./logger";
 import {
@@ -424,7 +424,7 @@ function enumerateDayKeysInclusive(start: string, end: string): string[] {
  * - Does **not** query `rawEvents` (physiology hydrate uses vendor readiness + dailyFacts only).
  * - Missing calendar days are omitted (no per-day 404).
  * - Uses the same resolution rules as GET /users/me/sleep-night per requested day.
- * - Prefetches doc IDs from `start-2` through `end` so wake-day lookback stays in-memory.
+ * - Prefetches `[start-2, end]` with **one** document-ID range query (no per-day `.get()` fan-out).
  */
 export async function loadSleepNightViewsForRange(
   uid: string,
@@ -437,10 +437,27 @@ export async function loadSleepNightViewsForRange(
   const fetchStart = dayMinus(start, 2);
   const fetchIds = enumerateDayKeysInclusive(fetchStart, end);
 
-  const snaps = await Promise.all(fetchIds.map((id) => col.doc(id).get()));
+  // Single bounded query: YYYY-MM-DD doc ids sort lexicographically with calendar order.
+  const rangeSnap = await col
+    .where(documentIdPath, ">=", fetchStart)
+    .where(documentIdPath, "<=", end)
+    .get();
+
   const byId = new Map<string, SleepNightDocumentDto | null>();
-  for (let i = 0; i < fetchIds.length; i++) {
-    byId.set(fetchIds[i]!, parseSleepNightSnapshot(snaps[i]!));
+  for (const id of fetchIds) {
+    byId.set(id, null);
+  }
+  for (const doc of rangeSnap.docs) {
+    // Ignore unexpected ids outside the enumerated window (defensive).
+    if (!byId.has(doc.id)) continue;
+    byId.set(
+      doc.id,
+      parseSleepNightSnapshot({
+        exists: true,
+        id: doc.id,
+        data: () => doc.data() as Record<string, unknown> | undefined,
+      }),
+    );
   }
 
   const requestedDays = enumerateDayKeysInclusive(start, end);

--- a/services/api/src/routes/__tests__/gateway-openapi-sleep-nights-range.contract.test.ts
+++ b/services/api/src/routes/__tests__/gateway-openapi-sleep-nights-range.contract.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const repoRoot = join(__dirname, "..", "..", "..", "..", "..");
+const openApiPath = join(repoRoot, "infra", "gateway", "openapi.yaml");
+
+describe("infra/gateway/openapi.yaml — GET /users/me/sleep-nights", () => {
+  let yaml: string;
+
+  beforeAll(() => {
+    yaml = readFileSync(openApiPath, "utf8");
+  });
+
+  it("includes GET /users/me/sleep-nights with required start and end", () => {
+    expect(yaml).toContain("/users/me/sleep-nights:");
+    expect(yaml).toContain("operationId: sleepNightsRangeGet");
+    expect(yaml).toContain("name: start");
+    expect(yaml).toContain("name: end");
+  });
+});

--- a/services/api/src/routes/__tests__/usersMe.sleepNights.range.test.ts
+++ b/services/api/src/routes/__tests__/usersMe.sleepNights.range.test.ts
@@ -1,0 +1,101 @@
+/**
+ * GET /users/me/sleep-nights — bounded authenticated SleepNight range read.
+ */
+import express from "express";
+import type http from "http";
+import { AddressInfo } from "net";
+
+jest.mock("../../lib/sleepNightRead", () => ({
+  loadSleepNightView: jest.fn(),
+  loadSleepNightViewsForRange: jest.fn(),
+}));
+
+jest.mock("../../db", () => ({
+  userCollection: jest.fn(),
+  documentIdPath: { _: "documentId" },
+}));
+
+import { loadSleepNightViewsForRange } from "../../lib/sleepNightRead";
+import usersMeRoutes from "../usersMe";
+
+const mockLoadRange = loadSleepNightViewsForRange as jest.MockedFunction<typeof loadSleepNightViewsForRange>;
+
+describe("GET /users/me/sleep-nights", () => {
+  let server: http.Server;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    const app = express();
+    app.use((req, _res, next) => {
+      (req as unknown as { uid: string }).uid = "user_sleep_night_range";
+      next();
+    });
+    app.use("/users/me", usersMeRoutes);
+    server = app.listen(0);
+    const addr = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${addr.port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  beforeEach(() => {
+    mockLoadRange.mockReset();
+  });
+
+  it("returns 400 when start/end are missing", async () => {
+    const res = await fetch(`${baseUrl}/users/me/sleep-nights`);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when start > end", async () => {
+    const res = await fetch(`${baseUrl}/users/me/sleep-nights?start=2026-05-10&end=2026-05-01`);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when inclusive span exceeds 90 days", async () => {
+    const res = await fetch(`${baseUrl}/users/me/sleep-nights?start=2026-01-01&end=2026-04-10`);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 200 with empty nights when none resolve", async () => {
+    mockLoadRange.mockResolvedValue([]);
+    const res = await fetch(`${baseUrl}/users/me/sleep-nights?start=2026-05-01&end=2026-05-07`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.dayCount).toBe(7);
+    expect(body.resolvedCount).toBe(0);
+    expect(body.nights).toEqual([]);
+    expect(mockLoadRange).toHaveBeenCalledWith("user_sleep_night_range", "2026-05-01", "2026-05-07");
+  });
+
+  it("returns 200 with resolved nights (missing days omitted)", async () => {
+    mockLoadRange.mockResolvedValue([
+      {
+        requestedDay: "2026-05-02",
+        anchorDay: "2026-05-02",
+        wakeDay: "2026-05-02",
+        resolution: "exact_anchor",
+        isFallback: false,
+        sleepNight: {
+          anchorDay: "2026-05-02",
+          wakeDay: "2026-05-02",
+          provider: "oura",
+          source: "ouraVendorSleep",
+          sourceDocumentId: "s1",
+          score: 80,
+          isComplete: true,
+          totalSleepMinutes: 400,
+        },
+      },
+    ]);
+    const res = await fetch(`${baseUrl}/users/me/sleep-nights?start=2026-05-01&end=2026-05-03`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.dayCount).toBe(3);
+    expect(body.resolvedCount).toBe(1);
+    expect(body.nights).toHaveLength(1);
+    expect(body.nights[0].requestedDay).toBe("2026-05-02");
+  });
+});

--- a/services/api/src/routes/usersMe.ts
+++ b/services/api/src/routes/usersMe.ts
@@ -24,6 +24,7 @@ import {
   workoutMonthSummariesRebuildRangeRequestDtoSchema,
   workoutMonthSummariesRebuildRangeResponseDtoSchema,
   isAcceptedWorkoutMonthSummaryRow,
+  countInclusiveCalendarDays,
 } from "@oli/contracts";
 import {
   nutritionReadProviderForItem,
@@ -57,6 +58,9 @@ import {
   sleepViewDtoSchema,
   readinessViewDtoSchema,
   sleepNightViewDtoSchema,
+  sleepNightRangeQuerySchema,
+  sleepNightRangeResponseDtoSchema,
+  SLEEP_NIGHT_RANGE_MAX_DAYS,
   nutritionFoodSearchResponseDtoSchema,
   nutritionFoodDetailResponseDtoSchema,
   type InsightDto,
@@ -65,7 +69,7 @@ import {
 
 import { db, userCollection, documentIdPath } from "../db";
 import { fillSleepContributorsFromStored } from "../lib/ouraVendorSnapshot";
-import { loadSleepNightView } from "../lib/sleepNightRead";
+import { loadSleepNightView, loadSleepNightViewsForRange } from "../lib/sleepNightRead";
 import {
   isRawEventIngestSuppressionDocId,
   shouldLogSuppressionAuditForId,
@@ -2178,6 +2182,75 @@ router.get(
     const parsed = sleepNightViewDtoSchema.safeParse(view);
     if (!parsed.success) {
       invalidDoc500(req, res, "sleepNight", parsed.error.flatten());
+      return;
+    }
+    res.status(200).json(parsed.data);
+  }),
+);
+
+router.get(
+  "/sleep-nights",
+  asyncHandler(async (req: AuthedRequest, res: Response) => {
+    const uid = requireUid(req, res);
+    if (!uid) return;
+
+    const parsedQ = sleepNightRangeQuerySchema.safeParse(req.query);
+    if (!parsedQ.success) {
+      res.status(400).json({
+        ok: false,
+        error: {
+          code: "INVALID_QUERY",
+          message: "Invalid query params",
+          details: parsedQ.error.flatten(),
+          requestId: getRid(req),
+        },
+      });
+      return;
+    }
+
+    const { start, end } = parsedQ.data;
+    if (start > end) {
+      res.status(400).json({
+        ok: false,
+        error: {
+          code: "INVALID_QUERY",
+          message: "start must be <= end",
+          requestId: getRid(req),
+        },
+      });
+      return;
+    }
+
+    const dayCount = countInclusiveCalendarDays(start, end);
+    if (dayCount < 1 || dayCount > SLEEP_NIGHT_RANGE_MAX_DAYS) {
+      res.status(400).json({
+        ok: false,
+        error: {
+          code: "INVALID_QUERY",
+          message: `Inclusive day span must be 1..${SLEEP_NIGHT_RANGE_MAX_DAYS}`,
+          requestId: getRid(req),
+        },
+      });
+      return;
+    }
+
+    logger.info({
+      msg: "[SLEEP_NIGHT_RANGE_ROUTE]",
+      version: "sleep-night-range-v1",
+      dayCount,
+    });
+
+    const nights = await loadSleepNightViewsForRange(uid, start, end);
+    const out = {
+      start,
+      end,
+      dayCount,
+      resolvedCount: nights.length,
+      nights,
+    };
+    const parsed = sleepNightRangeResponseDtoSchema.safeParse(out);
+    if (!parsed.success) {
+      invalidDoc500(req, res, "sleepNightRange", parsed.error.flatten());
       return;
     }
     res.status(200).json(parsed.data);

--- a/services/api/src/types/dtos.ts
+++ b/services/api/src/types/dtos.ts
@@ -69,8 +69,20 @@ export {
 export type { SleepViewDto, ReadinessViewDto } from "@oli/contracts/ouraVendor";
 
 // Canonical SleepNight read surface (GET /users/me/sleep-night)
-export { sleepNightViewDtoSchema, sleepNightDocumentSchema } from "@oli/contracts/sleepNight";
-export type { SleepNightViewDto, SleepNightDocumentDto, SleepNightResolution } from "@oli/contracts/sleepNight";
+export {
+  sleepNightViewDtoSchema,
+  sleepNightDocumentSchema,
+  sleepNightRangeQuerySchema,
+  sleepNightRangeResponseDtoSchema,
+  SLEEP_NIGHT_RANGE_MAX_DAYS,
+} from "@oli/contracts/sleepNight";
+export type {
+  SleepNightViewDto,
+  SleepNightDocumentDto,
+  SleepNightResolution,
+  SleepNightRangeQuery,
+  SleepNightRangeResponseDto,
+} from "@oli/contracts/sleepNight";
 
 // Nutrition — dev food catalog read surface (GET /users/me/nutrition/*)
 export {


### PR DESCRIPTION
## Summary
- Adds authenticated `GET /users/me/sleep-nights?start=&end=` with an inclusive max span of 90 calendar days.
- Returns sparse `nights[]` (missing days omitted; no per-day 404) using the same SleepNight resolution rules as the exact-day endpoint, without reading `rawEvents` on the range path.
- Includes typed contracts, OpenAPI registration, client helper `getSleepNightsRange`, tests, and a privacy-safe audit note.

## Test plan
- [ ] Confirm CI passes on this draft PR
- [ ] Verify gateway OpenAPI includes `/users/me/sleep-nights` with required `start`/`end`
- [ ] After deploy (separate authorization): smoke-test authenticated range read for a short week window and oversize span → 400
- [ ] Confirm PR #180 remains draft and untouched


Made with [Cursor](https://cursor.com)