### PR TITLE
fix(runtime): SleepNight range client + privacy-safe telemetry for PR #180

### DIFF
--- a/lib/api/__tests__/http.redactUrl.privacy.test.ts
+++ b/lib/api/__tests__/http.redactUrl.privacy.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, beforeEach, afterEach } from "@jest/globals";
+
+import { debugRedactedAuthedUrl } from "@/lib/api/http";
+
+describe("debugRedactedAuthedUrl privacy", () => {
+  const prevBase = process.env.EXPO_PUBLIC_BACKEND_BASE_URL;
+  const prevKey = process.env.EXPO_PUBLIC_GATEWAY_API_KEY;
+
+  beforeEach(() => {
+    process.env.EXPO_PUBLIC_BACKEND_BASE_URL = "https://oli-gateway-cw04f997.uc.gateway.dev";
+    process.env.EXPO_PUBLIC_GATEWAY_API_KEY = "test-gateway-key";
+  });
+
+  afterEach(() => {
+    if (prevBase === undefined) delete process.env.EXPO_PUBLIC_BACKEND_BASE_URL;
+    else process.env.EXPO_PUBLIC_BACKEND_BASE_URL = prevBase;
+    if (prevKey === undefined) delete process.env.EXPO_PUBLIC_GATEWAY_API_KEY;
+    else process.env.EXPO_PUBLIC_GATEWAY_API_KEY = prevKey;
+  });
+
+  it("redacts gateway key and day query values from sleep-night URLs", () => {
+    const out = debugRedactedAuthedUrl("/users/me/sleep-night?day=2026-07-10");
+    expect(out).toContain("key=REDACTED");
+    expect(out).toContain("day=REDACTED_DAY");
+    expect(out).not.toContain("2026-07-10");
+    expect(out).not.toContain("test-gateway-key");
+  });
+});

--- a/lib/api/__tests__/mobileHttpTelemetry.test.ts
+++ b/lib/api/__tests__/mobileHttpTelemetry.test.ts
@@ -1,0 +1,169 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  MOBILE_HTTP_TELEMETRY_LOG_LABEL,
+  MOBILE_HTTP_TELEMETRY_OPERATION,
+  MOBILE_HTTP_TELEMETRY_PROHIBITED_KEYS,
+  UNMATCHED_ROUTE_TEMPLATE,
+  assertMobileHttpTelemetryPayloadSafe,
+  buildMobileHttpTelemetryEvent,
+  emitMobileHttpTelemetry,
+  isStrictUuid,
+  toMobileRouteTemplate,
+} from "@/lib/api/mobileHttpTelemetry";
+
+describe("mobileHttpTelemetry", () => {
+  const prevVerbose = process.env.EXPO_PUBLIC_MOBILE_HTTP_TELEMETRY_VERBOSE;
+
+  afterEach(() => {
+    if (prevVerbose === undefined) {
+      delete process.env.EXPO_PUBLIC_MOBILE_HTTP_TELEMETRY_VERBOSE;
+    } else {
+      process.env.EXPO_PUBLIC_MOBILE_HTTP_TELEMETRY_VERBOSE = prevVerbose;
+    }
+    jest.restoreAllMocks();
+  });
+
+  it("maps sleep-night query path to a day-free route template", () => {
+    expect(toMobileRouteTemplate("/users/me/sleep-night?day=2026-07-10")).toBe(
+      "/users/me/sleep-night",
+    );
+  });
+
+  it("parameterizes path day segments and rejects residual dates", () => {
+    expect(toMobileRouteTemplate("/users/me/sleep-nights/2026-07-10")).toBe(
+      "/users/me/sleep-nights/:day",
+    );
+  });
+
+  it("returns unmatched sentinel for non-API roots", () => {
+    expect(toMobileRouteTemplate("https://evil.example/x")).toBe(UNMATCHED_ROUTE_TEMPLATE);
+    expect(toMobileRouteTemplate("/admin/secret")).toBe(UNMATCHED_ROUTE_TEMPLATE);
+  });
+
+  it("builds a successful GET event with only allowed fields", () => {
+    const event = buildMobileHttpTelemetryEvent({
+      method: "GET",
+      routePath: "/users/me/sleep-night?day=2026-07-10&t=focus:2026-07-10",
+      statusCode: 200,
+      durationMs: 12.7,
+      authenticated: true,
+      apiKeyPresent: true,
+    });
+    expect(event.operation).toBe(MOBILE_HTTP_TELEMETRY_OPERATION);
+    expect(event.method).toBe("GET");
+    expect(event.routeTemplate).toBe("/users/me/sleep-night");
+    expect(event.statusCode).toBe(200);
+    expect(event.durationMs).toBe(13);
+    expect(event.authenticated).toBe(true);
+    expect(event.apiKeyPresent).toBe(true);
+    expect(event.retryCount).toBe(0);
+    expect(event.safeErrorCode).toBe("NONE");
+    expect(isStrictUuid(event.requestId)).toBe(true);
+    assertMobileHttpTelemetryPayloadSafe(event as unknown as Record<string, unknown>);
+    for (const key of MOBILE_HTTP_TELEMETRY_PROHIBITED_KEYS) {
+      expect(event).not.toHaveProperty(key);
+    }
+    const json = JSON.stringify(event);
+    expect(json).not.toContain("2026-07-10");
+    expect(json).not.toMatch(/https?:\/\//i);
+    expect(json).not.toMatch(/[?&](key|day|t)=/);
+  });
+
+  it.each([
+    [200, "POST", "NONE"],
+    [400, "POST", "HTTP_4XX"],
+    [401, "GET", "HTTP_4XX"],
+    [404, "GET", "HTTP_4XX"],
+    [500, "POST", "HTTP_5XX"],
+  ] as const)("maps status %s %s to %s", (status, method, code) => {
+    const event = buildMobileHttpTelemetryEvent({
+      method,
+      routePath: "/integrations/oura/status",
+      statusCode: status,
+      durationMs: 1,
+      authenticated: true,
+      apiKeyPresent: false,
+    });
+    expect(event.safeErrorCode).toBe(code);
+  });
+
+  it("maps network and timeout failures", () => {
+    expect(
+      buildMobileHttpTelemetryEvent({
+        method: "GET",
+        routePath: "/users/me/preferences",
+        statusCode: 0,
+        durationMs: 1,
+        authenticated: true,
+        apiKeyPresent: false,
+        networkError: "Network error",
+      }).safeErrorCode,
+    ).toBe("NETWORK");
+    expect(
+      buildMobileHttpTelemetryEvent({
+        method: "GET",
+        routePath: "/users/me/preferences",
+        statusCode: 0,
+        durationMs: 1,
+        authenticated: true,
+        apiKeyPresent: false,
+        networkError: "Request timed out",
+      }).safeErrorCode,
+    ).toBe("TIMEOUT");
+  });
+
+  it("generates a unique strict UUID per event", () => {
+    const a = buildMobileHttpTelemetryEvent({
+      method: "GET",
+      routePath: "/health",
+      statusCode: 200,
+      durationMs: 1,
+      authenticated: false,
+      apiKeyPresent: false,
+    });
+    const b = buildMobileHttpTelemetryEvent({
+      method: "GET",
+      routePath: "/health",
+      statusCode: 200,
+      durationMs: 1,
+      authenticated: false,
+      apiKeyPresent: false,
+    });
+    expect(isStrictUuid(a.requestId)).toBe(true);
+    expect(isStrictUuid(b.requestId)).toBe(true);
+    expect(a.requestId).not.toBe(b.requestId);
+  });
+
+  it("does not emit under Jest by default", () => {
+    const spy = jest.spyOn(console, "log").mockImplementation(() => undefined);
+    process.env.EXPO_PUBLIC_MOBILE_HTTP_TELEMETRY_VERBOSE = "1";
+    emitMobileHttpTelemetry({
+      method: "GET",
+      routePath: "/health",
+      statusCode: 500,
+      durationMs: 1,
+      authenticated: false,
+      apiKeyPresent: false,
+    });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("source guard: telemetry helper never constructs raw-URL payloads", () => {
+    const src = readFileSync(join(__dirname, "../mobileHttpTelemetry.ts"), "utf8");
+    expect(src).not.toMatch(/console\.log\(\s*["']\[NET_TRACE\]/);
+    expect(src).not.toMatch(/console\.log\([^\n]*\burl\s*:/);
+    expect(src).toContain(MOBILE_HTTP_TELEMETRY_LOG_LABEL);
+    expect(src).toContain("MOBILE_HTTP_TELEMETRY_PROHIBITED_KEYS");
+    expect(src).toContain("assertMobileHttpTelemetryPayloadSafe");
+  });
+
+  it("source guard: http.ts emits route-template helper only", () => {
+    const src = readFileSync(join(__dirname, "../http.ts"), "utf8");
+    expect(src).not.toMatch(/console\.log\(\s*["']\[NET_TRACE\]/);
+    expect(src).not.toContain("safeNetTraceLog");
+    expect(src).toContain("emitMobileHttpTelemetry");
+    expect(src).not.toMatch(/emitMobileHttpTelemetry\(\{[\s\S]*?\burl\s*:/);
+  });
+});

--- a/lib/api/http.ts
+++ b/lib/api/http.ts
@@ -127,9 +127,15 @@ function redactUrlForLogs(rawUrl: string): string {
   try {
     const u = new URL(rawUrl);
     if (u.searchParams.has("key")) u.searchParams.set("key", "REDACTED");
+    // Health day queries and similar calendar keys — keep param presence, hide values.
+    for (const param of ["day", "start", "end", "from", "to", "anchorDay", "wakeDay"]) {
+      if (u.searchParams.has(param)) u.searchParams.set(param, "REDACTED_DAY");
+    }
+    // Path segments that look like YYYY-MM-DD
+    u.pathname = u.pathname.replace(/\d{4}-\d{2}-\d{2}/g, "REDACTED_DAY");
     return u.toString();
   } catch {
-    return rawUrl;
+    return rawUrl.replace(/\d{4}-\d{2}-\d{2}/g, "REDACTED_DAY");
   }
 }
 

--- a/lib/api/http.ts
+++ b/lib/api/http.ts
@@ -1,4 +1,6 @@
 // lib/api/http.ts
+import { emitMobileHttpTelemetry } from "@/lib/api/mobileHttpTelemetry";
+
 export type JsonPrimitive = string | number | boolean | null;
 export type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
 
@@ -139,29 +141,6 @@ function redactUrlForLogs(rawUrl: string): string {
   }
 }
 
-/** When `1`, log every successful HTTP response in dev (verbose). Default: only failures/timeouts. */
-function netTraceVerboseSuccess(): boolean {
-  return process.env.EXPO_PUBLIC_NET_TRACE === "1";
-}
-
-function safeNetTraceLog(fields: Record<string, unknown>): void {
-  // DEV ONLY: keep deterministic network traces without shipping logs.
-  if (!__DEV__) return;
-  // Silence Jest/CI to keep logs clean and deterministic.
-  if (process.env.JEST_WORKER_ID) return;
-
-  const status = typeof fields.status === "number" ? fields.status : undefined;
-  const networkError =
-    typeof fields.networkError === "string" && fields.networkError.trim().length > 0;
-  const isFailure =
-    networkError || status === undefined || status < 200 || status > 299;
-  if (!isFailure && !netTraceVerboseSuccess()) return;
-
-  // No secrets: url is redacted (key=REDACTED) + booleans + status + requestId.
-  // eslint-disable-next-line no-console
-  console.log("[NET_TRACE]", JSON.stringify(fields));
-}
-
 function debugLogBackendBaseUrlOncePerCall(baseRaw: string | undefined): void {
   if (!__DEV__ || process.env.JEST_WORKER_ID) return;
   if (process.env.EXPO_PUBLIC_DEBUG_API_BASE_URL !== "1") return;
@@ -209,20 +188,31 @@ export function debugRedactedAuthedUrl(path: string, opts?: { cacheBust?: string
   return redactUrlForLogs(url);
 }
 
-async function apiFetchJson<T>(url: string, init: RequestInit, timeoutMs?: number): Promise<ApiResult<T>> {
+type ApiFetchTelemetry = {
+  /** Caller path (may include query). Used only for route-template mapping. */
+  routePath: string;
+};
+
+async function apiFetchJson<T>(
+  url: string,
+  init: RequestInit,
+  timeoutMs?: number,
+  telemetry?: ApiFetchTelemetry,
+): Promise<ApiResult<T>> {
   const controller = new AbortController();
   const t = timeoutMs ?? 15000;
   const timer = setTimeout(() => controller.abort(), t);
+  const startedAt = Date.now();
 
   // ---- instrumentation (privacy-safe) ----
   const h = toHeaderRecord(init.headers);
   const hasAuthHeader = typeof h["authorization"] === "string" && h["authorization"].trim().length > 0;
-  const hasForwardedAuthHeader =
-    typeof h["x-forwarded-authorization"] === "string" && h["x-forwarded-authorization"].trim().length > 0;
   const hasApiKeyHeader = typeof h["x-api-key"] === "string" && h["x-api-key"].trim().length > 0;
   const hasApiKeyQueryParam = hasApiKeyInUrl(url);
   const method = (init.method ?? "GET").toUpperCase();
-  const urlForLogs = redactUrlForLogs(url);
+  const routePath = telemetry?.routePath ?? "/";
+  const authenticated = hasAuthHeader;
+  const apiKeyPresent = hasApiKeyHeader || hasApiKeyQueryParam;
   // ----------------------------------------
 
   try {
@@ -237,16 +227,14 @@ async function apiFetchJson<T>(url: string, init: RequestInit, timeoutMs?: numbe
     const status = res.status;
     const responseContentType = res.headers.get("content-type");
 
-    // ---- instrumentation (privacy-safe) ----
-    safeNetTraceLog({
+    // ---- instrumentation (privacy-safe route template only) ----
+    emitMobileHttpTelemetry({
       method,
-      url: urlForLogs,
-      hasAuthHeader,
-      hasForwardedAuthHeader,
-      hasApiKeyHeader,
-      hasApiKeyQueryParam,
-      status,
-      requestId: rid ?? "missing",
+      routePath,
+      statusCode: status,
+      durationMs: Date.now() - startedAt,
+      authenticated,
+      apiKeyPresent,
     });
     // ----------------------------------------
 
@@ -335,16 +323,14 @@ async function apiFetchJson<T>(url: string, init: RequestInit, timeoutMs?: numbe
 
     const msg = isAbort ? "Request timed out" : e instanceof Error ? e.message : "Network error";
 
-    // ---- instrumentation (privacy-safe) ----
-    safeNetTraceLog({
+    // ---- instrumentation (privacy-safe route template only) ----
+    emitMobileHttpTelemetry({
       method,
-      url: urlForLogs,
-      hasAuthHeader,
-      hasForwardedAuthHeader,
-      hasApiKeyHeader,
-      hasApiKeyQueryParam,
-      status: 0,
-      requestId: "missing",
+      routePath,
+      statusCode: 0,
+      durationMs: Date.now() - startedAt,
+      authenticated,
+      apiKeyPresent,
       networkError: msg,
     });
     // ----------------------------------------
@@ -411,7 +397,7 @@ export async function apiGetJsonAuthed<T>(path: string, idToken: string, opts?: 
   const headers = buildHeaders(headerOpts);
   headers.Authorization = `Bearer ${idToken}`;
 
-  return apiFetchJson<T>(url, { method: "GET", headers }, opts?.timeoutMs);
+  return apiFetchJson<T>(url, { method: "GET", headers }, opts?.timeoutMs, { routePath: path });
 }
 
 export async function apiPostJsonAuthed<T>(
@@ -459,7 +445,12 @@ export async function apiPostJsonAuthed<T>(
 
   const bodyStr = JSON.stringify(body);
 
-  return apiFetchJson<T>(url, { method: "POST", headers, body: bodyStr }, opts?.timeoutMs);
+  return apiFetchJson<T>(
+    url,
+    { method: "POST", headers, body: bodyStr },
+    opts?.timeoutMs,
+    { routePath: path },
+  );
 }
 
 export async function apiPutJsonAuthed<T>(
@@ -506,7 +497,12 @@ export async function apiPutJsonAuthed<T>(
 
   const bodyStr = JSON.stringify(body);
 
-  return apiFetchJson<T>(url, { method: "PUT", headers, body: bodyStr }, opts?.timeoutMs);
+  return apiFetchJson<T>(
+    url,
+    { method: "PUT", headers, body: bodyStr },
+    opts?.timeoutMs,
+    { routePath: path },
+  );
 }
 
 export async function apiDeleteJsonAuthed<T>(
@@ -549,5 +545,7 @@ export async function apiDeleteJsonAuthed<T>(
   const headers = buildHeaders(headerOpts);
   headers.Authorization = `Bearer ${idToken}`;
 
-  return apiFetchJson<T>(url, { method: "DELETE", headers }, opts?.timeoutMs);
+  return apiFetchJson<T>(url, { method: "DELETE", headers }, opts?.timeoutMs, {
+    routePath: path,
+  });
 }

--- a/lib/api/mobileHttpTelemetry.ts
+++ b/lib/api/mobileHttpTelemetry.ts
@@ -93,7 +93,7 @@ export function toMobileRouteTemplate(routePath: string): string {
   if (!bare.startsWith("/")) return UNMATCHED_ROUTE_TEMPLATE;
   if (bare.includes("://") || bare.includes("@")) return UNMATCHED_ROUTE_TEMPLATE;
 
-  let template = bare
+  const template = bare
     .replace(/\/\d{4}-\d{2}-\d{2}(?=\/|$)/g, "/:day")
     .replace(
       /\/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}(?=\/|$)/gi,

--- a/lib/api/mobileHttpTelemetry.ts
+++ b/lib/api/mobileHttpTelemetry.ts
@@ -163,7 +163,7 @@ export function buildMobileHttpTelemetryEvent(input: {
     retryCount,
     safeErrorCode: resolveSafeErrorCode({
       statusCode: input.statusCode,
-      networkError: input.networkError,
+      ...(input.networkError != null ? { networkError: input.networkError } : {}),
     }),
   };
 }

--- a/lib/api/mobileHttpTelemetry.ts
+++ b/lib/api/mobileHttpTelemetry.ts
@@ -1,0 +1,226 @@
+/**
+ * Privacy-safe mobile HTTP completion telemetry.
+ *
+ * Emits only route templates and closed unions — never URLs, query values,
+ * cache-bust values, keys, tokens, or health dates.
+ */
+
+export const MOBILE_HTTP_TELEMETRY_OPERATION = "mobile_http_request_completed" as const;
+export const MOBILE_HTTP_TELEMETRY_LOG_LABEL = "[MOBILE_HTTP]" as const;
+export const UNMATCHED_ROUTE_TEMPLATE = "UNMATCHED_ROUTE" as const;
+
+export type MobileHttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+
+export type MobileHttpSafeErrorCode =
+  | "NONE"
+  | "HTTP_4XX"
+  | "HTTP_5XX"
+  | "NETWORK"
+  | "TIMEOUT"
+  | "UNKNOWN";
+
+export type MobileHttpTelemetryEvent = {
+  operation: typeof MOBILE_HTTP_TELEMETRY_OPERATION;
+  method: MobileHttpMethod;
+  routeTemplate: string;
+  statusCode: number;
+  durationMs: number;
+  requestId: string;
+  authenticated: boolean;
+  apiKeyPresent: boolean;
+  retryCount: number;
+  safeErrorCode: MobileHttpSafeErrorCode;
+};
+
+/** Keys that must never appear on a mobile HTTP telemetry payload. */
+export const MOBILE_HTTP_TELEMETRY_PROHIBITED_KEYS = [
+  "url",
+  "originalUrl",
+  "query",
+  "day",
+  "date",
+  "start",
+  "end",
+  "cacheBust",
+  "key",
+  "token",
+  "authorization",
+  "body",
+  "response",
+  "path",
+  "host",
+  "hostname",
+  "headers",
+  "stack",
+  "payload",
+] as const;
+
+const STRICT_UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const METHOD_SET = new Set<string>(["GET", "POST", "PUT", "PATCH", "DELETE"]);
+
+export function isStrictUuid(value: string): boolean {
+  return STRICT_UUID_RE.test(value);
+}
+
+export function newTelemetryRequestId(): string {
+  const c = globalThis.crypto as { randomUUID?: () => string } | undefined;
+  if (c && typeof c.randomUUID === "function") {
+    return c.randomUUID();
+  }
+  // Deterministic-shape fallback when crypto.randomUUID is unavailable.
+  const bytes = new Uint8Array(16);
+  for (let i = 0; i < 16; i += 1) bytes[i] = Math.floor(Math.random() * 256);
+  bytes[6] = (bytes[6]! & 0x0f) | 0x40;
+  bytes[8] = (bytes[8]! & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+export function normalizeMobileHttpMethod(raw: string): MobileHttpMethod {
+  const m = raw.toUpperCase();
+  if (METHOD_SET.has(m)) return m as MobileHttpMethod;
+  return "GET";
+}
+
+/**
+ * Map a caller path (may include query) to a static route template.
+ * Query strings are discarded. Calendar days and opaque ids are parameterized.
+ */
+export function toMobileRouteTemplate(routePath: string): string {
+  const bare = routePath.split("?")[0] ?? "";
+  if (!bare.startsWith("/")) return UNMATCHED_ROUTE_TEMPLATE;
+  if (bare.includes("://") || bare.includes("@")) return UNMATCHED_ROUTE_TEMPLATE;
+
+  let template = bare
+    .replace(/\/\d{4}-\d{2}-\d{2}(?=\/|$)/g, "/:day")
+    .replace(
+      /\/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}(?=\/|$)/gi,
+      "/:id",
+    )
+    .replace(/\/[A-Za-z0-9_-]{24,}(?=\/|$)/g, "/:id");
+
+  // Reject residual YYYY-MM-DD anywhere (defense in depth).
+  if (/\d{4}-\d{2}-\d{2}/.test(template)) return UNMATCHED_ROUTE_TEMPLATE;
+
+  // Only allow known API roots used by the mobile client.
+  const allowedPrefix =
+    template === "/health" ||
+    template.startsWith("/users/me") ||
+    template.startsWith("/integrations/") ||
+    template.startsWith("/v1/");
+  if (!allowedPrefix) return UNMATCHED_ROUTE_TEMPLATE;
+
+  return template;
+}
+
+export function resolveSafeErrorCode(input: {
+  statusCode: number;
+  networkError?: string | null;
+}): MobileHttpSafeErrorCode {
+  const msg = (input.networkError ?? "").toLowerCase();
+  if (msg.includes("timed out") || msg.includes("timeout") || msg.includes("abort")) {
+    return "TIMEOUT";
+  }
+  if (input.statusCode === 0 || msg.length > 0) return "NETWORK";
+  if (input.statusCode >= 500) return "HTTP_5XX";
+  if (input.statusCode >= 400) return "HTTP_4XX";
+  if (input.statusCode >= 200 && input.statusCode < 300) return "NONE";
+  return "UNKNOWN";
+}
+
+export function buildMobileHttpTelemetryEvent(input: {
+  method: string;
+  routePath: string;
+  statusCode: number;
+  durationMs: number;
+  authenticated: boolean;
+  apiKeyPresent: boolean;
+  retryCount?: number;
+  networkError?: string | null;
+}): MobileHttpTelemetryEvent {
+  const durationMs =
+    Number.isFinite(input.durationMs) && input.durationMs >= 0
+      ? Math.round(input.durationMs)
+      : 0;
+  const retryCount =
+    typeof input.retryCount === "number" &&
+    Number.isFinite(input.retryCount) &&
+    input.retryCount >= 0
+      ? Math.floor(input.retryCount)
+      : 0;
+
+  return {
+    operation: MOBILE_HTTP_TELEMETRY_OPERATION,
+    method: normalizeMobileHttpMethod(input.method),
+    routeTemplate: toMobileRouteTemplate(input.routePath),
+    statusCode: Number.isFinite(input.statusCode) ? Math.trunc(input.statusCode) : 0,
+    durationMs,
+    requestId: newTelemetryRequestId(),
+    authenticated: input.authenticated === true,
+    apiKeyPresent: input.apiKeyPresent === true,
+    retryCount,
+    safeErrorCode: resolveSafeErrorCode({
+      statusCode: input.statusCode,
+      networkError: input.networkError,
+    }),
+  };
+}
+
+export function assertMobileHttpTelemetryPayloadSafe(
+  event: Record<string, unknown>,
+): void {
+  for (const key of MOBILE_HTTP_TELEMETRY_PROHIBITED_KEYS) {
+    if (Object.prototype.hasOwnProperty.call(event, key)) {
+      throw new Error(`mobile http telemetry prohibited key: ${key}`);
+    }
+  }
+  const serialized = JSON.stringify(event);
+  if (/https?:\/\//i.test(serialized)) {
+    throw new Error("mobile http telemetry must not contain absolute URLs");
+  }
+  if (/[?&](key|day|start|end|t)=/i.test(serialized)) {
+    throw new Error("mobile http telemetry must not contain query-bearing strings");
+  }
+  if (/\d{4}-\d{2}-\d{2}/.test(serialized)) {
+    throw new Error("mobile http telemetry must not contain calendar day values");
+  }
+}
+
+/** When `1`, log every successful response in DEV. Default: failures/timeouts only. */
+function verboseSuccessTelemetry(): boolean {
+  return (
+    process.env.EXPO_PUBLIC_MOBILE_HTTP_TELEMETRY_VERBOSE === "1" ||
+    process.env.EXPO_PUBLIC_NET_TRACE === "1"
+  );
+}
+
+/**
+ * Emit one privacy-safe completion event (route templates only; never raw URLs).
+ */
+export function emitMobileHttpTelemetry(input: {
+  method: string;
+  routePath: string;
+  statusCode: number;
+  durationMs: number;
+  authenticated: boolean;
+  apiKeyPresent: boolean;
+  retryCount?: number;
+  networkError?: string | null;
+}): void {
+  if (!__DEV__) return;
+  if (process.env.JEST_WORKER_ID) return;
+
+  const event = buildMobileHttpTelemetryEvent(input);
+  assertMobileHttpTelemetryPayloadSafe(event as unknown as Record<string, unknown>);
+
+  const isFailure =
+    event.safeErrorCode !== "NONE" ||
+    event.statusCode < 200 ||
+    event.statusCode > 299;
+  if (!isFailure && !verboseSuccessTelemetry()) return;
+
+  // eslint-disable-next-line no-console
+  console.log(MOBILE_HTTP_TELEMETRY_LOG_LABEL, JSON.stringify(event));
+}

--- a/lib/api/usersMe.ts
+++ b/lib/api/usersMe.ts
@@ -427,17 +427,17 @@ export const logWorkoutTitleOverride = async (
   const idempotencyKey = workoutTitleOverrideIdempotencyKey();
 
   if (__DEV__ && !process.env.JEST_WORKER_ID) {
-    // Temporary: trace ingest shape when debugging HTTP 400 (remove once stable).
+    // Privacy-safe: never log full ingest payload, titles, IDs, or timestamps.
     // eslint-disable-next-line no-console
     console.log("[workout_title_override] POST /ingest (pre-send)", {
+      operation: "workout_title_override_ingest",
       kind: ingestBody.kind,
-      fullPayload: ingestBody,
-      targetWorkoutId: payload.targetWorkoutId,
-      displayName: payload.displayName,
-      appliedAt: payload.appliedAt,
-      timeZone: ingestBody.timeZone,
-      observedAt: ingestBody.observedAt,
-      idempotencyKey,
+      hasTargetWorkoutId: Boolean(payload.targetWorkoutId),
+      hasDisplayName: typeof payload.displayName === "string" && payload.displayName.length > 0,
+      hasAppliedAt: Boolean(payload.appliedAt),
+      hasTimeZone: Boolean(ingestBody.timeZone),
+      hasObservedAt: Boolean(ingestBody.observedAt),
+      hasIdempotencyKey: Boolean(idempotencyKey),
     });
   }
 

--- a/lib/data/activity/appleHealthForcedLocalTodaySteps.ts
+++ b/lib/data/activity/appleHealthForcedLocalTodaySteps.ts
@@ -111,7 +111,7 @@ export async function runForcedLocalTodayAppleHealthStepsIngest(
 
   const pulled = await pullStepCountForLocalCalendarDay(todayKey);
   if (!pulled.ok) {
-    devLog("skip: hk pull failed", { day: todayKey, error: pulled.error });
+    devLog("skip: hk pull failed", { hasError: Boolean(pulled.error) });
     return;
   }
 
@@ -119,9 +119,9 @@ export async function runForcedLocalTodayAppleHealthStepsIngest(
   const storedSteps = await fetchStoredStepsForDay(todayKey, token);
 
   devLog("hk vs stored", {
-    day: todayKey,
-    hkSteps: hkStepsRounded,
-    storedSteps,
+    hasHkSteps: true,
+    hasStoredSteps: storedSteps !== null,
+    stepsMatch: storedSteps === null ? null : storedSteps === hkStepsRounded,
     hkEmpty: pulled.hkEmpty === true,
   });
 
@@ -144,11 +144,10 @@ export async function runForcedLocalTodayAppleHealthStepsIngest(
   const idempotencyKey = stepsIdempotencyKey(todayKey);
 
   devLog("post /ingest", {
-    day: todayKey,
-    idempotencyKey,
-    payloadSteps: body.payload.steps,
-    payloadStart: body.payload.start,
-    payloadTimezone: body.payload.timezone,
+    hasIdempotencyKey: Boolean(idempotencyKey),
+    hasPayloadSteps: typeof body.payload.steps === "number",
+    hasPayloadStart: Boolean(body.payload.start),
+    hasPayloadTimezone: Boolean(body.payload.timezone),
   });
 
   const res = await ingestRawEvent(body, token, {
@@ -157,9 +156,9 @@ export async function runForcedLocalTodayAppleHealthStepsIngest(
   });
 
   devLog("ingest response", {
-    day: todayKey,
     ok: res.ok,
-    ...(res.ok ? {} : { error: res.error, requestId: res.requestId }),
+    status: res.status,
+    ...(res.ok ? {} : { hasError: Boolean(res.error), hasRequestId: Boolean(res.requestId) }),
   });
 
   if (!res.ok) return;

--- a/lib/data/activity/appleHealthForcedLocalTodaySteps.ts
+++ b/lib/data/activity/appleHealthForcedLocalTodaySteps.ts
@@ -105,7 +105,7 @@ export async function runForcedLocalTodayAppleHealthStepsIngest(
 
   const perm = await requestPermissions();
   if (!perm.ok) {
-    devLog("skip: no permissions", { day: todayKey });
+    devLog("skip: no permissions", { hasDayKey: Boolean(todayKey) });
     return;
   }
 

--- a/lib/data/activity/appleHealthForcedLocalYesterdaySteps.ts
+++ b/lib/data/activity/appleHealthForcedLocalYesterdaySteps.ts
@@ -32,6 +32,19 @@ function devLog(message: string, data: Record<string, unknown>): void {
   console.log(`[AH:steps-yesterday] ${message}`, data);
 }
 
+/** Privacy-safe fields only — never log step counts or other health magnitudes. */
+function privacySafeStepsCompareLog(input: {
+  hasHkSteps: boolean;
+  hasStoredSteps: boolean;
+  stepsMatch: boolean | null;
+}): Record<string, unknown> {
+  return {
+    hasHkSteps: input.hasHkSteps,
+    hasStoredSteps: input.hasStoredSteps,
+    stepsMatch: input.stepsMatch,
+  };
+}
+
 function roundSteps(n: number): number {
   return Math.round(n);
 }
@@ -99,13 +112,20 @@ export async function runForcedLocalYesterdayAppleHealthStepsIngest(
 
   const pulled = await pullStepCountForLocalCalendarDay(yesterdayYmd);
   if (!pulled.ok) {
-    devLog("skip: hk pull failed", { day: yesterdayYmd, error: pulled.error });
+    devLog("skip: hk pull failed", { hasError: Boolean(pulled.error) });
     return;
   }
 
   const hkStepsRounded = roundSteps(pulled.steps);
   const storedSteps = await fetchStoredStepsForDay(yesterdayYmd, token);
-  devLog("hk vs stored", { day: yesterdayYmd, hkSteps: hkStepsRounded, storedSteps });
+  devLog(
+    "hk vs stored",
+    privacySafeStepsCompareLog({
+      hasHkSteps: true,
+      hasStoredSteps: storedSteps !== null,
+      stepsMatch: storedSteps === null ? null : storedSteps === hkStepsRounded,
+    }),
+  );
   if (storedSteps !== null && storedSteps === hkStepsRounded) {
     await setLastIngestedStepsForDay(yesterdayYmd, hkStepsRounded);
     return;
@@ -123,11 +143,10 @@ export async function runForcedLocalYesterdayAppleHealthStepsIngest(
   const idempotencyKey = stepsIdempotencyKey(yesterdayYmd);
 
   devLog("post /ingest", {
-    day: yesterdayYmd,
-    idempotencyKey,
-    payloadSteps: body.payload.steps,
-    payloadStart: body.payload.start,
-    payloadTimezone: body.payload.timezone,
+    hasIdempotencyKey: Boolean(idempotencyKey),
+    hasPayloadSteps: typeof body.payload.steps === "number",
+    hasPayloadStart: Boolean(body.payload.start),
+    hasPayloadTimezone: Boolean(body.payload.timezone),
   });
 
   const res = await ingestRawEvent(body, token, {
@@ -136,9 +155,9 @@ export async function runForcedLocalYesterdayAppleHealthStepsIngest(
   });
 
   devLog("ingest response", {
-    day: yesterdayYmd,
     ok: res.ok,
-    ...(res.ok ? {} : { error: res.error, requestId: res.requestId }),
+    status: res.status,
+    ...(res.ok ? {} : { hasError: Boolean(res.error), hasRequestId: Boolean(res.requestId) }),
   });
 
   if (!res.ok) return;

--- a/lib/data/dash/__tests__/weeklyFitnessSleepAverageDev.privacy.test.ts
+++ b/lib/data/dash/__tests__/weeklyFitnessSleepAverageDev.privacy.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, jest, beforeEach, afterEach } from "@jest/globals";
+
+import { logWeeklyFitnessSleepAverageDev } from "@/lib/data/dash/weeklyFitnessCompletedSleepNights";
+import type { DayKey } from "@/lib/ui/calendar/types";
+
+describe("logWeeklyFitnessSleepAverageDev privacy", () => {
+  const logSpy = jest.spyOn(console, "log").mockImplementation(() => undefined);
+
+  beforeEach(() => {
+    logSpy.mockClear();
+  });
+
+  afterEach(() => {
+    logSpy.mockReset();
+  });
+
+  it("logs counts only — never minutes, day keys, or per-night health samples", () => {
+    logWeeklyFitnessSleepAverageDev({
+      todayDayKey: "2026-07-10" as DayKey,
+      weekStartDay: "2026-07-05" as DayKey,
+      weekEndDay: "2026-07-11" as DayKey,
+      lastCountableWakeDay: "2026-07-10" as DayKey,
+      completedNights: [
+        {
+          calendarDay: "2026-07-09" as DayKey,
+          wakeDay: "2026-07-09" as DayKey,
+          minutes: 412,
+          resolution: "exact_anchor",
+          sourceDocumentId: "s:1",
+        },
+      ],
+      skipped: [],
+      averageMinutes: 412,
+    });
+
+    if (!__DEV__) {
+      expect(logSpy).not.toHaveBeenCalled();
+      return;
+    }
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const [label, payload] = logSpy.mock.calls[0]!;
+    expect(label).toBe("[WEEKLY_FITNESS_SLEEP]");
+    expect(payload).toEqual({
+      operation: "weekly_fitness_sleep_average",
+      denominatorNights: 1,
+      skippedCount: 0,
+      hasAverageMinutes: true,
+    });
+    const serialized = JSON.stringify(payload);
+    expect(serialized).not.toMatch(/412/);
+    expect(serialized).not.toMatch(/2026-07/);
+    expect(serialized).not.toMatch(/"minutes"\s*:/);
+  });
+});

--- a/lib/data/dash/dailySleepCardViewModel.ts
+++ b/lib/data/dash/dailySleepCardViewModel.ts
@@ -153,8 +153,15 @@ export function logDailySleepTruthDev(input: {
 }): void {
   if (!__DEV__) return;
   if (!isDebugDataLogsEnabled()) return;
-  // eslint-disable-next-line no-console -- dev-only truth audit (no PII)
-  console.log(
-    `[DAILY_SLEEP_TRUTH] requestedDay=${input.requestedDay} factsStatus=${input.factsStatus} factsDay=${input.factsDay ?? "null"} renderStatus=${input.renderStatus} blockedStale=${input.blockedStale} sleepSettled=${input.sleepSettled} sleepResolution=${input.sleepResolution ?? "null"} sleepRequestedDay=${input.sleepRequestedDay ?? "null"}`,
-  );
+  // eslint-disable-next-line no-console -- dev-only truth audit (no day keys / health values)
+  console.log("[DAILY_SLEEP_TRUTH]", {
+    operation: "daily_sleep_truth",
+    factsStatus: input.factsStatus,
+    hasFactsDay: input.factsDay != null,
+    renderStatus: input.renderStatus,
+    blockedStale: input.blockedStale,
+    sleepSettled: input.sleepSettled,
+    hasSleepResolution: input.sleepResolution != null,
+    sleepRequestedDayMatches: input.sleepRequestedDay === input.requestedDay,
+  });
 }

--- a/lib/data/dash/useDashOuraViews.ts
+++ b/lib/data/dash/useDashOuraViews.ts
@@ -93,8 +93,12 @@ export function useDashOuraViews(day: string, options?: UseDashOuraViewsOptions)
     const bust = withUniqueCacheBust(bustOpts, myGen);
 
     if (__DEV__) {
-      // eslint-disable-next-line no-console -- Dash Oura sleep fetch audit (dev-only)
-      console.log("[DASH_OURA_SLEEP_FETCH_START]", { day: dayKey, enabled: enabledRef.current });
+      // eslint-disable-next-line no-console -- Dash Oura sleep fetch audit (dev-only, privacy-safe)
+      console.log("[DASH_OURA_SLEEP_FETCH_START]", {
+        operation: "dash_oura_sleep_fetch_start",
+        hasDayKey: Boolean(dayKey),
+        enabled: enabledRef.current,
+      });
     }
 
     let devSleepDone: Record<string, unknown> | null = null;
@@ -107,36 +111,40 @@ export function useDashOuraViews(day: string, options?: UseDashOuraViewsOptions)
         devSleepDone = {
           ok: sleepRes.ok,
           outcome: sleepOutcome.status,
-          requestedDay: ready?.requestedDay,
-          resolvedDay: ready?.resolvedDay,
-          score: ready?.score,
-          error: sleepOutcome.status === "error" ? sleepOutcome.error : undefined,
+          hasRequestedDay: Boolean(ready?.requestedDay),
+          requestedDayMatches: ready?.requestedDay === dayKey,
+          hasResolvedDay: Boolean(ready?.resolvedDay),
+          hasScore: typeof ready?.score === "number" && Number.isFinite(ready.score),
+          hasError: sleepOutcome.status === "error",
         };
         if (myGen !== generationRef.current) return;
         setSleepView(sleepOutcome.status === "ready" ? sleepOutcome.data : undefined);
       })
       .catch((e: unknown) => {
+        const message = e instanceof Error ? e.message : String(e);
         devSleepDone = {
           ok: false,
           outcome: "error",
-          error: e instanceof Error ? e.message : String(e),
+          hasError: true,
         };
-        sleepErrorRef.current = typeof devSleepDone.error === "string" ? devSleepDone.error : undefined;
+        sleepErrorRef.current = message;
         if (myGen === generationRef.current) setSleepView(undefined);
       })
       .finally(() => {
         if (__DEV__) {
           const stale = myGen !== generationRef.current;
           const d = devSleepDone;
-          // eslint-disable-next-line no-console -- Dash Oura sleep fetch audit (dev-only)
+          // eslint-disable-next-line no-console -- Dash Oura sleep fetch audit (dev-only, privacy-safe)
           console.log("[DASH_OURA_SLEEP_FETCH_DONE]", {
-            day: dayKey,
+            operation: "dash_oura_sleep_fetch_done",
+            hasDayKey: Boolean(dayKey),
             ok: Boolean(d?.ok),
             outcome: typeof d?.outcome === "string" ? d.outcome : "incomplete",
-            requestedDay: d?.requestedDay,
-            resolvedDay: d?.resolvedDay,
-            score: d?.score,
-            error: d?.error,
+            hasRequestedDay: Boolean(d?.hasRequestedDay),
+            requestedDayMatches: Boolean(d?.requestedDayMatches),
+            hasResolvedDay: Boolean(d?.hasResolvedDay),
+            hasScore: Boolean(d?.hasScore),
+            hasError: Boolean(d?.hasError),
             cancelled: stale,
             stale,
           });
@@ -201,26 +209,26 @@ export function useDashOuraViews(day: string, options?: UseDashOuraViewsOptions)
 
   useEffect(() => {
     if (!__DEV__) return;
-    // eslint-disable-next-line no-console -- Dash Oura views audit (dev-only)
+    // eslint-disable-next-line no-console -- Dash Oura views audit (dev-only, privacy-safe)
     console.log("[DASH_OURA_VIEWS_DEBUG]", {
-      day,
+      operation: "dash_oura_views",
+      hasDayKey: Boolean(day),
       enabled,
       sleepViewLoading,
       readinessViewLoading,
-      sleepViewRequestedDay: sleepView?.requestedDay,
-      sleepViewResolvedDay: sleepView?.resolvedDay,
-      sleepViewScore: sleepView?.score,
-      sleepError: sleepErrorRef.current,
-      readinessError: readinessErrorRef.current,
+      hasSleepView: sleepView != null,
+      sleepRequestedDayMatches: sleepView?.requestedDay === day,
+      hasSleepResolvedDay: Boolean(sleepView?.resolvedDay),
+      hasSleepScore: typeof sleepView?.score === "number" && Number.isFinite(sleepView.score),
+      hasSleepError: Boolean(sleepErrorRef.current),
+      hasReadinessError: Boolean(readinessErrorRef.current),
     });
   }, [
     day,
     enabled,
     sleepViewLoading,
     readinessViewLoading,
-    sleepView?.requestedDay,
-    sleepView?.resolvedDay,
-    sleepView?.score,
+    sleepView,
   ]);
 
   return useMemo(

--- a/lib/data/dash/useWeeklyFitnessCard.ts
+++ b/lib/data/dash/useWeeklyFitnessCard.ts
@@ -166,11 +166,10 @@ export function useWeeklyFitnessCard(): UseWeeklyFitnessCardResult {
       const { perDay, total } = sumWeeklyStrengthWorkoutsCountFromDailyFacts(strengthFactsInput);
       // eslint-disable-next-line no-console
       console.log("[WEEKLY_FITNESS_STRENGTH_TOTAL]", {
-        weekStartDay,
-        weekEndDay,
-        perDayStrengthWorkoutsCount: perDay,
-        computedWeeklyTotal: total,
-        renderedValueLabel: strength.valueLabel,
+        operation: "weekly_fitness_strength_total",
+        dayCount: Object.keys(perDay).length,
+        hasWeeklyTotal: Number.isFinite(total),
+        hasValueLabel: Boolean(strength.valueLabel),
       });
     }
 

--- a/lib/data/dash/useWeeklyFitnessDailyFactsRollup.ts
+++ b/lib/data/dash/useWeeklyFitnessDailyFactsRollup.ts
@@ -228,16 +228,15 @@ export function useWeeklyFitnessDailyFactsRollup(
       if (isDebugDataLogsEnabled()) {
         // eslint-disable-next-line no-console
         console.log("[WEEKLY_FITNESS_DAILY_FACTS]", {
-        weekStart: keys[0] ?? null,
-        weekEnd: keys[keys.length - 1] ?? null,
-        dayCount: keys.length,
-        missingDayCount,
-        errorDayCount,
-        strengthByDay,
-        strengthWeekTotal,
-        durationMs: Math.round(performance.now() - waveStart),
-        status: finalStatus,
-      });
+          operation: "weekly_fitness_daily_facts",
+          dayCount: keys.length,
+          missingDayCount,
+          errorDayCount,
+          strengthDayCount: Object.keys(strengthByDay).length,
+          hasStrengthWeekTotal: Number.isFinite(strengthWeekTotal),
+          durationMs: Math.round(performance.now() - waveStart),
+          status: finalStatus,
+        });
       }
     }
 

--- a/lib/data/dash/weeklyFitnessCompletedSleepNights.ts
+++ b/lib/data/dash/weeklyFitnessCompletedSleepNights.ts
@@ -167,7 +167,10 @@ export function averageMinutesFromCompletedSleepNights(
   return Math.round(total / completedNights.length);
 }
 
-/** Dev-only: log included nights and denominator for Weekly Fitness sleep average audits. */
+/**
+ * Dev-only: privacy-safe Weekly Fitness sleep average audit.
+ * Never logs minutes, scores, calendar day keys, or per-night health samples.
+ */
 export function logWeeklyFitnessSleepAverageDev(input: {
   todayDayKey: DayKey;
   weekStartDay: DayKey;
@@ -180,20 +183,9 @@ export function logWeeklyFitnessSleepAverageDev(input: {
   if (!__DEV__) return;
   // eslint-disable-next-line no-console -- dev-only Weekly Fitness sleep audit
   console.log("[WEEKLY_FITNESS_SLEEP]", {
-    todayDayKey: input.todayDayKey,
-    weekWakeWindow: {
-      start: input.weekStartDay,
-      end: input.weekEndDay,
-      lastCountableWakeDay: input.lastCountableWakeDay,
-    },
+    operation: "weekly_fitness_sleep_average",
     denominatorNights: input.completedNights.length,
-    averageMinutes: input.averageMinutes,
-    included: input.completedNights.map((n) => ({
-      calendarDay: n.calendarDay,
-      wakeDay: n.wakeDay,
-      minutes: n.minutes,
-      resolution: n.resolution,
-    })),
-    skipped: input.skipped,
+    skippedCount: input.skipped.length,
+    hasAverageMinutes: Number.isFinite(input.averageMinutes),
   });
 }

--- a/lib/data/energy/__tests__/buildEnergyBaselineVm.test.ts
+++ b/lib/data/energy/__tests__/buildEnergyBaselineVm.test.ts
@@ -455,7 +455,7 @@ describe("buildEnergyBaselineVm — per-range coverage thresholds", () => {
 });
 
 describe("buildEnergyBaselineVm — diagnostic logging", () => {
-  it("logs todayDayKey, baselineEndDay, requiredDayCount, validDayCount, earliest/latestIncludedDay per row", () => {
+  it("logs privacy-safe counts only (no energy magnitudes or calendar day keys)", () => {
     const spy = jest.spyOn(console, "log").mockImplementation(jest.fn());
     try {
       const energyByDay = fillCompleteSame(days7, 2230, 2714);
@@ -466,13 +466,18 @@ describe("buildEnergyBaselineVm — diagnostic logging", () => {
       });
       expect(day7Calls.length).toBeGreaterThan(0);
       const payload = day7Calls[0]![1] as Record<string, unknown>;
-      expect(payload.todayDayKey).toBe(today);
-      expect(payload.baselineEndDay).toBe(baselineEndDay);
+      expect(payload.operation).toBe("energy_baseline_window");
       expect(payload.requiredDayCount).toBe(REQUIRED_DAY_COUNT_7);
       expect(payload.validDayCount).toBe(REQUIRED_DAY_COUNT_7);
       expect(payload.hasFullCoverage).toBe(true);
-      expect(payload.earliestIncludedDay).toBe(days7[0]);
-      expect(payload.latestIncludedDay).toBe(baselineEndDay);
+      expect(payload.hasAvgLow).toBe(true);
+      expect(payload.hasAvgHigh).toBe(true);
+      const serialized = JSON.stringify(payload);
+      expect(serialized).not.toMatch(/2230|2714/);
+      expect(serialized).not.toMatch(/2026-/);
+      expect(payload).not.toHaveProperty("todayDayKey");
+      expect(payload).not.toHaveProperty("avgLow");
+      expect(payload).not.toHaveProperty("earliestIncludedDay");
     } finally {
       spy.mockRestore();
     }

--- a/lib/data/energy/buildEnergyBaselineVm.ts
+++ b/lib/data/energy/buildEnergyBaselineVm.ts
@@ -211,18 +211,16 @@ function averagesFromPairs(
  * values have been validated against backend data.
  */
 function logEnergyBaselineDiagnostics(
-  todayDayKey: DayKey,
-  baselineEndDay: DayKey,
+  _todayDayKey: DayKey,
+  _baselineEndDay: DayKey,
   diagnostics: readonly EnergyWindowDiagnostic[],
 ): void {
   if (!__DEV__) return;
   for (const d of diagnostics) {
-    // eslint-disable-next-line no-console -- intentional dev diagnostics (Energy Baseline QA verification)
+    // eslint-disable-next-line no-console -- intentional privacy-safe Energy Baseline diagnostics
     console.log("[EnergyBaseline audit]", {
-      todayDayKey,
-      baselineEndDay,
+      operation: "energy_baseline_window",
       key: d.key,
-      label: d.label,
       windowDayCount: d.windowDayCount,
       requiredDayCount: d.requiredDayCount,
       validDayCount: d.validDayCount,
@@ -232,14 +230,8 @@ function logEnergyBaselineDiagnostics(
       excludedIncompleteCount: d.excludedIncompleteCount,
       excludedBmrOnlyCount: d.excludedBmrOnlyCount,
       excludedStepsOnlyCount: d.excludedStepsOnlyCount,
-      earliestIncludedDay: d.earliestIncludedDay,
-      latestIncludedDay: d.latestIncludedDay,
-      avgLow: d.avgLow,
-      avgHigh: d.avgHigh,
-      minLow: d.minLow,
-      maxLow: d.maxLow,
-      minHigh: d.minHigh,
-      maxHigh: d.maxHigh,
+      hasAvgLow: d.avgLow != null && Number.isFinite(d.avgLow),
+      hasAvgHigh: d.avgHigh != null && Number.isFinite(d.avgHigh),
       includedConfidenceMix: d.includedConfidenceMix,
     });
   }

--- a/lib/data/sleep/__tests__/computeSleepBaselineFetchDayKeys.test.ts
+++ b/lib/data/sleep/__tests__/computeSleepBaselineFetchDayKeys.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "@jest/globals";
 
 import {
+  SLEEP_NIGHT_PER_DAY_FETCH_MAX_DAYS,
+  boundSleepNightFetchDayKeys,
   computeSleepBaselineFetchDayKeys,
   computeSleepOverviewFetchDayKeys,
 } from "@/lib/data/sleep/sleepOverviewRanges";
@@ -30,9 +32,42 @@ describe("computeSleepBaselineFetchDayKeys", () => {
     }
   });
 
-  it("includes today and a year-ago day (covers d365)", () => {
+  it("stays within the interactive per-day fetch bound (no 30/90/365 fan-out)", () => {
     const keys = computeSleepBaselineFetchDayKeys(today);
-    expect(keys).toContain(today);
-    expect(keys.some((d) => d.startsWith("2025-"))).toBe(true);
+    expect(keys.length).toBeLessThanOrEqual(SLEEP_NIGHT_PER_DAY_FETCH_MAX_DAYS);
+    expect(keys.length).toBeLessThanOrEqual(7);
+    expect(keys.length).toBeGreaterThan(0);
+  });
+
+  it("does not include a year-ago day (range API required for long baselines)", () => {
+    const keys = computeSleepBaselineFetchDayKeys(today);
+    expect(keys.some((d) => d.startsWith("2025-"))).toBe(false);
+  });
+});
+
+describe("computeSleepOverviewFetchDayKeys", () => {
+  const today = "2026-04-06" as DayKey;
+
+  it("stays within the interactive per-day fetch bound", () => {
+    const keys = computeSleepOverviewFetchDayKeys(today, today);
+    const elapsed = keys.filter((d) => d <= today);
+    expect(elapsed.length).toBeLessThanOrEqual(SLEEP_NIGHT_PER_DAY_FETCH_MAX_DAYS);
+  });
+});
+
+describe("boundSleepNightFetchDayKeys", () => {
+  it("keeps the most recent maxDays when given a year of keys", () => {
+    const today = "2026-07-10" as DayKey;
+    const yearKeys: DayKey[] = [];
+    for (let i = 365; i >= 0; i--) {
+      const d = new Date(Date.UTC(2026, 6, 10));
+      d.setUTCDate(d.getUTCDate() - i);
+      yearKeys.push(d.toISOString().slice(0, 10) as DayKey);
+    }
+    expect(yearKeys.length).toBeGreaterThan(SLEEP_NIGHT_PER_DAY_FETCH_MAX_DAYS);
+    const bounded = boundSleepNightFetchDayKeys(yearKeys, today);
+    expect(bounded.filter((d) => d <= today).length).toBe(SLEEP_NIGHT_PER_DAY_FETCH_MAX_DAYS);
+    expect(bounded[bounded.length - 1] === today || bounded.includes(today)).toBe(true);
+    expect(bounded.filter((d) => d <= today).every((d) => d <= today)).toBe(true);
   });
 });

--- a/lib/data/sleep/__tests__/computeSleepBaselineFetchDayKeys.test.ts
+++ b/lib/data/sleep/__tests__/computeSleepBaselineFetchDayKeys.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from "@jest/globals";
 
+import { SLEEP_NIGHT_RANGE_MAX_DAYS } from "@oli/contracts";
+
 import {
-  SLEEP_NIGHT_PER_DAY_FETCH_MAX_DAYS,
-  boundSleepNightFetchDayKeys,
   computeSleepBaselineFetchDayKeys,
   computeSleepOverviewFetchDayKeys,
+  sleepNightRangeFetchWindows,
 } from "@/lib/data/sleep/sleepOverviewRanges";
 import type { DayKey } from "@/lib/ui/calendar/types";
 
@@ -32,42 +33,41 @@ describe("computeSleepBaselineFetchDayKeys", () => {
     }
   });
 
-  it("stays within the interactive per-day fetch bound (no 30/90/365 fan-out)", () => {
+  it("includes today and a year-ago day (covers d365)", () => {
     const keys = computeSleepBaselineFetchDayKeys(today);
-    expect(keys.length).toBeLessThanOrEqual(SLEEP_NIGHT_PER_DAY_FETCH_MAX_DAYS);
-    expect(keys.length).toBeLessThanOrEqual(7);
-    expect(keys.length).toBeGreaterThan(0);
-  });
-
-  it("does not include a year-ago day (range API required for long baselines)", () => {
-    const keys = computeSleepBaselineFetchDayKeys(today);
-    expect(keys.some((d) => d.startsWith("2025-"))).toBe(false);
+    expect(keys).toContain(today);
+    expect(keys.some((d) => d.startsWith("2025-"))).toBe(true);
   });
 });
 
-describe("computeSleepOverviewFetchDayKeys", () => {
-  const today = "2026-04-06" as DayKey;
-
-  it("stays within the interactive per-day fetch bound", () => {
-    const keys = computeSleepOverviewFetchDayKeys(today, today);
-    const elapsed = keys.filter((d) => d <= today);
-    expect(elapsed.length).toBeLessThanOrEqual(SLEEP_NIGHT_PER_DAY_FETCH_MAX_DAYS);
+describe("sleepNightRangeFetchWindows", () => {
+  it("returns empty for no keys", () => {
+    expect(sleepNightRangeFetchWindows([])).toEqual([]);
   });
-});
 
-describe("boundSleepNightFetchDayKeys", () => {
-  it("keeps the most recent maxDays when given a year of keys", () => {
-    const today = "2026-07-10" as DayKey;
+  it("returns one window when span is within API max", () => {
+    const keys = ["2026-04-01", "2026-04-06"] as DayKey[];
+    expect(sleepNightRangeFetchWindows(keys)).toEqual([{ start: "2026-04-01", end: "2026-04-06" }]);
+  });
+
+  it("chunks a year span into windows of at most SLEEP_NIGHT_RANGE_MAX_DAYS", () => {
     const yearKeys: DayKey[] = [];
     for (let i = 365; i >= 0; i--) {
-      const d = new Date(Date.UTC(2026, 6, 10));
+      const d = new Date(Date.UTC(2026, 3, 6));
       d.setUTCDate(d.getUTCDate() - i);
       yearKeys.push(d.toISOString().slice(0, 10) as DayKey);
     }
-    expect(yearKeys.length).toBeGreaterThan(SLEEP_NIGHT_PER_DAY_FETCH_MAX_DAYS);
-    const bounded = boundSleepNightFetchDayKeys(yearKeys, today);
-    expect(bounded.filter((d) => d <= today).length).toBe(SLEEP_NIGHT_PER_DAY_FETCH_MAX_DAYS);
-    expect(bounded[bounded.length - 1] === today || bounded.includes(today)).toBe(true);
-    expect(bounded.filter((d) => d <= today).every((d) => d <= today)).toBe(true);
+    const windows = sleepNightRangeFetchWindows(yearKeys);
+    expect(windows.length).toBeGreaterThan(1);
+    expect(windows.length).toBe(Math.ceil(yearKeys.length / SLEEP_NIGHT_RANGE_MAX_DAYS));
+    for (const w of windows) {
+      const start = new Date(`${w.start}T12:00:00.000Z`);
+      const end = new Date(`${w.end}T12:00:00.000Z`);
+      const inclusive = Math.round((end.getTime() - start.getTime()) / 86_400_000) + 1;
+      expect(inclusive).toBeLessThanOrEqual(SLEEP_NIGHT_RANGE_MAX_DAYS);
+      expect(w.start <= w.end).toBe(true);
+    }
+    expect(windows[0]!.start).toBe(yearKeys[0]);
+    expect(windows[windows.length - 1]!.end).toBe(yearKeys[yearKeys.length - 1]);
   });
 });

--- a/lib/data/sleep/__tests__/useSleepNightRollupMap.test.tsx
+++ b/lib/data/sleep/__tests__/useSleepNightRollupMap.test.tsx
@@ -162,4 +162,31 @@ describe("useSleepNightRollupMap", () => {
     expect(out).toContain("settled=1/1");
     expect(out).toContain("views=1");
   });
+
+  it("caps year-long dayKeys to SLEEP_NIGHT_PER_DAY_FETCH_MAX_DAYS network calls", async () => {
+    getSleepNightMock.mockImplementation(async () => ({
+      ok: false,
+      status: 404,
+      requestId: "r",
+      error: { code: "NOT_FOUND", message: "missing" },
+    }) as never);
+
+    const yearKeys: DayKey[] = [];
+    for (let i = 365; i >= 0; i--) {
+      const d = new Date(Date.UTC(2026, 3, 6));
+      d.setUTCDate(d.getUTCDate() - i);
+      yearKeys.push(d.toISOString().slice(0, 10) as DayKey);
+    }
+
+    await act(async () => {
+      renderer.create(<Probe dayKeys={yearKeys} />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getSleepNightMock.mock.calls.length).toBeLessThanOrEqual(14);
+    expect(getSleepNightMock.mock.calls.length).toBeGreaterThan(0);
+  });
 });

--- a/lib/data/sleep/__tests__/useSleepNightRollupMap.test.tsx
+++ b/lib/data/sleep/__tests__/useSleepNightRollupMap.test.tsx
@@ -2,7 +2,9 @@ import React from "react";
 import renderer, { act } from "react-test-renderer";
 import { Text } from "react-native";
 
-import { getSleepNight } from "@/lib/api/usersMe";
+import { SLEEP_NIGHT_RANGE_MAX_DAYS } from "@oli/contracts";
+
+import { getSleepNightsRange } from "@/lib/api/usersMe";
 import { useSleepNightRollupMap } from "@/lib/data/sleep/useSleepNightRollupMap";
 import type { DayKey } from "@/lib/ui/calendar/types";
 
@@ -13,7 +15,7 @@ jest.mock("@/lib/auth/AuthProvider", () => ({
 }));
 
 jest.mock("@/lib/api/usersMe", () => ({
-  getSleepNight: jest.fn(),
+  getSleepNightsRange: jest.fn(),
 }));
 
 jest.mock("@/lib/ui/calendar/dateUtils", () => ({
@@ -21,7 +23,7 @@ jest.mock("@/lib/ui/calendar/dateUtils", () => ({
   getTodayDayKeyLocal: () => "2026-04-06",
 }));
 
-const getSleepNightMock = getSleepNight as jest.MockedFunction<typeof getSleepNight>;
+const getSleepNightsRangeMock = getSleepNightsRange as jest.MockedFunction<typeof getSleepNightsRange>;
 
 function makeView(day: DayKey, minutes: number) {
   return {
@@ -59,7 +61,7 @@ function Probe({ dayKeys }: { dayKeys: readonly DayKey[] }) {
 
 describe("useSleepNightRollupMap", () => {
   beforeEach(() => {
-    getSleepNightMock.mockReset();
+    getSleepNightsRangeMock.mockReset();
     mockUseAuth.mockReturnValue({
       user: { uid: "u1" },
       initializing: false,
@@ -78,7 +80,7 @@ describe("useSleepNightRollupMap", () => {
     const out = root.root.findByProps({ testID: "out" }).props.children as string;
     expect(out).toContain("status=ready");
     expect(out).toContain("views=0");
-    expect(getSleepNightMock).not.toHaveBeenCalled();
+    expect(getSleepNightsRangeMock).not.toHaveBeenCalled();
   });
 
   it("settles when initializing then user is absent (no token branch)", async () => {
@@ -96,15 +98,21 @@ describe("useSleepNightRollupMap", () => {
     });
     const out = root.root.findByProps({ testID: "out" }).props.children as string;
     expect(out).toContain("status=ready");
-    expect(getSleepNightMock).not.toHaveBeenCalled();
+    expect(getSleepNightsRangeMock).not.toHaveBeenCalled();
   });
 
-  it("fetches elapsed days and populates per-day cells with views", async () => {
-    getSleepNightMock.mockImplementation(async (day: string) => ({
+  it("fetches one range and populates per-day cells with views", async () => {
+    getSleepNightsRangeMock.mockImplementation(async (start, end) => ({
       ok: true,
       status: 200,
       requestId: "r",
-      json: makeView(day as DayKey, 445),
+      json: {
+        start,
+        end,
+        dayCount: 2,
+        resolvedCount: 2,
+        nights: [makeView("2026-04-05", 445), makeView("2026-04-06", 445)],
+      },
     }) as never);
     let root!: renderer.ReactTestRenderer;
     await act(async () => {
@@ -118,11 +126,40 @@ describe("useSleepNightRollupMap", () => {
     expect(out).toContain("status=ready");
     expect(out).toContain("settled=2/2");
     expect(out).toContain("views=2");
+    expect(getSleepNightsRangeMock).toHaveBeenCalledTimes(1);
+    expect(getSleepNightsRangeMock.mock.calls[0]!.slice(0, 2)).toEqual(["2026-04-05", "2026-04-06"]);
+  });
+
+  it("marks sparse missing nights as settled empty without per-day 404s", async () => {
+    getSleepNightsRangeMock.mockImplementation(async (start, end) => ({
+      ok: true,
+      status: 200,
+      requestId: "r",
+      json: {
+        start,
+        end,
+        dayCount: 2,
+        resolvedCount: 1,
+        nights: [makeView("2026-04-06", 400)],
+      },
+    }) as never);
+    let root!: renderer.ReactTestRenderer;
+    await act(async () => {
+      root = renderer.create(<Probe dayKeys={["2026-04-05", "2026-04-06"]} />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const out = root.root.findByProps({ testID: "out" }).props.children as string;
+    expect(out).toContain("status=ready");
+    expect(out).toContain("settled=2/2");
+    expect(out).toContain("views=1");
   });
 
   it("drops stale wave responses when dayKeys changes mid-flight", async () => {
     let resolveA: ((v: unknown) => void) | null = null;
-    getSleepNightMock.mockImplementationOnce(
+    getSleepNightsRangeMock.mockImplementationOnce(
       () =>
         new Promise((res) => {
           resolveA = (v) => res(v as never);
@@ -134,11 +171,17 @@ describe("useSleepNightRollupMap", () => {
       root = renderer.create(<Probe dayKeys={["2026-04-05"]} />);
     });
 
-    getSleepNightMock.mockImplementationOnce(async (day: string) => ({
+    getSleepNightsRangeMock.mockImplementationOnce(async (start, end) => ({
       ok: true,
       status: 200,
       requestId: "r",
-      json: makeView(day as DayKey, 360),
+      json: {
+        start,
+        end,
+        dayCount: 1,
+        resolvedCount: 1,
+        nights: [makeView("2026-04-06", 360)],
+      },
     }) as never);
 
     await act(async () => {
@@ -153,7 +196,13 @@ describe("useSleepNightRollupMap", () => {
         ok: true,
         status: 200,
         requestId: "r",
-        json: makeView("2026-04-05", 999),
+        json: {
+          start: "2026-04-05",
+          end: "2026-04-05",
+          dayCount: 1,
+          resolvedCount: 1,
+          nights: [makeView("2026-04-05", 999)],
+        },
       });
       await Promise.resolve();
     });
@@ -163,12 +212,18 @@ describe("useSleepNightRollupMap", () => {
     expect(out).toContain("views=1");
   });
 
-  it("caps year-long dayKeys to SLEEP_NIGHT_PER_DAY_FETCH_MAX_DAYS network calls", async () => {
-    getSleepNightMock.mockImplementation(async () => ({
-      ok: false,
-      status: 404,
+  it("chunks year-long dayKeys into bounded range calls (not one per day)", async () => {
+    getSleepNightsRangeMock.mockImplementation(async (start, end) => ({
+      ok: true,
+      status: 200,
       requestId: "r",
-      error: { code: "NOT_FOUND", message: "missing" },
+      json: {
+        start,
+        end,
+        dayCount: 1,
+        resolvedCount: 0,
+        nights: [],
+      },
     }) as never);
 
     const yearKeys: DayKey[] = [];
@@ -186,7 +241,9 @@ describe("useSleepNightRollupMap", () => {
       await Promise.resolve();
     });
 
-    expect(getSleepNightMock.mock.calls.length).toBeLessThanOrEqual(14);
-    expect(getSleepNightMock.mock.calls.length).toBeGreaterThan(0);
+    const expectedWindows = Math.ceil(yearKeys.length / SLEEP_NIGHT_RANGE_MAX_DAYS);
+    expect(getSleepNightsRangeMock.mock.calls.length).toBe(expectedWindows);
+    expect(getSleepNightsRangeMock.mock.calls.length).toBeLessThan(yearKeys.length);
+    expect(getSleepNightsRangeMock.mock.calls.length).toBeGreaterThan(1);
   });
 });

--- a/lib/data/sleep/sleepOverviewRanges.ts
+++ b/lib/data/sleep/sleepOverviewRanges.ts
@@ -1,57 +1,60 @@
 import {
-  ACTIVITY_OVERVIEW_TRAILING_12_MONTH_DAY_COUNT,
-  ACTIVITY_OVERVIEW_TRAILING_30_DAY_COUNT,
   ACTIVITY_OVERVIEW_TRAILING_7_DAY_COUNT,
   activityTrailingNDaysInclusive,
-  activityYtdInclusiveThroughEndDay,
-  getActivityOverviewAnchorEndDay,
 } from "@/lib/data/activity/activityOverviewRanges";
 import { getWeekDaysForAnchor } from "@/lib/ui/calendar/dateUtils";
 import type { DayKey } from "@/lib/ui/calendar/types";
 
 /**
- * Union of sleep-night keys for the Sleep overview screen: baseline windows, selected strip week,
- * and today (for strip future-day handling).
+ * Max calendar days requested via per-day GET /users/me/sleep-night.
+ *
+ * Interactive Sleep surfaces (Today + week strip/nav) must not fan out one request per
+ * historical day. Longer Sleep Baseline windows (30 / 90 / YTD / 12 Month) require a
+ * **batched/range SleepNight read API** — none exists today (only `GET …/sleep-night?day=`).
+ */
+export const SLEEP_NIGHT_PER_DAY_FETCH_MAX_DAYS = 14;
+
+/**
+ * Union of sleep-night keys for the Sleep overview screen: selected strip week, trailing
+ * 7-day window, and today. Does **not** request 30/90/365-day history over the wire.
  */
 export function computeSleepOverviewFetchDayKeys(
   stripSelectedDay: DayKey,
   todayDayKey: DayKey,
 ): DayKey[] {
-  const overviewEnd = getActivityOverviewAnchorEndDay(todayDayKey);
-  const trail = activityTrailingNDaysInclusive(
-    overviewEnd,
-    ACTIVITY_OVERVIEW_TRAILING_12_MONTH_DAY_COUNT,
-  );
-  const ytd = activityYtdInclusiveThroughEndDay(todayDayKey);
   const d7 = activityTrailingNDaysInclusive(todayDayKey, ACTIVITY_OVERVIEW_TRAILING_7_DAY_COUNT);
-  const d30 = activityTrailingNDaysInclusive(todayDayKey, ACTIVITY_OVERVIEW_TRAILING_30_DAY_COUNT);
-  const d90 = activityTrailingNDaysInclusive(overviewEnd, 90);
   const stripWeek = getWeekDaysForAnchor(stripSelectedDay);
-  const set = new Set<DayKey>([...trail, ...ytd, ...d7, ...d30, ...d90, todayDayKey, ...stripWeek]);
+  const set = new Set<DayKey>([...d7, todayDayKey, ...stripWeek]);
   if (stripSelectedDay > todayDayKey) {
     set.add(stripSelectedDay);
   }
-  return [...set].sort();
+  return boundSleepNightFetchDayKeys([...set], todayDayKey);
 }
 
 /**
- * Subset of {@link computeSleepOverviewFetchDayKeys} that drives the **Sleep Baseline** card
- * windows only — 7 / 30 / 90 / YTD / 12 Month. Future days (`day > todayDayKey`) are excluded so
- * the per-window readiness selector in the screen hook doesn't wait on cells the rollup will
- * future days are excluded — the rollup does not request them.
+ * Network keys for Sleep Baseline / Health Baseline sleep composition.
  *
- * Pure helper — no `useMemo`, no Firebase, no API. Caller memoizes.
+ * Only the trailing 7-day window is fetched via per-day reads. Longer baseline rows remain
+ * honest (`hasEnoughData: false`) until a range/batch Sleep endpoint exists.
  */
 export function computeSleepBaselineFetchDayKeys(todayDayKey: DayKey): DayKey[] {
-  const overviewEnd = getActivityOverviewAnchorEndDay(todayDayKey);
-  const trail = activityTrailingNDaysInclusive(
-    overviewEnd,
-    ACTIVITY_OVERVIEW_TRAILING_12_MONTH_DAY_COUNT,
-  );
-  const ytd = activityYtdInclusiveThroughEndDay(todayDayKey);
   const d7 = activityTrailingNDaysInclusive(todayDayKey, ACTIVITY_OVERVIEW_TRAILING_7_DAY_COUNT);
-  const d30 = activityTrailingNDaysInclusive(todayDayKey, ACTIVITY_OVERVIEW_TRAILING_30_DAY_COUNT);
-  const d90 = activityTrailingNDaysInclusive(overviewEnd, 90);
-  const set = new Set<DayKey>([...trail, ...ytd, ...d7, ...d30, ...d90]);
-  return [...set].filter((d) => d <= todayDayKey).sort();
+  return boundSleepNightFetchDayKeys(d7, todayDayKey);
+}
+
+/**
+ * Defense-in-depth: keep only the most recent {@link SLEEP_NIGHT_PER_DAY_FETCH_MAX_DAYS}
+ * elapsed day keys (≤ today). Future keys are preserved (not fetched by the rollup partition).
+ * Never expands the set.
+ */
+export function boundSleepNightFetchDayKeys(
+  dayKeys: readonly DayKey[],
+  todayDayKey: DayKey,
+  maxDays: number = SLEEP_NIGHT_PER_DAY_FETCH_MAX_DAYS,
+): DayKey[] {
+  const future = dayKeys.filter((d) => d > todayDayKey);
+  const elapsed = dayKeys.filter((d) => d <= todayDayKey).sort();
+  const capped =
+    elapsed.length <= maxDays ? elapsed : elapsed.slice(elapsed.length - maxDays);
+  return [...capped, ...future].sort();
 }

--- a/lib/data/sleep/sleepOverviewRanges.ts
+++ b/lib/data/sleep/sleepOverviewRanges.ts
@@ -1,60 +1,94 @@
+import { SLEEP_NIGHT_RANGE_MAX_DAYS } from "@oli/contracts";
 import {
+  ACTIVITY_OVERVIEW_TRAILING_12_MONTH_DAY_COUNT,
+  ACTIVITY_OVERVIEW_TRAILING_30_DAY_COUNT,
   ACTIVITY_OVERVIEW_TRAILING_7_DAY_COUNT,
   activityTrailingNDaysInclusive,
+  activityYtdInclusiveThroughEndDay,
+  getActivityOverviewAnchorEndDay,
 } from "@/lib/data/activity/activityOverviewRanges";
-import { getWeekDaysForAnchor } from "@/lib/ui/calendar/dateUtils";
+import { addCalendarDaysToDayKey, getWeekDaysForAnchor } from "@/lib/ui/calendar/dateUtils";
 import type { DayKey } from "@/lib/ui/calendar/types";
 
-/**
- * Max calendar days requested via per-day GET /users/me/sleep-night.
- *
- * Interactive Sleep surfaces (Today + week strip/nav) must not fan out one request per
- * historical day. Longer Sleep Baseline windows (30 / 90 / YTD / 12 Month) require a
- * **batched/range SleepNight read API** — none exists today (only `GET …/sleep-night?day=`).
- */
-export const SLEEP_NIGHT_PER_DAY_FETCH_MAX_DAYS = 14;
+/** Re-export API policy max for SleepNight range client chunking. */
+export { SLEEP_NIGHT_RANGE_MAX_DAYS };
 
 /**
- * Union of sleep-night keys for the Sleep overview screen: selected strip week, trailing
- * 7-day window, and today. Does **not** request 30/90/365-day history over the wire.
+ * Union of sleep-night keys for the Sleep overview screen: baseline windows, selected strip week,
+ * and today (for strip future-day handling).
  */
 export function computeSleepOverviewFetchDayKeys(
   stripSelectedDay: DayKey,
   todayDayKey: DayKey,
 ): DayKey[] {
+  const overviewEnd = getActivityOverviewAnchorEndDay(todayDayKey);
+  const trail = activityTrailingNDaysInclusive(
+    overviewEnd,
+    ACTIVITY_OVERVIEW_TRAILING_12_MONTH_DAY_COUNT,
+  );
+  const ytd = activityYtdInclusiveThroughEndDay(todayDayKey);
   const d7 = activityTrailingNDaysInclusive(todayDayKey, ACTIVITY_OVERVIEW_TRAILING_7_DAY_COUNT);
+  const d30 = activityTrailingNDaysInclusive(todayDayKey, ACTIVITY_OVERVIEW_TRAILING_30_DAY_COUNT);
+  const d90 = activityTrailingNDaysInclusive(overviewEnd, 90);
   const stripWeek = getWeekDaysForAnchor(stripSelectedDay);
-  const set = new Set<DayKey>([...d7, todayDayKey, ...stripWeek]);
+  const set = new Set<DayKey>([...trail, ...ytd, ...d7, ...d30, ...d90, todayDayKey, ...stripWeek]);
   if (stripSelectedDay > todayDayKey) {
     set.add(stripSelectedDay);
   }
-  return boundSleepNightFetchDayKeys([...set], todayDayKey);
+  return [...set].sort();
 }
 
 /**
- * Network keys for Sleep Baseline / Health Baseline sleep composition.
+ * Subset of {@link computeSleepOverviewFetchDayKeys} that drives the **Sleep Baseline** card
+ * windows only — 7 / 30 / 90 / YTD / 12 Month. Future days (`day > todayDayKey`) are excluded so
+ * the per-window readiness selector in the screen hook doesn't wait on cells the rollup will
+ * never request.
  *
- * Only the trailing 7-day window is fetched via per-day reads. Longer baseline rows remain
- * honest (`hasEnoughData: false`) until a range/batch Sleep endpoint exists.
+ * Pure helper — no `useMemo`, no Firebase, no API. Caller memoizes.
  */
 export function computeSleepBaselineFetchDayKeys(todayDayKey: DayKey): DayKey[] {
+  const overviewEnd = getActivityOverviewAnchorEndDay(todayDayKey);
+  const trail = activityTrailingNDaysInclusive(
+    overviewEnd,
+    ACTIVITY_OVERVIEW_TRAILING_12_MONTH_DAY_COUNT,
+  );
+  const ytd = activityYtdInclusiveThroughEndDay(todayDayKey);
   const d7 = activityTrailingNDaysInclusive(todayDayKey, ACTIVITY_OVERVIEW_TRAILING_7_DAY_COUNT);
-  return boundSleepNightFetchDayKeys(d7, todayDayKey);
+  const d30 = activityTrailingNDaysInclusive(todayDayKey, ACTIVITY_OVERVIEW_TRAILING_30_DAY_COUNT);
+  const d90 = activityTrailingNDaysInclusive(overviewEnd, 90);
+  const set = new Set<DayKey>([...trail, ...ytd, ...d7, ...d30, ...d90]);
+  return [...set].filter((d) => d <= todayDayKey).sort();
 }
 
+export type SleepNightRangeFetchWindow = {
+  start: DayKey;
+  end: DayKey;
+};
+
 /**
- * Defense-in-depth: keep only the most recent {@link SLEEP_NIGHT_PER_DAY_FETCH_MAX_DAYS}
- * elapsed day keys (≤ today). Future keys are preserved (not fetched by the rollup partition).
- * Never expands the set.
+ * Split an inclusive calendar span covering `dayKeys` into contiguous windows of at most
+ * {@link SLEEP_NIGHT_RANGE_MAX_DAYS} days for `GET /users/me/sleep-nights`.
+ * Uses min→max of the requested keys (sparse response; missing days omitted server-side).
  */
-export function boundSleepNightFetchDayKeys(
+export function sleepNightRangeFetchWindows(
   dayKeys: readonly DayKey[],
-  todayDayKey: DayKey,
-  maxDays: number = SLEEP_NIGHT_PER_DAY_FETCH_MAX_DAYS,
-): DayKey[] {
-  const future = dayKeys.filter((d) => d > todayDayKey);
-  const elapsed = dayKeys.filter((d) => d <= todayDayKey).sort();
-  const capped =
-    elapsed.length <= maxDays ? elapsed : elapsed.slice(elapsed.length - maxDays);
-  return [...capped, ...future].sort();
+  maxDays: number = SLEEP_NIGHT_RANGE_MAX_DAYS,
+): SleepNightRangeFetchWindow[] {
+  if (dayKeys.length === 0) return [];
+  if (maxDays < 1) {
+    throw new Error("sleepNightRangeFetchWindows: maxDays must be >= 1");
+  }
+  const sorted = [...dayKeys].sort();
+  const rangeStart = sorted[0]!;
+  const rangeEnd = sorted[sorted.length - 1]!;
+  const windows: SleepNightRangeFetchWindow[] = [];
+  let cursor = rangeStart;
+  while (cursor <= rangeEnd) {
+    const tentativeEnd = addCalendarDaysToDayKey(cursor, maxDays - 1);
+    const end = tentativeEnd < rangeEnd ? tentativeEnd : rangeEnd;
+    windows.push({ start: cursor, end });
+    if (end >= rangeEnd) break;
+    cursor = addCalendarDaysToDayKey(end, 1);
+  }
+  return windows;
 }

--- a/lib/data/sleep/useSleepNightRollupMap.ts
+++ b/lib/data/sleep/useSleepNightRollupMap.ts
@@ -4,6 +4,10 @@ import { getSleepNight } from "@/lib/api/usersMe";
 import { useAuth } from "@/lib/auth/AuthProvider";
 import type { WeeklyFitnessSleepNightCell } from "@/lib/data/dash/weeklyFitnessCompletedSleepNights";
 import { partitionOuraWeekPresenceDayKeys } from "@/lib/data/oura/useOuraViewWeekSnapshotPresence";
+import {
+  SLEEP_NIGHT_PER_DAY_FETCH_MAX_DAYS,
+  boundSleepNightFetchDayKeys,
+} from "@/lib/data/sleep/sleepOverviewRanges";
 import { truthOutcomeFromApiResult } from "@/lib/data/truthOutcome";
 import { logDataHookTiming } from "@/lib/dev/logDataHookTiming";
 import { getTodayDayKeyLocal } from "@/lib/ui/calendar/dateUtils";
@@ -43,10 +47,10 @@ export function useSleepNightRollupMap(dayKeys: readonly DayKey[]): SleepNightRo
   });
 
   const keySig = useMemo(() => [...dayKeys].sort().join("\0"), [dayKeys]);
-  const { daysToFetch } = useMemo(
-    () => partitionOuraWeekPresenceDayKeys(dayKeys, todayDayKey),
-    [keySig, todayDayKey, dayKeys],
-  );
+  const { daysToFetch } = useMemo(() => {
+    const bounded = boundSleepNightFetchDayKeys(dayKeys, todayDayKey);
+    return partitionOuraWeekPresenceDayKeys(bounded, todayDayKey);
+  }, [keySig, todayDayKey, dayKeys]);
   const fetchSig = useMemo(() => [...daysToFetch].sort().join("\0"), [daysToFetch]);
 
   const sleepNightByDay = useMemo(
@@ -65,8 +69,16 @@ export function useSleepNightRollupMap(dayKeys: readonly DayKey[]): SleepNightRo
     async (cacheBust?: string) => {
       const seq = ++requestSeq.current;
       const keys = keysRef.current;
-      const { daysToFetch: days } = partitionOuraWeekPresenceDayKeys(keys, todayDayKey);
+      const bounded = boundSleepNightFetchDayKeys(keys, todayDayKey);
+      const { daysToFetch: days } = partitionOuraWeekPresenceDayKeys(bounded, todayDayKey);
       const { initializing: init, userUid, getIdToken: getToken } = authRef.current;
+
+      if (__DEV__ && keys.filter((d) => d <= todayDayKey).length > SLEEP_NIGHT_PER_DAY_FETCH_MAX_DAYS) {
+        logDataHookTiming("useSleepNightRollupMap", "start", {
+          status: "bounded-fetch",
+          resultApprox: `requestedElapsed:${keys.filter((d) => d <= todayDayKey).length};capped:${SLEEP_NIGHT_PER_DAY_FETCH_MAX_DAYS}`,
+        });
+      }
 
       const safeSet = (next: RollupInternalState) => {
         if (seq === requestSeq.current) setState(next);

--- a/lib/data/sleep/useSleepNightRollupMap.ts
+++ b/lib/data/sleep/useSleepNightRollupMap.ts
@@ -1,13 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { getSleepNight } from "@/lib/api/usersMe";
+import type { SleepNightViewDto } from "@oli/contracts";
+
+import { getSleepNightsRange } from "@/lib/api/usersMe";
 import { useAuth } from "@/lib/auth/AuthProvider";
 import type { WeeklyFitnessSleepNightCell } from "@/lib/data/dash/weeklyFitnessCompletedSleepNights";
 import { partitionOuraWeekPresenceDayKeys } from "@/lib/data/oura/useOuraViewWeekSnapshotPresence";
-import {
-  SLEEP_NIGHT_PER_DAY_FETCH_MAX_DAYS,
-  boundSleepNightFetchDayKeys,
-} from "@/lib/data/sleep/sleepOverviewRanges";
+import { sleepNightRangeFetchWindows } from "@/lib/data/sleep/sleepOverviewRanges";
 import { truthOutcomeFromApiResult } from "@/lib/data/truthOutcome";
 import { logDataHookTiming } from "@/lib/dev/logDataHookTiming";
 import { getTodayDayKeyLocal } from "@/lib/ui/calendar/dateUtils";
@@ -27,8 +26,16 @@ export type SleepNightRollupHookState = RollupInternalState & {
 
 const emptyCells = (): Partial<Record<DayKey, WeeklyFitnessSleepNightCell>> => ({});
 
+function cellFromRangeNight(view: SleepNightViewDto | undefined): WeeklyFitnessSleepNightCell {
+  if (view == null) return { settled: true };
+  // Range API returns exact_anchor / wake_day only; ignore densifying prior-night if ever present.
+  if (view.resolution === "latest_completed_prior_night") return { settled: true };
+  return { settled: true, view };
+}
+
 /**
- * Fetches GET /users/me/sleep-night for elapsed keys only (no future calendar days).
+ * Fetches GET /users/me/sleep-nights for elapsed keys (chunked at the API 90-day max).
+ * Maps sparse nights into per-day cells; missing days settle empty.
  * Same cell shape and attribution rules as Dash Daily Sleep / Weekly Fitness sleep.
  */
 export function useSleepNightRollupMap(dayKeys: readonly DayKey[]): SleepNightRollupHookState {
@@ -47,10 +54,10 @@ export function useSleepNightRollupMap(dayKeys: readonly DayKey[]): SleepNightRo
   });
 
   const keySig = useMemo(() => [...dayKeys].sort().join("\0"), [dayKeys]);
-  const { daysToFetch } = useMemo(() => {
-    const bounded = boundSleepNightFetchDayKeys(dayKeys, todayDayKey);
-    return partitionOuraWeekPresenceDayKeys(bounded, todayDayKey);
-  }, [keySig, todayDayKey, dayKeys]);
+  const { daysToFetch } = useMemo(
+    () => partitionOuraWeekPresenceDayKeys(dayKeys, todayDayKey),
+    [keySig, todayDayKey, dayKeys],
+  );
   const fetchSig = useMemo(() => [...daysToFetch].sort().join("\0"), [daysToFetch]);
 
   const sleepNightByDay = useMemo(
@@ -69,16 +76,9 @@ export function useSleepNightRollupMap(dayKeys: readonly DayKey[]): SleepNightRo
     async (cacheBust?: string) => {
       const seq = ++requestSeq.current;
       const keys = keysRef.current;
-      const bounded = boundSleepNightFetchDayKeys(keys, todayDayKey);
-      const { daysToFetch: days } = partitionOuraWeekPresenceDayKeys(bounded, todayDayKey);
+      const { daysToFetch: days } = partitionOuraWeekPresenceDayKeys(keys, todayDayKey);
       const { initializing: init, userUid, getIdToken: getToken } = authRef.current;
-
-      if (__DEV__ && keys.filter((d) => d <= todayDayKey).length > SLEEP_NIGHT_PER_DAY_FETCH_MAX_DAYS) {
-        logDataHookTiming("useSleepNightRollupMap", "start", {
-          status: "bounded-fetch",
-          resultApprox: `requestedElapsed:${keys.filter((d) => d <= todayDayKey).length};capped:${SLEEP_NIGHT_PER_DAY_FETCH_MAX_DAYS}`,
-        });
-      }
+      const windows = sleepNightRangeFetchWindows(days);
 
       const safeSet = (next: RollupInternalState) => {
         if (seq === requestSeq.current) setState(next);
@@ -135,26 +135,58 @@ export function useSleepNightRollupMap(dayKeys: readonly DayKey[]): SleepNightRo
 
       const bust = cacheBust ? `${cacheBust}` : undefined;
       const waveResults: Partial<Record<DayKey, WeeklyFitnessSleepNightCell>> = {};
+      const daySet = new Set(days);
       const waveStart = __DEV__ ? performance.now() : 0;
 
+      if (__DEV__) {
+        logDataHookTiming("useSleepNightRollupMap", "start", {
+          status: "range-fetch",
+          resultApprox: `daysToFetch:${days.length};windows:${windows.length}`,
+        });
+      }
+
       await Promise.all(
-        days.map(async (day) => {
-          let cell: WeeklyFitnessSleepNightCell = { settled: true };
+        windows.map(async (window) => {
+          const windowDays = days.filter((d) => d >= window.start && d <= window.end);
+          const settleEmpty = () => {
+            for (const day of windowDays) {
+              waveResults[day] = { settled: true };
+            }
+          };
+
           try {
-            const res = await getSleepNight(day, token, bust ? { cacheBust: `${bust}:${day}` } : undefined);
+            const res = await getSleepNightsRange(
+              window.start,
+              window.end,
+              token,
+              bust ? { cacheBust: `${bust}:${window.start}:${window.end}` } : undefined,
+            );
             const outcome = truthOutcomeFromApiResult(res);
-            if (outcome.status === "ready") {
-              cell = { settled: true, view: outcome.data };
+            if (outcome.status !== "ready") {
+              settleEmpty();
+            } else {
+              const byRequested = new Map<string, SleepNightViewDto>();
+              for (const night of outcome.data.nights) {
+                if (!daySet.has(night.requestedDay as DayKey)) continue;
+                byRequested.set(night.requestedDay, night);
+              }
+              for (const day of windowDays) {
+                waveResults[day] = cellFromRangeNight(byRequested.get(day));
+              }
             }
           } catch {
-            cell = { settled: true };
+            settleEmpty();
           }
-          waveResults[day] = cell;
+
           setState((prev) => {
             if (seq !== requestSeq.current) return prev;
+            const patch: Partial<Record<DayKey, WeeklyFitnessSleepNightCell>> = {};
+            for (const day of windowDays) {
+              patch[day] = waveResults[day]!;
+            }
             return {
               ...prev,
-              sleepNightByDay: { ...prev.sleepNightByDay, [day]: cell },
+              sleepNightByDay: { ...prev.sleepNightByDay, ...patch },
               isRefreshing: true,
             };
           });
@@ -167,14 +199,14 @@ export function useSleepNightRollupMap(dayKeys: readonly DayKey[]): SleepNightRo
         logDataHookTiming("useSleepNightRollupMap", "end", {
           durationMs: Math.round(performance.now() - waveStart),
           userAvailable: Boolean(userUid),
-          resultApprox: `daysToFetch:${days.length}`,
+          resultApprox: `daysToFetch:${days.length};windows:${windows.length}`,
           status: "wave-done",
         });
       }
 
       const finalCells: Partial<Record<DayKey, WeeklyFitnessSleepNightCell>> = {};
       for (const day of days) {
-        finalCells[day] = waveResults[day]!;
+        finalCells[day] = waveResults[day] ?? { settled: true };
       }
       setState((prev) => {
         if (seq !== requestSeq.current) return prev;

--- a/lib/data/useSleepDayView.ts
+++ b/lib/data/useSleepDayView.ts
@@ -97,15 +97,15 @@ export function useSleepDayView(
       const hasSleepSignal = dailyFactsHasSleepSignal(sleepForSignal);
 
       if (__DEV__ && typeof process.env.JEST_WORKER_ID === "undefined") {
-        // eslint-disable-next-line no-console
+        // eslint-disable-next-line no-console -- privacy-safe sleep day view audit
         console.log("SLEEP_DEBUG", {
-          day: dayKey,
+          operation: "sleep_day_view",
+          hasDayKey: Boolean(dayKey),
           factsOutcome: factsOutcome.status,
           hasSleepSignal,
           hasScore: sleepForSignal?.oliSleepScore != null,
-          oliScoreValue: sleepForSignal?.oliSleepScore?.value ?? null,
-          mainSleepMinutes: sleepForSignal?.mainSleepMinutes,
-          totalMinutes: sleepForSignal?.totalMinutes,
+          hasMainSleepMinutes: typeof sleepForSignal?.mainSleepMinutes === "number",
+          hasTotalMinutes: typeof sleepForSignal?.totalMinutes === "number",
           chosenStatus:
             factsOutcome.status === "ready" && hasSleepSignal
               ? "oli"

--- a/lib/debug/workoutDayDebug.ts
+++ b/lib/debug/workoutDayDebug.ts
@@ -66,8 +66,31 @@ export function workoutDayDebugRowTouchesAuditDates(args: {
 
 export function logWorkoutDayDebug(tag: string, payload: Record<string, unknown>): void {
   if (!workoutDayDebugEnabled()) return;
+  // Privacy-safe: counts / booleans / redacted presence only — never timestamps, titles, IDs, or health values.
+  const safe: Record<string, unknown> = { operation: tag };
+  for (const [k, v] of Object.entries(payload)) {
+    if (typeof v === "boolean" || typeof v === "number") {
+      safe[k] = v;
+      continue;
+    }
+    if (Array.isArray(v)) {
+      safe[`${k}Count`] = v.length;
+      continue;
+    }
+    if (v == null) {
+      safe[`has${k[0]!.toUpperCase()}${k.slice(1)}`] = false;
+      continue;
+    }
+    if (typeof v === "string") {
+      safe[`has${k[0]!.toUpperCase()}${k.slice(1)}`] = v.length > 0;
+      continue;
+    }
+    if (typeof v === "object") {
+      safe[`has${k[0]!.toUpperCase()}${k.slice(1)}`] = true;
+    }
+  }
   // eslint-disable-next-line no-console
-  console.log(`[WORKOUT_DAY_DEBUG] ${tag}`, payload);
+  console.log(`[WORKOUT_DAY_DEBUG] ${tag}`, safe);
 }
 
 export function workoutDayDebugPayloadStartedAt(payload: unknown): string | null {

--- a/lib/hooks/__tests__/useDailySleepCard.ouraDisconnected.test.tsx
+++ b/lib/hooks/__tests__/useDailySleepCard.ouraDisconnected.test.tsx
@@ -4,15 +4,8 @@ import { Text } from "react-native";
 
 import { getSleepNight } from "@/lib/api/usersMe";
 import { useDailySleepCard } from "@/lib/hooks/useDailySleepCard";
-import { __resetSleepTodayRecoveryLedgerForTests } from "@/lib/data/sleep/runSleepTodayRecoveryIfMissing";
 
 const DAY = "2026-05-26";
-
-const mockPostOuraSleepDayRefresh = jest.fn();
-jest.mock("@/lib/api/ouraSleepDayRefresh", () => ({
-  postOuraSleepDayRefresh: (...args: unknown[]) =>
-    mockPostOuraSleepDayRefresh(...args),
-}));
 
 const mockUseOuraPresence = jest.fn();
 jest.mock("@/lib/data/useOuraPresence", () => ({
@@ -50,13 +43,6 @@ function Probe({ day }: { day: string }) {
 describe("useDailySleepCard — ouraDisconnected", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    __resetSleepTodayRecoveryLedgerForTests();
-    mockPostOuraSleepDayRefresh.mockResolvedValue({
-      ok: true,
-      status: 200,
-      requestId: "r1",
-      json: { ok: true, requestId: "r1", day: DAY, pullNowStatus: 202 },
-    });
     mockUseAuth.mockReturnValue({
       user: { uid: "user-a" },
       initializing: false,

--- a/lib/hooks/__tests__/useDailySleepCard.todayRecovery.test.tsx
+++ b/lib/hooks/__tests__/useDailySleepCard.todayRecovery.test.tsx
@@ -4,7 +4,6 @@ import { Text } from "react-native";
 
 import { getSleepNight } from "@/lib/api/usersMe";
 import { useDailySleepCard } from "@/lib/hooks/useDailySleepCard";
-import { __resetSleepTodayRecoveryLedgerForTests } from "@/lib/data/sleep/runSleepTodayRecoveryIfMissing";
 
 const TODAY = "2026-04-06";
 const YESTERDAY = "2026-04-05";
@@ -12,8 +11,7 @@ const YESTERDAY = "2026-04-05";
 const mockPostOuraSleepDayRefresh = jest.fn();
 
 jest.mock("@/lib/api/ouraSleepDayRefresh", () => ({
-  postOuraSleepDayRefresh: (...args: unknown[]) =>
-    mockPostOuraSleepDayRefresh(...args),
+  postOuraSleepDayRefresh: (...args: unknown[]) => mockPostOuraSleepDayRefresh(...args),
 }));
 
 const mockUseAuth = jest.fn();
@@ -37,10 +35,9 @@ function Probe({ day }: { day: string }) {
   return <Text testID="out">{vm.status}</Text>;
 }
 
-describe("useDailySleepCard today-recovery", () => {
+describe("useDailySleepCard Dash sleep-day-refresh gate", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    __resetSleepTodayRecoveryLedgerForTests();
     mockUseAuth.mockReturnValue({
       user: { uid: "user-a" },
       initializing: false,
@@ -54,7 +51,7 @@ describe("useDailySleepCard today-recovery", () => {
     });
   });
 
-  it("fires exactly one canonical recovery call when today is settled-and-missing", async () => {
+  it("does NOT POST sleep-day-refresh when today is settled-and-missing", async () => {
     getSleepNightMock.mockResolvedValue({
       ok: false,
       status: 404,
@@ -73,11 +70,10 @@ describe("useDailySleepCard today-recovery", () => {
     });
 
     expect(root.root.findByProps({ testID: "out" }).props.children).toBe("missing");
-    expect(mockPostOuraSleepDayRefresh).toHaveBeenCalledTimes(1);
-    expect(mockPostOuraSleepDayRefresh.mock.calls[0]?.[1]).toEqual({ day: TODAY });
+    expect(mockPostOuraSleepDayRefresh).not.toHaveBeenCalled();
   });
 
-  it("does NOT fire recovery for a historical missing day (yesterday)", async () => {
+  it("does NOT POST sleep-day-refresh for a historical missing day", async () => {
     getSleepNightMock.mockResolvedValue({
       ok: false,
       status: 404,
@@ -96,7 +92,7 @@ describe("useDailySleepCard today-recovery", () => {
     expect(mockPostOuraSleepDayRefresh).not.toHaveBeenCalled();
   });
 
-  it("does NOT fire recovery when today's sleep is already attributed (ready)", async () => {
+  it("still settles ready attributed nights without refresh", async () => {
     getSleepNightMock.mockResolvedValue({
       ok: true,
       status: 200,
@@ -119,7 +115,7 @@ describe("useDailySleepCard today-recovery", () => {
           updatedAt: `${TODAY}T12:00:00.000Z`,
         },
       },
-    });
+    } as never);
 
     let root!: renderer.ReactTestRenderer;
     await act(async () => {
@@ -129,46 +125,7 @@ describe("useDailySleepCard today-recovery", () => {
       await Promise.resolve();
       await Promise.resolve();
     });
-
     expect(root.root.findByProps({ testID: "out" }).props.children).toBe("ready");
     expect(mockPostOuraSleepDayRefresh).not.toHaveBeenCalled();
-  });
-
-  it("rejects latest_completed_prior_night as not-attributed and triggers recovery", async () => {
-    getSleepNightMock.mockResolvedValue({
-      ok: true,
-      status: 200,
-      requestId: null,
-      json: {
-        requestedDay: TODAY,
-        anchorDay: YESTERDAY,
-        wakeDay: YESTERDAY,
-        resolution: "latest_completed_prior_night",
-        isFallback: false,
-        sleepNight: {
-          anchorDay: YESTERDAY,
-          wakeDay: YESTERDAY,
-          provider: "oura",
-          source: "ouraVendorSleep",
-          sourceDocumentId: "s1",
-          isComplete: true,
-          mainSleepMinutes: 420,
-          totalSleepMinutes: 420,
-          updatedAt: `${YESTERDAY}T12:00:00.000Z`,
-        },
-      },
-    });
-
-    let root!: renderer.ReactTestRenderer;
-    await act(async () => {
-      root = renderer.create(<Probe day={TODAY} />);
-    });
-    await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
-    });
-
-    expect(root.root.findByProps({ testID: "out" }).props.children).toBe("missing");
-    expect(mockPostOuraSleepDayRefresh).toHaveBeenCalledTimes(1);
   });
 });

--- a/lib/hooks/useDailySleepCard.ts
+++ b/lib/hooks/useDailySleepCard.ts
@@ -1,15 +1,12 @@
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 
-import { useAuth } from "@/lib/auth/AuthProvider";
 import {
   buildDailySleepCardViewModel,
   sleepNightIsAttributedToCalendarDay,
   type DailySleepCardViewModel,
 } from "@/lib/data/dash/dailySleepCardViewModel";
-import { runSleepTodayRecoveryIfMissing } from "@/lib/data/sleep/runSleepTodayRecoveryIfMissing";
 import { useOuraPresence } from "@/lib/data/useOuraPresence";
 import { useSleepNight } from "@/lib/hooks/useSleepNight";
-import { getTodayDayKeyLocal } from "@/lib/ui/calendar/dateUtils";
 import type { DayKey } from "@/lib/ui/calendar/types";
 
 import type { TruthGetOptions } from "@/lib/api/usersMe";
@@ -35,10 +32,13 @@ export type UseDailySleepCardResult = {
 /**
  * Dash Daily Sleep truth boundary: `GET /users/me/sleep-night` + calendar-day guards.
  * Never surfaces bounded prior-night fallback or sticky prior-day UI state as today's truth.
+ *
+ * Does not auto-invoke `sleep-day-refresh` on mount/focus/missing. Normal Dash rendering
+ * relies on the authenticated SleepNight read path; maintenance refresh stays explicit
+ * (Sleep overview / pull-to-refresh coordinators).
  */
 export function useDailySleepCard(day: DayKey, options?: { enabled?: boolean }): UseDailySleepCardResult {
   const enabled = options?.enabled ?? true;
-  const { user, getIdToken } = useAuth();
   const sleepNight = useSleepNight(day, { enabled });
   const ouraPresence = useOuraPresence();
 
@@ -82,25 +82,6 @@ export function useDailySleepCard(day: DayKey, options?: { enabled?: boolean }):
       sleepRequestedDay: sleepNight.view?.requestedDay ?? null,
     };
   }, [day, sleepNight.settled, sleepNight.view]);
-
-  // Today-recovery: when the canonical SleepNight view is settled-and-missing
-  // for the local today, trigger the canonical refresh path once (rate-limited
-  // per uid:day). All Firebase / API access stays in the data layer.
-  const uid = user?.uid ?? "";
-  const refetchSleep = sleepNight.refetch;
-  useEffect(() => {
-    if (!enabled) return;
-    if (!uid) return;
-    if (vm.status !== "missing") return;
-    if (day !== getTodayDayKeyLocal()) return;
-    void runSleepTodayRecoveryIfMissing({
-      uid,
-      requestedDay: day,
-      isMissing: true,
-      getIdToken,
-      refetchSleep,
-    });
-  }, [enabled, uid, vm.status, day, getIdToken, refetchSleep]);
 
   const refetch = useMemo(
     () => (opts?: TruthGetOptions) => {

--- a/lib/hooks/useDashSleepAnchorDay.ts
+++ b/lib/hooks/useDashSleepAnchorDay.ts
@@ -68,19 +68,20 @@ export function useDashSleepAnchorDay(calendarToday: string): UseDashSleepAnchor
 
   useEffect(() => {
     if (!__DEV__) return;
-    // eslint-disable-next-line no-console -- Dash sleep lock audit (dev-only)
+    // eslint-disable-next-line no-console -- Dash sleep lock audit (dev-only, privacy-safe)
     console.log("[DASH_SLEEP_LOCK_DEBUG]", {
-      calendarDay: calendarToday,
+      operation: "dash_sleep_lock",
+      hasCalendarDay: Boolean(calendarToday),
       freshReason: fresh.selectedReason,
-      freshAnchorDay: fresh.sleepAnchorDay,
+      hasFreshAnchorDay: Boolean(fresh.sleepAnchorDay),
       freshSettled: fresh.sleepAnchorSettled,
-      lockBeforeDay: lockBefore?.resolution.sleepAnchorDay ?? null,
+      hasLockBefore: lockBefore != null,
       lockBeforeReason: lockBefore?.resolution.selectedReason ?? null,
       lockBeforeSettled: lockBefore?.resolution.sleepAnchorSettled ?? null,
-      lockAfterDay: lockAfter?.resolution.sleepAnchorDay ?? null,
+      hasLockAfter: lockAfter != null,
       lockAfterReason: lockAfter?.resolution.selectedReason ?? null,
       lockAfterSettled: lockAfter?.resolution.sleepAnchorSettled ?? null,
-      mergedDay: merged.sleepAnchorDay,
+      hasMergedDay: Boolean(merged.sleepAnchorDay),
       mergedReason: merged.selectedReason,
       mergedSettled: merged.sleepAnchorSettled,
       isUsingCachedSettledAnchor,
@@ -106,12 +107,11 @@ export function useDashSleepAnchorDay(calendarToday: string): UseDashSleepAnchor
 
   const invalidateSettledAnchor = useCallback(() => {
     if (__DEV__) {
-      const stackHint = new Error("invalidateSettledAnchor").stack?.split("\n").slice(1, 4).join(" \u2192 ");
-      // eslint-disable-next-line no-console -- Dash sleep lock audit (dev-only)
+      // eslint-disable-next-line no-console -- Dash sleep lock audit (dev-only, privacy-safe)
       console.log("[DASH_SLEEP_INVALIDATE_DEBUG]", {
-        calendarDay: calendarToday,
+        operation: "dash_sleep_invalidate",
+        hasCalendarDay: Boolean(calendarToday),
         reason: "invalidateSettledAnchor",
-        stackHint: stackHint ?? null,
       });
     }
     anchorLockRef.current = null;
@@ -120,12 +120,13 @@ export function useDashSleepAnchorDay(calendarToday: string): UseDashSleepAnchor
 
   useEffect(() => {
     if (!__DEV__) return;
-    // eslint-disable-next-line no-console -- Dash sleep anchor audit (dev-only)
+    // eslint-disable-next-line no-console -- Dash sleep anchor audit (dev-only, privacy-safe)
     console.log("[DASH_SLEEP_ANCHOR_DEBUG]", {
-      calendarDay: calendarToday,
-      previousDay,
+      operation: "dash_sleep_anchor",
+      hasCalendarDay: Boolean(calendarToday),
+      hasPreviousDay: Boolean(previousDay),
       selectedReason: merged.selectedReason,
-      sleepAnchorDay: merged.sleepAnchorDay,
+      hasSleepAnchorDay: Boolean(merged.sleepAnchorDay),
       sleepAnchorSettled: merged.sleepAnchorSettled,
       isUsingCachedSettledAnchor,
       probeLoading: probe.loading,

--- a/lib/integrations/appleHealth/runAppleHealthStepsBackfill.ts
+++ b/lib/integrations/appleHealth/runAppleHealthStepsBackfill.ts
@@ -213,23 +213,24 @@ export async function runAppleHealthStepsBackfill(
         payloadDay: body.payload.day,
       });
       devLog("post /ingest", {
-        day,
-        idempotencyKey,
-        hkSteps: pulled.steps,
-        payloadSteps: body.payload.steps,
-        payloadStart: body.payload.start,
-        payloadTimezone: body.payload.timezone,
-        lastIngested,
+        operation: "steps_backfill_ingest",
+        hasIdempotencyKey: Boolean(idempotencyKey),
+        hasHkSteps: typeof pulled.steps === "number" && Number.isFinite(pulled.steps),
+        hasPayloadSteps: typeof body.payload.steps === "number",
+        hasPayloadStart: Boolean(body.payload.start),
+        hasPayloadTimezone: Boolean(body.payload.timezone),
+        hasLastIngested: lastIngested != null,
       });
       const res = await deps.ingestRawEvent(body, opts.token, {
         idempotencyKey,
         timeoutMs: 15000,
       });
       devLog("ingest response", {
-        day,
-        idempotencyKey,
+        operation: "steps_backfill_ingest_response",
         ok: res.ok,
-        ...(res.ok ? {} : { error: res.error, requestId: res.requestId }),
+        ...(res.ok
+          ? {}
+          : { hasError: Boolean(res.error), hasRequestId: Boolean(res.requestId) }),
       });
       if (!res.ok) {
         await deps.setBackfillState({


### PR DESCRIPTION
## Summary
- Replace temporary per-day SleepNight fan-out with live `GET /users/me/sleep-nights` (chunked at the 90-day API max) for overview/baseline rollups.
- Finish privacy-safe mobile telemetry redaction (counts/booleans only; no day keys, scores, minutes, or health magnitudes).
- Stacked on draft PR #180 (`integrate/dashboard-daily-sleep-score-corrected` @ `94ba880`, which already includes merged main / SleepNight range API).

## Test plan
- [ ] CI green on this PR
- [ ] Physical-device Metro smoke: Dash Daily Sleep + Weekly Fitness sleep load without per-day sleep-night fan-out
- [ ] NET_TRACE / privacy logs show redacted day params; no scores/minutes/day keys in default telemetry
- [ ] Sleep overview / Health Baseline windows settle via range responses (sparse missing days OK)
- [ ] Confirm no deploy/backfill/sleep-day-refresh required for this client-only change

## Notes
- Do not merge until PR #180 is ready and this PR’s CI + device smoke pass.
- Supersedes temporary `78c96f4` week-scale per-day bound in the final tree.


Made with [Cursor](https://cursor.com)