### PR TITLE
fix(privacy): redact Oura refresh telemetry

### DIFF
--- a/docs/audits/2026-07-12-oura-refresh-telemetry-privacy-audit.md
+++ b/docs/audits/2026-07-12-oura-refresh-telemetry-privacy-audit.md
@@ -104,13 +104,18 @@ HTTP status or retry control flow.
 
 ## requestId origin
 
-- API: `requestIdMiddleware` in `services/api/src/lib/logger.ts` sets `req.rid`
-  from client `x-request-id` when length > 6, otherwise `crypto.randomUUID()`.
-- Pull-now reads `req.rid` / `x-request-id` — **not** `Idempotency-Key`.
-- Idempotency remains a separate header and is never logged.
-- Function consumer uses producer `requestId` from the post-raw payload; it does
-  **not** fall back to Pub/Sub `messageId` / `event.id`.
-- Enqueue telemetry logs `queued: true` and never logs Pub/Sub `messageId`.
+- API middleware (`requestIdMiddleware`) may still echo a client `x-request-id`
+  on the HTTP response for general request correlation.
+- **Oura refresh telemetry and post-raw producer/consumer traces use Option B:**
+  `sanitizeOuraTelemetryRequestId` / `sanitizeOuraPostRawRequestId` accept only
+  RFC UUID form (max 36 chars). Invalid values are discarded and replaced with
+  `crypto.randomUUID()` — never hashed, truncated, or encoded.
+- Pull-now `getRequestId` sanitizes before telemetry, requestRecords correlation,
+  and post-raw publish so the Function never receives an arbitrary client string.
+- Function `onOuraPostRawRequested` sanitizes the producer `requestId` and never
+  falls back to Pub/Sub `messageId` / `event.id`.
+- Idempotency remains a separate `Idempotency-Key` header and is never used as
+  `requestId`.
 
 ## API logger boundary
 

--- a/docs/audits/2026-07-12-oura-refresh-telemetry-privacy-audit.md
+++ b/docs/audits/2026-07-12-oura-refresh-telemetry-privacy-audit.md
@@ -1,10 +1,10 @@
 # Oura Refresh Telemetry Privacy Audit
 
-**Date:** 2026-07-12  
-**Base SHA:** `02a7b1b7d95027a0066eeee6527376cf3be312e0`  
-**Base tree:** `ed46b86cf07d804747b0feb24cd663863c21e599`  
-**Privacy branch:** `fix/pr183-oura-refresh-privacy`  
-**Privacy worktree:** `/Users/danielhendel/oli-oura-refresh-privacy`  
+**Date:** 2026-07-12
+**Base SHA:** `02a7b1b7d95027a0066eeee6527376cf3be312e0`
+**Base tree:** `ed46b86cf07d804747b0feb24cd663863c21e599`
+**Privacy branch:** `fix/pr183-oura-refresh-privacy`
+**Privacy worktree:** `/Users/danielhendel/oli-oura-refresh-privacy`
 **Safety ref:** `safety/weekly-fitness-before-oura-privacy-02a7b1b` → `02a7b1b7d95027a0066eeee6527376cf3be312e0`
 
 ## Original gate result

--- a/docs/audits/2026-07-12-oura-refresh-telemetry-privacy-audit.md
+++ b/docs/audits/2026-07-12-oura-refresh-telemetry-privacy-audit.md
@@ -1,0 +1,252 @@
+# Oura Refresh Telemetry Privacy Audit
+
+**Date:** 2026-07-12  
+**Base SHA:** `02a7b1b7d95027a0066eeee6527376cf3be312e0`  
+**Base tree:** `ed46b86cf07d804747b0feb24cd663863c21e599`  
+**Privacy branch:** `fix/pr183-oura-refresh-privacy`  
+**Privacy worktree:** `/Users/danielhendel/oli-oura-refresh-privacy`  
+**Safety ref:** `safety/weekly-fitness-before-oura-privacy-02a7b1b` → `02a7b1b7d95027a0066eeee6527376cf3be312e0`
+
+## Original gate result
+
+Weekly Fitness v2 final staging cutover was blocked by the mandatory refresh-path
+privacy gate. Active Oura pull-now, backfill, provider-fetch, post-raw API, and
+post-raw Function paths emitted prohibited user and health metadata.
+
+No traffic shift, Gateway attach, Function rollback, or Oura refresh occurred
+during the blocked cutover or this repair.
+
+## Affected files
+
+### API
+
+- `services/api/src/routes/integrations/ouraPullNow.ts`
+- `services/api/src/lib/ouraApi.ts`
+- `services/api/src/lib/ouraVendorSnapshot.ts`
+- `services/api/src/lib/ouraIngestWrite.ts`
+- `services/api/src/lib/ouraTokenRefreshSingleFlight.ts`
+- `services/api/src/lib/oura/ouraSleepPhysiology.ts` (unsafe debug permanently disabled)
+- `services/api/src/lib/ouraRefreshTelemetry.ts` (new typed boundary)
+
+### Functions
+
+- `services/functions/src/oura/ouraPostRawHandler.ts`
+- `services/functions/src/oura/onOuraPostRawRequested.ts`
+- `services/functions/src/oura/ouraPostRawTelemetry.ts` (new typed boundary)
+
+## Affected event names (before → after)
+
+Prohibited-shaped legacy events (examples of names / shapes removed or replaced):
+
+- `oura_pull_sleep_date_window` (`sleepStartStr` / `sleepEndStr` / `coreStartStr` / `coreEndStr`)
+- `oura_pull_sleep_latest_wake` (`latestWakeIso` / `latestSleepId`)
+- `[OURA_SLEEP_LATEST_AUDIT]` (env-gated health dates / scores)
+- `[OURA_SLEEP_PHYSIOLOGY_DEBUG]` (env-gated uid / day / physiology)
+- Provider fetch logs with `startDate` / `endDate` / `uid`
+- Raw-event / post-raw / backfill logs with `uid`, `messageId`, `day`, `snapshotId`, raw `err`
+- Function logs with `uid`, `day`, `anchorDay`, raw `err`
+
+Replacement operations are closed typed strings such as:
+
+- `oura_pull_window`, `oura_pull_sleep_summary`, `oura_pull_failed`
+- `oura_provider_fetch_completed`, `oura_provider_fetch_page_capped`
+- `oura_raw_event_persist_*`, `oura_raw_events_core_write_done`
+- `oura_post_raw_enqueued`, `oura_post_raw_persist_*`
+- `oura_backfill_*`
+- `oura_vendor_snapshot_*`
+- `oura_token_refresh_*`
+- Function: `oura_post_raw_started` / `_completed` / `_rejected` / `_failed` / `_domain_*`
+
+## Prohibited field names
+
+Never accepted by typed telemetry helpers and rejected by the privacy assertion helper:
+
+`uid`, `userId`, `email`, `day`, `date`, `start`, `end`, `startStr`, `endStr`,
+`sleepStartStr`, `sleepEndStr`, `coreStartStr`, `coreEndStr`, `requestedDay`,
+`resolvedDay`, `providerDay`, `latestWakeIso`, `latestSleepId`, `sleepId`,
+`providerId`, `documentId`, `docId`, `rawEventId`, `messageId`, `score`,
+`minutes`, `seconds`, `stressHigh`, `recoveryHigh`, `token`, `accessToken`,
+`refreshToken`, `idempotencyKey`, `url`, `query`, `payload`, `response`,
+`stack`, `errorMessage`, `err`, `sampleKeys`, `snapshotId`, `anchorDay`,
+`waitedMs`
+
+Hashed or truncated forms of the above remain prohibited.
+
+## Final allowlist
+
+Operational metadata only, including:
+
+`operation`, `status`, `durationMs`, `requestId`, `providerConnected`, `queued`,
+`retryable`, `pageCount`, `chunkIndex`, `chunkCount`, `chunkDayCount`,
+`windowDayCount`, `sleepStartOverlapDayCount`, `sleepEndOverlapDayCount`,
+`providerItemCount`, `validatedItemCount`, `acceptedItemCount`,
+`rejectedItemCount`, `duplicateCount`, `rawEventCreatedCount`,
+`rawEventExistingCount`, domain `*DocumentCount` / `*Count` aggregates,
+`writtenCount`, `failedCount`, `metadataWritten`, `safeErrorCode`, `domain`,
+`dataset`, `hasSleepDocuments`, `backfillStatus` (lifecycle enum string only)
+
+## Safe error-code list
+
+API (`OuraSafeErrorCode`):
+
+`NO_CONNECTION`, `TOKEN_UNAVAILABLE`, `PROVIDER_UNAUTHORIZED`,
+`PROVIDER_RATE_LIMITED`, `PROVIDER_TIMEOUT`, `PROVIDER_NETWORK`,
+`PROVIDER_SCHEMA_INVALID`, `RAW_EVENT_PERSIST_FAILED`,
+`POST_RAW_PUBLISH_FAILED`, `POST_RAW_PERSIST_FAILED`,
+`FUNCTION_PAYLOAD_INVALID`, `FUNCTION_PERSIST_FAILED`, `UNKNOWN`
+
+Function (`OuraPostRawSafeErrorCode`):
+
+`FUNCTION_PAYLOAD_INVALID`, `FUNCTION_PERSIST_FAILED`, `UNKNOWN`
+
+Raw `Error.message` / stacks are never emitted. Categorization does not alter
+HTTP status or retry control flow.
+
+## requestId origin
+
+- API: `requestIdMiddleware` in `services/api/src/lib/logger.ts` sets `req.rid`
+  from client `x-request-id` when length > 6, otherwise `crypto.randomUUID()`.
+- Pull-now reads `req.rid` / `x-request-id` — **not** `Idempotency-Key`.
+- Idempotency remains a separate header and is never logged.
+- Function consumer uses producer `requestId` from the post-raw payload; it does
+  **not** fall back to Pub/Sub `messageId` / `event.id`.
+- Enqueue telemetry logs `queued: true` and never logs Pub/Sub `messageId`.
+
+## API logger boundary
+
+`services/api/src/lib/ouraRefreshTelemetry.ts`
+
+- Closed discriminated union `OuraRefreshTelemetryEvent`
+- `logOuraRefreshTelemetry(event)` only
+- `categorizeOuraSafeError(err, hint?)` returns `{ safeErrorCode, retryable }`
+- No `Record<string, unknown>` public API, no object spread from provider/request/error objects
+
+## Function logger boundary
+
+`services/functions/src/oura/ouraPostRawTelemetry.ts`
+
+- Closed `OuraPostRawTelemetryEvent`
+- `logOuraPostRawTelemetry(event)` only
+- `categorizeOuraPostRawSafeError(err, hint?)`
+
+## Unsafe audit removal
+
+- `[OURA_SLEEP_LATEST_AUDIT]` removed from pull-now path.
+- `[OURA_SLEEP_PHYSIOLOGY_DEBUG]` permanently disabled: `logOuraSleepPhysiologyDebugIfEnabled`
+  is a no-op regardless of environment variables. Call sites may remain; nothing is emitted.
+
+## Source guards
+
+- `services/api/src/lib/__tests__/ouraRefreshTelemetrySourceGuard.test.ts`
+  guards: pull-now, ouraApi, vendor snapshot, ingest write, token refresh single-flight
+- `services/functions/src/oura/__tests__/ouraPostRawTelemetrySourceGuard.test.ts`
+  guards: `ouraPostRawHandler`, `onOuraPostRawRequested`
+
+Direct `logger.info|warn|error` / `console.log|warn|error` in those files fail the suite.
+
+## Test matrix
+
+| Area | Coverage |
+|---|---|
+| Telemetry unit | API + Function event serialization privacy |
+| Safe error categorization | Status/code mapping; message never returned |
+| Source guards | Active refresh files |
+| Ingest write | Core write + deferred vendor detail; privacy assert on logs |
+| Pull-now | Success / no-token / post-raw persist failure / enqueue |
+| Backfill | Chunk success path + chunk failure continuation |
+| Vendor snapshot | Write / drop paths |
+| Post-raw Function | Absent/present `dailyStressDocs`, writes, privacy on captured logs |
+| Forbidden keys / value patterns | Assertion helper unit coverage |
+
+Synthetic sentinels only — no real user values.
+
+## Functional parity evidence
+
+Diff review limited telemetry / logging / console-guard allowlists / permanently
+disabled physiology debug. Unchanged by design:
+
+- Oura provider endpoints, OAuth scopes, date-window calculations, pagination
+- Response validation, raw-event IDs, storage paths, vendor document IDs
+- Daily Stress / Daily Sleep / Readiness / Sleep persistence
+- Post-raw message schema including additive `dailyStressDocs`
+- Idempotency / requestRecords / HTTP statuses / API DTOs
+- OpenAPI, Firestore rules/indexes
+- Weekly Fitness UI and scoring behavior
+
+## OpenAPI hash result
+
+```text
+diff 02a7b1b..HEAD -- infra/gateway/openapi.yaml: empty
+SHA-256: 35201567f39138c686cd33a7f89296ee12f172b5c03e28f9e1b3c14804281048
+```
+
+Existing unattached Gateway config
+`oli-api-config-weekly-fitness-02a7b1b-20260712-181743` remains contract-compatible
+by OpenAPI content hash. Its config ID embeds the older source SHA; a future
+release may reuse it or create a provenance-clean replacement. Final cutover
+authorization must state which choice is used.
+
+## Artifact invalidation
+
+Any source change makes prior preflight artifacts ineligible for final cutover.
+
+```text
+Superseded API preflight revision:
+oli-api-00231-gul
+
+Superseded API image digest:
+sha256:16018a3f5e6820a4af5a68c0c7558c2190d3671d17269eff68b818d988e89889
+
+Reason:
+built before privacy repair
+
+Current live normal API remains:
+oli-api-00229-yaz
+
+Current live Function needing replacement before refresh:
+onourapostrawrequested-00053-bub
+
+Reason:
+packaged before privacy repair
+```
+
+Do not delete those artifacts. Do not roll the Function back during this repair
+(prior revision may share unsafe logging and would remove `dailyStressDocs`
+consumer support).
+
+## Deployment re-preflight requirements
+
+1. Push / review the privacy branch (separate authorization)
+2. Obtain green CI
+3. Build a new immutable API image
+4. Deploy a corrected Function consumer
+5. Deploy a new zero-traffic API revision
+6. Rerun tagged smoke
+7. Verify privacy-safe logs
+8. Reuse or replace the unattached Gateway config based on OpenAPI hash
+9. Obtain new final cutover authorization
+
+This audit does **not** authorize push, deploy, traffic shift, Gateway attach,
+or Oura refresh.
+
+## Separate mobile telemetry debt
+
+Out of scope for this branch:
+
+- mobile Workout debug telemetry
+- mobile Energy audit telemetry
+- Apple Health backfill telemetry
+- Weekly Fitness render-frequency telemetry
+- full-year Activity/Workout transport
+- sleep-day-refresh 500
+- physical-device verification
+
+## Remaining risks
+
+- Global API access logs (`accessLogMiddleware`) still include `uid` for all
+  routes; not part of the Oura refresh typed boundary in this repair.
+- `onOuraPullScheduled` Function scheduler logs were not in the mandatory
+  pull-now → post-raw inventory for this cutover gate; treat as follow-up if
+  scheduled pull is re-enabled against staging.
+- Client-supplied `x-request-id` remains a correlation id only; operators must
+  not place health identifiers in that header.

--- a/services/api/src/lib/__tests__/ouraIngestWrite.test.ts
+++ b/services/api/src/lib/__tests__/ouraIngestWrite.test.ts
@@ -4,6 +4,7 @@
 import { writeOuraRawEvents } from "../ouraIngestWrite";
 import { userCollection } from "../../db";
 import { logger } from "../logger";
+import { assertOuraTelemetryPrivacy } from "../testSupport/assertOuraTelemetryPrivacy";
 
 jest.mock("../../db", () => ({
   userCollection: jest.fn(),
@@ -19,6 +20,7 @@ const mockSet = jest.fn().mockResolvedValue(undefined);
 
 describe("writeOuraRawEvents", () => {
   let infoSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -29,11 +31,21 @@ describe("writeOuraRawEvents", () => {
       doc: () => ({ create: mockCreate, get: mockGet, set: mockSet }),
     });
     infoSpy = jest.spyOn(logger, "info").mockImplementation(() => undefined);
+    errorSpy = jest.spyOn(logger, "error").mockImplementation(() => undefined);
   });
 
   afterEach(() => {
     infoSpy.mockRestore();
+    errorSpy.mockRestore();
   });
+
+  function assertAllLoggedPrivacySafe(): void {
+    for (const spy of [infoSpy, errorSpy]) {
+      for (const call of spy.mock.calls) {
+        assertOuraTelemetryPrivacy(call[0]);
+      }
+    }
+  }
 
   it("awaits core writes and returns core-only counts when ouraRawItems are deferred", async () => {
     const sleepItems = [
@@ -61,20 +73,20 @@ describe("writeOuraRawEvents", () => {
     expect(infoSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         msg: "oura_raw_events_core_write_done",
-        uid: "uid1",
+        operation: "oura_raw_events_core_write_done",
         requestId: "req-1",
-        eventsCreated: 1,
-        eventsAlreadyExists: 0,
+        rawEventCreatedCount: 1,
+        rawEventExistingCount: 0,
       }),
     );
     expect(infoSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         msg: "oura_raw_events_vendor_detail_deferred",
-        uid: "uid1",
         requestId: "req-1",
-        ouraRawCount: 2,
+        rawItemCount: 2,
       }),
     );
+    assertAllLoggedPrivacySafe();
   });
 
   it("does not log deferred when ouraRawItems is empty", async () => {
@@ -87,5 +99,6 @@ describe("writeOuraRawEvents", () => {
       (c: [Record<string, unknown>]) => c[0]?.msg === "oura_raw_events_vendor_detail_deferred",
     );
     expect(deferredCalls).toHaveLength(0);
+    assertAllLoggedPrivacySafe();
   });
 });

--- a/services/api/src/lib/__tests__/ouraIngestWrite.test.ts
+++ b/services/api/src/lib/__tests__/ouraIngestWrite.test.ts
@@ -74,16 +74,20 @@ describe("writeOuraRawEvents", () => {
       expect.objectContaining({
         msg: "oura_raw_events_core_write_done",
         operation: "oura_raw_events_core_write_done",
-        requestId: "req-1",
         rawEventCreatedCount: 1,
         rawEventExistingCount: 0,
+        requestId: expect.stringMatching(
+          /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+        ),
       }),
     );
     expect(infoSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         msg: "oura_raw_events_vendor_detail_deferred",
-        requestId: "req-1",
         rawItemCount: 2,
+        requestId: expect.stringMatching(
+          /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+        ),
       }),
     );
     assertAllLoggedPrivacySafe();

--- a/services/api/src/lib/__tests__/ouraRefreshTelemetry.test.ts
+++ b/services/api/src/lib/__tests__/ouraRefreshTelemetry.test.ts
@@ -1,8 +1,10 @@
 /**
  * Unit tests: categorizeOuraSafeError + logOuraRefreshTelemetry emit only privacy-safe fields.
  */
-import { categorizeOuraSafeError, logOuraRefreshTelemetry, type OuraRefreshTelemetryEvent } from "../ouraRefreshTelemetry";
+import { categorizeOuraSafeError, logOuraRefreshTelemetry, sanitizeOuraTelemetryRequestId, type OuraRefreshTelemetryEvent } from "../ouraRefreshTelemetry";
 import { assertOuraTelemetryPrivacy } from "../testSupport/assertOuraTelemetryPrivacy";
+
+const SAFE_REQUEST_ID = "3237605a-ceb7-44bc-958e-be8954b9e939";
 
 class FakeOuraApiError extends Error {
   constructor(
@@ -131,20 +133,20 @@ describe("logOuraRefreshTelemetry", () => {
   }
 
   const sampleEvents: OuraRefreshTelemetryEvent[] = [
-    { operation: "oura_reconnect_cleanup_failed", requestId: "req_1", safeErrorCode: "UNKNOWN" },
-    { operation: "oura_pull_failed", requestId: "req_1", safeErrorCode: "NO_CONNECTION", retryable: false },
-    { operation: "oura_token_refresh_busy", requestId: "req_1", retryable: true },
-    { operation: "oura_token_refresh_in_flight_join", requestId: "req_1" },
-    { operation: "oura_token_refresh_lock_wait", requestId: "req_1" },
-    { operation: "oura_token_refresh_lock_unavailable", requestId: "req_1" },
-    { operation: "oura_token_refresh_lock_stolen", requestId: "req_1" },
-    { operation: "oura_token_refresh_lock_acquired", requestId: "req_1" },
-    { operation: "oura_token_refresh_concurrent_success_detected", requestId: "req_1" },
-    { operation: "oura_token_refresh_invalid_grant_cleanup", requestId: "req_1" },
-    { operation: "oura_token_refresh_lock_released", requestId: "req_1" },
+    { operation: "oura_reconnect_cleanup_failed", requestId: "3237605a-ceb7-44bc-958e-be8954b9e939", safeErrorCode: "UNKNOWN" },
+    { operation: "oura_pull_failed", requestId: "3237605a-ceb7-44bc-958e-be8954b9e939", safeErrorCode: "NO_CONNECTION", retryable: false },
+    { operation: "oura_token_refresh_busy", requestId: "3237605a-ceb7-44bc-958e-be8954b9e939", retryable: true },
+    { operation: "oura_token_refresh_in_flight_join", requestId: "3237605a-ceb7-44bc-958e-be8954b9e939" },
+    { operation: "oura_token_refresh_lock_wait", requestId: "3237605a-ceb7-44bc-958e-be8954b9e939" },
+    { operation: "oura_token_refresh_lock_unavailable", requestId: "3237605a-ceb7-44bc-958e-be8954b9e939" },
+    { operation: "oura_token_refresh_lock_stolen", requestId: "3237605a-ceb7-44bc-958e-be8954b9e939" },
+    { operation: "oura_token_refresh_lock_acquired", requestId: "3237605a-ceb7-44bc-958e-be8954b9e939" },
+    { operation: "oura_token_refresh_concurrent_success_detected", requestId: "3237605a-ceb7-44bc-958e-be8954b9e939" },
+    { operation: "oura_token_refresh_invalid_grant_cleanup", requestId: "3237605a-ceb7-44bc-958e-be8954b9e939" },
+    { operation: "oura_token_refresh_lock_released", requestId: "3237605a-ceb7-44bc-958e-be8954b9e939" },
     {
       operation: "oura_raw_events_core_write_done",
-      requestId: "req_1",
+      requestId: "3237605a-ceb7-44bc-958e-be8954b9e939",
       rawEventCreatedCount: 4,
       rawEventExistingCount: 1,
       sleepDocumentCount: 2,
@@ -152,76 +154,76 @@ describe("logOuraRefreshTelemetry", () => {
       stepsDocumentCount: 0,
       workoutDocumentCount: 1,
     },
-    { operation: "oura_raw_events_vendor_detail_deferred", requestId: "req_1", rawItemCount: 10 },
+    { operation: "oura_raw_events_vendor_detail_deferred", requestId: "3237605a-ceb7-44bc-958e-be8954b9e939", rawItemCount: 10 },
     {
       operation: "oura_raw_events_vendor_detail_deferred_failed",
-      requestId: "req_1",
+      requestId: "3237605a-ceb7-44bc-958e-be8954b9e939",
       rawItemCount: 10,
       safeErrorCode: "RAW_EVENT_PERSIST_FAILED",
     },
     {
       operation: "oura_raw_event_write_failed",
-      requestId: "req_1",
+      requestId: "3237605a-ceb7-44bc-958e-be8954b9e939",
       domain: "sleep",
       safeErrorCode: "RAW_EVENT_PERSIST_FAILED",
       failedCount: 1,
     },
-    { operation: "oura_legacy_recovery_skipped", requestId: "req_1", backfillStatus: "running" },
-    { operation: "oura_legacy_recovery_detected", requestId: "req_1", backfillStatus: null },
-    { operation: "oura_legacy_recovery_started", requestId: "req_1" },
-    { operation: "oura_legacy_recovery_failed", requestId: "req_1", safeErrorCode: "UNKNOWN" },
+    { operation: "oura_legacy_recovery_skipped", requestId: "3237605a-ceb7-44bc-958e-be8954b9e939", backfillStatus: "running" },
+    { operation: "oura_legacy_recovery_detected", requestId: "3237605a-ceb7-44bc-958e-be8954b9e939", backfillStatus: null },
+    { operation: "oura_legacy_recovery_started", requestId: "3237605a-ceb7-44bc-958e-be8954b9e939" },
+    { operation: "oura_legacy_recovery_failed", requestId: "3237605a-ceb7-44bc-958e-be8954b9e939", safeErrorCode: "UNKNOWN" },
     {
       operation: "oura_pull_window",
-      requestId: "req_1",
+      requestId: "3237605a-ceb7-44bc-958e-be8954b9e939",
       windowDayCount: 30,
       sleepStartOverlapDayCount: 2,
       sleepEndOverlapDayCount: 1,
     },
-    { operation: "oura_provider_fetch_skipped", requestId: "req_1", dataset: "workout", safeErrorCode: "UNKNOWN" },
-    { operation: "oura_pull_sleep_summary", requestId: "req_1", hasSleepDocuments: true, sleepDocumentCount: 3 },
-    { operation: "oura_pull_fetch_completed", requestId: "req_1", sleepDocumentCount: 3, readinessDocumentCount: 3 },
-    { operation: "oura_ingest_docs_dropped", requestId: "req_1", sleepDocumentCount: 3, rejectedItemCount: 1 },
-    { operation: "oura_ingest_item_counts", requestId: "req_1", sleepItemCount: 2, hrvItemCount: 3 },
+    { operation: "oura_provider_fetch_skipped", requestId: "3237605a-ceb7-44bc-958e-be8954b9e939", dataset: "workout", safeErrorCode: "UNKNOWN" },
+    { operation: "oura_pull_sleep_summary", requestId: "3237605a-ceb7-44bc-958e-be8954b9e939", hasSleepDocuments: true, sleepDocumentCount: 3 },
+    { operation: "oura_pull_fetch_completed", requestId: "3237605a-ceb7-44bc-958e-be8954b9e939", sleepDocumentCount: 3, readinessDocumentCount: 3 },
+    { operation: "oura_ingest_docs_dropped", requestId: "3237605a-ceb7-44bc-958e-be8954b9e939", sleepDocumentCount: 3, rejectedItemCount: 1 },
+    { operation: "oura_ingest_item_counts", requestId: "3237605a-ceb7-44bc-958e-be8954b9e939", sleepItemCount: 2, hrvItemCount: 3 },
     {
       operation: "oura_raw_event_persist_started",
-      requestId: "req_1",
+      requestId: "3237605a-ceb7-44bc-958e-be8954b9e939",
       sleepItemCount: 2,
       hrvItemCount: 3,
       stepsItemCount: 0,
       workoutItemCount: 0,
       rawItemCount: 5,
     },
-    { operation: "oura_raw_event_persist_completed", requestId: "req_1", rawEventCreatedCount: 4, rawEventExistingCount: 1 },
+    { operation: "oura_raw_event_persist_completed", requestId: "3237605a-ceb7-44bc-958e-be8954b9e939", rawEventCreatedCount: 4, rawEventExistingCount: 1 },
     {
       operation: "oura_post_raw_enqueued",
-      requestId: "req_1",
+      requestId: "3237605a-ceb7-44bc-958e-be8954b9e939",
       queued: true,
       sleepDocumentCount: 3,
       readinessDocumentCount: 3,
       dailySleepDocumentCount: 3,
       dailyStressDocumentCount: 3,
     },
-    { operation: "oura_post_raw_enqueue_failed", requestId: "req_1", safeErrorCode: "POST_RAW_PUBLISH_FAILED" },
+    { operation: "oura_post_raw_enqueue_failed", requestId: "3237605a-ceb7-44bc-958e-be8954b9e939", safeErrorCode: "POST_RAW_PUBLISH_FAILED" },
     {
       operation: "oura_post_raw_persist_started",
-      requestId: "req_1",
+      requestId: "3237605a-ceb7-44bc-958e-be8954b9e939",
       sleepDocumentCount: 3,
       readinessDocumentCount: 3,
       dailySleepDocumentCount: 3,
       dailyStressDocumentCount: 3,
     },
-    { operation: "oura_post_raw_persist_completed", requestId: "req_1", writtenCount: 9, metadataWritten: true },
+    { operation: "oura_post_raw_persist_completed", requestId: "3237605a-ceb7-44bc-958e-be8954b9e939", writtenCount: 9, metadataWritten: true },
     {
       operation: "oura_post_raw_persist_failed",
-      requestId: "req_1",
+      requestId: "3237605a-ceb7-44bc-958e-be8954b9e939",
       safeErrorCode: "POST_RAW_PERSIST_FAILED",
       metadataWritten: false,
     },
-    { operation: "oura_backfill_skipped", requestId: "req_1", safeErrorCode: "NO_CONNECTION" },
-    { operation: "oura_backfill_started", requestId: "req_1" },
+    { operation: "oura_backfill_skipped", requestId: "3237605a-ceb7-44bc-958e-be8954b9e939", safeErrorCode: "NO_CONNECTION" },
+    { operation: "oura_backfill_started", requestId: "3237605a-ceb7-44bc-958e-be8954b9e939" },
     {
       operation: "oura_backfill_chunk_completed",
-      requestId: "req_1",
+      requestId: "3237605a-ceb7-44bc-958e-be8954b9e939",
       chunkIndex: 0,
       chunkCount: 3,
       chunkDayCount: 30,
@@ -230,7 +232,7 @@ describe("logOuraRefreshTelemetry", () => {
     },
     {
       operation: "oura_backfill_chunk_failed",
-      requestId: "req_1",
+      requestId: "3237605a-ceb7-44bc-958e-be8954b9e939",
       chunkIndex: 1,
       chunkCount: 3,
       chunkDayCount: 30,
@@ -238,18 +240,18 @@ describe("logOuraRefreshTelemetry", () => {
     },
     {
       operation: "oura_backfill_completed",
-      requestId: "req_1",
+      requestId: "3237605a-ceb7-44bc-958e-be8954b9e939",
       sleepSnapshotWrittenCount: 12,
       readinessSnapshotWrittenCount: 12,
     },
-    { operation: "oura_backfill_failed", requestId: "req_1", safeErrorCode: "UNKNOWN" },
-    { operation: "oura_provider_fetch_page_capped", requestId: "req_1", dataset: "sleep", pageCount: 100, providerItemCount: 900 },
-    { operation: "oura_provider_fetch_completed", requestId: "req_1", dataset: "sleep", pageCount: 3, providerItemCount: 27 },
-    { operation: "oura_vendor_snapshot_docs_received", requestId: "req_1", domain: "sleep", sleepDocumentCount: 3 },
-    { operation: "oura_vendor_snapshot_docs_dropped", requestId: "req_1", domain: "sleep", rejectedItemCount: 1, sleepDocumentCount: 3 },
-    { operation: "oura_vendor_snapshot_extracted", requestId: "req_1", domain: "sleep", validatedItemCount: 2, sleepDocumentCount: 3 },
-    { operation: "oura_vendor_snapshot_write_failed", requestId: "req_1", domain: "sleep", safeErrorCode: "UNKNOWN", failedCount: 1 },
-    { operation: "oura_vendor_snapshot_written", requestId: "req_1", domain: "sleep", writtenCount: 2, failedCount: 0 },
+    { operation: "oura_backfill_failed", requestId: "3237605a-ceb7-44bc-958e-be8954b9e939", safeErrorCode: "UNKNOWN" },
+    { operation: "oura_provider_fetch_page_capped", requestId: "3237605a-ceb7-44bc-958e-be8954b9e939", dataset: "sleep", pageCount: 100, providerItemCount: 900 },
+    { operation: "oura_provider_fetch_completed", requestId: "3237605a-ceb7-44bc-958e-be8954b9e939", dataset: "sleep", pageCount: 3, providerItemCount: 27 },
+    { operation: "oura_vendor_snapshot_docs_received", requestId: "3237605a-ceb7-44bc-958e-be8954b9e939", domain: "sleep", sleepDocumentCount: 3 },
+    { operation: "oura_vendor_snapshot_docs_dropped", requestId: "3237605a-ceb7-44bc-958e-be8954b9e939", domain: "sleep", rejectedItemCount: 1, sleepDocumentCount: 3 },
+    { operation: "oura_vendor_snapshot_extracted", requestId: "3237605a-ceb7-44bc-958e-be8954b9e939", domain: "sleep", validatedItemCount: 2, sleepDocumentCount: 3 },
+    { operation: "oura_vendor_snapshot_write_failed", requestId: "3237605a-ceb7-44bc-958e-be8954b9e939", domain: "sleep", safeErrorCode: "UNKNOWN", failedCount: 1 },
+    { operation: "oura_vendor_snapshot_written", requestId: "3237605a-ceb7-44bc-958e-be8954b9e939", domain: "sleep", writtenCount: 2, failedCount: 0 },
   ];
 
   it("emits every sample event via the correct console method with no thrown errors", () => {
@@ -262,14 +264,14 @@ describe("logOuraRefreshTelemetry", () => {
   });
 
   it("routes failure operations to console.error", () => {
-    logOuraRefreshTelemetry({ operation: "oura_pull_failed", requestId: "req_1", safeErrorCode: "NO_CONNECTION", retryable: false });
+    logOuraRefreshTelemetry({ operation: "oura_pull_failed", requestId: "3237605a-ceb7-44bc-958e-be8954b9e939", safeErrorCode: "NO_CONNECTION", retryable: false });
     expect(errorSpy).toHaveBeenCalledTimes(1);
     expect(infoSpy).not.toHaveBeenCalled();
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
   it("routes degraded-but-non-fatal operations to console.warn", () => {
-    logOuraRefreshTelemetry({ operation: "oura_token_refresh_busy", requestId: "req_1", retryable: true });
+    logOuraRefreshTelemetry({ operation: "oura_token_refresh_busy", requestId: "3237605a-ceb7-44bc-958e-be8954b9e939", retryable: true });
     expect(warnSpy).toHaveBeenCalledTimes(1);
     expect(infoSpy).not.toHaveBeenCalled();
     expect(errorSpy).not.toHaveBeenCalled();
@@ -278,7 +280,7 @@ describe("logOuraRefreshTelemetry", () => {
   it("routes docs-dropped operations to console.log (info), not warn", () => {
     logOuraRefreshTelemetry({
       operation: "oura_vendor_snapshot_docs_dropped",
-      requestId: "req_1",
+      requestId: "3237605a-ceb7-44bc-958e-be8954b9e939",
       domain: "sleep",
       rejectedItemCount: 1,
       sleepDocumentCount: 1,
@@ -288,7 +290,7 @@ describe("logOuraRefreshTelemetry", () => {
   });
 
   it("routes routine operations to console.log (info)", () => {
-    logOuraRefreshTelemetry({ operation: "oura_backfill_started", requestId: "req_1" });
+    logOuraRefreshTelemetry({ operation: "oura_backfill_started", requestId: "3237605a-ceb7-44bc-958e-be8954b9e939" });
     expect(infoSpy).toHaveBeenCalledTimes(1);
     expect(warnSpy).not.toHaveBeenCalled();
     expect(errorSpy).not.toHaveBeenCalled();
@@ -297,7 +299,7 @@ describe("logOuraRefreshTelemetry", () => {
   it("includes operation and msg (same value) plus the event's own fields only", () => {
     logOuraRefreshTelemetry({
       operation: "oura_pull_window",
-      requestId: "req_1",
+      requestId: "3237605a-ceb7-44bc-958e-be8954b9e939",
       windowDayCount: 30,
       sleepStartOverlapDayCount: 2,
       sleepEndOverlapDayCount: 1,
@@ -321,5 +323,47 @@ describe("logOuraRefreshTelemetry", () => {
       const payload = capturedPayload(spy);
       expect(() => assertOuraTelemetryPrivacy(payload)).not.toThrow();
     }
+  });
+
+  it("replaces unsafe requestId before emit and never logs the raw candidate", () => {
+    const unsafe = "user_SENTINEL@example.com";
+    logOuraRefreshTelemetry({
+      operation: "oura_backfill_started",
+      requestId: unsafe,
+    });
+    const payload = capturedPayload(infoSpy);
+    expect(payload.requestId).not.toBe(unsafe);
+    expect(String(payload.requestId)).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+    expect(JSON.stringify(payload)).not.toContain("SENTINEL");
+    expect(JSON.stringify(payload)).not.toContain("@example.com");
+  });
+});
+
+describe("sanitizeOuraTelemetryRequestId", () => {
+  const uuidRe = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+  it("accepts a valid UUID", () => {
+    expect(sanitizeOuraTelemetryRequestId(SAFE_REQUEST_ID)).toBe(SAFE_REQUEST_ID);
+  });
+
+  it.each([
+    ["arbitrary text", "not-a-uuid-at-all"],
+    ["email-like", "user_SENTINEL@example.com"],
+    ["date-like", "2026-07-12"],
+    ["url-like", "https://evil.example/path"],
+    ["bearer-token-like", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.aaa.bbb"],
+    ["firebase-token-like", "eyJhbGciOiJSUzI1NiIsImtpZCI6ImZha2UifQ.payload.sig"],
+    ["idempotency-key-like", "idempotency-oura-pull-abc123"],
+    ["uid-like", "firebaseUid_SENTINEL_abc"],
+    ["oversized", `${"a".repeat(40)}`],
+    ["empty", ""],
+    ["spaces", "3237605a-ceb7-44bc-958e-be8954b9e939 extra"],
+  ])("replaces %s input with a new UUID", (_label, input) => {
+    const out = sanitizeOuraTelemetryRequestId(input);
+    expect(out).toMatch(uuidRe);
+    expect(out).not.toBe(input);
+    expect(out).not.toContain("SENTINEL");
   });
 });

--- a/services/api/src/lib/__tests__/ouraRefreshTelemetry.test.ts
+++ b/services/api/src/lib/__tests__/ouraRefreshTelemetry.test.ts
@@ -1,0 +1,325 @@
+/**
+ * Unit tests: categorizeOuraSafeError + logOuraRefreshTelemetry emit only privacy-safe fields.
+ */
+import { categorizeOuraSafeError, logOuraRefreshTelemetry, type OuraRefreshTelemetryEvent } from "../ouraRefreshTelemetry";
+import { assertOuraTelemetryPrivacy } from "../testSupport/assertOuraTelemetryPrivacy";
+
+class FakeOuraApiError extends Error {
+  constructor(
+    message: string,
+    public readonly code: string,
+    public readonly status?: number,
+  ) {
+    super(message);
+    this.name = "OuraApiError";
+  }
+}
+
+describe("categorizeOuraSafeError", () => {
+  it("maps 401 / OURA_UNAUTHORIZED to PROVIDER_UNAUTHORIZED, not retryable", () => {
+    expect(categorizeOuraSafeError(new FakeOuraApiError("nope", "OURA_UNAUTHORIZED", 401))).toEqual({
+      safeErrorCode: "PROVIDER_UNAUTHORIZED",
+      retryable: false,
+    });
+    expect(categorizeOuraSafeError(new FakeOuraApiError("nope", "OURA_TOKEN_REFRESH_FAILED", 401))).toEqual({
+      safeErrorCode: "PROVIDER_UNAUTHORIZED",
+      retryable: false,
+    });
+  });
+
+  it("maps 429 to PROVIDER_RATE_LIMITED, retryable", () => {
+    expect(categorizeOuraSafeError(new FakeOuraApiError("slow down", "OURA_FETCH_FAILED", 429))).toEqual({
+      safeErrorCode: "PROVIDER_RATE_LIMITED",
+      retryable: true,
+    });
+  });
+
+  it("maps 408 to PROVIDER_TIMEOUT, retryable", () => {
+    expect(categorizeOuraSafeError(new FakeOuraApiError("slow", "OURA_FETCH_FAILED", 408))).toEqual({
+      safeErrorCode: "PROVIDER_TIMEOUT",
+      retryable: true,
+    });
+  });
+
+  it("maps 5xx to PROVIDER_NETWORK, retryable", () => {
+    expect(categorizeOuraSafeError(new FakeOuraApiError("boom", "OURA_FETCH_FAILED", 503))).toEqual({
+      safeErrorCode: "PROVIDER_NETWORK",
+      retryable: true,
+    });
+  });
+
+  it("maps OURA_TOKEN_INVALID to PROVIDER_SCHEMA_INVALID, not retryable", () => {
+    expect(categorizeOuraSafeError(new FakeOuraApiError("bad shape", "OURA_TOKEN_INVALID", 200))).toEqual({
+      safeErrorCode: "PROVIDER_SCHEMA_INVALID",
+      retryable: false,
+    });
+  });
+
+  it("maps network-like plain errors to PROVIDER_NETWORK", () => {
+    expect(categorizeOuraSafeError(new Error("fetch failed"))).toEqual({
+      safeErrorCode: "PROVIDER_NETWORK",
+      retryable: true,
+    });
+    expect(categorizeOuraSafeError(new Error("ECONNRESET"))).toEqual({
+      safeErrorCode: "PROVIDER_NETWORK",
+      retryable: true,
+    });
+  });
+
+  it("maps timeout-like plain errors to PROVIDER_TIMEOUT", () => {
+    expect(categorizeOuraSafeError(new Error("request timeout exceeded"))).toEqual({
+      safeErrorCode: "PROVIDER_TIMEOUT",
+      retryable: true,
+    });
+  });
+
+  it("falls back to a valid hint when the error is unclassifiable", () => {
+    expect(categorizeOuraSafeError(new Error("mystery"), "TOKEN_UNAVAILABLE")).toEqual({
+      safeErrorCode: "TOKEN_UNAVAILABLE",
+      retryable: false,
+    });
+  });
+
+  it("falls back to UNKNOWN when there is no hint and the error is unclassifiable", () => {
+    expect(categorizeOuraSafeError(new Error("mystery"))).toEqual({
+      safeErrorCode: "UNKNOWN",
+      retryable: false,
+    });
+    expect(categorizeOuraSafeError("just a string")).toEqual({
+      safeErrorCode: "UNKNOWN",
+      retryable: false,
+    });
+  });
+
+  it("ignores an invalid hint string rather than accepting an arbitrary value", () => {
+    expect(categorizeOuraSafeError(new Error("mystery"), "NOT_A_REAL_CODE")).toEqual({
+      safeErrorCode: "UNKNOWN",
+      retryable: false,
+    });
+  });
+
+  it("never returns the underlying Error.message in the result", () => {
+    const err = new Error("this message must never leak into telemetry: uid=user_secret_123");
+    const result = categorizeOuraSafeError(err);
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("user_secret_123");
+    expect(serialized).not.toContain("this message must never leak");
+  });
+});
+
+describe("logOuraRefreshTelemetry", () => {
+  let infoSpy: jest.SpyInstance;
+  let warnSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    infoSpy = jest.spyOn(console, "log").mockImplementation(() => undefined);
+    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    infoSpy.mockRestore();
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  function capturedPayload(spy: jest.SpyInstance): Record<string, unknown> {
+    expect(spy).toHaveBeenCalledTimes(1);
+    const raw = spy.mock.calls[0]![0] as string;
+    return JSON.parse(raw) as Record<string, unknown>;
+  }
+
+  const sampleEvents: OuraRefreshTelemetryEvent[] = [
+    { operation: "oura_reconnect_cleanup_failed", requestId: "req_1", safeErrorCode: "UNKNOWN" },
+    { operation: "oura_pull_failed", requestId: "req_1", safeErrorCode: "NO_CONNECTION", retryable: false },
+    { operation: "oura_token_refresh_busy", requestId: "req_1", retryable: true },
+    { operation: "oura_token_refresh_in_flight_join", requestId: "req_1" },
+    { operation: "oura_token_refresh_lock_wait", requestId: "req_1" },
+    { operation: "oura_token_refresh_lock_unavailable", requestId: "req_1" },
+    { operation: "oura_token_refresh_lock_stolen", requestId: "req_1" },
+    { operation: "oura_token_refresh_lock_acquired", requestId: "req_1" },
+    { operation: "oura_token_refresh_concurrent_success_detected", requestId: "req_1" },
+    { operation: "oura_token_refresh_invalid_grant_cleanup", requestId: "req_1" },
+    { operation: "oura_token_refresh_lock_released", requestId: "req_1" },
+    {
+      operation: "oura_raw_events_core_write_done",
+      requestId: "req_1",
+      rawEventCreatedCount: 4,
+      rawEventExistingCount: 1,
+      sleepDocumentCount: 2,
+      hrvDocumentCount: 1,
+      stepsDocumentCount: 0,
+      workoutDocumentCount: 1,
+    },
+    { operation: "oura_raw_events_vendor_detail_deferred", requestId: "req_1", rawItemCount: 10 },
+    {
+      operation: "oura_raw_events_vendor_detail_deferred_failed",
+      requestId: "req_1",
+      rawItemCount: 10,
+      safeErrorCode: "RAW_EVENT_PERSIST_FAILED",
+    },
+    {
+      operation: "oura_raw_event_write_failed",
+      requestId: "req_1",
+      domain: "sleep",
+      safeErrorCode: "RAW_EVENT_PERSIST_FAILED",
+      failedCount: 1,
+    },
+    { operation: "oura_legacy_recovery_skipped", requestId: "req_1", backfillStatus: "running" },
+    { operation: "oura_legacy_recovery_detected", requestId: "req_1", backfillStatus: null },
+    { operation: "oura_legacy_recovery_started", requestId: "req_1" },
+    { operation: "oura_legacy_recovery_failed", requestId: "req_1", safeErrorCode: "UNKNOWN" },
+    {
+      operation: "oura_pull_window",
+      requestId: "req_1",
+      windowDayCount: 30,
+      sleepStartOverlapDayCount: 2,
+      sleepEndOverlapDayCount: 1,
+    },
+    { operation: "oura_provider_fetch_skipped", requestId: "req_1", dataset: "workout", safeErrorCode: "UNKNOWN" },
+    { operation: "oura_pull_sleep_summary", requestId: "req_1", hasSleepDocuments: true, sleepDocumentCount: 3 },
+    { operation: "oura_pull_fetch_completed", requestId: "req_1", sleepDocumentCount: 3, readinessDocumentCount: 3 },
+    { operation: "oura_ingest_docs_dropped", requestId: "req_1", sleepDocumentCount: 3, rejectedItemCount: 1 },
+    { operation: "oura_ingest_item_counts", requestId: "req_1", sleepItemCount: 2, hrvItemCount: 3 },
+    {
+      operation: "oura_raw_event_persist_started",
+      requestId: "req_1",
+      sleepItemCount: 2,
+      hrvItemCount: 3,
+      stepsItemCount: 0,
+      workoutItemCount: 0,
+      rawItemCount: 5,
+    },
+    { operation: "oura_raw_event_persist_completed", requestId: "req_1", rawEventCreatedCount: 4, rawEventExistingCount: 1 },
+    {
+      operation: "oura_post_raw_enqueued",
+      requestId: "req_1",
+      queued: true,
+      sleepDocumentCount: 3,
+      readinessDocumentCount: 3,
+      dailySleepDocumentCount: 3,
+      dailyStressDocumentCount: 3,
+    },
+    { operation: "oura_post_raw_enqueue_failed", requestId: "req_1", safeErrorCode: "POST_RAW_PUBLISH_FAILED" },
+    {
+      operation: "oura_post_raw_persist_started",
+      requestId: "req_1",
+      sleepDocumentCount: 3,
+      readinessDocumentCount: 3,
+      dailySleepDocumentCount: 3,
+      dailyStressDocumentCount: 3,
+    },
+    { operation: "oura_post_raw_persist_completed", requestId: "req_1", writtenCount: 9, metadataWritten: true },
+    {
+      operation: "oura_post_raw_persist_failed",
+      requestId: "req_1",
+      safeErrorCode: "POST_RAW_PERSIST_FAILED",
+      metadataWritten: false,
+    },
+    { operation: "oura_backfill_skipped", requestId: "req_1", safeErrorCode: "NO_CONNECTION" },
+    { operation: "oura_backfill_started", requestId: "req_1" },
+    {
+      operation: "oura_backfill_chunk_completed",
+      requestId: "req_1",
+      chunkIndex: 0,
+      chunkCount: 3,
+      chunkDayCount: 30,
+      sleepSnapshotWrittenCount: 5,
+      readinessSnapshotWrittenCount: 5,
+    },
+    {
+      operation: "oura_backfill_chunk_failed",
+      requestId: "req_1",
+      chunkIndex: 1,
+      chunkCount: 3,
+      chunkDayCount: 30,
+      safeErrorCode: "UNKNOWN",
+    },
+    {
+      operation: "oura_backfill_completed",
+      requestId: "req_1",
+      sleepSnapshotWrittenCount: 12,
+      readinessSnapshotWrittenCount: 12,
+    },
+    { operation: "oura_backfill_failed", requestId: "req_1", safeErrorCode: "UNKNOWN" },
+    { operation: "oura_provider_fetch_page_capped", requestId: "req_1", dataset: "sleep", pageCount: 100, providerItemCount: 900 },
+    { operation: "oura_provider_fetch_completed", requestId: "req_1", dataset: "sleep", pageCount: 3, providerItemCount: 27 },
+    { operation: "oura_vendor_snapshot_docs_received", requestId: "req_1", domain: "sleep", sleepDocumentCount: 3 },
+    { operation: "oura_vendor_snapshot_docs_dropped", requestId: "req_1", domain: "sleep", rejectedItemCount: 1, sleepDocumentCount: 3 },
+    { operation: "oura_vendor_snapshot_extracted", requestId: "req_1", domain: "sleep", validatedItemCount: 2, sleepDocumentCount: 3 },
+    { operation: "oura_vendor_snapshot_write_failed", requestId: "req_1", domain: "sleep", safeErrorCode: "UNKNOWN", failedCount: 1 },
+    { operation: "oura_vendor_snapshot_written", requestId: "req_1", domain: "sleep", writtenCount: 2, failedCount: 0 },
+  ];
+
+  it("emits every sample event via the correct console method with no thrown errors", () => {
+    for (const event of sampleEvents) {
+      infoSpy.mockClear();
+      warnSpy.mockClear();
+      errorSpy.mockClear();
+      expect(() => logOuraRefreshTelemetry(event)).not.toThrow();
+    }
+  });
+
+  it("routes failure operations to console.error", () => {
+    logOuraRefreshTelemetry({ operation: "oura_pull_failed", requestId: "req_1", safeErrorCode: "NO_CONNECTION", retryable: false });
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("routes degraded-but-non-fatal operations to console.warn", () => {
+    logOuraRefreshTelemetry({ operation: "oura_token_refresh_busy", requestId: "req_1", retryable: true });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("routes docs-dropped operations to console.log (info), not warn", () => {
+    logOuraRefreshTelemetry({
+      operation: "oura_vendor_snapshot_docs_dropped",
+      requestId: "req_1",
+      domain: "sleep",
+      rejectedItemCount: 1,
+      sleepDocumentCount: 1,
+    });
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("routes routine operations to console.log (info)", () => {
+    logOuraRefreshTelemetry({ operation: "oura_backfill_started", requestId: "req_1" });
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("includes operation and msg (same value) plus the event's own fields only", () => {
+    logOuraRefreshTelemetry({
+      operation: "oura_pull_window",
+      requestId: "req_1",
+      windowDayCount: 30,
+      sleepStartOverlapDayCount: 2,
+      sleepEndOverlapDayCount: 1,
+    });
+    const payload = capturedPayload(infoSpy);
+    expect(payload.operation).toBe("oura_pull_window");
+    expect(payload.msg).toBe("oura_pull_window");
+    expect(payload.windowDayCount).toBe(30);
+    expect(payload.sleepStartOverlapDayCount).toBe(2);
+    expect(payload.sleepEndOverlapDayCount).toBe(1);
+    expect(payload.level).toBe("info");
+  });
+
+  it("every sample event serializes to JSON with no privacy violations", () => {
+    for (const event of sampleEvents) {
+      infoSpy.mockClear();
+      warnSpy.mockClear();
+      errorSpy.mockClear();
+      logOuraRefreshTelemetry(event);
+      const spy = errorSpy.mock.calls.length > 0 ? errorSpy : warnSpy.mock.calls.length > 0 ? warnSpy : infoSpy;
+      const payload = capturedPayload(spy);
+      expect(() => assertOuraTelemetryPrivacy(payload)).not.toThrow();
+    }
+  });
+});

--- a/services/api/src/lib/__tests__/ouraRefreshTelemetrySourceGuard.test.ts
+++ b/services/api/src/lib/__tests__/ouraRefreshTelemetrySourceGuard.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Source guard: fails if any file in the active Oura refresh path calls
+ * logger.info/warn/error or console.log/warn/error directly instead of routing
+ * through the typed ouraRefreshTelemetry / ouraPostRawTelemetry helpers.
+ *
+ * Importing the telemetry module (and calling its exported functions) is allowed —
+ * only direct logger/console calls are forbidden in these files.
+ */
+import fs from "fs";
+import path from "path";
+
+const REPO_ROOT = path.resolve(__dirname, "../../../../..");
+
+/** Files that MUST NOT call logger.info/warn/error or console.log/warn/error directly. */
+const GUARDED_FILES: string[] = [
+  "services/api/src/routes/integrations/ouraPullNow.ts",
+  "services/api/src/lib/ouraApi.ts",
+  "services/api/src/lib/ouraVendorSnapshot.ts",
+  "services/api/src/lib/ouraIngestWrite.ts",
+  "services/api/src/lib/ouraTokenRefreshSingleFlight.ts",
+];
+
+/** logger.info(...) / logger.warn(...) / logger.error(...) as a direct call. */
+const DIRECT_LOGGER_CALL_REGEX = /\blogger\.(info|warn|error)\s*\(/;
+const DIRECT_CONSOLE_CALL_REGEX = /\bconsole\.(log|warn|error)\s*\(/;
+
+describe("Oura refresh path source guard", () => {
+  for (const relPath of GUARDED_FILES) {
+    it(`${relPath} has no direct logger.*/console.* calls`, () => {
+      const absPath = path.join(REPO_ROOT, relPath);
+      expect(fs.existsSync(absPath)).toBe(true);
+      const source = fs.readFileSync(absPath, "utf8");
+
+      const loggerMatches = source.match(new RegExp(DIRECT_LOGGER_CALL_REGEX, "g")) ?? [];
+      const consoleMatches = source.match(new RegExp(DIRECT_CONSOLE_CALL_REGEX, "g")) ?? [];
+
+      expect({ file: relPath, loggerCalls: loggerMatches, consoleCalls: consoleMatches }).toEqual({
+        file: relPath,
+        loggerCalls: [],
+        consoleCalls: [],
+      });
+    });
+  }
+
+  it("guarded files still route logging through logOuraRefreshTelemetry", () => {
+    for (const relPath of GUARDED_FILES) {
+      const absPath = path.join(REPO_ROOT, relPath);
+      const source = fs.readFileSync(absPath, "utf8");
+      expect(source.includes("logOuraRefreshTelemetry") || source.includes("categorizeOuraSafeError")).toBe(true);
+    }
+  });
+});

--- a/services/api/src/lib/__tests__/ouraVendorSnapshot.test.ts
+++ b/services/api/src/lib/__tests__/ouraVendorSnapshot.test.ts
@@ -1,6 +1,7 @@
 /**
  * Oura vendor snapshot writer — shape and write behavior.
  */
+import { allowConsoleForThisTest } from "../../../../../scripts/test/consoleGuard";
 import { userCollection } from "../../db";
 import {
   writeOuraVendorSleepSnapshots,
@@ -38,6 +39,10 @@ function mockReadinessCollection() {
 describe("ouraVendorSnapshot", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    allowConsoleForThisTest({
+      error: [/oura_vendor_snapshot_/],
+      warn: [/oura_vendor_snapshot_/],
+    });
     (userCollection as jest.Mock).mockImplementation((_uid: string, name: string) => {
       if (name === "ouraVendorReadiness") return mockReadinessCollection();
       return {

--- a/services/api/src/lib/oura/ouraSleepPhysiology.ts
+++ b/services/api/src/lib/oura/ouraSleepPhysiology.ts
@@ -83,7 +83,8 @@ export type OuraSleepPhysiologyDebug = {
  * document ids, and physiology fields. Environment gating is not privacy protection.
  * Call sites may remain; this function is a no-op.
  */
-export function logOuraSleepPhysiologyDebugIfEnabled(_debug: OuraSleepPhysiologyDebug): void {
+export function logOuraSleepPhysiologyDebugIfEnabled(debug: OuraSleepPhysiologyDebug): void {
+  void debug;
   return;
 }
 

--- a/services/api/src/lib/oura/ouraSleepPhysiology.ts
+++ b/services/api/src/lib/oura/ouraSleepPhysiology.ts
@@ -4,7 +4,6 @@
  * Matches Oura app sleep summary; not derived from heartrate/HRV time series.
  */
 
-import { logger } from "../logger";
 import type { OuraSleepWindowDocument } from "./resolveOuraSleepIngestBase";
 
 function coerceOptionalNumber(val: unknown): number | undefined {
@@ -79,17 +78,13 @@ export type OuraSleepPhysiologyDebug = {
   end: string | null;
 };
 
-export function logOuraSleepPhysiologyDebugIfEnabled(debug: OuraSleepPhysiologyDebug): void {
-  if (
-    process.env.OURA_SLEEP_PHYSIOLOGY_DEBUG !== "1" &&
-    process.env.OURA_SLEEP_PHYSIOLOGY_DEBUG !== "true"
-  ) {
-    return;
-  }
-  logger.info({
-    msg: "[OURA_SLEEP_PHYSIOLOGY_DEBUG]",
-    ...debug,
-  });
+/**
+ * Permanently disabled: previously env-gated debug telemetry logged uid, day,
+ * document ids, and physiology fields. Environment gating is not privacy protection.
+ * Call sites may remain; this function is a no-op.
+ */
+export function logOuraSleepPhysiologyDebugIfEnabled(_debug: OuraSleepPhysiologyDebug): void {
+  return;
 }
 
 /** Emit debug line for one Oura sleep API document (pull-now / snapshot write). */

--- a/services/api/src/lib/ouraApi.ts
+++ b/services/api/src/lib/ouraApi.ts
@@ -3,7 +3,7 @@
  * Used by POST /integrations/oura/pull-now. OAuth token URL and scopes match integrations.ts.
  */
 
-import { logger } from "./logger";
+import { logOuraRefreshTelemetry } from "./ouraRefreshTelemetry";
 import {
   normalizeOuraLatencyRawToMinutes,
   ouraSleepWakeIsoForLog,
@@ -250,27 +250,24 @@ export async function fetchOuraSleep(
       break;
     }
     if (pages >= OURA_SLEEP_FETCH_MAX_PAGES) {
-      logger.error({
-        msg: "oura_sleep_fetch_page_cap",
-        startDate,
-        endDate,
-        pages,
+      logOuraRefreshTelemetry({
+        operation: "oura_provider_fetch_page_capped",
+        dataset: "sleep",
+        pageCount: pages,
+        providerItemCount: aggregated.length,
         ...(options?.requestId ? { requestId: options.requestId } : {}),
-        ...(options?.uid ? { uid: options.uid } : {}),
       });
       break;
     }
     nextRequestToken = responseNext;
   }
 
-  logger.info({
-    msg: "oura_sleep_fetch_complete",
-    startDate,
-    endDate,
-    pages,
-    rowCount: aggregated.length,
+  logOuraRefreshTelemetry({
+    operation: "oura_provider_fetch_completed",
+    dataset: "sleep",
+    pageCount: pages,
+    providerItemCount: aggregated.length,
     ...(options?.requestId ? { requestId: options.requestId } : {}),
-    ...(options?.uid ? { uid: options.uid } : {}),
   });
 
   return aggregated;
@@ -367,27 +364,23 @@ export async function fetchOuraDailySleep(
     if (!token) break;
     nextRequestToken = token;
     if (pages >= 50) {
-      logger.warn({
-        msg: "oura_daily_sleep_fetch_page_cap",
-        startDate,
-        endDate,
-        pages,
-        rowCount: aggregated.length,
+      logOuraRefreshTelemetry({
+        operation: "oura_provider_fetch_page_capped",
+        dataset: "daily_sleep",
+        pageCount: pages,
+        providerItemCount: aggregated.length,
         ...(options?.requestId ? { requestId: options.requestId } : {}),
-        ...(options?.uid ? { uid: options.uid } : {}),
       });
       break;
     }
   }
 
-  logger.info({
-    msg: "oura_daily_sleep_fetch_complete",
-    startDate,
-    endDate,
-    pages,
-    rowCount: aggregated.length,
+  logOuraRefreshTelemetry({
+    operation: "oura_provider_fetch_completed",
+    dataset: "daily_sleep",
+    pageCount: pages,
+    providerItemCount: aggregated.length,
     ...(options?.requestId ? { requestId: options.requestId } : {}),
-    ...(options?.uid ? { uid: options.uid } : {}),
   });
 
   return aggregated;
@@ -450,20 +443,22 @@ export async function fetchOuraDailyStress(
     if (!token) break;
     nextRequestToken = token;
     if (pages >= OURA_DAILY_STRESS_FETCH_MAX_PAGES) {
-      logger.warn({
-        msg: "oura_daily_stress_fetch_page_cap",
-        pages,
-        rowCount: aggregated.length,
+      logOuraRefreshTelemetry({
+        operation: "oura_provider_fetch_page_capped",
+        dataset: "daily_stress",
+        pageCount: pages,
+        providerItemCount: aggregated.length,
         ...(options?.requestId ? { requestId: options.requestId } : {}),
       });
       break;
     }
   }
 
-  logger.info({
-    msg: "oura_daily_stress_fetch_complete",
-    pages,
-    rowCount: aggregated.length,
+  logOuraRefreshTelemetry({
+    operation: "oura_provider_fetch_completed",
+    dataset: "daily_stress",
+    pageCount: pages,
+    providerItemCount: aggregated.length,
     ...(options?.requestId ? { requestId: options.requestId } : {}),
   });
 

--- a/services/api/src/lib/ouraIngestWrite.ts
+++ b/services/api/src/lib/ouraIngestWrite.ts
@@ -13,7 +13,7 @@ import type {
 } from "./ouraApi";
 import { userCollection } from "../db";
 import { writeFailure } from "./writeFailure";
-import { logger } from "./logger";
+import { categorizeOuraSafeError, logOuraRefreshTelemetry } from "./ouraRefreshTelemetry";
 
 const OURA_SOURCE_ID = "oura";
 const OURA_SOURCE_TYPE = "oura";
@@ -65,37 +65,31 @@ export async function writeOuraRawEvents(
     stepsRes.alreadyExists +
     workoutRes.alreadyExists;
 
-  logger.info({
-    msg: "oura_raw_events_core_write_done",
-    uid,
+  logOuraRefreshTelemetry({
+    operation: "oura_raw_events_core_write_done",
     requestId,
-    sleepCreated: sleepRes.created,
-    sleepAlreadyExists: sleepRes.alreadyExists,
-    hrvCreated: hrvRes.created,
-    hrvAlreadyExists: hrvRes.alreadyExists,
-    stepsCreated: stepsRes.created,
-    stepsAlreadyExists: stepsRes.alreadyExists,
-    workoutCreated: workoutRes.created,
-    workoutAlreadyExists: workoutRes.alreadyExists,
-    eventsCreated,
-    eventsAlreadyExists,
+    rawEventCreatedCount: eventsCreated,
+    rawEventExistingCount: eventsAlreadyExists,
+    sleepDocumentCount: sleepRes.created,
+    hrvDocumentCount: hrvRes.created,
+    stepsDocumentCount: stepsRes.created,
+    workoutDocumentCount: workoutRes.created,
   });
 
   if (ouraRawItems.length > 0) {
-    logger.info({
-      msg: "oura_raw_events_vendor_detail_deferred",
-      uid,
+    logOuraRefreshTelemetry({
+      operation: "oura_raw_events_vendor_detail_deferred",
       requestId,
-      ouraRawCount: ouraRawItems.length,
+      rawItemCount: ouraRawItems.length,
     });
     void writeOuraRawLoop(rawEventsCol, ouraRawItems, receivedAt, uid, requestId).catch(
       (err: unknown) => {
-        logger.error({
-          msg: "oura_raw_events_vendor_detail_deferred_error",
-          uid,
+        const { safeErrorCode } = categorizeOuraSafeError(err, "RAW_EVENT_PERSIST_FAILED");
+        logOuraRefreshTelemetry({
+          operation: "oura_raw_events_vendor_detail_deferred_failed",
           requestId,
-          ouraRawCount: ouraRawItems.length,
-          err: err instanceof Error ? err.message : String(err),
+          rawItemCount: ouraRawItems.length,
+          safeErrorCode,
         });
       },
     );
@@ -173,12 +167,13 @@ async function writeSleepLoop(
         created += 1;
       }
     } catch (err: unknown) {
-      logger.error({
-        msg: "oura_ingest_sleep_write_error",
-        uid,
-        rawEventId: item.idempotencyKey,
+      const { safeErrorCode } = categorizeOuraSafeError(err, "RAW_EVENT_PERSIST_FAILED");
+      logOuraRefreshTelemetry({
+        operation: "oura_raw_event_write_failed",
         requestId,
-        err: err instanceof Error ? err.message : String(err),
+        domain: "sleep",
+        safeErrorCode,
+        failedCount: 1,
       });
     }
   }
@@ -243,12 +238,13 @@ async function writeHrvLoop(
       if (existing.exists) {
         alreadyExists += 1;
       } else {
-        logger.error({
-          msg: "oura_ingest_hrv_write_error",
-          uid,
-          rawEventId: item.idempotencyKey,
+        const { safeErrorCode } = categorizeOuraSafeError(err, "RAW_EVENT_PERSIST_FAILED");
+        logOuraRefreshTelemetry({
+          operation: "oura_raw_event_write_failed",
           requestId,
-          err: err instanceof Error ? err.message : String(err),
+          domain: "hrv",
+          safeErrorCode,
+          failedCount: 1,
         });
       }
     }
@@ -314,12 +310,13 @@ async function writeStepsLoop(
       if (existing.exists) {
         alreadyExists += 1;
       } else {
-        logger.error({
-          msg: "oura_ingest_steps_write_error",
-          uid,
-          rawEventId: item.idempotencyKey,
+        const { safeErrorCode } = categorizeOuraSafeError(err, "RAW_EVENT_PERSIST_FAILED");
+        logOuraRefreshTelemetry({
+          operation: "oura_raw_event_write_failed",
           requestId,
-          err: err instanceof Error ? err.message : String(err),
+          domain: "steps",
+          safeErrorCode,
+          failedCount: 1,
         });
       }
     }
@@ -386,12 +383,13 @@ async function writeWorkoutLoop(
       if (existing.exists) {
         alreadyExists += 1;
       } else {
-        logger.error({
-          msg: "oura_ingest_workout_write_error",
-          uid,
-          rawEventId: item.idempotencyKey,
+        const { safeErrorCode } = categorizeOuraSafeError(err, "RAW_EVENT_PERSIST_FAILED");
+        logOuraRefreshTelemetry({
+          operation: "oura_raw_event_write_failed",
           requestId,
-          err: err instanceof Error ? err.message : String(err),
+          domain: "workout",
+          safeErrorCode,
+          failedCount: 1,
         });
       }
     }
@@ -449,12 +447,13 @@ async function writeOuraRawLoop(
       if (existing.exists) {
         alreadyExists += 1;
       } else {
-        logger.error({
-          msg: "oura_ingest_oura_raw_write_error",
-          uid,
-          rawEventId: item.idempotencyKey,
+        const { safeErrorCode } = categorizeOuraSafeError(err, "RAW_EVENT_PERSIST_FAILED");
+        logOuraRefreshTelemetry({
+          operation: "oura_raw_event_write_failed",
           requestId,
-          err: err instanceof Error ? err.message : String(err),
+          domain: "oura_raw",
+          safeErrorCode,
+          failedCount: 1,
         });
       }
     }

--- a/services/api/src/lib/ouraRefreshTelemetry.ts
+++ b/services/api/src/lib/ouraRefreshTelemetry.ts
@@ -1,0 +1,403 @@
+/**
+ * Privacy-safe telemetry for the Oura refresh path (pull-now, backfill, provider fetch,
+ * vendor snapshot writes, post-raw enqueue/persist).
+ *
+ * Design goal: every call site in the active Oura refresh path logs through
+ * `logOuraRefreshTelemetry` with a closed set of typed, aggregate-only fields.
+ * No uid, dates/day strings, document/snapshot ids, scores, tokens, or raw error
+ * messages are ever accepted by this module's event types.
+ */
+
+import { logger } from "./logger";
+
+/** Closed set of privacy-safe error codes for the Oura refresh path. */
+export type OuraSafeErrorCode =
+  | "NO_CONNECTION"
+  | "TOKEN_UNAVAILABLE"
+  | "PROVIDER_UNAUTHORIZED"
+  | "PROVIDER_RATE_LIMITED"
+  | "PROVIDER_TIMEOUT"
+  | "PROVIDER_NETWORK"
+  | "PROVIDER_SCHEMA_INVALID"
+  | "RAW_EVENT_PERSIST_FAILED"
+  | "POST_RAW_PUBLISH_FAILED"
+  | "POST_RAW_PERSIST_FAILED"
+  | "FUNCTION_PAYLOAD_INVALID"
+  | "FUNCTION_PERSIST_FAILED"
+  | "UNKNOWN";
+
+const OURA_SAFE_ERROR_CODES: ReadonlySet<string> = new Set([
+  "NO_CONNECTION",
+  "TOKEN_UNAVAILABLE",
+  "PROVIDER_UNAUTHORIZED",
+  "PROVIDER_RATE_LIMITED",
+  "PROVIDER_TIMEOUT",
+  "PROVIDER_NETWORK",
+  "PROVIDER_SCHEMA_INVALID",
+  "RAW_EVENT_PERSIST_FAILED",
+  "POST_RAW_PUBLISH_FAILED",
+  "POST_RAW_PERSIST_FAILED",
+  "FUNCTION_PAYLOAD_INVALID",
+  "FUNCTION_PERSIST_FAILED",
+  "UNKNOWN",
+]);
+
+/** Error codes that are safe to retry (rate limit / timeout / transient network / best-effort persistence). */
+const RETRYABLE_SAFE_ERROR_CODES: ReadonlySet<OuraSafeErrorCode> = new Set([
+  "PROVIDER_RATE_LIMITED",
+  "PROVIDER_TIMEOUT",
+  "PROVIDER_NETWORK",
+  "RAW_EVENT_PERSIST_FAILED",
+  "POST_RAW_PUBLISH_FAILED",
+  "POST_RAW_PERSIST_FAILED",
+  "FUNCTION_PERSIST_FAILED",
+]);
+
+function isOuraSafeErrorCode(v: unknown): v is OuraSafeErrorCode {
+  return typeof v === "string" && OURA_SAFE_ERROR_CODES.has(v);
+}
+
+/**
+ * Structural (duck-typed) check for `OuraApiError`-shaped errors. Intentionally avoids
+ * importing the class from `./ouraApi` to keep this module dependency-free (ouraApi.ts
+ * imports telemetry helpers from here; importing back would create a cycle).
+ */
+function isOuraApiErrorLike(err: unknown): err is { code: string; status?: number; message?: string } {
+  return (
+    !!err &&
+    typeof err === "object" &&
+    "code" in err &&
+    typeof (err as { code?: unknown }).code === "string"
+  );
+}
+
+function isNetworkLikeError(err: Error): boolean {
+  const text = `${err.name} ${err.message}`.toLowerCase();
+  return (
+    text.includes("network") ||
+    text.includes("econnreset") ||
+    text.includes("econnrefused") ||
+    text.includes("enotfound") ||
+    text.includes("eai_again") ||
+    text.includes("fetch failed")
+  );
+}
+
+function isTimeoutLikeError(err: Error): boolean {
+  const text = `${err.name} ${err.message}`.toLowerCase();
+  return text.includes("timeout") || text.includes("etimedout");
+}
+
+/**
+ * Categorize any thrown value into a closed, privacy-safe error code + retryable flag.
+ * Never returns (or otherwise leaks) `Error.message` — the message is only inspected
+ * internally to pick a category, never echoed back to the caller.
+ *
+ * `hint` is an optional fallback `OuraSafeErrorCode` to use when the error itself can't
+ * be classified more specifically (e.g. a caller already knows the failure is a
+ * NO_CONNECTION / TOKEN_UNAVAILABLE situation before an exception is even involved).
+ */
+export function categorizeOuraSafeError(
+  err: unknown,
+  hint?: string,
+): { safeErrorCode: OuraSafeErrorCode; retryable: boolean } {
+  const fallback: OuraSafeErrorCode = isOuraSafeErrorCode(hint) ? hint : "UNKNOWN";
+
+  const finalize = (code: OuraSafeErrorCode): { safeErrorCode: OuraSafeErrorCode; retryable: boolean } => ({
+    safeErrorCode: code,
+    retryable: RETRYABLE_SAFE_ERROR_CODES.has(code),
+  });
+
+  if (isOuraApiErrorLike(err)) {
+    const status = typeof err.status === "number" ? err.status : undefined;
+    if (status === 401 || err.code === "OURA_UNAUTHORIZED" || err.code === "OURA_TOKEN_REFRESH_FAILED") {
+      return finalize("PROVIDER_UNAUTHORIZED");
+    }
+    if (status === 429) return finalize("PROVIDER_RATE_LIMITED");
+    if (status === 408) return finalize("PROVIDER_TIMEOUT");
+    if (typeof status === "number" && status >= 500) return finalize("PROVIDER_NETWORK");
+    if (err.code === "OURA_TOKEN_INVALID") return finalize("PROVIDER_SCHEMA_INVALID");
+    return finalize(fallback);
+  }
+
+  if (err instanceof Error) {
+    if (isTimeoutLikeError(err)) return finalize("PROVIDER_TIMEOUT");
+    if (isNetworkLikeError(err)) return finalize("PROVIDER_NETWORK");
+  }
+
+  return finalize(fallback);
+}
+
+/** Common fields every Oura refresh telemetry event may carry. */
+type OuraRefreshTelemetryBase = {
+  requestId?: string;
+  durationMs?: number;
+};
+
+export type OuraRefreshTelemetryEvent =
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_reconnect_cleanup_failed";
+      safeErrorCode: OuraSafeErrorCode;
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_pull_failed";
+      safeErrorCode: OuraSafeErrorCode;
+      retryable: boolean;
+      cleanedUp?: boolean;
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_token_refresh_busy";
+      retryable: true;
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_token_refresh_in_flight_join";
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_token_refresh_lock_wait";
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_token_refresh_lock_unavailable";
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_token_refresh_lock_stolen";
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_token_refresh_lock_acquired";
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_token_refresh_concurrent_success_detected";
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_token_refresh_invalid_grant_cleanup";
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_token_refresh_lock_released";
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_raw_events_core_write_done";
+      rawEventCreatedCount: number;
+      rawEventExistingCount: number;
+      sleepDocumentCount: number;
+      hrvDocumentCount: number;
+      stepsDocumentCount: number;
+      workoutDocumentCount: number;
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_raw_events_vendor_detail_deferred";
+      rawItemCount: number;
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_raw_events_vendor_detail_deferred_failed";
+      rawItemCount: number;
+      safeErrorCode: OuraSafeErrorCode;
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_raw_event_write_failed";
+      domain: string;
+      safeErrorCode: OuraSafeErrorCode;
+      failedCount: number;
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_legacy_recovery_skipped";
+      backfillStatus?: string | null;
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_legacy_recovery_detected";
+      backfillStatus?: string | null;
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_legacy_recovery_started";
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_legacy_recovery_failed";
+      safeErrorCode: OuraSafeErrorCode;
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_pull_window";
+      windowDayCount: number;
+      sleepStartOverlapDayCount: number;
+      sleepEndOverlapDayCount: number;
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_provider_fetch_skipped";
+      dataset: string;
+      safeErrorCode: OuraSafeErrorCode;
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_pull_sleep_summary";
+      hasSleepDocuments: boolean;
+      sleepDocumentCount: number;
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_pull_fetch_completed";
+      sleepDocumentCount: number;
+      readinessDocumentCount: number;
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_ingest_docs_dropped";
+      sleepDocumentCount: number;
+      rejectedItemCount: number;
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_ingest_item_counts";
+      sleepItemCount: number;
+      hrvItemCount: number;
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_raw_event_persist_started";
+      sleepItemCount: number;
+      hrvItemCount: number;
+      stepsItemCount: number;
+      workoutItemCount: number;
+      rawItemCount: number;
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_raw_event_persist_completed";
+      rawEventCreatedCount: number;
+      rawEventExistingCount: number;
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_post_raw_enqueued";
+      queued: true;
+      sleepDocumentCount: number;
+      readinessDocumentCount: number;
+      dailySleepDocumentCount: number;
+      dailyStressDocumentCount: number;
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_post_raw_enqueue_failed";
+      safeErrorCode: OuraSafeErrorCode;
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_post_raw_persist_started";
+      sleepDocumentCount: number;
+      readinessDocumentCount: number;
+      dailySleepDocumentCount: number;
+      dailyStressDocumentCount: number;
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_post_raw_persist_completed";
+      writtenCount: number;
+      metadataWritten: boolean;
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_post_raw_persist_failed";
+      safeErrorCode: OuraSafeErrorCode;
+      metadataWritten: boolean;
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_backfill_skipped";
+      safeErrorCode: OuraSafeErrorCode;
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_backfill_started";
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_backfill_chunk_completed";
+      chunkIndex: number;
+      chunkCount: number;
+      chunkDayCount: number;
+      sleepSnapshotWrittenCount: number;
+      readinessSnapshotWrittenCount: number;
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_backfill_chunk_failed";
+      chunkIndex: number;
+      chunkCount: number;
+      chunkDayCount: number;
+      safeErrorCode: OuraSafeErrorCode;
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_backfill_completed";
+      sleepSnapshotWrittenCount: number;
+      readinessSnapshotWrittenCount: number;
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_backfill_failed";
+      safeErrorCode: OuraSafeErrorCode;
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_provider_fetch_page_capped";
+      dataset: string;
+      pageCount: number;
+      providerItemCount: number;
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_provider_fetch_completed";
+      dataset: string;
+      pageCount: number;
+      providerItemCount: number;
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_vendor_snapshot_docs_received";
+      domain: string;
+      sleepDocumentCount?: number;
+      dailySleepDocumentCount?: number;
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_vendor_snapshot_docs_dropped";
+      domain: string;
+      rejectedItemCount: number;
+      sleepDocumentCount?: number;
+      readinessDocumentCount?: number;
+      dailyStressDocumentCount?: number;
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_vendor_snapshot_extracted";
+      domain: string;
+      validatedItemCount: number;
+      sleepDocumentCount?: number;
+      readinessDocumentCount?: number;
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_vendor_snapshot_write_failed";
+      domain: string;
+      safeErrorCode: OuraSafeErrorCode;
+      failedCount?: number;
+    })
+  | (OuraRefreshTelemetryBase & {
+      operation: "oura_vendor_snapshot_written";
+      domain: string;
+      writtenCount: number;
+      failedCount: number;
+    });
+
+/** Operations logged at `error` level (hard failures). */
+const ERROR_OPERATIONS: ReadonlySet<string> = new Set([
+  "oura_reconnect_cleanup_failed",
+  "oura_pull_failed",
+  "oura_legacy_recovery_failed",
+  "oura_post_raw_enqueue_failed",
+  "oura_post_raw_persist_failed",
+  "oura_backfill_failed",
+  "oura_vendor_snapshot_write_failed",
+  "oura_raw_events_vendor_detail_deferred_failed",
+  "oura_raw_event_write_failed",
+]);
+
+/** Operations logged at `warn` level (degraded but non-fatal). */
+const WARN_OPERATIONS: ReadonlySet<string> = new Set([
+  "oura_token_refresh_busy",
+  "oura_provider_fetch_skipped",
+  "oura_backfill_chunk_failed",
+  "oura_provider_fetch_page_capped",
+  "oura_token_refresh_lock_unavailable",
+]);
+
+/**
+ * Log a single Oura refresh telemetry event. Only the event's own typed fields are
+ * emitted (plus `msg`/`operation`, which are the same value) — no free-form fields,
+ * no error messages, no identifiers.
+ */
+export function logOuraRefreshTelemetry(event: OuraRefreshTelemetryEvent): void {
+  const { operation, ...rest } = event;
+  const payload: Record<string, unknown> = { msg: operation, operation, ...rest };
+
+  if (ERROR_OPERATIONS.has(operation)) {
+    logger.error(payload);
+  } else if (WARN_OPERATIONS.has(operation)) {
+    logger.warn(payload);
+  } else {
+    logger.info(payload);
+  }
+}

--- a/services/api/src/lib/ouraRefreshTelemetry.ts
+++ b/services/api/src/lib/ouraRefreshTelemetry.ts
@@ -8,7 +8,33 @@
  * messages are ever accepted by this module's event types.
  */
 
+import { randomUUID } from "crypto";
+
 import { logger } from "./logger";
+
+/**
+ * Strict opaque request-trace ID for Oura telemetry (Option B).
+ * Accepts only lowercase/uppercase RFC UUID form (36 chars). Anything else —
+ * including arbitrary `x-request-id`, emails, dates, URLs, tokens, idempotency
+ * keys, UIDs, or oversized strings — is discarded and replaced with a new
+ * server-generated UUID. Never hashes, truncates, or encodes unsafe input.
+ */
+const OURA_TELEMETRY_REQUEST_ID_UUID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const OURA_TELEMETRY_REQUEST_ID_MAX_LEN = 36;
+
+export function sanitizeOuraTelemetryRequestId(candidate: unknown): string {
+  if (typeof candidate !== "string") return randomUUID();
+  const trimmed = candidate.trim();
+  if (trimmed.length === 0 || trimmed.length > OURA_TELEMETRY_REQUEST_ID_MAX_LEN) {
+    return randomUUID();
+  }
+  if (!OURA_TELEMETRY_REQUEST_ID_UUID.test(trimmed)) {
+    return randomUUID();
+  }
+  return trimmed;
+}
 
 /** Closed set of privacy-safe error codes for the Oura refresh path. */
 export type OuraSafeErrorCode =
@@ -387,11 +413,14 @@ const WARN_OPERATIONS: ReadonlySet<string> = new Set([
 /**
  * Log a single Oura refresh telemetry event. Only the event's own typed fields are
  * emitted (plus `msg`/`operation`, which are the same value) — no free-form fields,
- * no error messages, no identifiers.
+ * no error messages, no identifiers. `requestId` is always sanitized before emit.
  */
 export function logOuraRefreshTelemetry(event: OuraRefreshTelemetryEvent): void {
-  const { operation, ...rest } = event;
+  const { operation, requestId, ...rest } = event;
   const payload: Record<string, unknown> = { msg: operation, operation, ...rest };
+  if (requestId !== undefined) {
+    payload.requestId = sanitizeOuraTelemetryRequestId(requestId);
+  }
 
   if (ERROR_OPERATIONS.has(operation)) {
     logger.error(payload);

--- a/services/api/src/lib/ouraTokenRefreshSingleFlight.ts
+++ b/services/api/src/lib/ouraTokenRefreshSingleFlight.ts
@@ -232,7 +232,7 @@ async function runRefresh(
     waitBudgetMs,
     pollBaseMs: DEFAULT_POLL_BASE_MS,
     pollJitterMs: DEFAULT_POLL_JITTER_MS,
-    onWait: (waitedMs) => {
+    onWait: () => {
       logOuraRefreshTelemetry({ operation: "oura_token_refresh_lock_wait", requestId });
     },
   });

--- a/services/api/src/lib/ouraTokenRefreshSingleFlight.ts
+++ b/services/api/src/lib/ouraTokenRefreshSingleFlight.ts
@@ -24,7 +24,7 @@
  */
 
 import { FieldValue, db, userCollection } from "../db";
-import { logger } from "./logger";
+import { logOuraRefreshTelemetry } from "./ouraRefreshTelemetry";
 import * as ouraSecrets from "./ouraSecrets";
 import { OuraApiError, refreshOuraAccessToken, type OuraTokenResult } from "./ouraApi";
 
@@ -192,9 +192,8 @@ export function refreshOuraTokenSingleFlight(
 ): Promise<OuraTokenRefreshOutcome> {
   const existing = inFlight.get(args.uid);
   if (existing) {
-    logger.info({
-      msg: "oura_token_refresh_in_flight_join",
-      uid: args.uid,
+    logOuraRefreshTelemetry({
+      operation: "oura_token_refresh_in_flight_join",
       requestId: args.requestId,
     });
     return existing;
@@ -234,24 +233,22 @@ async function runRefresh(
     pollBaseMs: DEFAULT_POLL_BASE_MS,
     pollJitterMs: DEFAULT_POLL_JITTER_MS,
     onWait: (waitedMs) => {
-      logger.info({ msg: "oura_token_refresh_lock_wait", uid, requestId, waitedMs });
+      logOuraRefreshTelemetry({ operation: "oura_token_refresh_lock_wait", requestId });
     },
   });
 
   if (!("release" in acquired)) {
-    logger.info({
-      msg: "oura_token_refresh_lock_unavailable",
-      uid,
+    logOuraRefreshTelemetry({
+      operation: "oura_token_refresh_lock_unavailable",
       requestId,
-      waitedMs: acquired.waitedMs,
     });
     return { kind: "lock_unavailable", waitedMs: acquired.waitedMs };
   }
 
   if (acquired.stolen) {
-    logger.info({ msg: "oura_token_refresh_lock_stolen", uid, requestId });
+    logOuraRefreshTelemetry({ operation: "oura_token_refresh_lock_stolen", requestId });
   } else {
-    logger.info({ msg: "oura_token_refresh_lock_acquired", uid, requestId });
+    logOuraRefreshTelemetry({ operation: "oura_token_refresh_lock_acquired", requestId });
   }
 
   try {
@@ -271,15 +268,14 @@ async function runRefresh(
 
       const currentToken = await ouraSecrets.getRefreshToken(uid);
       if (currentToken && currentToken !== attemptedToken) {
-        logger.info({
-          msg: "oura_token_refresh_concurrent_success_detected",
-          uid,
+        logOuraRefreshTelemetry({
+          operation: "oura_token_refresh_concurrent_success_detected",
           requestId,
         });
         return { kind: "invalid_grant", cleanedUp: false };
       }
 
-      logger.info({ msg: "oura_token_refresh_invalid_grant_cleanup", uid, requestId });
+      logOuraRefreshTelemetry({ operation: "oura_token_refresh_invalid_grant_cleanup", requestId });
       await performReconnectCleanup(uid, requestId);
       return { kind: "invalid_grant", cleanedUp: true };
     }
@@ -288,6 +284,6 @@ async function runRefresh(
     return { kind: "refreshed", tokens, rotated: true };
   } finally {
     await acquired.release();
-    logger.info({ msg: "oura_token_refresh_lock_released", uid, requestId });
+    logOuraRefreshTelemetry({ operation: "oura_token_refresh_lock_released", requestId });
   }
 }

--- a/services/api/src/lib/ouraVendorSnapshot.ts
+++ b/services/api/src/lib/ouraVendorSnapshot.ts
@@ -32,7 +32,7 @@ import { coerceOuraSleepScore0to100 } from "./sleepNight";
 import { FieldValue, userCollection } from "../db";
 import type { OuraSleepSnapshot, OuraReadinessSnapshot, OuraStressSnapshot } from "@oli/contracts";
 import { ouraDailyStressSummarySchema } from "@oli/contracts";
-import { logger } from "./logger";
+import { categorizeOuraSafeError, logOuraRefreshTelemetry } from "./ouraRefreshTelemetry";
 
 export type OuraSnapshotWriteResult = {
   attempted: number;
@@ -346,12 +346,12 @@ export async function writeOuraVendorSleepSnapshots(
   readinessDocs?: OuraDailyReadinessDocument[],
   dailySleepDocs?: OuraDailySleepDocument[],
 ): Promise<OuraSnapshotWriteResult> {
-  logger.info({
-    msg: "oura_sleep_snapshot_docs_received",
-    uid,
+  logOuraRefreshTelemetry({
+    operation: "oura_vendor_snapshot_docs_received",
+    domain: "sleep",
     requestId,
-    sleepDocCount: docs.length,
-    dailySleepDocCount: dailySleepDocs?.length ?? 0,
+    sleepDocumentCount: docs.length,
+    dailySleepDocumentCount: dailySleepDocs?.length ?? 0,
   });
 
   const col = userCollection(uid, "ouraVendorSleep");
@@ -362,14 +362,12 @@ export async function writeOuraVendorSleepSnapshots(
   let errors = 0;
 
   const pairs: { doc: OuraSleepDocument; snapshot: OuraSleepSnapshot }[] = [];
-  let droppedSampleKeys: string[] | undefined;
+  let anyDroppedForMissingDay = false;
   for (const doc of docs) {
     const snapshot = extractSleepSnapshot(doc, fetchedAt, { uid });
     if (!snapshot) {
       skippedMissingDay += 1;
-      if (!droppedSampleKeys && doc && typeof doc === "object") {
-        droppedSampleKeys = Object.keys(doc).slice(0, 20);
-      }
+      anyDroppedForMissingDay = true;
       continue;
     }
     pairs.push({ doc, snapshot });
@@ -387,25 +385,23 @@ export async function writeOuraVendorSleepSnapshots(
 
   const snapshots = [...pairs.map((p) => p.snapshot), ...dailySnapshots];
 
-  if (droppedSampleKeys !== undefined && skippedMissingDay > 0) {
-    logger.info({
-      msg: "oura_sleep_snapshot_docs_dropped",
-      uid,
+  if (anyDroppedForMissingDay && skippedMissingDay > 0) {
+    logOuraRefreshTelemetry({
+      operation: "oura_vendor_snapshot_docs_dropped",
+      domain: "sleep",
       requestId,
-      sleepDocCount: docs.length,
-      skippedMissingDay,
-      reason: "missing_day",
-      sampleKeys: droppedSampleKeys,
+      sleepDocumentCount: docs.length,
+      rejectedItemCount: skippedMissingDay,
     });
   }
 
-  logger.info({
-    msg: "oura_sleep_snapshot_extracted",
-    uid,
+  logOuraRefreshTelemetry({
+    operation: "oura_vendor_snapshot_extracted",
+    domain: "sleep",
     requestId,
-    sleepDocsReceived: docs.length,
-    sleepSnapshotsExtracted: snapshots.length,
-    readinessDocsForMerge: readinessDocs?.length ?? 0,
+    sleepDocumentCount: docs.length,
+    validatedItemCount: snapshots.length,
+    readinessDocumentCount: readinessDocs?.length ?? 0,
   });
 
   const readinessCol = userCollection(uid, "ouraVendorReadiness");
@@ -414,35 +410,6 @@ export async function writeOuraVendorSleepSnapshots(
     readinessCol as FirebaseFirestore.CollectionReference,
     lookupDays,
   );
-
-  if (process.env.OURA_SLEEP_SNAPSHOT_WRITE_AUDIT === "1" || process.env.OURA_SLEEP_SNAPSHOT_WRITE_AUDIT === "true") {
-    for (const { doc, snapshot } of pairs) {
-      const merged = buildSleepNightFirestorePayloadWithOuraReadiness(
-        doc,
-        snapshot.id,
-        readinessDocs,
-        persistedReadinessByDay,
-        { uid, requestedDay: snapshot.day },
-        dailySleepDocs,
-      );
-      const merge = merged?.payload;
-      logger.info({
-        msg: "[OURA_SLEEP_SNAPSHOT_WRITE_AUDIT]",
-        uid,
-        sourceDocumentId: snapshot.id,
-        vendorDay: snapshot.day,
-        anchorDay: merged?.anchorDay ?? null,
-        wakeDay: typeof merge?.wakeDay === "string" ? merge.wakeDay : null,
-        score: typeof merge?.score === "number" ? merge.score : null,
-        totalSleepMinutes: typeof merge?.totalSleepMinutes === "number" ? merge.totalSleepMinutes : null,
-        lowestHeartRateBpm: typeof merge?.lowestHeartRateBpm === "number" ? merge.lowestHeartRateBpm : null,
-        averageHrvMs: typeof merge?.averageHrvMs === "number" ? merge.averageHrvMs : null,
-        wroteVendorSleep: true,
-        wroteSleepNight: merged != null,
-        skippedReason: merged == null ? "sleep_night_build_failed" : null,
-      });
-    }
-  }
 
   for (let i = 0; i < snapshots.length; i += BATCH_CHUNK_SIZE) {
     const chunk = snapshots.slice(i, i + BATCH_CHUNK_SIZE);
@@ -454,13 +421,13 @@ export async function writeOuraVendorSleepSnapshots(
       await batch.commit();
       written += chunk.length;
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      logger.error({
-        msg: "oura_vendor_sleep_snapshot_batch_error",
-        uid,
+      const { safeErrorCode } = categorizeOuraSafeError(err);
+      logOuraRefreshTelemetry({
+        operation: "oura_vendor_snapshot_write_failed",
+        domain: "sleep",
         requestId,
-        chunkSize: chunk.length,
-        err: message,
+        safeErrorCode,
+        failedCount: chunk.length,
       });
       for (const snapshot of chunk) {
         try {
@@ -468,25 +435,24 @@ export async function writeOuraVendorSleepSnapshots(
           written += 1;
         } catch (singleErr) {
           errors += 1;
-          logger.error({
-            msg: "oura_vendor_sleep_snapshot_write_error",
-            uid,
+          logOuraRefreshTelemetry({
+            operation: "oura_vendor_snapshot_write_failed",
+            domain: "sleep",
             requestId,
-            snapshotId: snapshot.id,
-            day: snapshot.day,
-            err: singleErr instanceof Error ? singleErr.message : String(singleErr),
+            safeErrorCode: categorizeOuraSafeError(singleErr).safeErrorCode,
+            failedCount: 1,
           });
         }
       }
     }
   }
 
-  logger.info({
-    msg: "oura_sleep_snapshot_written",
-    uid,
+  logOuraRefreshTelemetry({
+    operation: "oura_vendor_snapshot_written",
+    domain: "sleep",
     requestId,
-    sleepSnapshotsWritten: written,
-    sleepSnapshotsErrors: errors,
+    writtenCount: written,
+    failedCount: errors,
   });
 
   let sleepNightsWritten = 0;
@@ -520,13 +486,13 @@ export async function writeOuraVendorSleepSnapshots(
       await batch.commit();
       sleepNightsWritten += ops;
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      logger.error({
-        msg: "sleep_night_batch_error",
-        uid,
+      const { safeErrorCode } = categorizeOuraSafeError(err);
+      logOuraRefreshTelemetry({
+        operation: "oura_vendor_snapshot_write_failed",
+        domain: "sleep_night",
         requestId,
-        chunkSize: chunk.length,
-        err: message,
+        safeErrorCode,
+        failedCount: chunk.length,
       });
       for (const { doc, snapshot } of chunk) {
         const merged = buildSleepNightFirestorePayloadWithOuraReadiness(
@@ -548,24 +514,24 @@ export async function writeOuraVendorSleepSnapshots(
           sleepNightsWritten += 1;
         } catch (singleErr) {
           sleepNightsErrors += 1;
-          logger.error({
-            msg: "sleep_night_write_error",
-            uid,
+          logOuraRefreshTelemetry({
+            operation: "oura_vendor_snapshot_write_failed",
+            domain: "sleep_night",
             requestId,
-            anchorDay: merged.anchorDay,
-            err: singleErr instanceof Error ? singleErr.message : String(singleErr),
+            safeErrorCode: categorizeOuraSafeError(singleErr).safeErrorCode,
+            failedCount: 1,
           });
         }
       }
     }
   }
 
-  logger.info({
-    msg: "sleep_night_written_after_vendor_sleep",
-    uid,
+  logOuraRefreshTelemetry({
+    operation: "oura_vendor_snapshot_written",
+    domain: "sleep_night",
     requestId,
-    sleepNightsWritten,
-    sleepNightsErrors,
+    writtenCount: sleepNightsWritten,
+    failedCount: sleepNightsErrors,
   });
 
   return {
@@ -593,29 +559,23 @@ export async function writeOuraVendorReadinessSnapshots(
 
   const snapshots: OuraReadinessSnapshot[] = [];
   let droppedReadiness = 0;
-  let droppedSampleKeys: string[] | undefined;
   for (const doc of docs) {
     const snapshot = extractReadinessSnapshot(doc, fetchedAt);
     if (!snapshot) {
       skippedMissingDay += 1;
       droppedReadiness += 1;
-      if (!droppedSampleKeys && doc && typeof doc === "object") {
-        droppedSampleKeys = Object.keys(doc).slice(0, 20);
-      }
       continue;
     }
     snapshots.push(snapshot);
   }
 
   if (droppedReadiness > 0) {
-    logger.info({
-      msg: "oura_readiness_snapshot_docs_dropped",
-      uid,
+    logOuraRefreshTelemetry({
+      operation: "oura_vendor_snapshot_docs_dropped",
+      domain: "readiness",
       requestId,
-      readinessDocCount: docs.length,
-      droppedReadiness,
-      reason: "missing_day",
-      sampleKeys: droppedSampleKeys ?? [],
+      readinessDocumentCount: docs.length,
+      rejectedItemCount: droppedReadiness,
     });
   }
 
@@ -629,13 +589,13 @@ export async function writeOuraVendorReadinessSnapshots(
       await batch.commit();
       written += chunk.length;
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      logger.error({
-        msg: "oura_vendor_readiness_snapshot_batch_error",
-        uid,
+      const { safeErrorCode } = categorizeOuraSafeError(err);
+      logOuraRefreshTelemetry({
+        operation: "oura_vendor_snapshot_write_failed",
+        domain: "readiness",
         requestId,
-        chunkSize: chunk.length,
-        err: message,
+        safeErrorCode,
+        failedCount: chunk.length,
       });
       for (const snapshot of chunk) {
         try {
@@ -643,13 +603,12 @@ export async function writeOuraVendorReadinessSnapshots(
           written += 1;
         } catch (singleErr) {
           errors += 1;
-          logger.error({
-            msg: "oura_vendor_readiness_snapshot_write_error",
-            uid,
+          logOuraRefreshTelemetry({
+            operation: "oura_vendor_snapshot_write_failed",
+            domain: "readiness",
             requestId,
-            snapshotId: snapshot.id,
-            day: snapshot.day,
-            err: singleErr instanceof Error ? singleErr.message : String(singleErr),
+            safeErrorCode: categorizeOuraSafeError(singleErr).safeErrorCode,
+            failedCount: 1,
           });
         }
       }
@@ -739,12 +698,12 @@ export async function writeOuraVendorStressSnapshots(
   }
 
   if (droppedStress > 0) {
-    logger.info({
-      msg: "oura_stress_snapshot_docs_dropped",
+    logOuraRefreshTelemetry({
+      operation: "oura_vendor_snapshot_docs_dropped",
+      domain: "daily_stress",
       requestId,
-      stressDocCount: docs.length,
-      droppedStress,
-      reason: "missing_day",
+      dailyStressDocumentCount: docs.length,
+      rejectedItemCount: droppedStress,
     });
   }
 
@@ -760,12 +719,13 @@ export async function writeOuraVendorStressSnapshots(
       await batch.commit();
       written += chunk.length;
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      logger.error({
-        msg: "oura_vendor_stress_snapshot_batch_error",
+      const { safeErrorCode } = categorizeOuraSafeError(err);
+      logOuraRefreshTelemetry({
+        operation: "oura_vendor_snapshot_write_failed",
+        domain: "daily_stress",
         requestId,
-        chunkSize: chunk.length,
-        err: message,
+        safeErrorCode,
+        failedCount: chunk.length,
       });
       for (const snapshot of chunk) {
         try {
@@ -775,10 +735,12 @@ export async function writeOuraVendorStressSnapshots(
           written += 1;
         } catch (singleErr) {
           errors += 1;
-          logger.error({
-            msg: "oura_vendor_stress_snapshot_write_error",
+          logOuraRefreshTelemetry({
+            operation: "oura_vendor_snapshot_write_failed",
+            domain: "daily_stress",
             requestId,
-            err: singleErr instanceof Error ? singleErr.message : String(singleErr),
+            safeErrorCode: categorizeOuraSafeError(singleErr).safeErrorCode,
+            failedCount: 1,
           });
         }
       }

--- a/services/api/src/lib/testSupport/assertOuraTelemetryPrivacy.ts
+++ b/services/api/src/lib/testSupport/assertOuraTelemetryPrivacy.ts
@@ -1,0 +1,121 @@
+/**
+ * Shared recursive assertion helper for Oura refresh/post-raw telemetry privacy tests.
+ * Fails (throws) if a logged payload contains a prohibited key, or a string value that
+ * looks like a date, ISO timestamp, bearer token, API key, or Firestore path.
+ */
+
+/** Exact-match prohibited keys — never allowed anywhere in a telemetry payload. */
+export const PROHIBITED_TELEMETRY_KEYS: readonly string[] = [
+  "uid",
+  "userId",
+  "email",
+  "day",
+  "date",
+  "start",
+  "end",
+  "startStr",
+  "endStr",
+  "sleepStartStr",
+  "sleepEndStr",
+  "coreStartStr",
+  "coreEndStr",
+  "requestedDay",
+  "resolvedDay",
+  "providerDay",
+  "latestWakeIso",
+  "latestSleepId",
+  "sleepId",
+  "providerId",
+  "documentId",
+  "docId",
+  "rawEventId",
+  "messageId",
+  "score",
+  "minutes",
+  "seconds",
+  "stressHigh",
+  "recoveryHigh",
+  "token",
+  "accessToken",
+  "refreshToken",
+  "idempotencyKey",
+  "url",
+  "query",
+  "payload",
+  "response",
+  "stack",
+  "errorMessage",
+  "err",
+  "sampleKeys",
+  "snapshotId",
+  "anchorDay",
+  "waitedMs",
+];
+
+const PROHIBITED_KEY_SET = new Set(PROHIBITED_TELEMETRY_KEYS.map((k) => k.toLowerCase()));
+
+/** Value patterns that must never appear in a telemetry payload, regardless of key name. */
+const PROHIBITED_VALUE_PATTERNS: RegExp[] = [
+  /^\d{4}-\d{2}-\d{2}$/, // YYYY-MM-DD
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/, // ISO timestamp
+  /Bearer\s/,
+  /AIza/,
+  /users\//,
+];
+
+export type PrivacyViolation = {
+  path: string;
+  reason: string;
+};
+
+/**
+ * Recursively walk a value (object/array/primitive) and collect privacy violations:
+ * prohibited key names, or string values matching a prohibited pattern.
+ */
+export function findOuraTelemetryPrivacyViolations(value: unknown, path = "$"): PrivacyViolation[] {
+  const violations: PrivacyViolation[] = [];
+
+  const visit = (node: unknown, nodePath: string): void => {
+    if (node === null || node === undefined) return;
+
+    if (typeof node === "string") {
+      for (const pattern of PROHIBITED_VALUE_PATTERNS) {
+        if (pattern.test(node)) {
+          violations.push({ path: nodePath, reason: `value matches prohibited pattern ${pattern}` });
+          break;
+        }
+      }
+      return;
+    }
+
+    if (Array.isArray(node)) {
+      node.forEach((item, i) => visit(item, `${nodePath}[${i}]`));
+      return;
+    }
+
+    if (typeof node === "object") {
+      for (const [key, v] of Object.entries(node as Record<string, unknown>)) {
+        if (PROHIBITED_KEY_SET.has(key.toLowerCase())) {
+          violations.push({ path: `${nodePath}.${key}`, reason: `prohibited key "${key}"` });
+          continue;
+        }
+        visit(v, `${nodePath}.${key}`);
+      }
+    }
+  };
+
+  visit(value, path);
+  return violations;
+}
+
+/**
+ * Assert a telemetry payload (already-serialized-then-parsed JSON, or a plain object)
+ * has no privacy violations. Throws with a readable message listing all violations.
+ */
+export function assertOuraTelemetryPrivacy(value: unknown): void {
+  const violations = findOuraTelemetryPrivacyViolations(value);
+  if (violations.length > 0) {
+    const details = violations.map((v) => `  - ${v.path}: ${v.reason}`).join("\n");
+    throw new Error(`Oura telemetry privacy violation(s) found:\n${details}`);
+  }
+}

--- a/services/api/src/routes/integrations/__tests__/ouraBackfill.test.ts
+++ b/services/api/src/routes/integrations/__tests__/ouraBackfill.test.ts
@@ -1,6 +1,7 @@
 /**
  * Oura backfill — chunked, idempotent historical pull for sleep + readiness.
  */
+import { allowConsoleForThisTest } from "../../../../../../scripts/test/consoleGuard";
 import { triggerOuraBackfill } from "../ouraPullNow";
 
 jest.mock("../../../db", () => ({
@@ -76,6 +77,10 @@ const ouraVendorSnapshot = require("../../../lib/ouraVendorSnapshot");
 describe("triggerOuraBackfill", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    allowConsoleForThisTest({
+      error: [/oura_backfill_/],
+      warn: [/oura_backfill_/],
+    });
     (ouraSecrets.getRefreshToken as jest.Mock).mockResolvedValue("rt_xxx");
     (ouraApi.refreshOuraAccessToken as jest.Mock).mockResolvedValue({
       access_token: "at_yyy",

--- a/services/api/src/routes/integrations/__tests__/ouraPullNow.test.ts
+++ b/services/api/src/routes/integrations/__tests__/ouraPullNow.test.ts
@@ -199,7 +199,7 @@ describe("POST /integrations/oura/pull-now", () => {
     app.use(express.json());
     app.use((req, _res, next) => {
       (req as unknown as { uid: string; rid: string }).uid = "user_oura_1";
-      (req as unknown as { rid: string }).rid = "req-oura-pull";
+      (req as unknown as { rid: string }).rid = "3237605a-ceb7-44bc-958e-be8954b9e939";
       next();
     });
     app.use("/integrations/oura/pull-now", ouraPullNowRouter);
@@ -316,7 +316,7 @@ describe("POST /integrations/oura/pull-now", () => {
       .set("Idempotency-Key", "oura-pull-success");
     expect(res.status).toBe(202);
     expect(res.body.ok).toBe(true);
-    expect(res.body.requestId).toBe("req-oura-pull");
+    expect(res.body.requestId).toBe("3237605a-ceb7-44bc-958e-be8954b9e939");
     expect(res.body.eventsCreated).toBe(2);
     expect(res.body.eventsAlreadyExists).toBe(0);
     expect(res.body.windowDays).toBe(30);
@@ -329,7 +329,7 @@ describe("POST /integrations/oura/pull-now", () => {
       "user_oura_1",
       expect.any(Array),
       expect.any(Array),
-      "req-oura-pull",
+      "3237605a-ceb7-44bc-958e-be8954b9e939",
       expect.objectContaining({
         stepsItems: expect.any(Array),
         workoutItems: expect.any(Array),
@@ -351,14 +351,14 @@ describe("POST /integrations/oura/pull-now", () => {
     expect(ouraVendorSnapshot.writeOuraVendorSleepSnapshots).toHaveBeenCalledWith(
       "user_oura_1",
       expect.any(Array),
-      "req-oura-pull",
+      "3237605a-ceb7-44bc-958e-be8954b9e939",
       expect.any(Array),
       expect.any(Array),
     );
     expect(ouraVendorSnapshot.writeOuraVendorReadinessSnapshots).toHaveBeenCalledWith(
       "user_oura_1",
       expect.any(Array),
-      "req-oura-pull",
+      "3237605a-ceb7-44bc-958e-be8954b9e939",
     );
   });
 
@@ -428,7 +428,7 @@ describe("POST /integrations/oura/pull-now", () => {
     expect(res.body.ok).toBe(true);
     expect(ouraPostRawJob.publishOuraPostRawJob).toHaveBeenCalledWith(
       "user_oura_1",
-      "req-oura-pull",
+      "3237605a-ceb7-44bc-958e-be8954b9e939",
       expect.any(Array),
       expect.any(Array),
       expect.any(Array),

--- a/services/api/src/routes/integrations/__tests__/ouraPullNow.test.ts
+++ b/services/api/src/routes/integrations/__tests__/ouraPullNow.test.ts
@@ -217,8 +217,17 @@ describe("POST /integrations/oura/pull-now", () => {
     allowConsoleForThisTest({
       error: [
         (args: unknown[]) => String(args[0] ?? "").includes("oura_pull_now"),
-        (args: unknown[]) => String(args[0] ?? "").includes("oura_post_raw_persistence"),
+        (args: unknown[]) => String(args[0] ?? "").includes("oura_pull_failed"),
+        (args: unknown[]) => String(args[0] ?? "").includes("oura_post_raw_persist"),
+        (args: unknown[]) => String(args[0] ?? "").includes("oura_post_raw_enqueue"),
         (args: unknown[]) => String(args[0] ?? "").includes("oura_post_raw_job"),
+        (args: unknown[]) => String(args[0] ?? "").includes("oura_legacy_recovery"),
+        (args: unknown[]) => String(args[0] ?? "").includes("oura_reconnect"),
+      ],
+      warn: [
+        (args: unknown[]) => String(args[0] ?? "").includes("oura_token_refresh"),
+        (args: unknown[]) => String(args[0] ?? "").includes("oura_provider_fetch"),
+        (args: unknown[]) => String(args[0] ?? "").includes("oura_backfill"),
       ],
     });
     jest.clearAllMocks();
@@ -396,9 +405,17 @@ describe("POST /integrations/oura/pull-now", () => {
     await new Promise((r) => setImmediate(r));
     await new Promise((r) => setImmediate(r));
     const errorCalls = errorSpy.mock.calls.filter(
-      (c: unknown[]) => Array.isArray(c) && c[0]?.msg === "oura_post_raw_persistence_error",
+      (c: unknown[]) =>
+        Array.isArray(c) &&
+        typeof c[0] === "object" &&
+        c[0] != null &&
+        (c[0] as { msg?: string }).msg === "oura_post_raw_persist_failed",
     );
     expect(errorCalls.length).toBeGreaterThanOrEqual(1);
+    const payload = errorCalls[0]![0] as Record<string, unknown>;
+    expect(payload).not.toHaveProperty("uid");
+    expect(payload).toHaveProperty("safeErrorCode");
+    expect(payload).not.toHaveProperty("err");
     errorSpy.mockRestore();
   });
 

--- a/services/api/src/routes/integrations/ouraPullNow.ts
+++ b/services/api/src/routes/integrations/ouraPullNow.ts
@@ -37,7 +37,6 @@ import {
   type OuraDailySleepDocument,
   type OuraDailyStressDocument,
   OuraApiError,
-  ouraSleepWakeIsoForLog,
   resolveOuraSleepIngestBase,
 } from "../../lib/ouraApi";
 import { writeOuraRawEvents } from "../../lib/ouraIngestWrite";
@@ -48,7 +47,11 @@ import {
 } from "../../lib/ouraVendorSnapshot";
 import { deriveOuraSyncMetadataFields, isLegacyOuraIntegration } from "./ouraSyncMetadata";
 import { writeFailure } from "../../lib/writeFailure";
-import { logger } from "../../lib/logger";
+import {
+  categorizeOuraSafeError,
+  logOuraRefreshTelemetry,
+  type OuraSafeErrorCode,
+} from "../../lib/ouraRefreshTelemetry";
 import { publishOuraPostRawJob, getOuraPostRawTopic } from "../../lib/ouraPostRawJob";
 import { refreshOuraTokenSingleFlight } from "../../lib/ouraTokenRefreshSingleFlight";
 
@@ -113,12 +116,10 @@ async function performReconnectCleanupBestEffort(
     );
     await ouraConnectedRegistryDoc(uid).delete();
   } catch (cleanupErr) {
-    const sanitized = cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr);
-    logger.error({
-      msg: "oura_pull_now_reconnect_cleanup_error",
-      uid,
+    logOuraRefreshTelemetry({
+      operation: "oura_reconnect_cleanup_failed",
       requestId,
-      err: sanitized,
+      safeErrorCode: categorizeOuraSafeError(cleanupErr).safeErrorCode,
     });
   }
 }
@@ -133,7 +134,12 @@ export async function performOuraPullNowCore(
 ): Promise<OuraPullNowResult> {
   const refreshToken = await ouraSecrets.getRefreshToken(uid);
   if (!refreshToken) {
-    logger.error({ msg: "oura_pull_now_no_refresh_token", rid: requestId, uid });
+    logOuraRefreshTelemetry({
+      operation: "oura_pull_failed",
+      requestId,
+      safeErrorCode: "NO_CONNECTION",
+      retryable: false,
+    });
     try {
       await writeFailure({
         userId: uid,
@@ -170,7 +176,12 @@ export async function performOuraPullNowCore(
   }
 
   if (!clientId || !clientSecret) {
-    logger.error({ msg: "oura_pull_now_misconfig", rid: requestId, hasClientId: !!clientId });
+    logOuraRefreshTelemetry({
+      operation: "oura_pull_failed",
+      requestId,
+      safeErrorCode: "TOKEN_UNAVAILABLE",
+      retryable: false,
+    });
     return {
       statusCode: 500,
       body: {
@@ -197,7 +208,12 @@ export async function performOuraPullNowCore(
     if (outcome.kind === "refreshed") {
       accessToken = outcome.tokens.access_token;
     } else if (outcome.kind === "no_refresh_token") {
-      logger.error({ msg: "oura_pull_now_no_refresh_token", rid: requestId, uid });
+      logOuraRefreshTelemetry({
+        operation: "oura_pull_failed",
+        requestId,
+        safeErrorCode: "NO_CONNECTION",
+        retryable: false,
+      });
       try {
         await writeFailure({
           userId: uid,
@@ -224,11 +240,10 @@ export async function performOuraPullNowCore(
         },
       };
     } else if (outcome.kind === "lock_unavailable") {
-      logger.info({
-        msg: "oura_pull_now_token_refresh_busy",
-        rid: requestId,
-        uid,
-        waitedMs: outcome.waitedMs,
+      logOuraRefreshTelemetry({
+        operation: "oura_token_refresh_busy",
+        requestId,
+        retryable: true,
       });
       return {
         statusCode: 503,
@@ -242,10 +257,11 @@ export async function performOuraPullNowCore(
         },
       };
     } else {
-      logger.error({
-        msg: "oura_pull_now_token_refresh_failed",
-        rid: requestId,
-        uid,
+      logOuraRefreshTelemetry({
+        operation: "oura_pull_failed",
+        requestId,
+        safeErrorCode: "PROVIDER_UNAUTHORIZED",
+        retryable: false,
         cleanedUp: outcome.cleanedUp,
       });
       try {
@@ -276,7 +292,11 @@ export async function performOuraPullNowCore(
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    logger.error({ msg: "oura_pull_now_token_refresh_failed", rid: requestId, uid, err: message });
+    logOuraRefreshTelemetry({
+      operation: "oura_pull_failed",
+      requestId,
+      ...categorizeOuraSafeError(err, "PROVIDER_UNAUTHORIZED"),
+    });
     try {
       await writeFailure({
         userId: uid,
@@ -311,21 +331,15 @@ export async function performOuraPullNowCore(
   if (isLegacyOuraIntegration(integrationData)) {
     const backfillStatus = integrationData?.backfillStatus ?? null;
     if (backfillStatus === "running") {
-      logger.info({
-        msg: "oura_legacy_recovery_skipped_running",
-        uid,
+      logOuraRefreshTelemetry({
+        operation: "oura_legacy_recovery_skipped",
         requestId,
-        connected: true,
-        hasLastSnapshotAt: false,
         backfillStatus: "running",
       });
     } else {
-      logger.info({
-        msg: "oura_legacy_recovery_detected",
-        uid,
+      logOuraRefreshTelemetry({
+        operation: "oura_legacy_recovery_detected",
         requestId,
-        connected: true,
-        hasLastSnapshotAt: false,
         backfillStatus,
       });
       try {
@@ -338,20 +352,18 @@ export async function performOuraPullNowCore(
           { merge: true },
         );
       } catch (mergeErr) {
-        logger.error({
-          msg: "oura_legacy_recovery_metadata_error",
-          uid,
+        logOuraRefreshTelemetry({
+          operation: "oura_legacy_recovery_failed",
           requestId,
-          err: mergeErr instanceof Error ? mergeErr.message : String(mergeErr),
+          safeErrorCode: categorizeOuraSafeError(mergeErr).safeErrorCode,
         });
       }
-      logger.info({ msg: "oura_legacy_recovery_started", uid, requestId });
+      logOuraRefreshTelemetry({ operation: "oura_legacy_recovery_started", requestId });
       void triggerOuraBackfill(uid, requestId).catch((err: unknown) =>
-        logger.error({
-          msg: "oura_legacy_recovery_backfill_error",
-          uid,
+        logOuraRefreshTelemetry({
+          operation: "oura_legacy_recovery_failed",
           requestId,
-          err: err instanceof Error ? err.message : String(err),
+          safeErrorCode: categorizeOuraSafeError(err).safeErrorCode,
         }),
       );
     }
@@ -374,16 +386,12 @@ export async function performOuraPullNowCore(
   const sleepStartStr = toYmd(sleepRangeStart);
   const sleepEndStr = toYmd(sleepRangeEnd);
 
-  logger.info({
-    msg: "oura_pull_sleep_date_window",
-    uid,
+  logOuraRefreshTelemetry({
+    operation: "oura_pull_window",
     requestId,
-    sleepStartStr,
-    sleepEndStr,
-    coreStartStr: startStr,
-    coreEndStr: endStr,
-    sleepStartOverlapDays: PULL_SLEEP_START_OVERLAP_DAYS,
-    sleepEndOverlapDays: PULL_SLEEP_END_OVERLAP_DAYS,
+    windowDayCount: WINDOW_DAYS,
+    sleepStartOverlapDayCount: PULL_SLEEP_START_OVERLAP_DAYS,
+    sleepEndOverlapDayCount: PULL_SLEEP_END_OVERLAP_DAYS,
   });
 
   let sleepItems: OuraSleepIngestItem[] = [];
@@ -403,9 +411,12 @@ export async function performOuraPullNowCore(
     try {
       return await fn();
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      const code = err instanceof OuraApiError ? err.code : "OURA_FETCH_FAILED";
-      logger.info({ msg: "oura_pull_now_fetch_skipped", rid: requestId, uid, dataset: name, code, err: message });
+      logOuraRefreshTelemetry({
+        operation: "oura_provider_fetch_skipped",
+        requestId,
+        dataset: name,
+        safeErrorCode: categorizeOuraSafeError(err).safeErrorCode,
+      });
       return null;
     }
   };
@@ -445,96 +456,32 @@ export async function performOuraPullNowCore(
     dailySleepDocs = dailySleepDocsFetched ?? [];
     dailyStressDocs = dailyStressDocsFetched ?? [];
 
-    let latestWakeIso: string | null = null;
-    let latestSleepId: string | null = null;
-    for (const d of sleepDocs) {
-      const w = ouraSleepWakeIsoForLog(d);
-      if (!w) continue;
-      const t = Date.parse(w);
-      if (Number.isNaN(t)) continue;
-      if (!latestWakeIso || t > Date.parse(latestWakeIso)) {
-        latestWakeIso = w;
-        latestSleepId = typeof d.id === "string" ? d.id : null;
-      }
-    }
-    logger.info({
-      msg: "oura_pull_sleep_latest_wake",
-      uid,
+    logOuraRefreshTelemetry({
+      operation: "oura_pull_sleep_summary",
       requestId,
-      latestWakeIso,
-      latestSleepId,
-      sleepDocCount: sleepDocs.length,
+      hasSleepDocuments: sleepDocs.length > 0,
+      sleepDocumentCount: sleepDocs.length,
     });
 
-    if (process.env.OURA_SLEEP_LATEST_AUDIT === "1" || process.env.OURA_SLEEP_LATEST_AUDIT === "true") {
-      let latestDoc: OuraSleepDocument | null = null;
-      let latestWakeMs = -1;
-      for (const d of sleepDocs) {
-        const w = ouraSleepWakeIsoForLog(d);
-        if (!w) continue;
-        const t = Date.parse(w);
-        if (Number.isNaN(t)) continue;
-        if (!latestDoc || t > latestWakeMs) {
-          latestWakeMs = t;
-          latestDoc = d;
-        }
-      }
-      const r = latestDoc ? resolveOuraSleepIngestBase(latestDoc) : null;
-      const totalSec =
-        latestDoc && typeof latestDoc.total_sleep_duration === "number" ? latestDoc.total_sleep_duration : null;
-      const scoreRaw = latestDoc
-        ? ((latestDoc as { score?: unknown }).score ?? (latestDoc as { composite_score?: unknown }).composite_score)
-        : undefined;
-      const latestScore =
-        typeof scoreRaw === "number" && Number.isFinite(scoreRaw)
-          ? Math.round(Math.max(0, Math.min(100, scoreRaw)))
-          : typeof scoreRaw === "string"
-            ? (() => {
-                const n = Number(scoreRaw.trim());
-                return Number.isFinite(n) ? Math.round(Math.max(0, Math.min(100, n))) : null;
-              })()
-            : null;
-      logger.info({
-        msg: "[OURA_SLEEP_LATEST_AUDIT]",
-        uid,
-        requestedStart: sleepStartStr,
-        requestedEnd: sleepEndStr,
-        docsFetched: sleepDocs.length,
-        latestOuraDay: typeof latestDoc?.day === "string" ? latestDoc.day : null,
-        latestStart: r?.start ?? null,
-        latestEnd: r?.end ?? null,
-        latestScore,
-        latestTotalSleep: totalSec != null && totalSec >= 0 ? Math.round(totalSec / 60) : null,
-        latestEfficiency: typeof latestDoc?.efficiency === "number" ? latestDoc.efficiency : null,
-      });
-    }
-
-    logger.info({
-      msg: "oura_fetch_counts",
-      uid,
+    logOuraRefreshTelemetry({
+      operation: "oura_pull_fetch_completed",
       requestId,
-      sleepDocCount: sleepDocs.length,
-      readinessDocCount: readinessDocs.length,
+      sleepDocumentCount: sleepDocs.length,
+      readinessDocumentCount: readinessDocs.length,
     });
     sleepItems = sleepDocs.map(mapOuraSleepToIngestItem).filter((x): x is OuraSleepIngestItem => x !== null);
     hrvItems = readinessDocs.map(mapOuraReadinessToHrvItem).filter((x): x is OuraHrvIngestItem => x !== null);
     const sleepDropped = sleepDocs.length - sleepItems.length;
     if (sleepDropped > 0) {
-      const firstDoc = sleepDocs[0];
-      const sampleKeys = firstDoc && typeof firstDoc === "object" ? Object.keys(firstDoc).slice(0, 20) : [];
-      logger.info({
-        msg: "oura_sleep_docs_dropped",
-        uid,
+      logOuraRefreshTelemetry({
+        operation: "oura_ingest_docs_dropped",
         requestId,
-        sleepDocCount: sleepDocs.length,
-        sleepItemCount: sleepItems.length,
-        sleepDroppedCount: sleepDropped,
-        sampleKeys,
+        sleepDocumentCount: sleepDocs.length,
+        rejectedItemCount: sleepDropped,
       });
     }
-    logger.info({
-      msg: "oura_ingest_item_counts",
-      uid,
+    logOuraRefreshTelemetry({
+      operation: "oura_ingest_item_counts",
       requestId,
       sleepItemCount: sleepItems.length,
       hrvItemCount: hrvItems.length,
@@ -598,7 +545,11 @@ export async function performOuraPullNowCore(
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     const code = err instanceof OuraApiError ? err.code : "OURA_FETCH_FAILED";
-    logger.error({ msg: "oura_pull_now_fetch_failed", rid: requestId, uid, code, err: message });
+    logOuraRefreshTelemetry({
+      operation: "oura_pull_failed",
+      requestId,
+      ...categorizeOuraSafeError(err),
+    });
     try {
       await writeFailure({
         userId: uid,
@@ -626,15 +577,14 @@ export async function performOuraPullNowCore(
     };
   }
 
-  logger.info({
-    msg: "oura_raw_events_write_start",
-    uid,
+  logOuraRefreshTelemetry({
+    operation: "oura_raw_event_persist_started",
     requestId,
-    sleepCount: sleepItems.length,
-    hrvCount: hrvItems.length,
-    stepsCount: stepsItems.length,
-    workoutCount: workoutItems.length,
-    ouraRawCount: ouraRawItems.length,
+    sleepItemCount: sleepItems.length,
+    hrvItemCount: hrvItems.length,
+    stepsItemCount: stepsItems.length,
+    workoutItemCount: workoutItems.length,
+    rawItemCount: ouraRawItems.length,
   });
   const { eventsCreated, eventsAlreadyExists } = await writeOuraRawEvents(
     uid,
@@ -643,12 +593,11 @@ export async function performOuraPullNowCore(
     requestId,
     { stepsItems, workoutItems, ouraRawItems },
   );
-  logger.info({
-    msg: "oura_raw_events_write_done",
-    uid,
+  logOuraRefreshTelemetry({
+    operation: "oura_raw_event_persist_completed",
     requestId,
-    eventsCreated,
-    eventsAlreadyExists,
+    rawEventCreatedCount: eventsCreated,
+    rawEventExistingCount: eventsAlreadyExists,
   });
 
   const sleepDocsToUse = sleepDocs ?? [];
@@ -658,7 +607,7 @@ export async function performOuraPullNowCore(
 
   if (getOuraPostRawTopic()) {
     try {
-      const messageId = await publishOuraPostRawJob(
+      await publishOuraPostRawJob(
         uid,
         requestId,
         sleepDocsToUse,
@@ -666,15 +615,14 @@ export async function performOuraPullNowCore(
         dailySleepDocsToUse,
         dailyStressDocsToUse,
       );
-      logger.info({
-        msg: "oura_post_raw_job_enqueued",
-        uid,
+      logOuraRefreshTelemetry({
+        operation: "oura_post_raw_enqueued",
         requestId,
-        messageId: messageId ?? undefined,
-        sleepDocCount: sleepDocsToUse.length,
-        readinessDocCount: readinessDocsToUse.length,
-        dailySleepDocCount: dailySleepDocsToUse.length,
-        dailyStressDocCount: dailyStressDocsToUse.length,
+        queued: true,
+        sleepDocumentCount: sleepDocsToUse.length,
+        readinessDocumentCount: readinessDocsToUse.length,
+        dailySleepDocumentCount: dailySleepDocsToUse.length,
+        dailyStressDocumentCount: dailyStressDocsToUse.length,
       });
       void performOuraPostRawPersistence(
         uid,
@@ -684,20 +632,19 @@ export async function performOuraPullNowCore(
         dailySleepDocsToUse,
         dailyStressDocsToUse,
       ).catch((persistErr: unknown) => {
-          logger.error({
-            msg: "oura_post_raw_persistence_after_enqueue_error",
-            uid,
+          logOuraRefreshTelemetry({
+            operation: "oura_post_raw_persist_failed",
             requestId,
-            err: persistErr instanceof Error ? persistErr.message : String(persistErr),
+            safeErrorCode: categorizeOuraSafeError(persistErr, "POST_RAW_PERSIST_FAILED").safeErrorCode,
+            metadataWritten: false,
           });
         },
       );
     } catch (err) {
-      logger.error({
-        msg: "oura_post_raw_job_enqueue_error",
-        uid,
+      logOuraRefreshTelemetry({
+        operation: "oura_post_raw_enqueue_failed",
         requestId,
-        err: err instanceof Error ? err.message : String(err),
+        safeErrorCode: categorizeOuraSafeError(err, "POST_RAW_PUBLISH_FAILED").safeErrorCode,
       });
       void performOuraPostRawPersistence(
         uid,
@@ -707,11 +654,11 @@ export async function performOuraPullNowCore(
         dailySleepDocsToUse,
         dailyStressDocsToUse,
       ).catch((fallbackErr: unknown) => {
-          logger.error({
-            msg: "oura_post_raw_persistence_error",
-            uid,
+          logOuraRefreshTelemetry({
+            operation: "oura_post_raw_persist_failed",
             requestId,
-            err: fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr),
+            safeErrorCode: categorizeOuraSafeError(fallbackErr, "POST_RAW_PERSIST_FAILED").safeErrorCode,
+            metadataWritten: false,
           });
         },
       );
@@ -725,11 +672,11 @@ export async function performOuraPullNowCore(
       dailySleepDocsToUse,
       dailyStressDocsToUse,
     ).catch((err: unknown) => {
-      logger.error({
-        msg: "oura_post_raw_persistence_error",
-        uid,
+      logOuraRefreshTelemetry({
+        operation: "oura_post_raw_persist_failed",
         requestId,
-        err: err instanceof Error ? err.message : String(err),
+        safeErrorCode: categorizeOuraSafeError(err, "POST_RAW_PERSIST_FAILED").safeErrorCode,
+        metadataWritten: false,
       });
     });
   }
@@ -760,14 +707,13 @@ export async function performOuraPostRawPersistence(
   dailySleepDocs: OuraDailySleepDocument[] = [],
   dailyStressDocs: OuraDailyStressDocument[] = [],
 ): Promise<void> {
-  logger.info({
-    msg: "oura_post_raw_persistence_started",
-    uid,
+  logOuraRefreshTelemetry({
+    operation: "oura_post_raw_persist_started",
     requestId,
-    sleepDocCount: sleepDocs.length,
-    readinessDocCount: readinessDocs.length,
-    dailySleepDocCount: dailySleepDocs.length,
-    dailyStressDocCount: dailyStressDocs.length,
+    sleepDocumentCount: sleepDocs.length,
+    readinessDocumentCount: readinessDocs.length,
+    dailySleepDocumentCount: dailySleepDocs.length,
+    dailyStressDocumentCount: dailyStressDocs.length,
   });
 
   let sleepResult = { attempted: 0, written: 0, skippedMissingDay: 0, errors: 0 };
@@ -783,15 +729,11 @@ export async function performOuraPostRawPersistence(
     readinessResult = readinessRes;
     stressResult = stressRes;
   } catch (snapErr) {
-    logger.error({
-      msg: "oura_post_raw_persistence_error",
-      uid,
+    logOuraRefreshTelemetry({
+      operation: "oura_post_raw_persist_failed",
       requestId,
-      sleepWritten: 0,
-      readinessWritten: 0,
-      stressWritten: 0,
+      safeErrorCode: categorizeOuraSafeError(snapErr, "POST_RAW_PERSIST_FAILED").safeErrorCode,
       metadataWritten: false,
-      err: snapErr instanceof Error ? snapErr.message : String(snapErr),
     });
     return;
   }
@@ -814,26 +756,19 @@ export async function performOuraPostRawPersistence(
     await integrationRef.set(update, { merge: true });
     metadataWritten = true;
   } catch (metaErr) {
-    logger.error({
-      msg: "oura_post_raw_persistence_error",
-      uid,
+    logOuraRefreshTelemetry({
+      operation: "oura_post_raw_persist_failed",
       requestId,
-      sleepWritten: sleepResult.written,
-      readinessWritten: readinessResult.written,
-      stressWritten: stressResult.written,
+      safeErrorCode: categorizeOuraSafeError(metaErr, "POST_RAW_PERSIST_FAILED").safeErrorCode,
       metadataWritten: false,
-      err: metaErr instanceof Error ? metaErr.message : String(metaErr),
     });
     return;
   }
 
-  logger.info({
-    msg: "oura_post_raw_persistence_done",
-    uid,
+  logOuraRefreshTelemetry({
+    operation: "oura_post_raw_persist_completed",
     requestId,
-    sleepWritten: sleepResult.written,
-    readinessWritten: readinessResult.written,
-    stressWritten: stressResult.written,
+    writtenCount: totalSnapshotWritten,
     metadataWritten,
   });
 }
@@ -882,7 +817,7 @@ export async function triggerOuraBackfill(uid: string, requestId: string): Promi
 
   const refreshToken = await ouraSecrets.getRefreshToken(uid);
   if (!refreshToken) {
-    logger.info({ msg: "oura_backfill_skipped_no_token", uid, requestId });
+    logOuraRefreshTelemetry({ operation: "oura_backfill_skipped", requestId, safeErrorCode: "NO_CONNECTION" });
     return;
   }
 
@@ -894,7 +829,7 @@ export async function triggerOuraBackfill(uid: string, requestId: string): Promi
     // fall through
   }
   if (!clientId || !clientSecret) {
-    logger.info({ msg: "oura_backfill_skipped_misconfig", uid, requestId });
+    logOuraRefreshTelemetry({ operation: "oura_backfill_skipped", requestId, safeErrorCode: "TOKEN_UNAVAILABLE" });
     return;
   }
 
@@ -916,48 +851,56 @@ export async function triggerOuraBackfill(uid: string, requestId: string): Promi
           : outcome.kind === "no_refresh_token"
             ? "no_refresh_token"
             : `invalid_grant_cleanup=${outcome.cleanedUp}`;
-      logger.info({ msg: "oura_backfill_token_failed", uid, requestId, err: message });
+      const safeErrorCode: OuraSafeErrorCode =
+        outcome.kind === "lock_unavailable"
+          ? "PROVIDER_TIMEOUT"
+          : outcome.kind === "no_refresh_token"
+            ? "NO_CONNECTION"
+            : "PROVIDER_UNAUTHORIZED";
       try {
         await setBackfillRunning();
         await setBackfillFailed(message);
       } catch {
         // best-effort
       }
-      logger.info({ msg: "oura_backfill_failed", uid, requestId, err: message });
+      logOuraRefreshTelemetry({ operation: "oura_backfill_failed", requestId, safeErrorCode });
       return;
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    logger.info({ msg: "oura_backfill_token_failed", uid, requestId, err: message });
+    const { safeErrorCode } = categorizeOuraSafeError(err, "PROVIDER_UNAUTHORIZED");
     try {
       await setBackfillRunning();
       await setBackfillFailed(message);
     } catch {
       // best-effort
     }
-    logger.info({ msg: "oura_backfill_failed", uid, requestId, err: message });
+    logOuraRefreshTelemetry({ operation: "oura_backfill_failed", requestId, safeErrorCode });
     return;
   }
 
   try {
     await setBackfillRunning();
   } catch (mergeErr) {
-    logger.error({
-      msg: "oura_backfill_start_metadata_error",
-      uid,
+    logOuraRefreshTelemetry({
+      operation: "oura_backfill_failed",
       requestId,
-      err: mergeErr instanceof Error ? mergeErr.message : String(mergeErr),
+      safeErrorCode: categorizeOuraSafeError(mergeErr).safeErrorCode,
     });
   }
-  logger.info({ msg: "oura_backfill_started", uid, requestId });
+  logOuraRefreshTelemetry({ operation: "oura_backfill_started", requestId });
 
   const today = toYmd(new Date());
   let totalSleepWritten = 0;
   let totalReadinessWritten = 0;
   let lastChunkError: string | null = null;
+  let lastChunkSafeErrorCode: OuraSafeErrorCode | null = null;
+  const chunkCount = Math.ceil(BACKFILL_TOTAL_DAYS / BACKFILL_CHUNK_DAYS);
+  let chunkIndex = 0;
 
   for (let offsetEnd = BACKFILL_TOTAL_DAYS; offsetEnd > 0; offsetEnd -= BACKFILL_CHUNK_DAYS) {
     const offsetStart = Math.max(0, offsetEnd - BACKFILL_CHUNK_DAYS);
+    const chunkDayCount = offsetEnd - offsetStart;
     const startStr = dayMinus(today, offsetEnd);
     const endStr = dayMinus(today, offsetStart);
 
@@ -980,51 +923,56 @@ export async function triggerOuraBackfill(uid: string, requestId: string): Promi
       ]);
       totalSleepWritten += sleepRes.written;
       totalReadinessWritten += readinessRes.written;
-      logger.info({
-        msg: "oura_backfill_chunk_done",
-        uid,
+      logOuraRefreshTelemetry({
+        operation: "oura_backfill_chunk_completed",
         requestId,
-        startStr,
-        endStr,
-        sleepWritten: sleepRes.written,
-        readinessWritten: readinessRes.written,
+        chunkIndex,
+        chunkCount,
+        chunkDayCount,
+        sleepSnapshotWrittenCount: sleepRes.written,
+        readinessSnapshotWrittenCount: readinessRes.written,
       });
     } catch (chunkErr) {
       const message = chunkErr instanceof Error ? chunkErr.message : String(chunkErr);
+      const { safeErrorCode } = categorizeOuraSafeError(chunkErr);
       lastChunkError = message;
-      logger.info({
-        msg: "oura_backfill_chunk_error",
-        uid,
+      lastChunkSafeErrorCode = safeErrorCode;
+      logOuraRefreshTelemetry({
+        operation: "oura_backfill_chunk_failed",
         requestId,
-        startStr,
-        endStr,
-        err: message,
+        chunkIndex,
+        chunkCount,
+        chunkDayCount,
+        safeErrorCode,
       });
     }
+    chunkIndex += 1;
   }
 
   const anyWritten = totalSleepWritten + totalReadinessWritten > 0;
   try {
     if (anyWritten) {
       await setBackfillCompleted();
-      logger.info({
-        msg: "oura_backfill_completed",
-        uid,
+      logOuraRefreshTelemetry({
+        operation: "oura_backfill_completed",
         requestId,
-        sleepSnapshotsWritten: totalSleepWritten,
-        readinessSnapshotsWritten: totalReadinessWritten,
+        sleepSnapshotWrittenCount: totalSleepWritten,
+        readinessSnapshotWrittenCount: totalReadinessWritten,
       });
     } else {
       const errMsg = lastChunkError ?? "No data imported";
       await setBackfillFailed(errMsg);
-      logger.info({ msg: "oura_backfill_failed", uid, requestId, err: errMsg });
+      logOuraRefreshTelemetry({
+        operation: "oura_backfill_failed",
+        requestId,
+        safeErrorCode: lastChunkSafeErrorCode ?? "UNKNOWN",
+      });
     }
   } catch (metaErr) {
-    logger.error({
-      msg: "oura_backfill_finish_metadata_error",
-      uid,
+    logOuraRefreshTelemetry({
+      operation: "oura_backfill_failed",
       requestId,
-      err: metaErr instanceof Error ? metaErr.message : String(metaErr),
+      safeErrorCode: categorizeOuraSafeError(metaErr).safeErrorCode,
     });
   }
 }

--- a/services/api/src/routes/integrations/ouraPullNow.ts
+++ b/services/api/src/routes/integrations/ouraPullNow.ts
@@ -50,6 +50,7 @@ import { writeFailure } from "../../lib/writeFailure";
 import {
   categorizeOuraSafeError,
   logOuraRefreshTelemetry,
+  sanitizeOuraTelemetryRequestId,
   type OuraSafeErrorCode,
 } from "../../lib/ouraRefreshTelemetry";
 import { publishOuraPostRawJob, getOuraPostRawTopic } from "../../lib/ouraPostRawJob";
@@ -78,8 +79,15 @@ function dayMinus(ymd: string, days: number): string {
 
 export type OuraPullNowResult = { statusCode: number; body: Record<string, unknown> };
 
+/**
+ * Trace ID for the Oura refresh path (telemetry + post-raw producer payload).
+ * Sanitizes middleware/header values so arbitrary client `x-request-id` cannot
+ * enter logs or the Function consumer. Idempotency-Key remains a separate header.
+ */
 function getRequestId(req: Request): string {
-  return (req as AuthedRequest).rid ?? (req.header("x-request-id") ?? "unknown").toString();
+  const candidate =
+    (req as AuthedRequest).rid ?? (req.header("x-request-id") ?? "").toString();
+  return sanitizeOuraTelemetryRequestId(candidate);
 }
 
 function getIdempotencyKey(req: Request): string | undefined {

--- a/services/functions/src/oura/__tests__/ouraPostRawHandler.test.ts
+++ b/services/functions/src/oura/__tests__/ouraPostRawHandler.test.ts
@@ -1,7 +1,9 @@
 /**
  * Unit tests: Oura post-raw handler (runOuraPostRaw) writes snapshots + metadata.
  */
+import { logger } from "firebase-functions";
 import { runOuraPostRaw } from "../ouraPostRawHandler";
+import { assertOuraTelemetryPrivacy } from "../../../../api/src/lib/testSupport/assertOuraTelemetryPrivacy";
 
 const mockSet = jest.fn().mockResolvedValue(undefined);
 const mockCommit = jest.fn().mockResolvedValue(undefined);
@@ -34,15 +36,28 @@ jest.mock("firebase-admin/firestore", () => ({
 jest.mock("firebase-functions", () => ({
   logger: {
     info: jest.fn(),
+    warn: jest.fn(),
     error: jest.fn(),
   },
 }));
+
+function assertCapturedLoggerPrivacy(): void {
+  for (const method of ["info", "warn", "error"] as const) {
+    for (const call of (logger[method] as jest.Mock).mock.calls) {
+      assertOuraTelemetryPrivacy(call[0]);
+    }
+  }
+}
 
 describe("runOuraPostRaw", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockSet.mockResolvedValue(undefined);
     mockCommit.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    assertCapturedLoggerPrivacy();
   });
 
   it("writes integration metadata with lastRefreshAt even when zero snapshots", async () => {

--- a/services/functions/src/oura/__tests__/ouraPostRawTelemetry.test.ts
+++ b/services/functions/src/oura/__tests__/ouraPostRawTelemetry.test.ts
@@ -6,9 +6,12 @@ import { logger } from "firebase-functions";
 import {
   categorizeOuraPostRawSafeError,
   logOuraPostRawTelemetry,
+  sanitizeOuraPostRawRequestId,
   type OuraPostRawTelemetryEvent,
 } from "../ouraPostRawTelemetry";
 import { assertOuraTelemetryPrivacy } from "../../../../api/src/lib/testSupport/assertOuraTelemetryPrivacy";
+
+const SAFE_REQUEST_ID = "3237605a-ceb7-44bc-958e-be8954b9e939";
 
 jest.mock("firebase-functions", () => ({
   logger: {
@@ -43,7 +46,7 @@ describe("logOuraPostRawTelemetry", () => {
   const sampleEvents: OuraPostRawTelemetryEvent[] = [
     {
       operation: "oura_post_raw_started",
-      requestId: "req_1",
+      requestId: "3237605a-ceb7-44bc-958e-be8954b9e939",
       sleepDocumentCount: 2,
       readinessDocumentCount: 2,
       dailySleepDocumentCount: 1,
@@ -51,7 +54,7 @@ describe("logOuraPostRawTelemetry", () => {
     },
     {
       operation: "oura_post_raw_completed",
-      requestId: "req_1",
+      requestId: "3237605a-ceb7-44bc-958e-be8954b9e939",
       writtenCount: 5,
       sleepDocumentCount: 2,
       readinessDocumentCount: 2,
@@ -59,42 +62,42 @@ describe("logOuraPostRawTelemetry", () => {
       sleepNightDocumentCount: 2,
       metadataWritten: true,
     },
-    { operation: "oura_post_raw_rejected", requestId: "req_1", safeErrorCode: "FUNCTION_PAYLOAD_INVALID" },
+    { operation: "oura_post_raw_rejected", requestId: "3237605a-ceb7-44bc-958e-be8954b9e939", safeErrorCode: "FUNCTION_PAYLOAD_INVALID" },
     {
       operation: "oura_post_raw_failed",
-      requestId: "req_1",
+      requestId: "3237605a-ceb7-44bc-958e-be8954b9e939",
       safeErrorCode: "FUNCTION_PERSIST_FAILED",
       retryable: true,
     },
     {
       operation: "oura_post_raw_domain_docs_received",
-      requestId: "req_1",
+      requestId: "3237605a-ceb7-44bc-958e-be8954b9e939",
       domain: "sleep",
       sleepDocumentCount: 2,
       dailySleepDocumentCount: 1,
     },
     {
       operation: "oura_post_raw_domain_docs_dropped",
-      requestId: "req_1",
+      requestId: "3237605a-ceb7-44bc-958e-be8954b9e939",
       domain: "daily_stress",
       rejectedItemCount: 1,
     },
     {
       operation: "oura_post_raw_domain_extracted",
-      requestId: "req_1",
+      requestId: "3237605a-ceb7-44bc-958e-be8954b9e939",
       domain: "sleep",
       validatedItemCount: 2,
     },
     {
       operation: "oura_post_raw_domain_written",
-      requestId: "req_1",
+      requestId: "3237605a-ceb7-44bc-958e-be8954b9e939",
       domain: "sleep",
       writtenCount: 2,
       failedCount: 0,
     },
     {
       operation: "oura_post_raw_domain_write_failed",
-      requestId: "req_1",
+      requestId: "3237605a-ceb7-44bc-958e-be8954b9e939",
       domain: "readiness",
       safeErrorCode: "FUNCTION_PERSIST_FAILED",
       failedCount: 1,
@@ -102,7 +105,7 @@ describe("logOuraPostRawTelemetry", () => {
     },
     {
       operation: "oura_post_raw_metadata_failed",
-      requestId: "req_1",
+      requestId: "3237605a-ceb7-44bc-958e-be8954b9e939",
       safeErrorCode: "FUNCTION_PERSIST_FAILED",
       writtenCount: 3,
     },
@@ -134,5 +137,36 @@ describe("logOuraPostRawTelemetry", () => {
         latestWakeIso: "2026-07-12T06:00:00Z",
       }),
     ).toThrow(/privacy violation/);
+  });
+});
+
+describe("sanitizeOuraPostRawRequestId", () => {
+  const uuidRe = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+  it("accepts a valid UUID from the producer", () => {
+    expect(sanitizeOuraPostRawRequestId(SAFE_REQUEST_ID)).toBe(SAFE_REQUEST_ID);
+  });
+
+  it("never uses Pub/Sub messageId-like values as requestId", () => {
+    const messageIdLike = "projects/oli/topics/oura.post_raw.v1/messages/1234567890";
+    const out = sanitizeOuraPostRawRequestId(messageIdLike);
+    expect(out).toMatch(uuidRe);
+    expect(out).not.toBe(messageIdLike);
+    expect(out).not.toContain("messages");
+  });
+
+  it.each([
+    ["arbitrary text", "not-a-uuid"],
+    ["email-like", "user_SENTINEL@example.com"],
+    ["date-like", "2026-07-12"],
+    ["url-like", "https://evil.example/x"],
+    ["bearer-token-like", "Bearer aaa.bbb.ccc"],
+    ["idempotency-key-like", "Idempotency-Key-value-xyz"],
+    ["uid-like", "uid_SENTINEL"],
+    ["oversized", "a".repeat(64)],
+  ])("replaces %s with a server UUID", (_label, input) => {
+    const out = sanitizeOuraPostRawRequestId(input);
+    expect(out).toMatch(uuidRe);
+    expect(out).not.toContain("SENTINEL");
   });
 });

--- a/services/functions/src/oura/__tests__/ouraPostRawTelemetry.test.ts
+++ b/services/functions/src/oura/__tests__/ouraPostRawTelemetry.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Unit tests: categorizeOuraPostRawSafeError + logOuraPostRawTelemetry emit only
+ * privacy-safe fields. Logger output is captured and never printed.
+ */
+import { logger } from "firebase-functions";
+import {
+  categorizeOuraPostRawSafeError,
+  logOuraPostRawTelemetry,
+  type OuraPostRawTelemetryEvent,
+} from "../ouraPostRawTelemetry";
+import { assertOuraTelemetryPrivacy } from "../../../../api/src/lib/testSupport/assertOuraTelemetryPrivacy";
+
+jest.mock("firebase-functions", () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+describe("categorizeOuraPostRawSafeError", () => {
+  it("maps transient firestore-like errors to FUNCTION_PERSIST_FAILED retryable", () => {
+    expect(categorizeOuraPostRawSafeError(new Error("UNAVAILABLE: transient"))).toEqual({
+      safeErrorCode: "FUNCTION_PERSIST_FAILED",
+      retryable: true,
+    });
+  });
+
+  it("falls back to hint / UNKNOWN without leaking Error.message", () => {
+    const err = new Error("uid=user_secret_abc day=2026-07-12");
+    const result = categorizeOuraPostRawSafeError(err);
+    expect(result.safeErrorCode).toBe("UNKNOWN");
+    expect(JSON.stringify(result)).not.toContain("user_secret");
+    expect(JSON.stringify(result)).not.toContain("2026-07-12");
+  });
+});
+
+describe("logOuraPostRawTelemetry", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const sampleEvents: OuraPostRawTelemetryEvent[] = [
+    {
+      operation: "oura_post_raw_started",
+      requestId: "req_1",
+      sleepDocumentCount: 2,
+      readinessDocumentCount: 2,
+      dailySleepDocumentCount: 1,
+      dailyStressDocumentCount: 1,
+    },
+    {
+      operation: "oura_post_raw_completed",
+      requestId: "req_1",
+      writtenCount: 5,
+      sleepDocumentCount: 2,
+      readinessDocumentCount: 2,
+      dailyStressDocumentCount: 1,
+      sleepNightDocumentCount: 2,
+      metadataWritten: true,
+    },
+    { operation: "oura_post_raw_rejected", requestId: "req_1", safeErrorCode: "FUNCTION_PAYLOAD_INVALID" },
+    {
+      operation: "oura_post_raw_failed",
+      requestId: "req_1",
+      safeErrorCode: "FUNCTION_PERSIST_FAILED",
+      retryable: true,
+    },
+    {
+      operation: "oura_post_raw_domain_docs_received",
+      requestId: "req_1",
+      domain: "sleep",
+      sleepDocumentCount: 2,
+      dailySleepDocumentCount: 1,
+    },
+    {
+      operation: "oura_post_raw_domain_docs_dropped",
+      requestId: "req_1",
+      domain: "daily_stress",
+      rejectedItemCount: 1,
+    },
+    {
+      operation: "oura_post_raw_domain_extracted",
+      requestId: "req_1",
+      domain: "sleep",
+      validatedItemCount: 2,
+    },
+    {
+      operation: "oura_post_raw_domain_written",
+      requestId: "req_1",
+      domain: "sleep",
+      writtenCount: 2,
+      failedCount: 0,
+    },
+    {
+      operation: "oura_post_raw_domain_write_failed",
+      requestId: "req_1",
+      domain: "readiness",
+      safeErrorCode: "FUNCTION_PERSIST_FAILED",
+      failedCount: 1,
+      retryable: true,
+    },
+    {
+      operation: "oura_post_raw_metadata_failed",
+      requestId: "req_1",
+      safeErrorCode: "FUNCTION_PERSIST_FAILED",
+      writtenCount: 3,
+    },
+  ];
+
+  it("every sample event is privacy-safe when captured from logger", () => {
+    for (const event of sampleEvents) {
+      jest.clearAllMocks();
+      logOuraPostRawTelemetry(event);
+      const calls = [
+        ...(logger.error as jest.Mock).mock.calls,
+        ...(logger.warn as jest.Mock).mock.calls,
+        ...(logger.info as jest.Mock).mock.calls,
+      ];
+      expect(calls.length).toBe(1);
+      const payload = calls[0]![0] as Record<string, unknown>;
+      expect(() => assertOuraTelemetryPrivacy(payload)).not.toThrow();
+      expect(JSON.stringify(payload)).not.toContain("uid");
+      expect(JSON.stringify(payload)).not.toContain("2026-07-12");
+    }
+  });
+
+  it("rejects synthetic prohibited keys via assert helper", () => {
+    expect(() =>
+      assertOuraTelemetryPrivacy({
+        operation: "bad",
+        uid: "user_SENTINEL_UID",
+        day: "2026-07-12",
+        latestWakeIso: "2026-07-12T06:00:00Z",
+      }),
+    ).toThrow(/privacy violation/);
+  });
+});

--- a/services/functions/src/oura/__tests__/ouraPostRawTelemetrySourceGuard.test.ts
+++ b/services/functions/src/oura/__tests__/ouraPostRawTelemetrySourceGuard.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Source guard for Function post-raw path: no direct logger/console calls outside
+ * the typed ouraPostRawTelemetry helper.
+ */
+import fs from "fs";
+import path from "path";
+
+const REPO_ROOT = path.resolve(__dirname, "../../../../..");
+
+const GUARDED_FILES: string[] = [
+  "services/functions/src/oura/ouraPostRawHandler.ts",
+  "services/functions/src/oura/onOuraPostRawRequested.ts",
+];
+
+const DIRECT_LOGGER_CALL_REGEX = /\blogger\.(info|warn|error)\s*\(/;
+const DIRECT_CONSOLE_CALL_REGEX = /\bconsole\.(log|warn|error)\s*\(/;
+
+describe("Oura post-raw Function source guard", () => {
+  for (const relPath of GUARDED_FILES) {
+    it(`${relPath} has no direct logger.*/console.* calls`, () => {
+      const absPath = path.join(REPO_ROOT, relPath);
+      expect(fs.existsSync(absPath)).toBe(true);
+      const source = fs.readFileSync(absPath, "utf8");
+
+      const loggerMatches = source.match(new RegExp(DIRECT_LOGGER_CALL_REGEX, "g")) ?? [];
+      const consoleMatches = source.match(new RegExp(DIRECT_CONSOLE_CALL_REGEX, "g")) ?? [];
+
+      expect({ file: relPath, loggerCalls: loggerMatches, consoleCalls: consoleMatches }).toEqual({
+        file: relPath,
+        loggerCalls: [],
+        consoleCalls: [],
+      });
+    });
+  }
+
+  it("guarded files route logging through logOuraPostRawTelemetry", () => {
+    for (const relPath of GUARDED_FILES) {
+      const absPath = path.join(REPO_ROOT, relPath);
+      const source = fs.readFileSync(absPath, "utf8");
+      expect(source.includes("logOuraPostRawTelemetry")).toBe(true);
+    }
+  });
+});

--- a/services/functions/src/oura/onOuraPostRawRequested.ts
+++ b/services/functions/src/oura/onOuraPostRawRequested.ts
@@ -4,8 +4,11 @@
  */
 
 import { onMessagePublished } from "firebase-functions/v2/pubsub";
-import { logger } from "firebase-functions";
 import { runOuraPostRaw, type SleepDoc, type ReadinessDoc } from "./ouraPostRawHandler";
+import {
+  categorizeOuraPostRawSafeError,
+  logOuraPostRawTelemetry,
+} from "./ouraPostRawTelemetry";
 
 const TOPIC = "oura.post_raw.v1";
 
@@ -33,21 +36,33 @@ export const onOuraPostRawRequested = onMessagePublished(
     const payload = event.data?.message?.json as unknown;
 
     if (!payload || typeof payload !== "object") {
-      logger.error("oura.post_raw: invalid payload");
+      logOuraPostRawTelemetry({
+        operation: "oura_post_raw_rejected",
+        safeErrorCode: "FUNCTION_PAYLOAD_INVALID",
+      });
       return;
     }
 
     const {
       uid,
-      requestId = event.id ?? "unknown",
+      requestId = "unknown",
       sleepDocs = [],
       readinessDocs = [],
       dailySleepDocs = [],
       dailyStressDocs = [],
     } = payload as OuraPostRawMessage;
 
+    // Prefer producer requestId (API middleware UUID / client x-request-id). Do not
+    // fall back to Pub/Sub event/message ids — those are transport identifiers.
+    const safeRequestId =
+      typeof requestId === "string" && requestId.trim().length > 0 ? requestId.trim() : "unknown";
+
     if (!assertUid(uid)) {
-      logger.error("oura.post_raw: invalid uid", { uid });
+      logOuraPostRawTelemetry({
+        operation: "oura_post_raw_rejected",
+        requestId: safeRequestId,
+        safeErrorCode: "FUNCTION_PAYLOAD_INVALID",
+      });
       return;
     }
 
@@ -59,14 +74,20 @@ export const onOuraPostRawRequested = onMessagePublished(
     try {
       await runOuraPostRaw(
         uid,
-        requestId,
+        safeRequestId,
         sleep as SleepDoc[],
         readiness as ReadinessDoc[],
         dailySleep as import("../../../api/src/lib/ouraApi").OuraDailySleepDocument[],
         dailyStress as import("../../../api/src/lib/ouraApi").OuraDailyStressDocument[],
       );
     } catch (err) {
-      logger.error("oura.post_raw: failed", { uid, requestId, err });
+      const { safeErrorCode, retryable } = categorizeOuraPostRawSafeError(err, "FUNCTION_PERSIST_FAILED");
+      logOuraPostRawTelemetry({
+        operation: "oura_post_raw_failed",
+        requestId: safeRequestId,
+        safeErrorCode,
+        retryable,
+      });
       throw err;
     }
   },

--- a/services/functions/src/oura/onOuraPostRawRequested.ts
+++ b/services/functions/src/oura/onOuraPostRawRequested.ts
@@ -8,6 +8,7 @@ import { runOuraPostRaw, type SleepDoc, type ReadinessDoc } from "./ouraPostRawH
 import {
   categorizeOuraPostRawSafeError,
   logOuraPostRawTelemetry,
+  sanitizeOuraPostRawRequestId,
 } from "./ouraPostRawTelemetry";
 
 const TOPIC = "oura.post_raw.v1";
@@ -45,17 +46,16 @@ export const onOuraPostRawRequested = onMessagePublished(
 
     const {
       uid,
-      requestId = "unknown",
+      requestId,
       sleepDocs = [],
       readinessDocs = [],
       dailySleepDocs = [],
       dailyStressDocs = [],
     } = payload as OuraPostRawMessage;
 
-    // Prefer producer requestId (API middleware UUID / client x-request-id). Do not
-    // fall back to Pub/Sub event/message ids — those are transport identifiers.
-    const safeRequestId =
-      typeof requestId === "string" && requestId.trim().length > 0 ? requestId.trim() : "unknown";
+    // Prefer sanitized producer requestId only. Never fall back to Pub/Sub
+    // event/message ids — those are transport identifiers, not telemetry traces.
+    const safeRequestId = sanitizeOuraPostRawRequestId(requestId);
 
     if (!assertUid(uid)) {
       logOuraPostRawTelemetry({

--- a/services/functions/src/oura/ouraPostRawHandler.ts
+++ b/services/functions/src/oura/ouraPostRawHandler.ts
@@ -4,7 +4,10 @@
  */
 
 import { getFirestore, FieldValue } from "firebase-admin/firestore";
-import { logger } from "firebase-functions";
+import {
+  categorizeOuraPostRawSafeError,
+  logOuraPostRawTelemetry,
+} from "./ouraPostRawTelemetry";
 
 import { coerceOuraSleepScore0to100 } from "../../../api/src/lib/oura/buildSleepNightFromOuraDocument";
 import { resolveOuraSleepIngestBase } from "../../../api/src/lib/oura/resolveOuraSleepIngestBase";
@@ -322,11 +325,12 @@ async function writeSleepSnapshots(
   sleepNightsWritten: number;
   sleepNightsErrors: number;
 }> {
-  logger.info("oura_post_raw: sleep docs received", {
-    uid,
+  logOuraPostRawTelemetry({
+    operation: "oura_post_raw_domain_docs_received",
     requestId,
-    sleepDocCount: docs.length,
-    dailySleepDocCount: dailySleepDocs.length,
+    domain: "sleep",
+    sleepDocumentCount: docs.length,
+    dailySleepDocumentCount: dailySleepDocs.length,
   });
 
   const fetchedAt = new Date().toISOString();
@@ -337,14 +341,10 @@ async function writeSleepSnapshots(
   let errors = 0;
 
   const pairs: { doc: SleepDoc; snapshot: SleepSnapshot }[] = [];
-  let droppedSampleKeys: string[] | undefined;
   for (const doc of docs) {
     const snapshot = extractSleepSnapshot(doc, fetchedAt, { uid });
     if (!snapshot) {
       skippedMissingDay += 1;
-      if (!droppedSampleKeys && doc && typeof doc === "object") {
-        droppedSampleKeys = Object.keys(doc).slice(0, 20);
-      }
       continue;
     }
     pairs.push({ doc, snapshot });
@@ -362,22 +362,20 @@ async function writeSleepSnapshots(
 
   const snapshots = [...pairs.map((p) => p.snapshot), ...dailySnapshots];
 
-  if (droppedSampleKeys !== undefined && skippedMissingDay > 0) {
-    logger.info("oura_post_raw: sleep docs dropped", {
-      uid,
+  if (skippedMissingDay > 0) {
+    logOuraPostRawTelemetry({
+      operation: "oura_post_raw_domain_docs_dropped",
       requestId,
-      sleepDocCount: docs.length,
-      skippedMissingDay,
-      reason: "missing_day",
-      sampleKeys: droppedSampleKeys,
+      domain: "sleep",
+      rejectedItemCount: skippedMissingDay,
     });
   }
 
-  logger.info("oura_post_raw: sleep snapshots extracted", {
-    uid,
+  logOuraPostRawTelemetry({
+    operation: "oura_post_raw_domain_extracted",
     requestId,
-    sleepDocsReceived: docs.length,
-    sleepSnapshotsExtracted: snapshots.length,
+    domain: "sleep",
+    validatedItemCount: snapshots.length,
   });
 
   for (let i = 0; i < snapshots.length; i += BATCH_CHUNK_SIZE) {
@@ -390,31 +388,41 @@ async function writeSleepSnapshots(
       await batch.commit();
       written += chunk.length;
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      logger.error("oura_post_raw: sleep batch error", { uid, requestId, chunkSize: chunk.length, err: message });
+      const { safeErrorCode, retryable } = categorizeOuraPostRawSafeError(err, "FUNCTION_PERSIST_FAILED");
+      logOuraPostRawTelemetry({
+        operation: "oura_post_raw_domain_write_failed",
+        requestId,
+        domain: "sleep",
+        safeErrorCode,
+        failedCount: chunk.length,
+        retryable,
+      });
       for (const snapshot of chunk) {
         try {
           await col.doc(snapshot.id).set(stripUndefined(snapshot as unknown as Record<string, unknown>), { merge: true });
           written += 1;
         } catch (singleErr) {
           errors += 1;
-          logger.error("oura_post_raw: sleep write error", {
-            uid,
+          const cat = categorizeOuraPostRawSafeError(singleErr, "FUNCTION_PERSIST_FAILED");
+          logOuraPostRawTelemetry({
+            operation: "oura_post_raw_domain_write_failed",
             requestId,
-            snapshotId: snapshot.id,
-            day: snapshot.day,
-            err: singleErr instanceof Error ? singleErr.message : String(singleErr),
+            domain: "sleep",
+            safeErrorCode: cat.safeErrorCode,
+            failedCount: 1,
+            retryable: cat.retryable,
           });
         }
       }
     }
   }
 
-  logger.info("oura_post_raw: sleep snapshots written", {
-    uid,
+  logOuraPostRawTelemetry({
+    operation: "oura_post_raw_domain_written",
     requestId,
-    sleepSnapshotsWritten: written,
-    sleepSnapshotsErrors: errors,
+    domain: "sleep",
+    writtenCount: written,
+    failedCount: errors,
   });
 
   const readinessCol = db.collection("users").doc(uid).collection("ouraVendorReadiness");
@@ -455,8 +463,15 @@ async function writeSleepSnapshots(
       await batch.commit();
       sleepNightsWritten += ops;
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      logger.error("oura_post_raw: sleep_night_batch_error", { uid, requestId, chunkSize: chunk.length, err: message });
+      const { safeErrorCode, retryable } = categorizeOuraPostRawSafeError(err, "FUNCTION_PERSIST_FAILED");
+      logOuraPostRawTelemetry({
+        operation: "oura_post_raw_domain_write_failed",
+        requestId,
+        domain: "sleep_night",
+        safeErrorCode,
+        failedCount: chunk.length,
+        retryable,
+      });
       for (const { doc, snapshot } of chunk) {
         const merged = buildSleepNightFirestorePayloadWithOuraReadiness(
           doc,
@@ -477,22 +492,26 @@ async function writeSleepSnapshots(
           sleepNightsWritten += 1;
         } catch (singleErr) {
           sleepNightsErrors += 1;
-          logger.error("oura_post_raw: sleep_night_write_error", {
-            uid,
+          const cat = categorizeOuraPostRawSafeError(singleErr, "FUNCTION_PERSIST_FAILED");
+          logOuraPostRawTelemetry({
+            operation: "oura_post_raw_domain_write_failed",
             requestId,
-            anchorDay: merged.anchorDay,
-            err: singleErr instanceof Error ? singleErr.message : String(singleErr),
+            domain: "sleep_night",
+            safeErrorCode: cat.safeErrorCode,
+            failedCount: 1,
+            retryable: cat.retryable,
           });
         }
       }
     }
   }
 
-  logger.info("oura_post_raw: sleep_nights_written", {
-    uid,
+  logOuraPostRawTelemetry({
+    operation: "oura_post_raw_domain_written",
     requestId,
-    sleepNightsWritten,
-    sleepNightsErrors,
+    domain: "sleep_night",
+    writtenCount: sleepNightsWritten,
+    failedCount: sleepNightsErrors,
   });
 
   return { written, attempted: docs.length, skippedMissingDay, errors, sleepNightsWritten, sleepNightsErrors };
@@ -510,27 +529,21 @@ async function writeReadinessSnapshots(
 
   const snapshots: ReadinessSnapshot[] = [];
   let droppedReadiness = 0;
-  let droppedSampleKeys: string[] | undefined;
   for (const doc of docs) {
     const snapshot = extractReadinessSnapshot(doc, fetchedAt);
     if (!snapshot) {
       droppedReadiness += 1;
-      if (!droppedSampleKeys && doc && typeof doc === "object") {
-        droppedSampleKeys = Object.keys(doc).slice(0, 20);
-      }
       continue;
     }
     snapshots.push(snapshot);
   }
 
   if (droppedReadiness > 0) {
-    logger.info("oura_post_raw: readiness docs dropped", {
-      uid,
+    logOuraPostRawTelemetry({
+      operation: "oura_post_raw_domain_docs_dropped",
       requestId,
-      readinessDocCount: docs.length,
-      droppedReadiness,
-      reason: "missing_day",
-      sampleKeys: droppedSampleKeys ?? [],
+      domain: "readiness",
+      rejectedItemCount: droppedReadiness,
     });
   }
 
@@ -544,24 +557,41 @@ async function writeReadinessSnapshots(
       await batch.commit();
       written += chunk.length;
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      logger.error("oura_post_raw: readiness batch error", { uid, requestId, chunkSize: chunk.length, err: message });
+      const { safeErrorCode, retryable } = categorizeOuraPostRawSafeError(err, "FUNCTION_PERSIST_FAILED");
+      logOuraPostRawTelemetry({
+        operation: "oura_post_raw_domain_write_failed",
+        requestId,
+        domain: "readiness",
+        safeErrorCode,
+        failedCount: chunk.length,
+        retryable,
+      });
       for (const snapshot of chunk) {
         try {
           await col.doc(snapshot.id).set(stripUndefined(snapshot as unknown as Record<string, unknown>), { merge: true });
           written += 1;
         } catch (singleErr) {
-          logger.error("oura_post_raw: readiness write error", {
-            uid,
+          const cat = categorizeOuraPostRawSafeError(singleErr, "FUNCTION_PERSIST_FAILED");
+          logOuraPostRawTelemetry({
+            operation: "oura_post_raw_domain_write_failed",
             requestId,
-            snapshotId: snapshot.id,
-            day: snapshot.day,
-            err: singleErr instanceof Error ? singleErr.message : String(singleErr),
+            domain: "readiness",
+            safeErrorCode: cat.safeErrorCode,
+            failedCount: 1,
+            retryable: cat.retryable,
           });
         }
       }
     }
   }
+
+  logOuraPostRawTelemetry({
+    operation: "oura_post_raw_domain_written",
+    requestId,
+    domain: "readiness",
+    writtenCount: written,
+    failedCount: 0,
+  });
 
   return { written };
 }
@@ -650,11 +680,11 @@ async function writeStressSnapshots(
   }
 
   if (droppedStress > 0) {
-    logger.info("oura_post_raw: stress docs dropped", {
+    logOuraPostRawTelemetry({
+      operation: "oura_post_raw_domain_docs_dropped",
       requestId,
-      stressDocCount: docs.length,
-      droppedStress,
-      reason: "missing_day",
+      domain: "daily_stress",
+      rejectedItemCount: droppedStress,
     });
   }
 
@@ -670,11 +700,14 @@ async function writeStressSnapshots(
       await batch.commit();
       written += chunk.length;
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      logger.error("oura_post_raw: stress batch error", {
+      const { safeErrorCode, retryable } = categorizeOuraPostRawSafeError(err, "FUNCTION_PERSIST_FAILED");
+      logOuraPostRawTelemetry({
+        operation: "oura_post_raw_domain_write_failed",
         requestId,
-        chunkSize: chunk.length,
-        err: message,
+        domain: "daily_stress",
+        safeErrorCode,
+        failedCount: chunk.length,
+        retryable,
       });
       for (const snapshot of chunk) {
         try {
@@ -683,14 +716,27 @@ async function writeStressSnapshots(
           });
           written += 1;
         } catch (singleErr) {
-          logger.error("oura_post_raw: stress write error", {
+          const cat = categorizeOuraPostRawSafeError(singleErr, "FUNCTION_PERSIST_FAILED");
+          logOuraPostRawTelemetry({
+            operation: "oura_post_raw_domain_write_failed",
             requestId,
-            err: singleErr instanceof Error ? singleErr.message : String(singleErr),
+            domain: "daily_stress",
+            safeErrorCode: cat.safeErrorCode,
+            failedCount: 1,
+            retryable: cat.retryable,
           });
         }
       }
     }
   }
+
+  logOuraPostRawTelemetry({
+    operation: "oura_post_raw_domain_written",
+    requestId,
+    domain: "daily_stress",
+    writtenCount: written,
+    failedCount: 0,
+  });
 
   return { written };
 }
@@ -710,13 +756,13 @@ export async function runOuraPostRaw(
 ): Promise<RunOuraPostRawResult> {
   const db = getFirestore();
 
-  logger.info("oura_post_raw: started", {
-    uid,
+  logOuraPostRawTelemetry({
+    operation: "oura_post_raw_started",
     requestId,
-    sleepDocCount: sleepDocs.length,
-    readinessDocCount: readinessDocs.length,
-    dailySleepDocCount: dailySleepDocs.length,
-    dailyStressDocCount: dailyStressDocs.length,
+    sleepDocumentCount: sleepDocs.length,
+    readinessDocumentCount: readinessDocs.length,
+    dailySleepDocumentCount: dailySleepDocs.length,
+    dailyStressDocumentCount: dailyStressDocs.length,
   });
 
   const [sleepResult, readinessResult, stressResult] = await Promise.all([
@@ -740,23 +786,23 @@ export async function runOuraPostRaw(
     await integrationRef.set(update, { merge: true });
     metadataWritten = true;
   } catch (metaErr) {
-    logger.error("oura_post_raw: metadata error", {
-      uid,
+    const { safeErrorCode } = categorizeOuraPostRawSafeError(metaErr, "FUNCTION_PERSIST_FAILED");
+    logOuraPostRawTelemetry({
+      operation: "oura_post_raw_metadata_failed",
       requestId,
-      sleepWritten: sleepResult.written,
-      readinessWritten: readinessResult.written,
-      stressWritten: stressResult.written,
-      err: metaErr instanceof Error ? metaErr.message : String(metaErr),
+      safeErrorCode,
+      writtenCount: totalSnapshotWritten,
     });
   }
 
-  logger.info("oura_post_raw: done", {
-    uid,
+  logOuraPostRawTelemetry({
+    operation: "oura_post_raw_completed",
     requestId,
-    sleepWritten: sleepResult.written,
-    readinessWritten: readinessResult.written,
-    stressWritten: stressResult.written,
-    sleepNightsWritten: sleepResult.sleepNightsWritten,
+    writtenCount: totalSnapshotWritten,
+    sleepDocumentCount: sleepResult.written,
+    readinessDocumentCount: readinessResult.written,
+    dailyStressDocumentCount: stressResult.written,
+    sleepNightDocumentCount: sleepResult.sleepNightsWritten,
     metadataWritten,
   });
 

--- a/services/functions/src/oura/ouraPostRawTelemetry.ts
+++ b/services/functions/src/oura/ouraPostRawTelemetry.ts
@@ -1,0 +1,129 @@
+/**
+ * Privacy-safe telemetry for the Oura post-raw Function path
+ * (onOuraPostRawRequested → runOuraPostRaw).
+ *
+ * Closed typed events only — no uid, day, document/snapshot ids, health values,
+ * raw error messages, Pub/Sub payloads, or tokens.
+ */
+
+import { logger } from "firebase-functions";
+
+/** Closed set of privacy-safe error codes for the post-raw Function path. */
+export type OuraPostRawSafeErrorCode =
+  | "FUNCTION_PAYLOAD_INVALID"
+  | "FUNCTION_PERSIST_FAILED"
+  | "UNKNOWN";
+
+const RETRYABLE: ReadonlySet<OuraPostRawSafeErrorCode> = new Set(["FUNCTION_PERSIST_FAILED"]);
+
+export function categorizeOuraPostRawSafeError(
+  err: unknown,
+  hint?: OuraPostRawSafeErrorCode,
+): { safeErrorCode: OuraPostRawSafeErrorCode; retryable: boolean } {
+  const code: OuraPostRawSafeErrorCode = hint ?? "UNKNOWN";
+  if (err instanceof Error) {
+    const text = `${err.name} ${err.message}`.toLowerCase();
+    if (
+      text.includes("timeout") ||
+      text.includes("deadline") ||
+      text.includes("unavailable") ||
+      text.includes("aborted") ||
+      text.includes("resource exhausted")
+    ) {
+      return { safeErrorCode: "FUNCTION_PERSIST_FAILED", retryable: true };
+    }
+  }
+  return { safeErrorCode: code, retryable: RETRYABLE.has(code) };
+}
+
+type OuraPostRawTelemetryBase = {
+  requestId?: string;
+  durationMs?: number;
+};
+
+export type OuraPostRawTelemetryEvent =
+  | (OuraPostRawTelemetryBase & {
+      operation: "oura_post_raw_started";
+      sleepDocumentCount: number;
+      readinessDocumentCount: number;
+      dailySleepDocumentCount: number;
+      dailyStressDocumentCount: number;
+    })
+  | (OuraPostRawTelemetryBase & {
+      operation: "oura_post_raw_completed";
+      writtenCount: number;
+      sleepDocumentCount: number;
+      readinessDocumentCount: number;
+      dailyStressDocumentCount: number;
+      sleepNightDocumentCount: number;
+      metadataWritten: boolean;
+    })
+  | (OuraPostRawTelemetryBase & {
+      operation: "oura_post_raw_rejected";
+      safeErrorCode: OuraPostRawSafeErrorCode;
+    })
+  | (OuraPostRawTelemetryBase & {
+      operation: "oura_post_raw_failed";
+      safeErrorCode: OuraPostRawSafeErrorCode;
+      retryable: boolean;
+    })
+  | (OuraPostRawTelemetryBase & {
+      operation: "oura_post_raw_domain_docs_received";
+      domain: string;
+      sleepDocumentCount?: number;
+      dailySleepDocumentCount?: number;
+    })
+  | (OuraPostRawTelemetryBase & {
+      operation: "oura_post_raw_domain_docs_dropped";
+      domain: string;
+      rejectedItemCount: number;
+    })
+  | (OuraPostRawTelemetryBase & {
+      operation: "oura_post_raw_domain_extracted";
+      domain: string;
+      validatedItemCount: number;
+    })
+  | (OuraPostRawTelemetryBase & {
+      operation: "oura_post_raw_domain_written";
+      domain: string;
+      writtenCount: number;
+      failedCount: number;
+    })
+  | (OuraPostRawTelemetryBase & {
+      operation: "oura_post_raw_domain_write_failed";
+      domain: string;
+      safeErrorCode: OuraPostRawSafeErrorCode;
+      failedCount: number;
+      retryable: boolean;
+    })
+  | (OuraPostRawTelemetryBase & {
+      operation: "oura_post_raw_metadata_failed";
+      safeErrorCode: OuraPostRawSafeErrorCode;
+      writtenCount: number;
+    });
+
+const ERROR_OPERATIONS: ReadonlySet<string> = new Set([
+  "oura_post_raw_failed",
+  "oura_post_raw_rejected",
+  "oura_post_raw_domain_write_failed",
+  "oura_post_raw_metadata_failed",
+]);
+
+const WARN_OPERATIONS: ReadonlySet<string> = new Set([]);
+
+/**
+ * Log a single post-raw telemetry event. Only typed fields are emitted —
+ * no free-form metadata, error messages, or identifiers.
+ */
+export function logOuraPostRawTelemetry(event: OuraPostRawTelemetryEvent): void {
+  const { operation, ...rest } = event;
+  const payload: Record<string, unknown> = { msg: operation, operation, ...rest };
+
+  if (ERROR_OPERATIONS.has(operation)) {
+    logger.error(payload);
+  } else if (WARN_OPERATIONS.has(operation)) {
+    logger.warn(payload);
+  } else {
+    logger.info(payload);
+  }
+}

--- a/services/functions/src/oura/ouraPostRawTelemetry.ts
+++ b/services/functions/src/oura/ouraPostRawTelemetry.ts
@@ -6,7 +6,30 @@
  * raw error messages, Pub/Sub payloads, or tokens.
  */
 
+import { randomUUID } from "crypto";
 import { logger } from "firebase-functions";
+
+/**
+ * Strict opaque request-trace ID for post-raw telemetry (mirrors API Option B).
+ * Accepts only RFC UUID form. Invalid/missing values are replaced with a new
+ * server UUID — never Pub/Sub message IDs, never hashed/truncated unsafe input.
+ */
+const OURA_POST_RAW_REQUEST_ID_UUID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const OURA_POST_RAW_REQUEST_ID_MAX_LEN = 36;
+
+export function sanitizeOuraPostRawRequestId(candidate: unknown): string {
+  if (typeof candidate !== "string") return randomUUID();
+  const trimmed = candidate.trim();
+  if (trimmed.length === 0 || trimmed.length > OURA_POST_RAW_REQUEST_ID_MAX_LEN) {
+    return randomUUID();
+  }
+  if (!OURA_POST_RAW_REQUEST_ID_UUID.test(trimmed)) {
+    return randomUUID();
+  }
+  return trimmed;
+}
 
 /** Closed set of privacy-safe error codes for the post-raw Function path. */
 export type OuraPostRawSafeErrorCode =
@@ -116,8 +139,11 @@ const WARN_OPERATIONS: ReadonlySet<string> = new Set([]);
  * no free-form metadata, error messages, or identifiers.
  */
 export function logOuraPostRawTelemetry(event: OuraPostRawTelemetryEvent): void {
-  const { operation, ...rest } = event;
+  const { operation, requestId, ...rest } = event;
   const payload: Record<string, unknown> = { msg: operation, operation, ...rest };
+  if (requestId !== undefined) {
+    payload.requestId = sanitizeOuraPostRawRequestId(requestId);
+  }
 
   if (ERROR_OPERATIONS.has(operation)) {
     logger.error(payload);


### PR DESCRIPTION
## Dependency

This is a draft stacked privacy repair on top of Weekly Fitness v2 PR #183.

```text
main
└── PR #180
    └── PR #182
        └── PR #183 — Weekly Fitness v2
            └── this PR — Oura refresh telemetry privacy
```

Base:

```text
feat/weekly-fitness-v2
```

This PR must merge into the Weekly Fitness feature branch before a new backend
artifact is built.

Do not merge PR #183 before this repair is integrated.

## Summary

Redacts sensitive metadata from the complete Oura refresh path:

```text
pull-now
provider fetches
legacy backfill/recovery
raw-event persistence
vendor snapshot processing
post-raw enqueue
in-process post-raw persistence
onOuraPostRawRequested
```

Removed or prohibited telemetry includes:

- UIDs and user identifiers
- exact provider and health dates
- date windows
- wake timestamps
- provider record/document identifiers
- raw-event identifiers
- health scores and durations
- Pub/Sub message IDs
- raw error messages
- raw provider payloads
- tokens, keys and idempotency keys

Telemetry now emits only typed aggregate operational metadata, safe error
codes, durations, counts, booleans and sanitized trace identifiers.

## Typed boundaries

Adds focused typed telemetry boundaries for:

- Cloud Run API Oura refresh processing
- Gen2 Function Oura post-raw processing

Direct logger use in active refresh files is guarded by source tests.

## Request-ID safety

This repair sanitizes request identifiers for **Oura refresh and post-raw
telemetry only**. It is not a repository-wide `requestIdMiddleware` remediation.

On the Oura path, a valid RFC UUID (≤36 chars) may be retained; every other
incoming value is replaced with a server-generated `randomUUID()` before
telemetry emit and before the post-raw producer payload.

Arbitrary client-supplied values, identity-like values, dates, URLs, token
shapes and idempotency-key shapes cannot enter Oura refresh/post-raw telemetry.

The Function re-sanitizes the producer trace identifier and never uses the
Pub/Sub message ID as fallback. `Idempotency-Key` remains a separate header.

## Diagnostics removed

- `OURA_SLEEP_LATEST_AUDIT` removed
- `OURA_SLEEP_PHYSIOLOGY_DEBUG` made incapable of emitting health values,
  dates or identifiers

## Functional parity

Unchanged:

- provider endpoints
- OAuth scopes
- fetch windows
- pagination
- validation
- storage paths
- document identities
- Daily Stress ingestion
- Sleep/Daily Sleep/Readiness ingestion
- API response DTOs
- HTTP status behavior
- idempotency/retry behavior
- OpenAPI
- Weekly Fitness behavior

The only intended behavior change is the telemetry payload.

## Validation

Local gates:

- `npm ci`
- TypeScript
- ESLint
- client trust boundary
- invariants
- full Jest suite
- API build
- Functions build
- build-truth checksum
- iOS Expo export
- focused logger-capture tests
- source-guard tests
- forbidden-key/value-pattern tests

Expo Doctor retains only the same five documented pre-existing findings.

## Release impact

The previously built artifacts are superseded and must not be cut over:

```text
Cloud Run revision:
oli-api-00231-gul

image digest:
sha256:16018a3f5e6820a4af5a68c0c7558c2190d3671d17269eff68b818d988e89889

Function revision:
onourapostrawrequested-00053-bub
```

After this PR merges into `feat/weekly-fitness-v2`, deployment requires:

1. a new immutable API image;
2. a corrected Function consumer;
3. a new zero-traffic API revision;
4. tagged route and privacy-log verification;
5. final cutover authorization.

The existing unattached Gateway config remains contract-compatible because
OpenAPI is byte-for-byte unchanged. A provenance-clean replacement may still
be created later at deployment discretion.

## Out of scope

This focused repair does not fix unrelated mobile/runtime debt, including:

- Workout debug telemetry
- Energy audit telemetry
- Apple Health backfill telemetry
- Weekly Fitness render-frequency telemetry
- full-year Activity/Workout client transport
- sleep-day-refresh HTTP 500

Those remain separate blockers for the clean physical-device baseline.

## Runtime status

No deployment, traffic movement, Gateway attachment, refresh, backfill or
Firestore mutation was performed.

