### PR TITLE
fix(privacy): redact generic API access telemetry

### DIFF
--- a/docs/audits/2026-07-12-api-access-log-privacy-audit.md
+++ b/docs/audits/2026-07-12-api-access-log-privacy-audit.md
@@ -1,0 +1,191 @@
+# API Access-Log Privacy Repair Audit
+
+**Date:** 2026-07-12  
+**Privacy branch:** `fix/pr183-api-access-log-privacy`  
+**Privacy worktree:** `/Users/danielhendel/oli-api-access-log-privacy`  
+**Feature base SHA:** `8788c526e42b04eee7e7a1fc050a1e0f53923c49`  
+**Feature base tree:** `00b6f99f8efb90c475d529d8dd44a37ff4b94b10`  
+**Safety ref:** `safety/weekly-fitness-before-access-log-privacy-8788c52` (local only)
+
+This audit is privacy-safe. It contains no UIDs, emails, IPs, tokens, keys,
+exact health dates, query values, raw URLs, response bodies, or raw logs.
+
+---
+
+## 1. Original preflight finding
+
+Corrected Weekly Fitness backend preflight (`8788c52` / revision
+`oli-api-00232-yow`) found that generic API `accessLogMiddleware` emitted:
+
+| Prohibited field (name only) | Source |
+|---|---|
+| `uid` | `req.uid` after auth |
+| `path` (with query) | `sanitizePathForLogs(req.originalUrl)` — redacted only secret key names; left `start`/`end` and other health-range query values |
+| `rid` | raw request middleware id (not UUID-gated for telemetry) |
+| `method` / `status` / `ms` | operational (allowed shape, wrong event contract) |
+
+Event name was `msg: "request"`.
+
+### Inventory (pre-repair)
+
+| File | Function | Event | Current fields | Source | Safe? |
+|---|---|---|---|---|---|
+| `services/api/src/lib/logger.ts` | `accessLogMiddleware` | `request` | `msg`, `rid`, `method`, `path`, `status`, `ms`, `uid` | req + res | **No** |
+| `services/api/src/lib/logger.ts` | `requestIdMiddleware` | (none) | sets `rid` + `x-request-id` | header / `randomUUID()` | Yes (HTTP correlation) |
+| `services/api/src/lib/logger.ts` | `sanitizePathForLogs` | (helper) | path + query with partial redaction | `originalUrl` | **No** |
+
+---
+
+## 2. Final access-log allowlist
+
+Event: `operation` / `msg` = `http_request_completed`
+
+Allowed fields:
+
+- `operation`
+- `method` (normalized: GET/POST/PUT/PATCH/DELETE/OPTIONS/HEAD/OTHER)
+- `routeTemplate` (server-owned template only)
+- `statusCode`
+- `durationMs`
+- `requestId` (strict RFC UUID; invalid inputs replaced with `randomUUID()` for telemetry only)
+- `authenticated` (boolean)
+- `matchedRoute` (boolean)
+- `safeErrorCode` (optional closed union)
+
+Prohibited (never emitted): uid, userId, email, IP, headers, tokens, keys,
+raw path/URL/originalUrl, query names/values, start/end/day/date, bodies,
+raw errors/stacks, concrete path parameters.
+
+---
+
+## 3. Route-template derivation
+
+Preferred source after Express routing: `req.baseUrl + req.route.path`.
+
+| Case | Result |
+|---|---|
+| Nested matched route | e.g. `/users/me/oura-stress` |
+| Declared dynamic template | e.g. `/ingest/:rawEventId` (no concrete ID) |
+| Unmatched 404 | `UNMATCHED_ROUTE` |
+| RegExp / array / unsafe metadata | `MATCHED_ROUTE` |
+| Candidate with `?`, `#`, `@`, dates, tokens, encoded values, concrete `/users/<id>/` | `MATCHED_ROUTE` |
+
+Never falls back to `req.originalUrl` / `req.url` / query.
+
+---
+
+## 4. Request-ID sanitation
+
+`sanitizeApiAccessTelemetryRequestId`:
+
+- Accepts only strict UUID (36 chars)
+- Otherwise replaces with `randomUUID()` for **telemetry only**
+- Does not change HTTP `x-request-id` response header behavior
+
+---
+
+## 5. Auth-state and emission behavior
+
+- `authenticated`: `true` iff `req.uid` is a non-empty string; UID value never logged
+- One emission per request: `finish` and `close` share an `emitted` guard
+
+---
+
+## 6. Implementation files
+
+| Area | Path |
+|---|---|
+| Typed telemetry | `services/api/src/lib/apiAccessTelemetry.ts` |
+| Middleware | `services/api/src/middleware/accessLogMiddleware.ts` |
+| Logger (request-id only; access middleware removed) | `services/api/src/lib/logger.ts` |
+| App wiring | `services/api/src/index.ts` |
+| Privacy assertion | `services/api/src/lib/testSupport/assertApiAccessTelemetryPrivacy.ts` |
+| Tests | `services/api/src/lib/__tests__/apiAccessTelemetry.test.ts` |
+| Source guard | `services/api/src/lib/__tests__/apiAccessTelemetrySourceGuard.test.ts` |
+| Docs | `docs/audits/2026-07-12-api-access-log-privacy-audit.md` |
+
+---
+
+## 7. Test matrix
+
+- Request-ID accept/replace (UUID vs sentinels)
+- Method normalization
+- Nested / root / dynamic / unmatched / RegExp / array route templates
+- Logger-capture allowlist + sentinel absence
+- Middleware 2xx/4xx/5xx + safeErrorCode
+- finish/close single emission
+- OPTIONS
+- `x-request-id` response header parity
+- Forbidden-key / forbidden-value assertion
+- Direct-logger source guard on access middleware
+
+---
+
+## 8. Functional parity
+
+Unchanged by design:
+
+- Route registration, auth, UID scoping for **data** access
+- Query parsing, DTOs, HTTP statuses, CORS, OpenAPI
+- Idempotency, Oura provider/ingestion, post-raw Function, Firestore paths
+- Weekly Fitness product behavior, mobile behavior
+
+Only change: generic API access logs no longer emit UID, raw URL, query values,
+concrete path parameters, headers, or other sensitive request metadata.
+
+---
+
+## 9. OpenAPI / Gateway
+
+- OpenAPI SHA-256 (unchanged): `35201567f39138c686cd33a7f89296ee12f172b5c03e28f9e1b3c14804281048`
+- Gateway config `oli-api-config-weekly-fitness-8788c52-20260712-201806` remains contract-compatible
+- Do not attach or delete
+
+---
+
+## 10. Function artifact eligibility
+
+- No Function source diff vs `8788c52`
+- No `lib/contracts` diff
+- Firebase Functions source ownership remains `services/functions`
+- Conclusion recorded in the Cursor response after package comparison
+
+---
+
+## 11. API artifact invalidation
+
+| Artifact | Status |
+|---|---|
+| `oli-api-00232-yow` | **Superseded** — built before access-log privacy repair |
+| Digest `sha256:22b95775…` | Must not be cut over |
+| New immutable API image + zero-traffic revision | Required after merge/push of this repair |
+
+Preserve existing revisions/images.
+
+---
+
+## 12. Cloud Run platform request-log assessment
+
+Application access logging ≠ Cloud Run platform `run.googleapis.com/requests`.
+
+Platform request URL query behavior is assessed read-only in the Cursor response as:
+
+```text
+platformRequestUrlContainsQueryValues: true | false | not verified
+```
+
+When platform logs retain query values, treat as separate infrastructure privacy
+risk (log-router exclusion, retention/access policy, route redesign, etc.).
+Do not leave the application logger unsafe.
+
+---
+
+## 13. Remaining debt (out of scope)
+
+- Mobile Workout / Energy / Apple Health telemetry
+- Weekly Fitness render-frequency Sleep logging
+- Year-scale Activity / Workout hydration
+- Nutrition edge under-count; no Weekly Progress detail route
+- `sleep-day-refresh` HTTP 500
+- Physical-device verification; PR stack unmerged
+- Platform request-log query handling (if applicable)

--- a/docs/audits/2026-07-12-api-access-log-privacy-audit.md
+++ b/docs/audits/2026-07-12-api-access-log-privacy-audit.md
@@ -1,10 +1,10 @@
 # API Access-Log Privacy Repair Audit
 
-**Date:** 2026-07-12  
-**Privacy branch:** `fix/pr183-api-access-log-privacy`  
-**Privacy worktree:** `/Users/danielhendel/oli-api-access-log-privacy`  
-**Feature base SHA:** `8788c526e42b04eee7e7a1fc050a1e0f53923c49`  
-**Feature base tree:** `00b6f99f8efb90c475d529d8dd44a37ff4b94b10`  
+**Date:** 2026-07-12
+**Privacy branch:** `fix/pr183-api-access-log-privacy`
+**Privacy worktree:** `/Users/danielhendel/oli-api-access-log-privacy`
+**Feature base SHA:** `8788c526e42b04eee7e7a1fc050a1e0f53923c49`
+**Feature base tree:** `00b6f99f8efb90c475d529d8dd44a37ff4b94b10`
 **Safety ref:** `safety/weekly-fitness-before-access-log-privacy-8788c52` (local only)
 
 This audit is privacy-safe. It contains no UIDs, emails, IPs, tokens, keys,

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -24,7 +24,8 @@ import ouraSleepDayRefreshRouter from "./routes/integrations/ouraSleepDayRefresh
 import ouraPullRouter from "./routes/ouraPull";
 import { authMiddleware } from "./middleware/auth";
 import { requireInvokerAuth } from "./middleware/invokerAuth";
-import { accessLogMiddleware, requestIdMiddleware, logger, type RequestWithRid } from "./lib/logger";
+import { requestIdMiddleware, logger, type RequestWithRid } from "./lib/logger";
+import { accessLogMiddleware } from "./middleware/accessLogMiddleware";
 
 const assertNoUsersMeWriteRoutes = (router: Router): void => {
   // Regression invariant: /users/me must be READ-only.

--- a/services/api/src/lib/__tests__/apiAccessTelemetry.test.ts
+++ b/services/api/src/lib/__tests__/apiAccessTelemetry.test.ts
@@ -1,0 +1,495 @@
+/**
+ * Unit + middleware tests for privacy-safe generic API access telemetry.
+ * Uses synthetic sentinels only — never prints them to the console on failure paths
+ * that would echo payload bodies (assertions use not.toContain / privacy helper).
+ */
+import express, { type Express, type Request } from "express";
+import http from "http";
+import type { AddressInfo } from "net";
+
+import {
+  MATCHED_ROUTE_FALLBACK_TEMPLATE,
+  UNMATCHED_ROUTE_TEMPLATE,
+  buildApiAccessTelemetryEvent,
+  isTrustedRouteTemplate,
+  logApiAccessTelemetry,
+  normalizeApiAccessMethod,
+  resolveApiAccessRouteTemplate,
+  sanitizeApiAccessTelemetryRequestId,
+  safeErrorCodeForStatus,
+  type ApiAccessTelemetryEvent,
+} from "../apiAccessTelemetry";
+import { accessLogMiddleware } from "../../middleware/accessLogMiddleware";
+import { requestIdMiddleware } from "../logger";
+import { assertApiAccessTelemetryPrivacy } from "../testSupport/assertApiAccessTelemetryPrivacy";
+import * as loggerModule from "../logger";
+
+const SAFE_REQUEST_ID = "3237605a-ceb7-44bc-958e-be8954b9e939";
+
+/** Synthetic sentinels — referenced in assertions via not.toContain; do not console.log them. */
+const SENTINEL = {
+  uid: "UID_SENTINEL_abcdefghijklmnopqrstuv",
+  start: "2099-01-02",
+  end: "2099-01-09",
+  authorization: "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.SENTINEL.sig",
+  apiKey: "AIzaSySENTINEL_KEY_VALUE_XXXX",
+  unsafeRequestId: "not-a-uuid-SENTINEL-request-id",
+} as const;
+
+function captureInfoLogs(): { events: unknown[]; restore: () => void } {
+  const events: unknown[] = [];
+  const original = loggerModule.logger.info;
+  loggerModule.logger.info = (o: Record<string, unknown>) => {
+    events.push(o);
+  };
+  return {
+    events,
+    restore: () => {
+      loggerModule.logger.info = original;
+    },
+  };
+}
+
+describe("sanitizeApiAccessTelemetryRequestId", () => {
+  const uuidRe = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+  it("accepts a valid UUID", () => {
+    expect(sanitizeApiAccessTelemetryRequestId(SAFE_REQUEST_ID)).toBe(SAFE_REQUEST_ID);
+  });
+
+  it.each([
+    ["arbitrary text", "not-a-uuid-at-all"],
+    ["email-like", "user_SENTINEL@example.com"],
+    ["date-like", "2099-01-02"],
+    ["url-like", "https://evil.example/path?start=2099-01-02"],
+    ["bearer-token-like", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.aaa.bbb"],
+    ["firebase-token-like", "eyJhbGciOiJSUzI1NiIsImtpZCI6ImZha2UifQ.payload.sig"],
+    ["idempotency-key-like", "idempotency-oura-pull-abc123"],
+    ["uid-like", "firebaseUid_SENTINEL_abc"],
+    ["firestore-path", "users/abc123/ouraVendorSleep/doc"],
+    ["oversized", `${"a".repeat(40)}`],
+    ["empty", ""],
+  ])("replaces %s input with a new UUID", (_label, input) => {
+    const out = sanitizeApiAccessTelemetryRequestId(input);
+    expect(out).toMatch(uuidRe);
+    expect(out).not.toBe(input);
+    expect(out).not.toContain("SENTINEL");
+  });
+});
+
+describe("normalizeApiAccessMethod", () => {
+  it.each(["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"] as const)(
+    "keeps %s",
+    (m) => {
+      expect(normalizeApiAccessMethod(m)).toBe(m);
+      expect(normalizeApiAccessMethod(m.toLowerCase())).toBe(m);
+    },
+  );
+
+  it("maps unknown methods to OTHER", () => {
+    expect(normalizeApiAccessMethod("TRACE")).toBe("OTHER");
+    expect(normalizeApiAccessMethod(null)).toBe("OTHER");
+  });
+});
+
+describe("resolveApiAccessRouteTemplate", () => {
+  it("joins nested baseUrl + route.path", () => {
+    const req = {
+      baseUrl: "/users/me",
+      route: { path: "/oura-stress" },
+    } as unknown as Request;
+    expect(resolveApiAccessRouteTemplate(req)).toEqual({
+      routeTemplate: "/users/me/oura-stress",
+      matchedRoute: true,
+    });
+  });
+
+  it("preserves root route", () => {
+    const req = {
+      baseUrl: "",
+      route: { path: "/" },
+    } as unknown as Request;
+    expect(resolveApiAccessRouteTemplate(req)).toEqual({
+      routeTemplate: "/",
+      matchedRoute: true,
+    });
+  });
+
+  it("keeps declared dynamic templates without substituting params", () => {
+    const req = {
+      baseUrl: "",
+      route: { path: "/ingest/:rawEventId" },
+    } as unknown as Request;
+    expect(resolveApiAccessRouteTemplate(req)).toEqual({
+      routeTemplate: "/ingest/:rawEventId",
+      matchedRoute: true,
+    });
+  });
+
+  it("returns UNMATCHED_ROUTE when no route matched", () => {
+    const req = { baseUrl: "", originalUrl: "/nope?start=2099-01-02" } as unknown as Request;
+    expect(resolveApiAccessRouteTemplate(req)).toEqual({
+      routeTemplate: UNMATCHED_ROUTE_TEMPLATE,
+      matchedRoute: false,
+    });
+  });
+
+  it("returns MATCHED_ROUTE for RegExp route metadata", () => {
+    const req = {
+      baseUrl: "/users/me",
+      route: { path: /oura-.*/ },
+    } as unknown as Request;
+    expect(resolveApiAccessRouteTemplate(req)).toEqual({
+      routeTemplate: MATCHED_ROUTE_FALLBACK_TEMPLATE,
+      matchedRoute: true,
+    });
+  });
+
+  it("returns MATCHED_ROUTE for array route metadata", () => {
+    const req = {
+      baseUrl: "",
+      route: { path: ["/a", "/b"] },
+    } as unknown as Request;
+    expect(resolveApiAccessRouteTemplate(req)).toEqual({
+      routeTemplate: MATCHED_ROUTE_FALLBACK_TEMPLATE,
+      matchedRoute: true,
+    });
+  });
+
+  it("rejects templates containing query/date shapes", () => {
+    expect(isTrustedRouteTemplate("/users/me/oura-stress?start=2099-01-02")).toBe(false);
+    expect(isTrustedRouteTemplate("/users/UID_SENTINEL_abcdefghijklmnopqrstuv/x")).toBe(false);
+  });
+});
+
+describe("safeErrorCodeForStatus", () => {
+  it("omits codes for success", () => {
+    expect(safeErrorCodeForStatus(200)).toBeUndefined();
+    expect(safeErrorCodeForStatus(201)).toBeUndefined();
+  });
+
+  it("maps common error statuses", () => {
+    expect(safeErrorCodeForStatus(400)).toBe("CLIENT_ERROR");
+    expect(safeErrorCodeForStatus(401)).toBe("UNAUTHENTICATED");
+    expect(safeErrorCodeForStatus(403)).toBe("FORBIDDEN");
+    expect(safeErrorCodeForStatus(404)).toBe("NOT_FOUND");
+    expect(safeErrorCodeForStatus(500)).toBe("SERVER_ERROR");
+  });
+});
+
+describe("logApiAccessTelemetry", () => {
+  it("emits only allowlisted fields and sanitizes requestId", () => {
+    const { events, restore } = captureInfoLogs();
+    try {
+      const event: ApiAccessTelemetryEvent = {
+        operation: "http_request_completed",
+        method: "GET",
+        routeTemplate: "/users/me/oura-readiness-range",
+        statusCode: 200,
+        durationMs: 12,
+        requestId: SENTINEL.unsafeRequestId,
+        authenticated: true,
+        matchedRoute: true,
+      };
+      logApiAccessTelemetry(event);
+      expect(events).toHaveLength(1);
+      const payload = events[0] as Record<string, unknown>;
+      assertApiAccessTelemetryPrivacy(payload);
+      expect(payload.operation).toBe("http_request_completed");
+      expect(payload.method).toBe("GET");
+      expect(payload.routeTemplate).toBe("/users/me/oura-readiness-range");
+      expect(payload.statusCode).toBe(200);
+      expect(payload.authenticated).toBe(true);
+      expect(payload.matchedRoute).toBe(true);
+      expect(typeof payload.requestId).toBe("string");
+      expect(payload.requestId).not.toBe(SENTINEL.unsafeRequestId);
+      const serialized = JSON.stringify(payload);
+      expect(serialized).not.toContain("SENTINEL");
+      expect(serialized).not.toContain(SENTINEL.uid);
+      expect(serialized).not.toContain(SENTINEL.start);
+      expect(serialized).not.toContain(SENTINEL.end);
+      expect(serialized).not.toContain("originalUrl");
+      expect(serialized).not.toContain("uid");
+    } finally {
+      restore();
+    }
+  });
+
+  it("retains a valid UUID requestId", () => {
+    const { events, restore } = captureInfoLogs();
+    try {
+      logApiAccessTelemetry({
+        operation: "http_request_completed",
+        method: "GET",
+        routeTemplate: "/health",
+        statusCode: 200,
+        durationMs: 1,
+        requestId: SAFE_REQUEST_ID,
+        authenticated: false,
+        matchedRoute: true,
+      });
+      expect((events[0] as { requestId: string }).requestId).toBe(SAFE_REQUEST_ID);
+      assertApiAccessTelemetryPrivacy(events[0]);
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe("buildApiAccessTelemetryEvent", () => {
+  it("sets authenticated from uid presence without logging uid", () => {
+    const req = {
+      method: "GET",
+      baseUrl: "/users/me",
+      route: { path: "/oura-stress" },
+      rid: SAFE_REQUEST_ID,
+      uid: SENTINEL.uid,
+      originalUrl: `/users/me/oura-stress?start=${SENTINEL.start}&end=${SENTINEL.end}`,
+      query: { start: SENTINEL.start, end: SENTINEL.end },
+    } as unknown as Parameters<typeof buildApiAccessTelemetryEvent>[0]["req"];
+
+    const event = buildApiAccessTelemetryEvent({
+      req,
+      statusCode: 200,
+      durationMs: 5,
+    });
+    expect(event.authenticated).toBe(true);
+    expect(event.routeTemplate).toBe("/users/me/oura-stress");
+    const serialized = JSON.stringify(event);
+    expect(serialized).not.toContain(SENTINEL.uid);
+    expect(serialized).not.toContain(SENTINEL.start);
+    assertApiAccessTelemetryPrivacy({
+      msg: "http_request_completed",
+      level: "info",
+      ...event,
+    });
+  });
+});
+
+async function listen(app: Express): Promise<{
+  baseUrl: string;
+  close: () => Promise<void>;
+}> {
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const addr = server.address() as AddressInfo;
+  return {
+    baseUrl: `http://127.0.0.1:${addr.port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      }),
+  };
+}
+
+describe("accessLogMiddleware integration", () => {
+  it("emits one privacy-safe event for authenticated range GET; strips sentinels", async () => {
+    const { events, restore } = captureInfoLogs();
+    const app = express();
+    app.use(requestIdMiddleware);
+    app.use(accessLogMiddleware);
+    app.use((req, _res, next) => {
+      (req as Request & { uid?: string }).uid = SENTINEL.uid;
+      next();
+    });
+    const router = express.Router();
+    router.get("/oura-stress", (_req, res) => {
+      res.status(200).json({ ok: true });
+    });
+    app.use("/users/me", router);
+
+    const { baseUrl, close } = await listen(app);
+    try {
+      const res = await fetch(
+        `${baseUrl}/users/me/oura-stress?start=${encodeURIComponent(SENTINEL.start)}&end=${encodeURIComponent(SENTINEL.end)}`,
+        {
+          headers: {
+            Authorization: SENTINEL.authorization,
+            "x-api-key": SENTINEL.apiKey,
+            "x-request-id": SENTINEL.unsafeRequestId,
+          },
+        },
+      );
+      expect(res.status).toBe(200);
+      // Response correlation may still echo the unsafe incoming id (HTTP behavior unchanged).
+      expect(res.headers.get("x-request-id")).toBe(SENTINEL.unsafeRequestId);
+
+      expect(events.length).toBe(1);
+      const payload = events[0] as Record<string, unknown>;
+      assertApiAccessTelemetryPrivacy(payload);
+      expect(payload.operation).toBe("http_request_completed");
+      expect(payload.method).toBe("GET");
+      expect(payload.routeTemplate).toBe("/users/me/oura-stress");
+      expect(payload.statusCode).toBe(200);
+      expect(payload.authenticated).toBe(true);
+      expect(payload.matchedRoute).toBe(true);
+      expect(payload.requestId).not.toBe(SENTINEL.unsafeRequestId);
+      const serialized = JSON.stringify(payload);
+      for (const bad of Object.values(SENTINEL)) {
+        expect(serialized).not.toContain(bad);
+      }
+      expect(serialized).not.toContain("uid");
+      expect(serialized).not.toContain("originalUrl");
+      expect(serialized).not.toContain("query");
+    } finally {
+      restore();
+      await close();
+    }
+  });
+
+  it.each([
+    [200, undefined],
+    [201, undefined],
+    [400, "CLIENT_ERROR"],
+    [401, "UNAUTHENTICATED"],
+    [404, "NOT_FOUND"],
+    [500, "SERVER_ERROR"],
+  ] as const)("status %s maps safeErrorCode %s", async (status, code) => {
+    const { events, restore } = captureInfoLogs();
+    const app = express();
+    app.use(accessLogMiddleware);
+    app.get("/health", (_req, res) => {
+      res.status(status).end();
+    });
+    const { baseUrl, close } = await listen(app);
+    try {
+      await fetch(`${baseUrl}/health`);
+      expect(events).toHaveLength(1);
+      const payload = events[0] as Record<string, unknown>;
+      assertApiAccessTelemetryPrivacy(payload);
+      expect(payload.statusCode).toBe(status);
+      if (code === undefined) {
+        expect(payload.safeErrorCode).toBeUndefined();
+      } else {
+        expect(payload.safeErrorCode).toBe(code);
+      }
+    } finally {
+      restore();
+      await close();
+    }
+  });
+
+  it("emits UNMATCHED_ROUTE for 404 without logging the raw path", async () => {
+    const { events, restore } = captureInfoLogs();
+    const app = express();
+    app.use(accessLogMiddleware);
+    app.use((_req, res) => {
+      res.status(404).json({ ok: false });
+    });
+    const { baseUrl, close } = await listen(app);
+    try {
+      await fetch(`${baseUrl}/secret-path-${SENTINEL.start}?start=${SENTINEL.start}`);
+      expect(events).toHaveLength(1);
+      const payload = events[0] as Record<string, unknown>;
+      assertApiAccessTelemetryPrivacy(payload);
+      expect(payload.routeTemplate).toBe(UNMATCHED_ROUTE_TEMPLATE);
+      expect(payload.matchedRoute).toBe(false);
+      expect(JSON.stringify(payload)).not.toContain(SENTINEL.start);
+      expect(JSON.stringify(payload)).not.toContain("secret-path");
+    } finally {
+      restore();
+      await close();
+    }
+  });
+
+  it("emits once when finish then close both fire", async () => {
+    const { events, restore } = captureInfoLogs();
+    const app = express();
+    app.use(accessLogMiddleware);
+    app.get("/once", (_req, res) => {
+      res.status(200).end();
+    });
+    const { baseUrl, close } = await listen(app);
+    try {
+      await fetch(`${baseUrl}/once`);
+      // Allow close event to settle
+      await new Promise((r) => setTimeout(r, 20));
+      expect(events).toHaveLength(1);
+    } finally {
+      restore();
+      await close();
+    }
+  });
+
+  it("logs OPTIONS with normalized method and matched template", async () => {
+    const { events, restore } = captureInfoLogs();
+    const app = express();
+    app.use(accessLogMiddleware);
+    app.options("/prefs", (_req, res) => {
+      res.status(204).end();
+    });
+    const { baseUrl, close } = await listen(app);
+    try {
+      const res = await fetch(`${baseUrl}/prefs`, { method: "OPTIONS" });
+      expect(res.status).toBe(204);
+      expect(events).toHaveLength(1);
+      const payload = events[0] as Record<string, unknown>;
+      assertApiAccessTelemetryPrivacy(payload);
+      expect(payload.method).toBe("OPTIONS");
+      expect(payload.routeTemplate).toBe("/prefs");
+    } finally {
+      restore();
+      await close();
+    }
+  });
+
+  it("preserves x-request-id header when a valid UUID is supplied", async () => {
+    const { events, restore } = captureInfoLogs();
+    const app = express();
+    app.use(requestIdMiddleware);
+    app.use(accessLogMiddleware);
+    app.get("/ok", (_req, res) => {
+      res.status(200).end();
+    });
+    const { baseUrl, close } = await listen(app);
+    try {
+      const res = await fetch(`${baseUrl}/ok`, {
+        headers: { "x-request-id": SAFE_REQUEST_ID },
+      });
+      expect(res.headers.get("x-request-id")).toBe(SAFE_REQUEST_ID);
+      expect((events[0] as { requestId: string }).requestId).toBe(SAFE_REQUEST_ID);
+    } finally {
+      restore();
+      await close();
+    }
+  });
+});
+
+describe("assertApiAccessTelemetryPrivacy", () => {
+  it("rejects forbidden keys and values", () => {
+    expect(() =>
+      assertApiAccessTelemetryPrivacy({
+        operation: "http_request_completed",
+        uid: "x",
+      }),
+    ).toThrow(/prohibited key/);
+
+    expect(() =>
+      assertApiAccessTelemetryPrivacy({
+        operation: "http_request_completed",
+        method: "GET",
+        routeTemplate: "/x",
+        statusCode: 200,
+        durationMs: 1,
+        requestId: SAFE_REQUEST_ID,
+        authenticated: false,
+        matchedRoute: true,
+        path: "/leak",
+      }),
+    ).toThrow(/prohibited key/);
+
+    expect(() =>
+      assertApiAccessTelemetryPrivacy({
+        msg: "http_request_completed",
+        operation: "http_request_completed",
+        method: "GET",
+        routeTemplate: "/x",
+        statusCode: 200,
+        durationMs: 1,
+        requestId: "not-uuid",
+        authenticated: false,
+        matchedRoute: true,
+      }),
+    ).toThrow(/strict UUID/);
+  });
+});

--- a/services/api/src/lib/__tests__/apiAccessTelemetrySourceGuard.test.ts
+++ b/services/api/src/lib/__tests__/apiAccessTelemetrySourceGuard.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Source guard: generic API access-log production files must not call
+ * logger.info/warn/error or console.log/warn/error directly. Logging must go
+ * through `logApiAccessTelemetry` / `buildApiAccessTelemetryEvent`.
+ *
+ * Scoped to access-log files only — not a repository-wide logger prohibition.
+ */
+import fs from "fs";
+import path from "path";
+
+const REPO_ROOT = path.resolve(__dirname, "../../../../..");
+
+/** Production access-log files that MUST route logging through the typed helper. */
+const GUARDED_FILES: string[] = [
+  "services/api/src/middleware/accessLogMiddleware.ts",
+];
+
+const DIRECT_LOGGER_CALL_REGEX = /\blogger\.(info|warn|error)\s*\(/;
+const DIRECT_CONSOLE_CALL_REGEX = /\bconsole\.(log|warn|error)\s*\(/;
+
+describe("API access-log source guard", () => {
+  for (const relPath of GUARDED_FILES) {
+    it(`${relPath} has no direct logger.*/console.* calls`, () => {
+      const absPath = path.join(REPO_ROOT, relPath);
+      expect(fs.existsSync(absPath)).toBe(true);
+      const source = fs.readFileSync(absPath, "utf8");
+
+      const loggerMatches = source.match(new RegExp(DIRECT_LOGGER_CALL_REGEX, "g")) ?? [];
+      const consoleMatches = source.match(new RegExp(DIRECT_CONSOLE_CALL_REGEX, "g")) ?? [];
+
+      expect({ file: relPath, loggerCalls: loggerMatches, consoleCalls: consoleMatches }).toEqual({
+        file: relPath,
+        loggerCalls: [],
+        consoleCalls: [],
+      });
+    });
+  }
+
+  it("access middleware routes through logApiAccessTelemetry", () => {
+    const absPath = path.join(REPO_ROOT, GUARDED_FILES[0]!);
+    const source = fs.readFileSync(absPath, "utf8");
+    expect(source.includes("logApiAccessTelemetry")).toBe(true);
+    expect(source.includes("buildApiAccessTelemetryEvent")).toBe(true);
+    expect(source.includes("originalUrl")).toBe(false);
+    expect(source.includes("req.query")).toBe(false);
+    expect(source.includes("req.uid")).toBe(false);
+    expect(/\buid\s*:/.test(source)).toBe(false);
+  });
+
+  it("typed helper is the sole logger.info call site for access telemetry", () => {
+    const absPath = path.join(REPO_ROOT, "services/api/src/lib/apiAccessTelemetry.ts");
+    expect(fs.existsSync(absPath)).toBe(true);
+    const source = fs.readFileSync(absPath, "utf8");
+    expect(source.includes("logger.info")).toBe(true);
+    expect(source.includes("http_request_completed")).toBe(true);
+    // Helper must not accept free-form spreads from req/res
+    expect(source.includes("...req")).toBe(false);
+    expect(source.includes("...res")).toBe(false);
+  });
+});

--- a/services/api/src/lib/apiAccessTelemetry.ts
+++ b/services/api/src/lib/apiAccessTelemetry.ts
@@ -1,0 +1,275 @@
+/**
+ * Privacy-safe telemetry for generic API HTTP access logging.
+ *
+ * Design goal: every access-log emission goes through `logApiAccessTelemetry`
+ * with a closed set of typed, aggregate-only fields. No uid, email, raw URL,
+ * query names/values, headers, bodies, or concrete path parameters are accepted.
+ */
+
+import { randomUUID } from "crypto";
+import type { Request } from "express";
+
+import { logger } from "./logger";
+
+/**
+ * Strict opaque request-trace ID for access telemetry.
+ * Accepts only RFC UUID form (36 chars). Anything else is discarded and replaced
+ * with a new server-generated UUID. Never hashes, truncates, or encodes unsafe input.
+ * Does not change HTTP `x-request-id` response correlation.
+ */
+const ACCESS_TELEMETRY_REQUEST_ID_UUID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const ACCESS_TELEMETRY_REQUEST_ID_MAX_LEN = 36;
+
+export function sanitizeApiAccessTelemetryRequestId(candidate: unknown): string {
+  if (typeof candidate !== "string") return randomUUID();
+  const trimmed = candidate.trim();
+  if (trimmed.length === 0 || trimmed.length > ACCESS_TELEMETRY_REQUEST_ID_MAX_LEN) {
+    return randomUUID();
+  }
+  if (!ACCESS_TELEMETRY_REQUEST_ID_UUID.test(trimmed)) {
+    return randomUUID();
+  }
+  return trimmed;
+}
+
+export type ApiAccessHttpMethod =
+  | "GET"
+  | "POST"
+  | "PUT"
+  | "PATCH"
+  | "DELETE"
+  | "OPTIONS"
+  | "HEAD"
+  | "OTHER";
+
+const KNOWN_METHODS: ReadonlySet<string> = new Set([
+  "GET",
+  "POST",
+  "PUT",
+  "PATCH",
+  "DELETE",
+  "OPTIONS",
+  "HEAD",
+]);
+
+export function normalizeApiAccessMethod(method: unknown): ApiAccessHttpMethod {
+  if (typeof method !== "string") return "OTHER";
+  const upper = method.trim().toUpperCase();
+  if (KNOWN_METHODS.has(upper)) return upper as ApiAccessHttpMethod;
+  return "OTHER";
+}
+
+/** Closed operational error codes for access telemetry (optional). */
+export type ApiAccessSafeErrorCode =
+  | "CLIENT_ERROR"
+  | "UNAUTHENTICATED"
+  | "FORBIDDEN"
+  | "NOT_FOUND"
+  | "CONFLICT"
+  | "RATE_LIMITED"
+  | "SERVER_ERROR"
+  | "UNKNOWN";
+
+const SAFE_ERROR_CODES: ReadonlySet<string> = new Set([
+  "CLIENT_ERROR",
+  "UNAUTHENTICATED",
+  "FORBIDDEN",
+  "NOT_FOUND",
+  "CONFLICT",
+  "RATE_LIMITED",
+  "SERVER_ERROR",
+  "UNKNOWN",
+]);
+
+function isApiAccessSafeErrorCode(v: unknown): v is ApiAccessSafeErrorCode {
+  return typeof v === "string" && SAFE_ERROR_CODES.has(v);
+}
+
+export function safeErrorCodeForStatus(statusCode: number): ApiAccessSafeErrorCode | undefined {
+  if (!Number.isFinite(statusCode) || statusCode < 400) return undefined;
+  if (statusCode === 401) return "UNAUTHENTICATED";
+  if (statusCode === 403) return "FORBIDDEN";
+  if (statusCode === 404) return "NOT_FOUND";
+  if (statusCode === 409) return "CONFLICT";
+  if (statusCode === 429) return "RATE_LIMITED";
+  if (statusCode >= 500) return "SERVER_ERROR";
+  if (statusCode >= 400) return "CLIENT_ERROR";
+  return "UNKNOWN";
+}
+
+export const UNMATCHED_ROUTE_TEMPLATE = "UNMATCHED_ROUTE";
+export const MATCHED_ROUTE_FALLBACK_TEMPLATE = "MATCHED_ROUTE";
+
+/**
+ * Reject derived route-template candidates that look like concrete identifiers,
+ * query strings, tokens, or dates. Fall back to MATCHED_ROUTE when unsafe.
+ */
+const UNSAFE_ROUTE_TEMPLATE_PATTERNS: readonly RegExp[] = [
+  /[?#@]/,
+  /Bearer\s/i,
+  /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\./, // JWT-like
+  /\d{4}-\d{2}-\d{2}/, // YYYY-MM-DD or ISO date fragment
+  /%/, // encoded path values
+  /\/users\/(?!me(?:\/|$))[A-Za-z0-9_]{20,}/i, // concrete user path, not /users/me
+];
+
+export function isTrustedRouteTemplate(candidate: string): boolean {
+  if (typeof candidate !== "string") return false;
+  const trimmed = candidate.trim();
+  if (trimmed.length === 0 || trimmed.length > 256) return false;
+  if (trimmed !== UNMATCHED_ROUTE_TEMPLATE && trimmed !== MATCHED_ROUTE_FALLBACK_TEMPLATE) {
+    if (!trimmed.startsWith("/")) return false;
+  }
+  for (const pattern of UNSAFE_ROUTE_TEMPLATE_PATTERNS) {
+    if (pattern.test(trimmed)) return false;
+  }
+  return true;
+}
+
+function joinBaseAndRoutePath(baseUrl: string, routePath: string): string {
+  const base = baseUrl.trim();
+  const path = routePath.trim();
+  if (path === "" || path === "/") {
+    if (base === "" || base === "/") return "/";
+    return base.replace(/\/{2,}/g, "/") || "/";
+  }
+  if (base === "" || base === "/") {
+    return (path.startsWith("/") ? path : `/${path}`).replace(/\/{2,}/g, "/");
+  }
+  const left = base.endsWith("/") ? base.slice(0, -1) : base;
+  const right = path.startsWith("/") ? path : `/${path}`;
+  return `${left}${right}`.replace(/\/{2,}/g, "/");
+}
+
+export type RouteTemplateResolution = {
+  routeTemplate: string;
+  matchedRoute: boolean;
+};
+
+/**
+ * Derive a server-owned route template after Express routing when possible.
+ * Never falls back to raw URL / originalUrl / query.
+ */
+export function resolveApiAccessRouteTemplate(req: Request): RouteTemplateResolution {
+  const route = (req as Request & { route?: { path?: unknown } }).route;
+  if (!route) {
+    return { routeTemplate: UNMATCHED_ROUTE_TEMPLATE, matchedRoute: false };
+  }
+
+  const routePath = route.path;
+  if (typeof routePath !== "string") {
+    // RegExp, array, or other unsafe metadata
+    return { routeTemplate: MATCHED_ROUTE_FALLBACK_TEMPLATE, matchedRoute: true };
+  }
+
+  const baseUrl = typeof req.baseUrl === "string" ? req.baseUrl : "";
+  const joined = joinBaseAndRoutePath(baseUrl, routePath);
+  if (!isTrustedRouteTemplate(joined)) {
+    return { routeTemplate: MATCHED_ROUTE_FALLBACK_TEMPLATE, matchedRoute: true };
+  }
+  return { routeTemplate: joined, matchedRoute: true };
+}
+
+export type ApiAccessTelemetryEvent = {
+  operation: "http_request_completed";
+  method: ApiAccessHttpMethod;
+  routeTemplate: string;
+  statusCode: number;
+  durationMs: number;
+  requestId: string;
+  authenticated: boolean;
+  matchedRoute: boolean;
+  safeErrorCode?: ApiAccessSafeErrorCode;
+};
+
+function isFiniteNonNegativeInt(n: unknown): n is number {
+  return typeof n === "number" && Number.isFinite(n) && n >= 0;
+}
+
+/**
+ * Log one generic API access-completion event. Only the event's typed fields are
+ * emitted — requestId is always re-sanitized; routeTemplate is re-validated.
+ */
+export function logApiAccessTelemetry(event: ApiAccessTelemetryEvent): void {
+  const method = normalizeApiAccessMethod(event.method);
+  const statusCode = isFiniteNonNegativeInt(event.statusCode)
+    ? Math.round(event.statusCode)
+    : 0;
+  const durationMs = isFiniteNonNegativeInt(event.durationMs)
+    ? Math.round(event.durationMs)
+    : 0;
+  const requestId = sanitizeApiAccessTelemetryRequestId(event.requestId);
+
+  let routeTemplate = event.routeTemplate;
+  if (!isTrustedRouteTemplate(routeTemplate)) {
+    routeTemplate = event.matchedRoute
+      ? MATCHED_ROUTE_FALLBACK_TEMPLATE
+      : UNMATCHED_ROUTE_TEMPLATE;
+  }
+
+  const payload: {
+    msg: "http_request_completed";
+    operation: "http_request_completed";
+    method: ApiAccessHttpMethod;
+    routeTemplate: string;
+    statusCode: number;
+    durationMs: number;
+    requestId: string;
+    authenticated: boolean;
+    matchedRoute: boolean;
+    safeErrorCode?: ApiAccessSafeErrorCode;
+  } = {
+    msg: "http_request_completed",
+    operation: "http_request_completed",
+    method,
+    routeTemplate,
+    statusCode,
+    durationMs,
+    requestId,
+    authenticated: event.authenticated === true,
+    matchedRoute: event.matchedRoute === true,
+  };
+
+  if (event.safeErrorCode !== undefined && isApiAccessSafeErrorCode(event.safeErrorCode)) {
+    payload.safeErrorCode = event.safeErrorCode;
+  } else {
+    const derived = safeErrorCodeForStatus(statusCode);
+    if (derived) payload.safeErrorCode = derived;
+  }
+
+  logger.info(payload);
+}
+
+export type AccessLogRequestLike = Request & {
+  rid?: string;
+  uid?: string;
+};
+
+/**
+ * Build a privacy-safe access telemetry event from an Express request/response pair.
+ * Does not read headers, query, body, or raw URL.
+ */
+export function buildApiAccessTelemetryEvent(args: {
+  req: AccessLogRequestLike;
+  statusCode: number;
+  durationMs: number;
+}): ApiAccessTelemetryEvent {
+  const { req, statusCode, durationMs } = args;
+  const { routeTemplate, matchedRoute } = resolveApiAccessRouteTemplate(req);
+  const authenticated = typeof req.uid === "string" && req.uid.length > 0;
+  const event: ApiAccessTelemetryEvent = {
+    operation: "http_request_completed",
+    method: normalizeApiAccessMethod(req.method),
+    routeTemplate,
+    statusCode,
+    durationMs,
+    requestId: sanitizeApiAccessTelemetryRequestId(req.rid),
+    authenticated,
+    matchedRoute,
+  };
+  const code = safeErrorCodeForStatus(statusCode);
+  if (code) event.safeErrorCode = code;
+  return event;
+}

--- a/services/api/src/lib/logger.ts
+++ b/services/api/src/lib/logger.ts
@@ -12,32 +12,12 @@ export const logger = {
 
 export type RequestWithRid = Request & { rid?: string };
 
-const SECRET_QUERY_KEYS = ["key", "token", "access_token", "id_token", "refresh_token"];
-
-/**
- * Returns path + query string with secret query param values redacted for logs.
- */
-function sanitizePathForLogs(originalUrl: string): string {
-  try {
-    const q = originalUrl.indexOf("?");
-    if (q === -1) return originalUrl;
-    const pathPart = originalUrl.slice(0, q);
-    const search = originalUrl.slice(q + 1);
-    const params = new URLSearchParams(search);
-    const redacted = new URLSearchParams();
-    for (const [k, v] of params) {
-      redacted.set(k, SECRET_QUERY_KEYS.includes(k) ? "[REDACTED]" : v);
-    }
-    const newSearch = redacted.toString();
-    return newSearch ? `${pathPart}?${newSearch}` : pathPart;
-  } catch {
-    return originalUrl.replace(/key=[^&]*/g, "key=[REDACTED]");
-  }
-}
-
 /**
  * Ensures every request has a request id AND every response echoes it as `x-request-id`.
  * Mobile sends `x-request-id` so Cloud Run logs can be correlated in <60 seconds.
+ *
+ * Note: access-log telemetry may replace a non-UUID request id with a fresh UUID for
+ * logging only — HTTP response correlation still uses this `rid` / header value.
  */
 export function requestIdMiddleware(req: Request, res: Response, next: NextFunction) {
   const incoming = req.header("x-request-id");
@@ -46,28 +26,5 @@ export function requestIdMiddleware(req: Request, res: Response, next: NextFunct
   (req as RequestWithRid).rid = rid;
   res.setHeader("x-request-id", rid);
 
-  next();
-}
-
-/**
- * Structured access logging (Cloud Run friendly).
- * Emits one JSON line per request on finish.
- */
-export function accessLogMiddleware(req: Request, res: Response, next: NextFunction) {
-  const start = Date.now();
-  res.on("finish", () => {
-    const ms = Date.now() - start;
-    const withRid = req as RequestWithRid & { uid?: string };
-
-    logger.info({
-      msg: "request",
-      rid: withRid.rid ?? null,
-      method: req.method,
-      path: sanitizePathForLogs(req.originalUrl),
-      status: res.statusCode,
-      ms,
-      uid: withRid.uid ?? null,
-    });
-  });
   next();
 }

--- a/services/api/src/lib/testSupport/assertApiAccessTelemetryPrivacy.ts
+++ b/services/api/src/lib/testSupport/assertApiAccessTelemetryPrivacy.ts
@@ -1,0 +1,174 @@
+/**
+ * Recursive assertion helper for generic API access-log telemetry privacy tests.
+ * Synthetic data only — never print real UIDs, tokens, dates, or URLs.
+ */
+
+/** Exact-match prohibited keys — never allowed anywhere in an access telemetry payload. */
+export const PROHIBITED_API_ACCESS_TELEMETRY_KEYS: readonly string[] = [
+  "uid",
+  "userId",
+  "email",
+  "sub",
+  "ip",
+  "remoteAddress",
+  "forwardedFor",
+  "userAgent",
+  "referrer",
+  "authorization",
+  "cookie",
+  "token",
+  "apiKey",
+  "idempotencyKey",
+  "url",
+  "originalUrl",
+  "rawUrl",
+  "path",
+  "query",
+  "start",
+  "end",
+  "day",
+  "date",
+  "timestamp",
+  "cursor",
+  "providerId",
+  "documentId",
+  "rawEventId",
+  "workoutId",
+  "requestBody",
+  "responseBody",
+  "payload",
+  "response",
+  "error",
+  "errorMessage",
+  "stack",
+  "rid",
+  "ms",
+  "status",
+];
+
+const PROHIBITED_KEY_SET = new Set(
+  PROHIBITED_API_ACCESS_TELEMETRY_KEYS.map((k) => k.toLowerCase()),
+);
+
+const ALLOWED_KEYS = new Set([
+  "msg",
+  "level",
+  "operation",
+  "method",
+  "routetemplate",
+  "statuscode",
+  "durationms",
+  "requestid",
+  "authenticated",
+  "matchedroute",
+  "safeerrorcode",
+]);
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const PROHIBITED_VALUE_PATTERNS: RegExp[] = [
+  /^\d{4}-\d{2}-\d{2}$/,
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/,
+  /Bearer\s/i,
+  /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\./,
+  /AIza/,
+  /\/users\/(?!me(?:\/|$))[A-Za-z0-9_]{20,}/i, // concrete user path, not /users/me templates
+  /[?&](start|end|key|token)=/i,
+  /idempotency-/i,
+  /https?:\/\//i,
+];
+
+export type ApiAccessPrivacyViolation = {
+  path: string;
+  reason: string;
+};
+
+export function findApiAccessTelemetryPrivacyViolations(
+  value: unknown,
+  path = "$",
+): ApiAccessPrivacyViolation[] {
+  const violations: ApiAccessPrivacyViolation[] = [];
+
+  const visit = (node: unknown, nodePath: string): void => {
+    if (node === null || node === undefined) return;
+
+    if (typeof node === "string") {
+      for (const pattern of PROHIBITED_VALUE_PATTERNS) {
+        if (pattern.test(node)) {
+          violations.push({
+            path: nodePath,
+            reason: `value matches prohibited pattern ${pattern}`,
+          });
+          break;
+        }
+      }
+      return;
+    }
+
+    if (Array.isArray(node)) {
+      node.forEach((item, i) => visit(item, `${nodePath}[${i}]`));
+      return;
+    }
+
+    if (typeof node === "object") {
+      for (const [key, v] of Object.entries(node as Record<string, unknown>)) {
+        const lower = key.toLowerCase();
+        if (PROHIBITED_KEY_SET.has(lower)) {
+          violations.push({
+            path: `${nodePath}.${key}`,
+            reason: `prohibited key "${key}"`,
+          });
+          continue;
+        }
+        if (nodePath === "$" && !ALLOWED_KEYS.has(lower)) {
+          violations.push({
+            path: `${nodePath}.${key}`,
+            reason: `unexpected access-telemetry key "${key}"`,
+          });
+          continue;
+        }
+        if (lower === "requestid") {
+          if (typeof v !== "string" || !UUID_RE.test(v)) {
+            violations.push({
+              path: `${nodePath}.${key}`,
+              reason: "requestId must be a strict UUID",
+            });
+            continue;
+          }
+        }
+        if (lower === "routetemplate") {
+          if (typeof v !== "string") {
+            violations.push({
+              path: `${nodePath}.${key}`,
+              reason: "routeTemplate must be a string",
+            });
+            continue;
+          }
+          // Trusted templates may include :param names; still reject query/date/token shapes.
+          for (const pattern of PROHIBITED_VALUE_PATTERNS) {
+            if (pattern.test(v)) {
+              violations.push({
+                path: `${nodePath}.${key}`,
+                reason: `routeTemplate matches prohibited pattern ${pattern}`,
+              });
+              break;
+            }
+          }
+        }
+        visit(v, `${nodePath}.${key}`);
+      }
+    }
+  };
+
+  visit(value, path);
+  return violations;
+}
+
+export function assertApiAccessTelemetryPrivacy(value: unknown): void {
+  const violations = findApiAccessTelemetryPrivacyViolations(value);
+  if (violations.length > 0) {
+    const details = violations.map((v) => `  - ${v.path}: ${v.reason}`).join("\n");
+    throw new Error(`API access telemetry privacy violation(s) found:\n${details}`);
+  }
+}

--- a/services/api/src/middleware/accessLogMiddleware.ts
+++ b/services/api/src/middleware/accessLogMiddleware.ts
@@ -1,0 +1,36 @@
+/**
+ * Privacy-safe generic API access-log middleware.
+ *
+ * Emits exactly one typed completion event via `logApiAccessTelemetry`.
+ * Never logs uid, raw URL, query values, headers, or bodies.
+ */
+
+import type { NextFunction, Request, Response } from "express";
+
+import {
+  buildApiAccessTelemetryEvent,
+  logApiAccessTelemetry,
+  type AccessLogRequestLike,
+} from "../lib/apiAccessTelemetry";
+
+export function accessLogMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const startedAtMs = Date.now();
+  let emitted = false;
+
+  const emitOnce = (): void => {
+    if (emitted) return;
+    emitted = true;
+    const durationMs = Math.max(0, Math.round(Date.now() - startedAtMs));
+    logApiAccessTelemetry(
+      buildApiAccessTelemetryEvent({
+        req: req as AccessLogRequestLike,
+        statusCode: res.statusCode,
+        durationMs,
+      }),
+    );
+  };
+
+  res.on("finish", emitOnce);
+  res.on("close", emitOnce);
+  next();
+}


### PR DESCRIPTION
## Dependency

This is a draft stacked privacy repair on top of Weekly Fitness v2 PR #183.

```text
main
└── PR #180
    └── PR #182
        └── PR #183 — Weekly Fitness v2
            └── this PR — generic API access-log privacy
```

Base:

```text
feat/weekly-fitness-v2
```

This PR must be reviewed and merged into the Weekly Fitness feature branch
before a new API artifact is built.

## Summary

Replaces the generic API application access logger with a typed,
privacy-safe request-completion telemetry boundary.

The application logger no longer emits:

- authenticated UID or user claims
- raw URL
- original URL
- raw request path
- query names or values
- `start`, `end`, `day`, or date parameters
- concrete route identifiers
- IP addresses
- request headers
- tokens or keys
- request or response bodies
- raw errors or stacks

## Final application access-log contract

Allowed fields:

```text
operation
method
routeTemplate
statusCode
durationMs
requestId
authenticated
matchedRoute
optional safeErrorCode
```

The event is:

```text
http_request_completed
```

## Trusted route templates

The logger uses server-owned route metadata.

Examples:

```text
/users/me/oura-stress
/users/me/oura-readiness-range
/users/me/sleep-nights
```

It never falls back to a raw URL or query-bearing path.

Unmatched requests use:

```text
UNMATCHED_ROUTE
```

Unsafe or malformed route metadata uses:

```text
MATCHED_ROUTE
```

Declared route parameters remain templates, such as:

```text
/ingest/:rawEventId
```

Concrete IDs are never logged.

## Request-ID privacy

Access telemetry accepts only a strict UUID.

Unsafe request IDs are replaced with `randomUUID()` for telemetry.

The existing HTTP response correlation header behavior remains unchanged.

This repair does not claim to globally redesign request-ID handling outside
the API access telemetry path.

## Reliability

The middleware emits one completion event only.

Tests cover:

- response finish
- response close
- finish/close double-event protection
- 2xx
- 4xx
- 5xx
- OPTIONS
- matched routes
- nested routes
- dynamic route templates
- unmatched routes

## Functional parity

Unchanged:

- route registration
- authentication
- UID-scoped data access
- query parsing and validation
- DTOs
- HTTP status behavior
- idempotency
- Oura behavior
- persistence
- OpenAPI
- Gateway contracts
- Weekly Fitness behavior
- mobile behavior

The only intended behavior change is application access telemetry content.

## Function impact

No Function source or shared contract changed.

The deployed Function `onourapostrawrequested-00054-sen` remains
release-eligible only because package-relevant output is byte-equivalent.

## API artifact impact

The previous zero-traffic API preflight artifact is superseded:

```text
revision:
oli-api-00232-yow

digest:
sha256:22b95775f62e0ea3a6122254b6892425afb2d3124d654f423c3db57bd4f8098a
```

A new immutable API image and zero-traffic preflight are required after this
PR is merged into `feat/weekly-fitness-v2`.

## Gateway impact

OpenAPI is unchanged.

The existing unattached config remains contract-compatible:

```text
oli-api-config-weekly-fitness-8788c52-20260712-201806
```

No Gateway action occurred.

## Important remaining infrastructure risk

This PR repairs the application logger only.

Cloud Run platform-generated request logs may still store query-bearing
request URLs.

This PR does not claim that Cloud Run platform request logging is privacy-safe.

Final traffic cutover remains blocked pending a separate, explicit platform
logging decision.

Potential follow-up categories include:

- a Cloud Logging exclusion for the service request logs;
- retention and access-policy controls;
- moving health-range values out of request URLs;
- another approved infrastructure control.

## Validation

Local gate:

- `npm ci`
- typecheck
- lint
- client trust boundary
- invariants
- full Jest suite
- API build
- Functions build
- bundle checksum
- iOS Expo export
- access-logger capture tests
- route-template tests
- request-ID sanitation tests
- source guards
- privacy assertions
- ownership and range-route tests

Expo Doctor retains only the same five documented pre-existing findings.

## Out of scope

This PR does not address separate mobile/runtime debt, including:

- Workout debug telemetry
- Energy audit telemetry
- Apple Health telemetry
- repeated Weekly Fitness Sleep logging
- year-scale Activity loading
- year-scale Workout hydration
- sleep-day-refresh HTTP 500

No deployment, traffic movement, Gateway attachment, refresh, backfill,
Firestore mutation, or mobile release was performed.
