### PR TITLE
chore(infra): protect Oli request logs from sensitive URL storage

### DIFF
--- a/docs/audits/2026-07-12-platform-request-log-privacy-control.md
+++ b/docs/audits/2026-07-12-platform-request-log-privacy-control.md
@@ -1,0 +1,132 @@
+# Platform Request-Log Privacy Control Audit
+
+**Date:** 2026-07-12
+**Base feature SHA:** `77e4f46fea8f70adb8a2769ffc8316ad4b2d9daa`
+**Base feature tree:** `28cd12a0e56c7c08ad1c6930eac40a4e64b0cde8`
+**Platform branch:** `fix/pr183-platform-request-log-privacy`
+**Platform worktree:** `/Users/danielhendel/oli-platform-request-log-privacy`
+**Safety ref:** `safety/weekly-fitness-before-platform-log-control-77e4f46` (local only)
+
+This audit is privacy-safe. It contains no UIDs, emails, IPs, tokens, keys,
+exact health dates, query values, raw URLs, response bodies, or raw logs.
+
+---
+
+## 1. Live sink inventory (pre-apply)
+
+| Sink | Role | Retention (verified earlier / rechecked) | Stores affected request logs? |
+|---|---|---|---|
+| `_Default` | project application / request logs | 30 days | yes (pre-exclusion) |
+| `_Required` | audit-only | 400 days | no |
+
+Folder/organization sinks: none observed for the authorized account and
+current resource hierarchy.
+
+No Terraform ownership of `_Default` exists in-repo. Source owner for this
+release is the reviewed management script under `scripts/deploy/logging/`.
+
+---
+
+## 2. Affected log classes
+
+| Class | Log ID | Resource scope |
+|---|---|---|
+| Cloud Run automatic request logs | `run.googleapis.com/requests` | `cloud_run_revision` + `service_name=oli-api` + `location=us-central1` |
+| API Gateway request logs | `apigateway.googleapis.com/requests` | `apigateway.googleapis.com/Gateway` + `gateway_id=oli-gateway` + `location=us-central1` |
+| Managed-service endpoints log | `oli-api-0drj1f1cbrv7k.apigateway.oli-staging-fdbba.cloud.goog/endpoints_log` | `resource.type=api` + exact managed service label |
+| Legacy generic app access event | `run.googleapis.com/stdout` (app payload) | `oli-api` + `jsonPayload.msg="request"` |
+
+Resource-label scoping derived from live metadata-only samples. Unscoped
+`LOG_ID("apigateway.googleapis.com/requests")` alone is rejected.
+
+---
+
+## 3. Exclusion specification
+
+- **Name:** `oli_api_request_metadata_privacy_v1`
+- **Clause count:** 4
+- **Normalized filter SHA-256:**
+  `87f8c63c9889d5f094a5ad299355762a33773a147f35aca9802b895768983fa0`
+
+### Legacy event decision
+
+Include transitional exclusion for `jsonPayload.msg="request"` on `oli-api`
+only. Live samples: emitted by `oli-api` stdout; no other services observed
+with the same identifying fields in a 7-day window. Do **not** exclude
+`jsonPayload.operation="http_request_completed"`.
+
+---
+
+## 4. Observability dependency result
+
+| Dependency class | Result |
+|---|---|
+| Dashboards on request logs | none found |
+| Alerts on request logs | none found |
+| Log-based metrics on request logs | none found |
+| Cloud Run request-count metrics | available independently |
+| Cloud Run latency metrics | available independently |
+| Privacy-safe app telemetry after corrected API deploy | sufficient for route-level ops |
+
+---
+
+## 5. Existing-log age / retention
+
+- Affected bucket: `_Default`
+- Retention: 30 days
+- Selective deletion: **not performed** (not authorized)
+- Retroactive deletion: **no**
+- Approach: allow existing entries to expire under retention; maintain
+  least-privilege logging access
+
+---
+
+## 6. Source-control owner / apply-rollback plan
+
+| Action | Mechanism |
+|---|---|
+| Plan | backup + filter hash + intended action |
+| Apply | `--add-exclusion` only |
+| Verify | destination / inclusion filter / prior exclusions / `_Required` |
+| Rollback | `--remove-exclusions=oli_api_request_metadata_privacy_v1` |
+
+Never: `--clear-exclusions`, destination change, inclusion-filter replace,
+sink disable, `_Required` mutation, retention/IAM change.
+
+---
+
+## 7. Verification plan
+
+1. Pre-change sink backup (mode 600) + SHA-256.
+2. Count-only candidate-filter scope checks before apply.
+3. Apply + verify intended-only change.
+4. Synthetic non-user probes (Cloud Run, Gateway, legacy event surface).
+5. Bounded wait ≤10 minutes; require 0 stored marker matches on excluded
+   surfaces after apply time.
+6. Confirm unrelated / Function logs still route; Cloud Monitoring request
+   metrics remain available.
+7. Confirm future safe `http_request_completed` is not matched by the
+   exclusion filter (retained when emitted).
+
+---
+
+## 8. Long-term follow-ups (not in this task)
+
+- Gateway key transport: move query key to `x-api-key` or remove after proof.
+- Health-range transport: move day/range criteria off GET query params where
+  architecture permits.
+- Evaluate formal Terraform ownership of logging sinks in a later platform
+  sprint (do not import `_Default` during feature stabilization).
+- Remaining mobile Workout/Energy/Apple Health telemetry debt remains outside
+  this control.
+
+---
+
+## 9. Runtime impact of this change set
+
+- No API / Function / OpenAPI / mobile runtime source changes.
+- No backend image build, Cloud Run deploy, Function deploy, traffic shift,
+  or Gateway attachment in this control.
+- Function `onourapostrawrequested-00054-sen` remains release-eligible.
+- Corrected API access-log runtime still requires a later immutable image
+  build from the final feature head.

--- a/docs/runbooks/oli-api-request-log-privacy.md
+++ b/docs/runbooks/oli-api-request-log-privacy.md
@@ -1,0 +1,213 @@
+# Runbook: Oli API / Gateway request-log privacy control
+
+## Purpose
+
+Prevent future storage in the staging project `_Default` log bucket of
+platform-generated and legacy application request records that may contain
+health-range query values, exact health-day query values, Gateway consumer
+keys, raw request URLs, concrete request identifiers, or authenticated-user
+identifiers from the legacy access logger.
+
+## Privacy threat
+
+Cloud Run automatic request logs, API Gateway request logs, and the managed
+API Gateway endpoints log store request URLs that can include query values.
+The still-serving pre-repair API revision also emits a legacy generic
+application access event (`jsonPayload.msg="request"`) with prohibited
+request metadata. Application source for the corrected
+`http_request_completed` event is already merged, but is not yet deployed.
+
+## Exact source owner
+
+- Management script:
+  `scripts/deploy/logging/manage-oli-api-request-log-privacy.sh`
+- Filter specification:
+  `scripts/deploy/logging/oli-api-request-log-privacy.filter`
+- Constants:
+  `scripts/deploy/logging/oli-api-request-log-privacy.constants.sh`
+- Tests:
+  `scripts/deploy/logging/__tests__/manage-oli-api-request-log-privacy.test.ts`
+
+Terraform does **not** own `_Default` for this release. Do not import the
+system-created sink during feature stabilization.
+
+## Exact project
+
+```text
+oli-staging-fdbba
+```
+
+## Exact sink
+
+```text
+_Default
+```
+
+## Exclusion name
+
+```text
+oli_api_request_metadata_privacy_v1
+```
+
+## Privacy-safe filter explanation
+
+One atomic exclusion with four narrowly scoped OR clauses:
+
+1. Cloud Run automatic request logs for service `oli-api` in `us-central1`
+   (`LOG_ID("run.googleapis.com/requests")`).
+2. API Gateway automatic request logs for gateway `oli-gateway` in
+   `us-central1` (`LOG_ID("apigateway.googleapis.com/requests")`).
+3. Managed-service endpoints log for the Oli staging API managed service
+   (`…/endpoints_log`) scoped by `resource.type="api"` and the exact service
+   label.
+4. Transitional legacy application access event on `oli-api` only:
+   `jsonPayload.msg="request"`.
+
+Unrelated Cloud Run services, unrelated gateways, and the corrected
+`http_request_completed` application telemetry are **not** excluded.
+
+## Explicit guarantees
+
+```text
+Exclusions are forward-looking routing/storage controls.
+They do not retroactively delete already stored entries.
+```
+
+```text
+_Required is not modified.
+```
+
+```text
+Application http_request_completed telemetry remains stored.
+```
+
+## Pre-change backup
+
+Create a mode-700 directory outside the repository, then run `plan` (or let
+`apply` create the backup):
+
+```bash
+set +x
+umask 077
+SINK_BACKUP_DIR="$(mktemp -d)"
+chmod 700 "$SINK_BACKUP_DIR"
+
+scripts/deploy/logging/manage-oli-api-request-log-privacy.sh \
+  plan \
+  --project oli-staging-fdbba \
+  --backup-dir "$SINK_BACKUP_DIR"
+```
+
+The script writes mode-600 `_Default.pre.json` / `_Required.pre.json` and
+SHA-256 sidecars. Preserve the backup until final backend cutover verification
+completes. Do not commit it.
+
+## Apply command
+
+```bash
+scripts/deploy/logging/manage-oli-api-request-log-privacy.sh \
+  apply \
+  --project oli-staging-fdbba \
+  --backup-dir "$SINK_BACKUP_DIR"
+```
+
+Uses `--add-exclusion` only. Never `--clear-exclusions`. Never replaces the
+sink destination or inclusion filter. Never disables the sink.
+
+## Verification
+
+```bash
+scripts/deploy/logging/manage-oli-api-request-log-privacy.sh \
+  verify \
+  --project oli-staging-fdbba \
+  --backup-dir "$SINK_BACKUP_DIR"
+```
+
+Confirm destination, inclusion filter, writer identity, disabled state, and
+prior exclusions are unchanged; exactly the intended exclusion is present and
+enabled; `_Required` is unchanged.
+
+## Synthetic probe process
+
+1. Generate one random non-user probe marker (do not print it in reports).
+2. Issue one non-mutating Cloud Run `/health` probe with synthetic query
+   metadata via a short-lived identity token.
+3. Issue one non-mutating Gateway `/health` probe with synthetic query
+   metadata and **no** real Gateway key / Firebase token / user data.
+4. Wait up to 10 minutes (30s poll) for routing propagation.
+5. Count-only query for the marker across excluded surfaces; require 0 matches
+   for post-apply entries.
+6. Confirm pre-change entries still exist (exclusion is not retroactive).
+
+## Rollback
+
+```bash
+scripts/deploy/logging/manage-oli-api-request-log-privacy.sh \
+  rollback \
+  --project oli-staging-fdbba \
+  --backup-dir "$SINK_BACKUP_DIR"
+```
+
+Equivalent underlying mutation:
+
+```bash
+gcloud logging sinks update _Default \
+  --project=oli-staging-fdbba \
+  --remove-exclusions=oli_api_request_metadata_privacy_v1
+```
+
+Verify normalized sink specification hash returns to the pre-change hash.
+
+## Existing-log limitation
+
+Exclusions are forward-looking only. Existing affected entries in `_Default`
+are not deleted by this control.
+
+## Retention behavior
+
+- `_Default` retention remains 30 days (unchanged by this control).
+- `_Required` retention remains 400 days and is untouched.
+- Existing entries age out under current retention unless a separately
+  approved remediation changes policy.
+
+## Metrics / observability impact
+
+- No dashboards, alerts, or log-based metrics were found that depend on the
+  excluded request logs.
+- Cloud Run request-count and latency metrics remain available independently
+  of request-log storage.
+- Privacy-safe application telemetry (`http_request_completed`) remains
+  stored when emitted by a corrected API revision.
+- Function and unrelated application logs remain routed.
+
+## API-key follow-up
+
+Move Gateway consumer key from query string to `x-api-key` header, or remove
+the key after proving it is not required. Not performed by this control.
+
+## Health-range transport follow-up
+
+Move sensitive day/range criteria from GET query parameters to validated
+read-only POST query bodies where architecture permits. Not performed by this
+control.
+
+## Access control
+
+Maintain least-privilege Logging Viewer / sink admin access. Do not broaden
+IAM as part of this control. Do not alter logging IAM here.
+
+## Drift detection
+
+Re-run `plan` / `verify`. Same-name/same-filter is idempotent.
+Same-name/different-filter fails closed. Compare normalized filter hash and
+full sink specification hash against the source-controlled filter file and the
+pre-change backup.
+
+## Emergency response
+
+1. Run `rollback` with the preserved backup directory.
+2. Confirm pre-change specification hash restored.
+3. Confirm `_Required` unchanged.
+4. Do not use `--clear-exclusions`.
+5. Do not delete existing log entries.
+6. Stop further backend cutover until the privacy control is re-verified.

--- a/scripts/deploy/logging/__tests__/manage-oli-api-request-log-privacy.test.ts
+++ b/scripts/deploy/logging/__tests__/manage-oli-api-request-log-privacy.test.ts
@@ -335,6 +335,7 @@ esac
     backupDir: string,
     project = ALLOWED_PROJECT,
   ) {
+    fs.chmodSync(backupDir, 0o700);
     return spawnSync(
       "bash",
       [SCRIPT, mode, "--project", project, "--backup-dir", backupDir],

--- a/scripts/deploy/logging/__tests__/manage-oli-api-request-log-privacy.test.ts
+++ b/scripts/deploy/logging/__tests__/manage-oli-api-request-log-privacy.test.ts
@@ -1,0 +1,437 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { spawnSync } from "child_process";
+import { createHash } from "crypto";
+import { describe, expect, it, beforeAll, afterAll } from "@jest/globals";
+
+const LOGGING_DIR = path.resolve(__dirname, "..");
+const SCRIPT = path.join(LOGGING_DIR, "manage-oli-api-request-log-privacy.sh");
+const FILTER_FILE = path.join(LOGGING_DIR, "oli-api-request-log-privacy.filter");
+const CONSTANTS_FILE = path.join(
+  LOGGING_DIR,
+  "oli-api-request-log-privacy.constants.sh",
+);
+
+const ALLOWED_PROJECT = "oli-staging-fdbba";
+const EXCLUSION_NAME = "oli_api_request_metadata_privacy_v1";
+const SAFE_EVENT = "http_request_completed";
+const LEGACY_MSG = "request";
+
+const ENDPOINTS_LOG_ID =
+  "oli-api-0drj1f1cbrv7k.apigateway.oli-staging-fdbba.cloud.goog/endpoints_log";
+const ENDPOINTS_SERVICE =
+  "oli-api-0drj1f1cbrv7k.apigateway.oli-staging-fdbba.cloud.goog";
+
+function read(p: string): string {
+  return fs.readFileSync(p, "utf8");
+}
+
+function normalizeWs(s: string): string {
+  return s.trim().replace(/\s+/g, " ");
+}
+
+function sha256(s: string): string {
+  return createHash("sha256").update(s).digest("hex");
+}
+
+function clauseRequires(clause: string, needles: string[]): boolean {
+  return needles.every((n) => clause.includes(n));
+}
+
+function splitOrClauses(filter: string): string[] {
+  // Split top-level OR groups bounded by parentheses.
+  return normalizeWs(filter)
+    .split(/\s+OR\s+/)
+    .map((c) => c.trim());
+}
+
+describe("manage-oli-api-request-log-privacy", () => {
+  let scriptSrc = "";
+  let filterSrc = "";
+  let constantsSrc = "";
+  let filterNorm = "";
+  let mockGcloud = "";
+  let tmpRoot = "";
+
+  beforeAll(() => {
+    scriptSrc = read(SCRIPT);
+    filterSrc = read(FILTER_FILE);
+    constantsSrc = read(CONSTANTS_FILE);
+    filterNorm = normalizeWs(filterSrc);
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "oli-log-privacy-test-"));
+    fs.chmodSync(tmpRoot, 0o700);
+
+    mockGcloud = path.join(tmpRoot, "mock-gcloud");
+    fs.writeFileSync(
+      mockGcloud,
+      `#!/usr/bin/env bash
+set -euo pipefail
+STATE_DIR="\${MOCK_GCLOUD_STATE_DIR:?}"
+mkdir -p "\$STATE_DIR"
+echo "\$@" >> "\$STATE_DIR/commands.log"
+# Refuse live mutation markers in unit tests by requiring mock state.
+case "\$*" in
+  *"logging sinks describe _Default"*)
+    cat "\$STATE_DIR/default.json"
+    ;;
+  *"logging sinks describe _Required"*)
+    cat "\$STATE_DIR/required.json"
+    ;;
+  *"logging sinks update _Default"*--add-exclusion*)
+    python3 - "\$STATE_DIR" <<'PY'
+import json, pathlib, sys
+state = pathlib.Path(sys.argv[1])
+default = json.loads((state / "default.json").read_text())
+excl = {
+  "name": "oli_api_request_metadata_privacy_v1",
+  "description": "Privacy: prevent storage of Oli API/Gateway request metadata that may contain health-range values, API keys, concrete identifiers, or legacy authenticated request metadata.",
+  "filter": (state / "expected_filter_norm.txt").read_text().strip(),
+  "disabled": False,
+}
+default["exclusions"] = list(default.get("exclusions") or []) + [excl]
+(state / "default.json").write_text(json.dumps(default))
+print("Updated sink [_Default].")
+PY
+    ;;
+  *"logging sinks update _Default"*--remove-exclusions=oli_api_request_metadata_privacy_v1*)
+    python3 - "\$STATE_DIR" <<'PY'
+import json, pathlib, sys
+state = pathlib.Path(sys.argv[1])
+default = json.loads((state / "default.json").read_text())
+default["exclusions"] = [
+  e for e in (default.get("exclusions") or [])
+  if e.get("name") != "oli_api_request_metadata_privacy_v1"
+]
+(state / "default.json").write_text(json.dumps(default))
+print("Updated sink [_Default].")
+PY
+    ;;
+  *"logging sinks update"*)
+    echo "UNEXPECTED_MUTATION: \$*" >&2
+    exit 99
+    ;;
+  *)
+    echo "mock-gcloud unsupported: \$*" >&2
+    exit 2
+    ;;
+esac
+`,
+      { mode: 0o755 },
+    );
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("guards exact staging project and _Default only", () => {
+    expect(constantsSrc).toContain(
+      `OLI_REQUEST_LOG_PRIVACY_ALLOWED_PROJECT="${ALLOWED_PROJECT}"`,
+    );
+    expect(constantsSrc).toContain(
+      'OLI_REQUEST_LOG_PRIVACY_SINK_NAME="_Default"',
+    );
+    expect(constantsSrc).toContain(
+      'OLI_REQUEST_LOG_PRIVACY_REQUIRED_SINK_NAME="_Required"',
+    );
+    expect(scriptSrc).toContain("refusing non-staging project");
+    expect(scriptSrc).toContain('assert_sink_is_default');
+    expect(scriptSrc).toMatch(/\[\[ "\$OLI_REQUEST_LOG_PRIVACY_SINK_NAME" == "_Default" \]\]/);
+  });
+
+  it("rejects _Required as mutation target and never clears exclusions", () => {
+    expect(scriptSrc).toContain("--add-exclusion=");
+    expect(scriptSrc).toContain("--remove-exclusions=");
+    expect(scriptSrc).not.toContain("--clear-exclusions");
+    expect(scriptSrc).not.toMatch(/sinks update _Required/);
+    expect(scriptSrc).toContain("_Required sink changed unexpectedly");
+  });
+
+  it("preserves destination, inclusion filter, and enabled state", () => {
+    expect(scriptSrc).toContain('f"{field}_changed"');
+    expect(scriptSrc).toContain("disabled_changed");
+    expect(scriptSrc).toContain("intended_only_change");
+    expect(scriptSrc).not.toMatch(/--log-filter=/);
+    expect(scriptSrc).not.toMatch(/--destination=/);
+    expect(scriptSrc).not.toMatch(/--disabled/);
+  });
+
+  it("uses a stable valid exclusion name", () => {
+    expect(constantsSrc).toContain(
+      `OLI_REQUEST_LOG_PRIVACY_EXCLUSION_NAME="${EXCLUSION_NAME}"`,
+    );
+    expect(EXCLUSION_NAME).toMatch(/^[A-Za-z][A-Za-z0-9_]{0,99}$/);
+  });
+
+  it("scopes Cloud Run, Gateway, endpoints, and legacy clauses exactly", () => {
+    const clauses = splitOrClauses(filterSrc);
+    expect(clauses).toHaveLength(4);
+
+    const runClause = clauses.find((c) =>
+      c.includes('LOG_ID("run.googleapis.com/requests")'),
+    );
+    expect(runClause).toBeTruthy();
+    expect(
+      clauseRequires(runClause!, [
+        'resource.type="cloud_run_revision"',
+        'resource.labels.service_name="oli-api"',
+        'resource.labels.location="us-central1"',
+        'LOG_ID("run.googleapis.com/requests")',
+      ]),
+    ).toBe(true);
+
+    const gwClause = clauses.find((c) =>
+      c.includes('LOG_ID("apigateway.googleapis.com/requests")'),
+    );
+    expect(gwClause).toBeTruthy();
+    expect(
+      clauseRequires(gwClause!, [
+        'resource.type="apigateway.googleapis.com/Gateway"',
+        'resource.labels.gateway_id="oli-gateway"',
+        'resource.labels.location="us-central1"',
+        'LOG_ID("apigateway.googleapis.com/requests")',
+      ]),
+    ).toBe(true);
+    // Must not be an unscoped Gateway LOG_ID-only clause.
+    expect(gwClause).toContain("gateway_id");
+
+    const epClause = clauses.find((c) => c.includes(ENDPOINTS_LOG_ID));
+    expect(epClause).toBeTruthy();
+    expect(
+      clauseRequires(epClause!, [
+        'resource.type="api"',
+        `resource.labels.service="${ENDPOINTS_SERVICE}"`,
+        `LOG_ID("${ENDPOINTS_LOG_ID}")`,
+      ]),
+    ).toBe(true);
+
+    const legacyClause = clauses.find((c) =>
+      c.includes(`jsonPayload.msg="${LEGACY_MSG}"`),
+    );
+    expect(legacyClause).toBeTruthy();
+    expect(
+      clauseRequires(legacyClause!, [
+        'resource.type="cloud_run_revision"',
+        'resource.labels.service_name="oli-api"',
+        `jsonPayload.msg="${LEGACY_MSG}"`,
+      ]),
+    ).toBe(true);
+  });
+
+  it("does not exclude corrected http_request_completed events", () => {
+    expect(filterSrc).not.toContain(SAFE_EVENT);
+    expect(filterSrc).not.toContain("http_request_completed");
+    expect(filterSrc).not.toContain("operation=");
+  });
+
+  it("negative controls: unrelated services/gateways do not satisfy clauses", () => {
+    const clauses = splitOrClauses(filterSrc);
+    const synthetic = {
+      otherRun: {
+        type: "cloud_run_revision",
+        service_name: "unrelated-service",
+        location: "us-central1",
+        logId: "run.googleapis.com/requests",
+      },
+      otherGw: {
+        type: "apigateway.googleapis.com/Gateway",
+        gateway_id: "other-gateway",
+        location: "us-central1",
+        logId: "apigateway.googleapis.com/requests",
+      },
+      safeApp: {
+        type: "cloud_run_revision",
+        service_name: "oli-api",
+        operation: SAFE_EVENT,
+      },
+    };
+
+    const runClause = clauses.find((c) =>
+      c.includes('LOG_ID("run.googleapis.com/requests")'),
+    )!;
+    expect(runClause.includes(`service_name="${synthetic.otherRun.service_name}"`)).toBe(
+      false,
+    );
+    expect(runClause.includes('service_name="oli-api"')).toBe(true);
+
+    const gwClause = clauses.find((c) =>
+      c.includes('LOG_ID("apigateway.googleapis.com/requests")'),
+    )!;
+    expect(gwClause.includes(`gateway_id="${synthetic.otherGw.gateway_id}"`)).toBe(
+      false,
+    );
+    expect(gwClause.includes('gateway_id="oli-gateway"')).toBe(true);
+
+    // Safe future app event is not in any clause.
+    for (const c of clauses) {
+      expect(c).not.toContain(SAFE_EVENT);
+    }
+  });
+
+  it("never prints logs and never embeds sensitive query values", () => {
+    const corpus = [scriptSrc, filterSrc, constantsSrc].join("\n");
+    expect(corpus).not.toMatch(/gcloud logging read/);
+    expect(corpus).not.toMatch(/\bstart=\d{4}-\d{2}-\d{2}\b/);
+    expect(corpus).not.toMatch(/\bend=\d{4}-\d{2}-\d{2}\b/);
+    expect(corpus).not.toMatch(/[?&]key=/);
+    expect(corpus).not.toMatch(/api[_-]?key\s*[:=]\s*["']?[A-Za-z0-9_\-]{8,}/i);
+    expect(corpus).not.toMatch(/Bearer\s+[A-Za-z0-9\-._~+/]+=*/);
+    expect(scriptSrc).not.toContain("httpRequest.requestUrl");
+    expect(scriptSrc).toContain("Privacy-safe structured status lines only");
+  });
+
+  it("computes a stable normalized filter hash", () => {
+    expect(sha256(filterNorm)).toHaveLength(64);
+    expect(sha256(filterNorm)).toBe(sha256(normalizeWs(filterSrc)));
+  });
+
+  function seedMockState(opts?: {
+    existingExclusionFilter?: string;
+    extraExclusion?: { name: string; filter: string };
+  }) {
+    const stateDir = fs.mkdtempSync(path.join(tmpRoot, "state-"));
+    fs.chmodSync(stateDir, 0o700);
+    const defaultSink: Record<string, unknown> = {
+      name: "_Default",
+      destination: "logging.googleapis.com/projects/oli-staging-fdbba/locations/global/buckets/_Default",
+      filter: "NOT LOG_ID(\"cloudaudit.googleapis.com/activity\")",
+      disabled: false,
+      writerIdentity: "serviceAccount:mock-writer@example.iam.gserviceaccount.com",
+      exclusions: [] as Array<Record<string, unknown>>,
+    };
+    if (opts?.existingExclusionFilter) {
+      (defaultSink.exclusions as Array<Record<string, unknown>>).push({
+        name: EXCLUSION_NAME,
+        description: "Privacy: prevent storage of Oli API/Gateway request metadata that may contain health-range values, API keys, concrete identifiers, or legacy authenticated request metadata.",
+        filter: opts.existingExclusionFilter,
+        disabled: false,
+      });
+    }
+    if (opts?.extraExclusion) {
+      (defaultSink.exclusions as Array<Record<string, unknown>>).push({
+        name: opts.extraExclusion.name,
+        description: "preexisting",
+        filter: opts.extraExclusion.filter,
+        disabled: false,
+      });
+    }
+    const requiredSink = {
+      name: "_Required",
+      destination: "logging.googleapis.com/projects/oli-staging-fdbba/locations/global/buckets/_Required",
+      filter: "LOG_ID(\"cloudaudit.googleapis.com/activity\") OR LOG_ID(\"cloudaudit.googleapis.com/system_event\")",
+      disabled: false,
+      exclusions: [],
+    };
+    fs.writeFileSync(path.join(stateDir, "default.json"), JSON.stringify(defaultSink));
+    fs.writeFileSync(path.join(stateDir, "required.json"), JSON.stringify(requiredSink));
+    fs.writeFileSync(path.join(stateDir, "expected_filter_norm.txt"), filterNorm);
+    return stateDir;
+  }
+
+  function runScript(
+    mode: string,
+    stateDir: string,
+    backupDir: string,
+    project = ALLOWED_PROJECT,
+  ) {
+    return spawnSync(
+      "bash",
+      [SCRIPT, mode, "--project", project, "--backup-dir", backupDir],
+      {
+        env: {
+          ...process.env,
+          GCLOUD_BIN: mockGcloud,
+          MOCK_GCLOUD_STATE_DIR: stateDir,
+        },
+        encoding: "utf8",
+      },
+    );
+  }
+
+  it("refuses empty / wrong project", () => {
+    const stateDir = seedMockState();
+    const backupDir = fs.mkdtempSync(path.join(tmpRoot, "backup-"));
+    fs.chmodSync(backupDir, 0o700);
+    const empty = spawnSync("bash", [SCRIPT, "plan", "--backup-dir", backupDir], {
+      env: { ...process.env, GCLOUD_BIN: mockGcloud, MOCK_GCLOUD_STATE_DIR: stateDir },
+      encoding: "utf8",
+    });
+    expect(empty.status).not.toBe(0);
+
+    const wrong = runScript("plan", stateDir, backupDir, "oli-prod-not-allowed");
+    expect(wrong.status).not.toBe(0);
+    expect(wrong.stderr).toContain("refusing non-staging project");
+  });
+
+  it("same-name/same-filter is idempotent; different-filter fails", () => {
+    const backupDir = fs.mkdtempSync(path.join(tmpRoot, "backup-"));
+    fs.chmodSync(backupDir, 0o700);
+
+    const same = seedMockState({ existingExclusionFilter: filterNorm });
+    const sameRes = runScript("apply", same, backupDir);
+    expect(sameRes.status).toBe(0);
+    expect(sameRes.stdout).toContain("result=idempotent_noop");
+
+    const driftBackup = fs.mkdtempSync(path.join(tmpRoot, "backup-"));
+    fs.chmodSync(driftBackup, 0o700);
+    const drift = seedMockState({
+      existingExclusionFilter: 'resource.type="cloud_run_revision"',
+    });
+    const driftRes = runScript("apply", drift, driftBackup);
+    expect(driftRes.status).not.toBe(0);
+    expect(driftRes.stderr).toContain("same-name/different-filter");
+  });
+
+  it("apply adds only the intended exclusion and rollback restores pre-spec", () => {
+    const stateDir = seedMockState({
+      extraExclusion: {
+        name: "keep_me",
+        filter: 'resource.type="gce_instance"',
+      },
+    });
+    const backupDir = fs.mkdtempSync(path.join(tmpRoot, "backup-"));
+    fs.chmodSync(backupDir, 0o700);
+
+    const plan = runScript("plan", stateDir, backupDir);
+    expect(plan.status).toBe(0);
+    expect(plan.stdout).toContain(`exclusion_name=${EXCLUSION_NAME}`);
+    expect(plan.stdout).toContain("intended_action=add_exclusion");
+    expect(plan.stdout).toMatch(/filter_hash=[a-f0-9]{64}/);
+    expect(fs.statSync(path.join(backupDir, "_Default.pre.json")).mode & 0o777).toBe(
+      0o600,
+    );
+
+    const apply = runScript("apply", stateDir, backupDir);
+    expect(apply.status).toBe(0);
+    expect(apply.stdout).toContain("result=applied");
+    expect(apply.stdout).toContain("intended_only_change=true");
+
+    const cmds = read(path.join(stateDir, "commands.log"));
+    expect(cmds).toContain("--add-exclusion=");
+    expect(cmds).not.toContain("--clear-exclusions");
+
+    const verify = runScript("verify", stateDir, backupDir);
+    expect(verify.status).toBe(0);
+    expect(verify.stdout).toContain("result=verified");
+
+    const post = JSON.parse(read(path.join(stateDir, "default.json")));
+    const names = (post.exclusions as Array<{ name: string }>).map((e) => e.name).sort();
+    expect(names).toEqual(["keep_me", EXCLUSION_NAME].sort());
+
+    const rollback = runScript("rollback", stateDir, backupDir);
+    expect(rollback.status).toBe(0);
+    expect(rollback.stdout).toContain("result=rolled_back");
+    const after = JSON.parse(read(path.join(stateDir, "default.json")));
+    const afterNames = (after.exclusions as Array<{ name: string }>).map((e) => e.name);
+    expect(afterNames).toEqual(["keep_me"]);
+    expect(read(path.join(stateDir, "commands.log"))).toContain(
+      `--remove-exclusions=${EXCLUSION_NAME}`,
+    );
+  });
+
+  it("unit tests never invoke a real gcloud binary", () => {
+    expect(mockGcloud).not.toMatch(/(^|\/)gcloud$/);
+    expect(fs.readFileSync(mockGcloud, "utf8")).toContain("MOCK_GCLOUD_STATE_DIR");
+  });
+});

--- a/scripts/deploy/logging/manage-oli-api-request-log-privacy.sh
+++ b/scripts/deploy/logging/manage-oli-api-request-log-privacy.sh
@@ -1,0 +1,596 @@
+#!/usr/bin/env bash
+# Manage the forward-looking _Default exclusion for Oli API/Gateway request metadata.
+# Modes: plan | apply | verify | rollback
+# Never clears exclusions, never mutates _Required, never prints raw log entries.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=oli-api-request-log-privacy.constants.sh
+source "${SCRIPT_DIR}/oli-api-request-log-privacy.constants.sh"
+
+FILTER_FILE="${SCRIPT_DIR}/oli-api-request-log-privacy.filter"
+MODE=""
+PROJECT=""
+BACKUP_DIR=""
+GCLOUD_BIN="${GCLOUD_BIN:-gcloud}"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  manage-oli-api-request-log-privacy.sh <plan|apply|verify|rollback> \
+    --project oli-staging-fdbba \
+    --backup-dir <secure-dir>
+
+Environment:
+  GCLOUD_BIN  Override gcloud binary (tests only; never point at live gcloud in CI unit tests)
+EOF
+}
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+emit() {
+  # Privacy-safe structured status lines only.
+  printf '%s\n' "$*"
+}
+
+sha256_file() {
+  local path="$1"
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$path" | awk '{print $1}'
+  elif command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$path" | awk '{print $1}'
+  else
+    die "neither shasum nor sha256sum available"
+  fi
+}
+
+sha256_string() {
+  local s="$1"
+  if command -v shasum >/dev/null 2>&1; then
+    printf '%s' "$s" | shasum -a 256 | awk '{print $1}'
+  else
+    printf '%s' "$s" | sha256sum | awk '{print $1}'
+  fi
+}
+
+normalize_ws() {
+  # Collapse all whitespace to single spaces for stable hashing/comparison.
+  tr -s '[:space:]' ' ' | sed -e 's/^ //' -e 's/ $//'
+}
+
+load_filter() {
+  [[ -f "$FILTER_FILE" ]] || die "missing filter file: $FILTER_FILE"
+  local raw
+  raw="$(cat "$FILTER_FILE")"
+  [[ -n "${raw//[[:space:]]/}" ]] || die "filter file is empty"
+  printf '%s' "$raw"
+}
+
+normalized_filter() {
+  load_filter | normalize_ws
+}
+
+filter_hash() {
+  sha256_string "$(normalized_filter)"
+}
+
+require_project() {
+  [[ -n "$PROJECT" ]] || die "project is required"
+  [[ "$PROJECT" == "$OLI_REQUEST_LOG_PRIVACY_ALLOWED_PROJECT" ]] \
+    || die "refusing non-staging project '$PROJECT' (allowed: $OLI_REQUEST_LOG_PRIVACY_ALLOWED_PROJECT)"
+}
+
+require_backup_dir() {
+  [[ -n "$BACKUP_DIR" ]] || die "--backup-dir is required"
+  [[ -d "$BACKUP_DIR" ]] || die "backup dir does not exist: $BACKUP_DIR"
+  local mode
+  mode="$(stat -f '%Lp' "$BACKUP_DIR" 2>/dev/null || stat -c '%a' "$BACKUP_DIR")"
+  # Accept 700 or more restrictive owner-only modes.
+  case "$mode" in
+    7??|70?) ;;
+    *)
+      # Soft warning only if sticky bits differ; still require owner rwx and no group/other write.
+      if [[ ! "$mode" =~ ^7 ]]; then
+        die "backup dir permissions must be owner-restricted (got $mode; prefer 700)"
+      fi
+      ;;
+  esac
+}
+
+parse_args() {
+  [[ $# -ge 1 ]] || { usage; exit 1; }
+  MODE="$1"
+  shift
+  case "$MODE" in
+    plan|apply|verify|rollback) ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "unknown mode: $MODE" ;;
+  esac
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --project)
+        [[ $# -ge 2 ]] || die "--project requires a value"
+        PROJECT="$2"
+        shift 2
+        ;;
+      --project=*)
+        PROJECT="${1#*=}"
+        shift
+        ;;
+      --backup-dir)
+        [[ $# -ge 2 ]] || die "--backup-dir requires a value"
+        BACKUP_DIR="$2"
+        shift 2
+        ;;
+      --backup-dir=*)
+        BACKUP_DIR="${1#*=}"
+        shift
+        ;;
+      *)
+        die "unknown argument: $1"
+        ;;
+    esac
+  done
+}
+
+describe_sink_json() {
+  local sink="$1"
+  local out="$2"
+  "$GCLOUD_BIN" logging sinks describe "$sink" \
+    --project="$PROJECT" \
+    --format=json >"$out"
+}
+
+jq_field() {
+  local file="$1"
+  local expr="$2"
+  python3 - "$file" "$expr" <<'PY'
+import json, sys
+path, expr = sys.argv[1], sys.argv[2]
+with open(path) as f:
+    data = json.load(f)
+# Very small path resolver: a.b.c or exclusions[*].name
+cur = data
+for part in expr.split("."):
+    if part.endswith("[*]"):
+        key = part[:-3]
+        cur = cur.get(key) or []
+        break
+    if isinstance(cur, dict):
+        cur = cur.get(part)
+    else:
+        cur = None
+        break
+if isinstance(cur, list) and expr.endswith("exclusions[*].name"):
+    # handled below
+    pass
+if expr.endswith("exclusions[*].name"):
+    names = [e.get("name") for e in (data.get("exclusions") or []) if isinstance(e, dict)]
+    print("\n".join(names))
+elif cur is None:
+    print("")
+elif isinstance(cur, bool):
+    print("true" if cur else "false")
+else:
+    print(cur)
+PY
+}
+
+sink_disabled_bool() {
+  local file="$1"
+  python3 - "$file" <<'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+print("true" if data.get("disabled") is True else "false")
+PY
+}
+
+exclusion_names() {
+  local file="$1"
+  python3 - "$file" <<'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+for e in data.get("exclusions") or []:
+    if isinstance(e, dict) and e.get("name"):
+        print(e["name"])
+PY
+}
+
+exclusion_filter_raw() {
+  local file="$1"
+  local name="$2"
+  python3 - "$file" "$name" <<'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+want = sys.argv[2]
+for e in data.get("exclusions") or []:
+    if isinstance(e, dict) and e.get("name") == want:
+        print(e.get("filter") or "")
+        break
+PY
+}
+
+exclusion_disabled() {
+  local file="$1"
+  local name="$2"
+  python3 - "$file" "$name" <<'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+want = sys.argv[2]
+for e in data.get("exclusions") or []:
+    if isinstance(e, dict) and e.get("name") == want:
+        print("true" if e.get("disabled") is True else "false")
+        sys.exit(0)
+print("missing")
+PY
+}
+
+normalize_filter_string() {
+  printf '%s' "$1" | normalize_ws
+}
+
+spec_hash_from_file() {
+  local file="$1"
+  python3 - "$file" <<'PY'
+import json, hashlib, re, sys
+
+def norm_ws(s: str) -> str:
+    return re.sub(r"\s+", " ", (s or "").strip())
+
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+
+exclusions = []
+for e in data.get("exclusions") or []:
+    if not isinstance(e, dict):
+        continue
+    exclusions.append({
+        "name": e.get("name") or "",
+        "description": e.get("description") or "",
+        "filter": norm_ws(e.get("filter") or ""),
+        "disabled": bool(e.get("disabled") is True),
+    })
+exclusions.sort(key=lambda x: x["name"])
+
+canonical = {
+    "name": data.get("name") or "",
+    "destination": data.get("destination") or "",
+    "filter": norm_ws(data.get("filter") or ""),
+    "disabled": bool(data.get("disabled") is True),
+    "writerIdentity": data.get("writerIdentity") or "",
+    "exclusions": exclusions,
+}
+payload = json.dumps(canonical, sort_keys=True, separators=(",", ":"))
+print(hashlib.sha256(payload.encode()).hexdigest())
+PY
+}
+
+field_hash_from_file() {
+  local file="$1"
+  local field="$2"
+  python3 - "$file" "$field" <<'PY'
+import json, hashlib, re, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+val = data.get(sys.argv[2]) or ""
+if sys.argv[2] == "filter":
+    val = re.sub(r"\s+", " ", str(val).strip())
+print(hashlib.sha256(str(val).encode()).hexdigest())
+PY
+}
+
+assert_sink_is_default() {
+  [[ "$OLI_REQUEST_LOG_PRIVACY_SINK_NAME" == "_Default" ]] \
+    || die "refusing to operate on non-_Default sink constant"
+}
+
+assert_required_untouched_from_backup() {
+  local pre_required="$BACKUP_DIR/_Required.pre.json"
+  local post_required="$BACKUP_DIR/_Required.post.json"
+  [[ -f "$pre_required" ]] || return 0
+  describe_sink_json "$OLI_REQUEST_LOG_PRIVACY_REQUIRED_SINK_NAME" "$post_required"
+  chmod 600 "$post_required" 2>/dev/null || true
+  local pre_hash post_hash
+  pre_hash="$(spec_hash_from_file "$pre_required")"
+  post_hash="$(spec_hash_from_file "$post_required")"
+  [[ "$pre_hash" == "$post_hash" ]] || die "_Required sink changed unexpectedly"
+  emit "required_unchanged=true"
+  emit "required_spec_hash=$pre_hash"
+}
+
+backup_pre_state() {
+  local pre_default="$BACKUP_DIR/_Default.pre.json"
+  local pre_required="$BACKUP_DIR/_Required.pre.json"
+  describe_sink_json "$OLI_REQUEST_LOG_PRIVACY_SINK_NAME" "$pre_default"
+  chmod 600 "$pre_default"
+  sha256_file "$pre_default" >"$BACKUP_DIR/_Default.pre.sha256"
+  chmod 600 "$BACKUP_DIR/_Default.pre.sha256"
+  describe_sink_json "$OLI_REQUEST_LOG_PRIVACY_REQUIRED_SINK_NAME" "$pre_required"
+  chmod 600 "$pre_required"
+  sha256_file "$pre_required" >"$BACKUP_DIR/_Required.pre.sha256"
+  chmod 600 "$BACKUP_DIR/_Required.pre.sha256"
+
+  emit "operation=backup"
+  emit "project=$PROJECT"
+  emit "sink=$OLI_REQUEST_LOG_PRIVACY_SINK_NAME"
+  emit "pre_spec_hash=$(spec_hash_from_file "$pre_default")"
+  emit "destination_hash=$(field_hash_from_file "$pre_default" destination)"
+  emit "inclusion_filter_hash=$(field_hash_from_file "$pre_default" filter)"
+  emit "disabled=$(sink_disabled_bool "$pre_default")"
+  emit "backup_sha256=$(cat "$BACKUP_DIR/_Default.pre.sha256")"
+  local names
+  names="$(exclusion_names "$pre_default" | tr '\n' ',' | sed 's/,$//')"
+  emit "existing_exclusion_names=${names:-<none>}"
+}
+
+check_preconditions_from_pre() {
+  local pre_default="$BACKUP_DIR/_Default.pre.json"
+  [[ -f "$pre_default" ]] || die "missing pre-change backup: $pre_default"
+
+  local disabled
+  disabled="$(sink_disabled_bool "$pre_default")"
+  [[ "$disabled" == "false" ]] || die "_Default sink is disabled; refusing to apply"
+
+  local dest_hash filt_hash
+  dest_hash="$(field_hash_from_file "$pre_default" destination)"
+  filt_hash="$(field_hash_from_file "$pre_default" filter)"
+  [[ -n "$dest_hash" ]] || die "missing destination on _Default"
+  [[ -n "$filt_hash" ]] || die "missing inclusion filter on _Default"
+
+  local existing_filter existing_norm expected_norm
+  existing_filter="$(exclusion_filter_raw "$pre_default" "$OLI_REQUEST_LOG_PRIVACY_EXCLUSION_NAME")"
+  expected_norm="$(normalized_filter)"
+  if [[ -n "$existing_filter" ]]; then
+    existing_norm="$(normalize_filter_string "$existing_filter")"
+    if [[ "$existing_norm" == "$expected_norm" ]]; then
+      emit "idempotent_state=already_applied"
+      return 0
+    fi
+    die "same-name/different-filter drift for $OLI_REQUEST_LOG_PRIVACY_EXCLUSION_NAME"
+  fi
+  emit "idempotent_state=absent"
+}
+
+build_add_exclusion_arg() {
+  local filt desc
+  filt="$(normalized_filter)"
+  desc="$OLI_REQUEST_LOG_PRIVACY_EXCLUSION_DESCRIPTION"
+  # Filter must remain comma-free so it cannot break map parsing even with custom delimiters.
+  if [[ "$filt" == *","* ]]; then
+    die "exclusion filter contains comma; refusing unsafe --add-exclusion encoding"
+  fi
+  # Description may contain commas; use gcloud custom map delimiter form: ^DELIM^k=vDELIMk=v
+  local delim="|"
+  if [[ "$desc" == *"|"* || "$filt" == *"|"* || "$OLI_REQUEST_LOG_PRIVACY_EXCLUSION_NAME" == *"|"* ]]; then
+    delim=$'\x1f'
+  fi
+  if [[ "$desc" == *"$delim"* || "$filt" == *"$delim"* ]]; then
+    die "unable to choose safe delimiter for --add-exclusion encoding"
+  fi
+  printf '^%s^name=%s%sdescription=%s%sfilter=%s' \
+    "$delim" \
+    "$OLI_REQUEST_LOG_PRIVACY_EXCLUSION_NAME" \
+    "$delim" \
+    "$desc" \
+    "$delim" \
+    "$filt"
+}
+
+compare_intended_only_change() {
+  local pre="$1"
+  local post="$2"
+  python3 - "$pre" "$post" "$OLI_REQUEST_LOG_PRIVACY_EXCLUSION_NAME" "$(normalized_filter)" <<'PY'
+import json, re, sys
+
+def norm_ws(s: str) -> str:
+    return re.sub(r"\s+", " ", (s or "").strip())
+
+pre_path, post_path, excl_name, expected_filter = sys.argv[1:5]
+with open(pre_path) as f:
+    pre = json.load(f)
+with open(post_path) as f:
+    post = json.load(f)
+
+errors = []
+for field in ("destination", "filter", "writerIdentity"):
+    if (pre.get(field) or "") != (post.get(field) or ""):
+        errors.append(f"{field}_changed")
+if bool(pre.get("disabled") is True) != bool(post.get("disabled") is True):
+    errors.append("disabled_changed")
+
+pre_ex = {e.get("name"): e for e in (pre.get("exclusions") or []) if isinstance(e, dict)}
+post_ex = {e.get("name"): e for e in (post.get("exclusions") or []) if isinstance(e, dict)}
+
+# Previous exclusions must remain with identical normalized filters.
+for name, e in pre_ex.items():
+    if name == excl_name:
+        continue
+    if name not in post_ex:
+        errors.append(f"lost_exclusion:{name}")
+        continue
+    if norm_ws(e.get("filter") or "") != norm_ws(post_ex[name].get("filter") or ""):
+        errors.append(f"changed_exclusion:{name}")
+    if bool(e.get("disabled") is True) != bool(post_ex[name].get("disabled") is True):
+        errors.append(f"disabled_exclusion:{name}")
+
+if excl_name not in post_ex:
+    errors.append("missing_new_exclusion")
+else:
+    got = norm_ws(post_ex[excl_name].get("filter") or "")
+    if got != norm_ws(expected_filter):
+        errors.append("new_exclusion_filter_mismatch")
+    if post_ex[excl_name].get("disabled") is True:
+        errors.append("new_exclusion_disabled")
+
+# No unexpected extra exclusions beyond pre + new
+for name in post_ex:
+    if name not in pre_ex and name != excl_name:
+        errors.append(f"unexpected_exclusion:{name}")
+
+if errors:
+    print("FAIL:" + ",".join(errors))
+    sys.exit(1)
+print("OK")
+PY
+}
+
+cmd_plan() {
+  require_project
+  require_backup_dir
+  assert_sink_is_default
+  backup_pre_state
+  check_preconditions_from_pre
+  local fh existing
+  fh="$(filter_hash)"
+  emit "operation=plan"
+  emit "project=$PROJECT"
+  emit "sink=$OLI_REQUEST_LOG_PRIVACY_SINK_NAME"
+  emit "exclusion_name=$OLI_REQUEST_LOG_PRIVACY_EXCLUSION_NAME"
+  emit "filter_hash=$fh"
+  emit "clause_count=$OLI_REQUEST_LOG_PRIVACY_CLAUSE_COUNT"
+  existing="$(exclusion_filter_raw "$BACKUP_DIR/_Default.pre.json" "$OLI_REQUEST_LOG_PRIVACY_EXCLUSION_NAME")"
+  if [[ -n "$existing" ]]; then
+    if [[ "$(normalize_filter_string "$existing")" == "$(normalized_filter)" ]]; then
+      emit "current_state=already_applied"
+      emit "intended_action=noop"
+    else
+      die "same-name/different-filter drift"
+    fi
+  else
+    emit "current_state=absent"
+    emit "intended_action=add_exclusion"
+  fi
+  emit "result=ok"
+}
+
+cmd_apply() {
+  require_project
+  require_backup_dir
+  assert_sink_is_default
+  if [[ ! -f "$BACKUP_DIR/_Default.pre.json" ]]; then
+    backup_pre_state
+  else
+    emit "operation=reuse_backup"
+    emit "pre_spec_hash=$(spec_hash_from_file "$BACKUP_DIR/_Default.pre.json")"
+  fi
+  check_preconditions_from_pre
+
+  local existing
+  existing="$(exclusion_filter_raw "$BACKUP_DIR/_Default.pre.json" "$OLI_REQUEST_LOG_PRIVACY_EXCLUSION_NAME")"
+  if [[ -n "$existing" ]] && [[ "$(normalize_filter_string "$existing")" == "$(normalized_filter)" ]]; then
+    emit "operation=apply"
+    emit "project=$PROJECT"
+    emit "sink=$OLI_REQUEST_LOG_PRIVACY_SINK_NAME"
+    emit "exclusion_name=$OLI_REQUEST_LOG_PRIVACY_EXCLUSION_NAME"
+    emit "filter_hash=$(filter_hash)"
+    emit "result=idempotent_noop"
+    return 0
+  fi
+
+  local add_arg
+  add_arg="$(build_add_exclusion_arg)"
+  emit "operation=apply"
+  emit "project=$PROJECT"
+  emit "sink=$OLI_REQUEST_LOG_PRIVACY_SINK_NAME"
+  emit "exclusion_name=$OLI_REQUEST_LOG_PRIVACY_EXCLUSION_NAME"
+  emit "filter_hash=$(filter_hash)"
+  emit "gcloud_mutation=add_exclusion"
+
+  "$GCLOUD_BIN" logging sinks update "$OLI_REQUEST_LOG_PRIVACY_SINK_NAME" \
+    --project="$PROJECT" \
+    --add-exclusion="$add_arg"
+
+  local post_default="$BACKUP_DIR/_Default.post.json"
+  describe_sink_json "$OLI_REQUEST_LOG_PRIVACY_SINK_NAME" "$post_default"
+  chmod 600 "$post_default"
+  compare_intended_only_change "$BACKUP_DIR/_Default.pre.json" "$post_default" >/dev/null
+  assert_required_untouched_from_backup
+
+  emit "post_spec_hash=$(spec_hash_from_file "$post_default")"
+  emit "intended_only_change=true"
+  emit "result=applied"
+}
+
+cmd_verify() {
+  require_project
+  require_backup_dir
+  assert_sink_is_default
+  [[ -f "$BACKUP_DIR/_Default.pre.json" ]] || die "missing pre-change backup for verify"
+
+  local post_default="$BACKUP_DIR/_Default.verify.json"
+  describe_sink_json "$OLI_REQUEST_LOG_PRIVACY_SINK_NAME" "$post_default"
+  chmod 600 "$post_default"
+  compare_intended_only_change "$BACKUP_DIR/_Default.pre.json" "$post_default" >/dev/null
+
+  local excl_disabled
+  excl_disabled="$(exclusion_disabled "$post_default" "$OLI_REQUEST_LOG_PRIVACY_EXCLUSION_NAME")"
+  [[ "$excl_disabled" == "false" ]] || die "exclusion missing or disabled"
+
+  assert_required_untouched_from_backup
+
+  emit "operation=verify"
+  emit "project=$PROJECT"
+  emit "sink=$OLI_REQUEST_LOG_PRIVACY_SINK_NAME"
+  emit "exclusion_name=$OLI_REQUEST_LOG_PRIVACY_EXCLUSION_NAME"
+  emit "filter_hash=$(filter_hash)"
+  emit "pre_spec_hash=$(spec_hash_from_file "$BACKUP_DIR/_Default.pre.json")"
+  emit "post_spec_hash=$(spec_hash_from_file "$post_default")"
+  emit "destination_unchanged=true"
+  emit "inclusion_filter_unchanged=true"
+  emit "disabled_unchanged=true"
+  emit "previous_exclusions_preserved=true"
+  emit "exclusion_enabled=true"
+  emit "result=verified"
+}
+
+cmd_rollback() {
+  require_project
+  require_backup_dir
+  assert_sink_is_default
+  [[ -f "$BACKUP_DIR/_Default.pre.json" ]] || die "missing pre-change backup for rollback"
+
+  emit "operation=rollback"
+  emit "project=$PROJECT"
+  emit "sink=$OLI_REQUEST_LOG_PRIVACY_SINK_NAME"
+  emit "exclusion_name=$OLI_REQUEST_LOG_PRIVACY_EXCLUSION_NAME"
+  emit "gcloud_mutation=remove_exclusions"
+
+  "$GCLOUD_BIN" logging sinks update "$OLI_REQUEST_LOG_PRIVACY_SINK_NAME" \
+    --project="$PROJECT" \
+    --remove-exclusions="$OLI_REQUEST_LOG_PRIVACY_EXCLUSION_NAME"
+
+  local post_default="$BACKUP_DIR/_Default.rollback.json"
+  describe_sink_json "$OLI_REQUEST_LOG_PRIVACY_SINK_NAME" "$post_default"
+  chmod 600 "$post_default"
+
+  local pre_hash post_hash
+  pre_hash="$(spec_hash_from_file "$BACKUP_DIR/_Default.pre.json")"
+  post_hash="$(spec_hash_from_file "$post_default")"
+  [[ "$pre_hash" == "$post_hash" ]] || die "rollback did not restore normalized pre-change sink specification"
+
+  assert_required_untouched_from_backup
+
+  emit "pre_spec_hash=$pre_hash"
+  emit "post_spec_hash=$post_hash"
+  emit "result=rolled_back"
+}
+
+main() {
+  parse_args "$@"
+  require_project
+  case "$MODE" in
+    plan) cmd_plan ;;
+    apply) cmd_apply ;;
+    verify) cmd_verify ;;
+    rollback) cmd_rollback ;;
+  esac
+}
+
+main "$@"

--- a/scripts/deploy/logging/manage-oli-api-request-log-privacy.sh
+++ b/scripts/deploy/logging/manage-oli-api-request-log-privacy.sh
@@ -87,13 +87,20 @@ require_backup_dir() {
   [[ -n "$BACKUP_DIR" ]] || die "--backup-dir is required"
   [[ -d "$BACKUP_DIR" ]] || die "backup dir does not exist: $BACKUP_DIR"
   local mode
-  mode="$(stat -f '%Lp' "$BACKUP_DIR" 2>/dev/null || stat -c '%a' "$BACKUP_DIR")"
-  # Accept 700 or more restrictive owner-only modes.
+  # GNU stat treats -f as --file-system; only use BSD -f on Darwin.
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    mode="$(stat -f '%Lp' "$BACKUP_DIR")"
+  else
+    mode="$(stat -c '%a' "$BACKUP_DIR")"
+  fi
+  # Require owner-only access (700-style). Accept exact 700 or owner rwx with no group/other bits.
   case "$mode" in
-    7??|70?) ;;
+    700|7000) ;;
     *)
-      # Soft warning only if sticky bits differ; still require owner rwx and no group/other write.
-      if [[ ! "$mode" =~ ^7 ]]; then
+      # Also accept when sticky/setgid digits prefix a 700 mode (rare).
+      if [[ "$mode" =~ ^[0-7]?700$ ]]; then
+        :
+      else
         die "backup dir permissions must be owner-restricted (got $mode; prefer 700)"
       fi
       ;;

--- a/scripts/deploy/logging/oli-api-request-log-privacy.constants.sh
+++ b/scripts/deploy/logging/oli-api-request-log-privacy.constants.sh
@@ -1,0 +1,9 @@
+# Source-controlled constants for Oli API/Gateway request-log privacy exclusion.
+# Do not put secrets, UIDs, query values, or raw URLs in this file.
+
+OLI_REQUEST_LOG_PRIVACY_ALLOWED_PROJECT="oli-staging-fdbba"
+OLI_REQUEST_LOG_PRIVACY_SINK_NAME="_Default"
+OLI_REQUEST_LOG_PRIVACY_REQUIRED_SINK_NAME="_Required"
+OLI_REQUEST_LOG_PRIVACY_EXCLUSION_NAME="oli_api_request_metadata_privacy_v1"
+OLI_REQUEST_LOG_PRIVACY_EXCLUSION_DESCRIPTION="Privacy: prevent storage of Oli API/Gateway request metadata that may contain health-range values, API keys, concrete identifiers, or legacy authenticated request metadata."
+OLI_REQUEST_LOG_PRIVACY_CLAUSE_COUNT="4"

--- a/scripts/deploy/logging/oli-api-request-log-privacy.filter
+++ b/scripts/deploy/logging/oli-api-request-log-privacy.filter
@@ -1,0 +1,26 @@
+(
+  resource.type="cloud_run_revision"
+  AND resource.labels.service_name="oli-api"
+  AND resource.labels.location="us-central1"
+  AND LOG_ID("run.googleapis.com/requests")
+)
+OR
+(
+  resource.type="apigateway.googleapis.com/Gateway"
+  AND resource.labels.gateway_id="oli-gateway"
+  AND resource.labels.location="us-central1"
+  AND LOG_ID("apigateway.googleapis.com/requests")
+)
+OR
+(
+  resource.type="api"
+  AND resource.labels.service="oli-api-0drj1f1cbrv7k.apigateway.oli-staging-fdbba.cloud.goog"
+  AND resource.labels.location="us-central1"
+  AND LOG_ID("oli-api-0drj1f1cbrv7k.apigateway.oli-staging-fdbba.cloud.goog/endpoints_log")
+)
+OR
+(
+  resource.type="cloud_run_revision"
+  AND resource.labels.service_name="oli-api"
+  AND jsonPayload.msg="request"
+)


### PR DESCRIPTION
## Summary
- Application access logger is already repaired on the Weekly Fitness feature head (`http_request_completed`); the still-serving API revision predates that repair.
- Cloud Run and API Gateway platform request logs store query-bearing URLs that can include health-range values and Gateway consumer keys.
- This PR adds source-controlled `_Default` exclusion management tooling, tests/guards, runbook, and audit for a narrowly scoped forward-looking exclusion (`oli_api_request_metadata_privacy_v1`).
- `_Required` is untouched. `_Default` destination and inclusion filter are preserved. Existing stored logs are not deleted. The exclusion is forward-looking only.
- Application safe telemetry (`http_request_completed`) remains stored when emitted. No runtime API/Function/OpenAPI/mobile source changed in this PR.
- No live exclusion has yet been applied at PR creation. API-key/header and health-range POST-query migrations remain future work. No backend deployment occurred.

## Test plan
- [x] Focused Jest guards for project/`_Default`/`--add-exclusion`/`--remove-exclusions`/scope/idempotency/rollback
- [x] Local Code Check Gate (typecheck, lint, invariants, full test, builds, expo export)
- [ ] CI check + tf-validate on this PR
- [ ] After merge: apply via management script against staging `_Default` only; synthetic probe verification

Made with [Cursor](https://cursor.com)