### PR TITLE
fix(privacy): redact sleep-night route telemetry

### DIFF
--- a/services/api/src/lib/__tests__/sleepNightRouteTelemetrySourceGuard.test.ts
+++ b/services/api/src/lib/__tests__/sleepNightRouteTelemetrySourceGuard.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Source guard: SleepNight route version/range markers must emit only through
+ * `sleepNightRouteTelemetry.ts` with a closed privacy-safe payload.
+ *
+ * Does not forbid legitimate uid/day locals used for auth, validation, or reads.
+ */
+import fs from "fs";
+import path from "path";
+
+const REPO_ROOT = path.resolve(__dirname, "../../../../..");
+
+const HELPER_REL = "services/api/src/lib/sleepNightRouteTelemetry.ts";
+const ROUTE_REL = "services/api/src/routes/usersMe.ts";
+
+const PROHIBITED_TELEMETRY_IDENTIFIERS = [
+  "uid",
+  "userId",
+  "requestedDay",
+  "resolvedDay",
+  "anchorDay",
+  "wakeDay",
+  "start",
+  "end",
+  "date",
+  "timestamp",
+  "score",
+  "durationMinutes",
+  "sleepId",
+  "providerId",
+  "documentId",
+  "cursor",
+  "url",
+  "query",
+  "token",
+  "authorization",
+  "payload",
+  "response",
+  "error",
+  "stack",
+] as const;
+
+describe("SleepNight route telemetry source guard", () => {
+  it("typed helper exists and is the sole SLEEP_NIGHT_ROUTE_VERSION logger payload", () => {
+    const abs = path.join(REPO_ROOT, HELPER_REL);
+    expect(fs.existsSync(abs)).toBe(true);
+    const source = fs.readFileSync(abs, "utf8");
+
+    expect(source.includes('msg: "[SLEEP_NIGHT_ROUTE_VERSION]"')).toBe(true);
+    expect(source.includes('version: "sleep-night-resolution-v2"')).toBe(true);
+    expect(source.includes("logger.info")).toBe(true);
+    expect(source.includes("...")).toBe(false);
+
+    for (const id of PROHIBITED_TELEMETRY_IDENTIFIERS) {
+      // Property-style and type-field style: `uid:` / `uid?:` / `"uid"`
+      const prop = new RegExp(`(?:^|[\\s,{])${id}\\s*[?:]?\\s*:`, "m");
+      const quoted = new RegExp(`["']${id}["']\\s*:`);
+      expect({ id, propHit: prop.test(source), quotedHit: quoted.test(source) }).toEqual({
+        id,
+        propHit: false,
+        quotedHit: false,
+      });
+    }
+  });
+
+  it("usersMe sleep-night routes call typed helpers and do not inline route-version payloads", () => {
+    const abs = path.join(REPO_ROOT, ROUTE_REL);
+    expect(fs.existsSync(abs)).toBe(true);
+    const source = fs.readFileSync(abs, "utf8");
+
+    expect(source.includes("logSleepNightRouteVersionTelemetry")).toBe(true);
+    expect(source.includes("logSleepNightRangeRouteTelemetry")).toBe(true);
+
+    // No inline reconstruction of the blocked event family.
+    expect(source.includes('msg: "[SLEEP_NIGHT_ROUTE_VERSION]"')).toBe(false);
+    expect(source.includes('msg: "[SLEEP_NIGHT_RANGE_ROUTE]"')).toBe(false);
+
+    // The historical prohibited pairing must not reappear as a logger object.
+    expect(/logger\.info\(\s*\{[^}]*SLEEP_NIGHT_ROUTE_VERSION[^}]*uid/s.test(source)).toBe(false);
+    expect(/logger\.info\(\s*\{[^}]*requestedDay[^}]*uid/s.test(source)).toBe(false);
+  });
+});

--- a/services/api/src/lib/sleepNightRouteTelemetry.ts
+++ b/services/api/src/lib/sleepNightRouteTelemetry.ts
@@ -1,0 +1,38 @@
+/**
+ * Privacy-safe telemetry for SleepNight route-version markers.
+ *
+ * Closed payload only — no uid, day/date, scores, document IDs, URLs, tokens,
+ * or raw errors. Correlation for status/route remains on `http_request_completed`.
+ */
+
+import { logger } from "./logger";
+
+/** Exact-day SleepNight route version marker (aggregate only). */
+export type SleepNightRouteVersionTelemetry = {
+  msg: "[SLEEP_NIGHT_ROUTE_VERSION]";
+  version: "sleep-night-resolution-v2";
+};
+
+/** Range SleepNight route marker (aggregate dayCount only). */
+export type SleepNightRangeRouteTelemetry = {
+  msg: "[SLEEP_NIGHT_RANGE_ROUTE]";
+  version: "sleep-night-range-v1";
+  dayCount: number;
+};
+
+export function logSleepNightRouteVersionTelemetry(): void {
+  const event: SleepNightRouteVersionTelemetry = {
+    msg: "[SLEEP_NIGHT_ROUTE_VERSION]",
+    version: "sleep-night-resolution-v2",
+  };
+  logger.info(event);
+}
+
+export function logSleepNightRangeRouteTelemetry(dayCount: number): void {
+  const event: SleepNightRangeRouteTelemetry = {
+    msg: "[SLEEP_NIGHT_RANGE_ROUTE]",
+    version: "sleep-night-range-v1",
+    dayCount,
+  };
+  logger.info(event);
+}

--- a/services/api/src/lib/testSupport/assertSleepNightRouteTelemetryPrivacy.ts
+++ b/services/api/src/lib/testSupport/assertSleepNightRouteTelemetryPrivacy.ts
@@ -1,0 +1,136 @@
+/**
+ * Recursive assertion helper for SleepNight route telemetry privacy tests.
+ * Synthetic data only — never print real UIDs, tokens, dates, or URLs.
+ */
+
+export const PROHIBITED_SLEEP_NIGHT_ROUTE_TELEMETRY_KEYS: readonly string[] = [
+  "uid",
+  "userId",
+  "email",
+  "requestedDay",
+  "resolvedDay",
+  "anchorDay",
+  "wakeDay",
+  "start",
+  "end",
+  "date",
+  "day",
+  "timestamp",
+  "score",
+  "durationMinutes",
+  "totalSleepMinutes",
+  "sleepId",
+  "providerId",
+  "documentId",
+  "sourceDocumentId",
+  "cursor",
+  "url",
+  "path",
+  "query",
+  "token",
+  "authorization",
+  "payload",
+  "response",
+  "error",
+  "stack",
+];
+
+const PROHIBITED_KEY_SET = new Set(
+  PROHIBITED_SLEEP_NIGHT_ROUTE_TELEMETRY_KEYS.map((k) => k.toLowerCase()),
+);
+
+const ALLOWED_KEYS = new Set(["msg", "version", "daycount", "operation"]);
+
+const PROHIBITED_VALUE_PATTERNS: RegExp[] = [
+  /^\d{4}-\d{2}-\d{2}$/,
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/,
+  /Bearer\s/i,
+  /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\./,
+  /AIza/,
+  /^user_[A-Za-z0-9_]+$/i,
+  /^[A-Za-z0-9]{20,}$/, // UID-like / opaque id fixtures
+  /https?:\/\//i,
+  /[?&](day|start|end|key|token)=/i,
+];
+
+export type SleepNightRoutePrivacyViolation = {
+  path: string;
+  reason: string;
+};
+
+export function findSleepNightRouteTelemetryPrivacyViolations(
+  value: unknown,
+  path = "$",
+): SleepNightRoutePrivacyViolation[] {
+  const violations: SleepNightRoutePrivacyViolation[] = [];
+
+  const visit = (node: unknown, nodePath: string): void => {
+    if (node === null || node === undefined) return;
+
+    if (typeof node === "string") {
+      for (const pattern of PROHIBITED_VALUE_PATTERNS) {
+        if (pattern.test(node)) {
+          // Allow known safe version / msg literals.
+          if (
+            node === "[SLEEP_NIGHT_ROUTE_VERSION]" ||
+            node === "[SLEEP_NIGHT_RANGE_ROUTE]" ||
+            node === "sleep-night-resolution-v2" ||
+            node === "sleep-night-range-v1" ||
+            node === "sleep_night_read"
+          ) {
+            return;
+          }
+          violations.push({
+            path: nodePath,
+            reason: `value matches prohibited pattern ${pattern}`,
+          });
+          break;
+        }
+      }
+      return;
+    }
+
+    if (typeof node === "number") {
+      // Aggregate dayCount is allowed; health scores / durations typically fall in similar ranges —
+      // key allowlist already rejects score/duration keys. Numbers under non-dayCount keys are unexpected.
+      return;
+    }
+
+    if (Array.isArray(node)) {
+      node.forEach((item, i) => visit(item, `${nodePath}[${i}]`));
+      return;
+    }
+
+    if (typeof node === "object") {
+      for (const [key, v] of Object.entries(node as Record<string, unknown>)) {
+        const lower = key.toLowerCase();
+        if (PROHIBITED_KEY_SET.has(lower)) {
+          violations.push({
+            path: `${nodePath}.${key}`,
+            reason: `prohibited key "${key}"`,
+          });
+          continue;
+        }
+        if (nodePath === "$" && !ALLOWED_KEYS.has(lower)) {
+          violations.push({
+            path: `${nodePath}.${key}`,
+            reason: `unexpected sleep-night route telemetry key "${key}"`,
+          });
+          continue;
+        }
+        visit(v, `${nodePath}.${key}`);
+      }
+    }
+  };
+
+  visit(value, path);
+  return violations;
+}
+
+export function assertSleepNightRouteTelemetryPrivacy(value: unknown): void {
+  const violations = findSleepNightRouteTelemetryPrivacyViolations(value);
+  if (violations.length > 0) {
+    const details = violations.map((v) => `  - ${v.path}: ${v.reason}`).join("\n");
+    throw new Error(`SleepNight route telemetry privacy violation(s) found:\n${details}`);
+  }
+}

--- a/services/api/src/routes/__tests__/usersMe.sleepNight.telemetryPrivacy.test.ts
+++ b/services/api/src/routes/__tests__/usersMe.sleepNight.telemetryPrivacy.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Logger-capture privacy tests for SleepNight route telemetry.
+ * Synthetic fixtures only — never assert by printing real staging values.
+ */
+import express from "express";
+import type http from "http";
+import { AddressInfo } from "net";
+
+jest.mock("../../lib/sleepNightRead", () => ({
+  loadSleepNightView: jest.fn(),
+  loadSleepNightViewsForRange: jest.fn(),
+}));
+
+jest.mock("../../db", () => ({
+  userCollection: jest.fn(),
+  documentIdPath: { _: "documentId" },
+}));
+
+import { loadSleepNightView, loadSleepNightViewsForRange } from "../../lib/sleepNightRead";
+import usersMeRoutes from "../usersMe";
+import * as loggerModule from "../../lib/logger";
+import { assertSleepNightRouteTelemetryPrivacy } from "../../lib/testSupport/assertSleepNightRouteTelemetryPrivacy";
+
+const mockLoad = loadSleepNightView as jest.MockedFunction<typeof loadSleepNightView>;
+const mockLoadRange = loadSleepNightViewsForRange as jest.MockedFunction<
+  typeof loadSleepNightViewsForRange
+>;
+
+const SENTINEL = {
+  uid: "UID_SENTINEL_abcdefghijklmnopqrstuv",
+  day: "2099-01-02",
+  start: "2099-01-01",
+  end: "2099-01-03",
+  bearer: "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.SENTINEL.sig",
+  apiKey: "AIzaSySENTINEL_KEY_VALUE_XXXX",
+} as const;
+
+function captureInfoLogs(): { events: Record<string, unknown>[]; restore: () => void } {
+  const events: Record<string, unknown>[] = [];
+  const original = loggerModule.logger.info;
+  loggerModule.logger.info = (o: Record<string, unknown>) => {
+    events.push(o);
+  };
+  return {
+    events,
+    restore: () => {
+      loggerModule.logger.info = original;
+    },
+  };
+}
+
+function sleepNightRouteEvents(events: Record<string, unknown>[]): Record<string, unknown>[] {
+  return events.filter(
+    (e) =>
+      e.msg === "[SLEEP_NIGHT_ROUTE_VERSION]" || e.msg === "[SLEEP_NIGHT_RANGE_ROUTE]",
+  );
+}
+
+function assertNoSentinelLeak(events: Record<string, unknown>[]): void {
+  const blob = JSON.stringify(events);
+  expect(blob).not.toContain(SENTINEL.uid);
+  expect(blob).not.toContain(SENTINEL.day);
+  expect(blob).not.toContain(SENTINEL.start);
+  expect(blob).not.toContain(SENTINEL.end);
+  expect(blob).not.toContain(SENTINEL.bearer);
+  expect(blob).not.toContain(SENTINEL.apiKey);
+  expect(blob).not.toContain("eyJ");
+  expect(blob).not.toMatch(/\d{4}-\d{2}-\d{2}/);
+}
+
+describe("SleepNight route telemetry privacy (logger capture)", () => {
+  let server: http.Server;
+  let baseUrl: string;
+  let unauthServer: http.Server;
+  let unauthBaseUrl: string;
+
+  beforeAll(async () => {
+    const app = express();
+    app.use((req, _res, next) => {
+      (req as unknown as { uid: string }).uid = SENTINEL.uid;
+      next();
+    });
+    app.use("/users/me", usersMeRoutes);
+    server = app.listen(0);
+    baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+
+    const unauthApp = express();
+    unauthApp.use("/users/me", usersMeRoutes);
+    unauthServer = unauthApp.listen(0);
+    unauthBaseUrl = `http://127.0.0.1:${(unauthServer.address() as AddressInfo).port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    await new Promise<void>((resolve) => unauthServer.close(() => resolve()));
+  });
+
+  beforeEach(() => {
+    mockLoad.mockReset();
+    mockLoadRange.mockReset();
+  });
+
+  it("emits one privacy-safe version event on authenticated success", async () => {
+    mockLoad.mockResolvedValue({
+      requestedDay: SENTINEL.day,
+      anchorDay: SENTINEL.day,
+      wakeDay: SENTINEL.day,
+      resolution: "exact_anchor",
+      isFallback: false,
+      sleepNight: {
+        anchorDay: SENTINEL.day,
+        wakeDay: SENTINEL.day,
+        provider: "oura",
+        source: "ouraVendorSleep",
+        sourceDocumentId: "doc_SENTINEL",
+        score: 88,
+        isComplete: true,
+        totalSleepMinutes: 400,
+        updatedAt: "2099-01-02T12:00:00.000Z",
+      },
+    });
+
+    const cap = captureInfoLogs();
+    try {
+      const res = await fetch(`${baseUrl}/users/me/sleep-night?day=${SENTINEL.day}`);
+      expect(res.status).toBe(200);
+      const routeEvents = sleepNightRouteEvents(cap.events);
+      expect(routeEvents).toHaveLength(1);
+      expect(routeEvents[0]).toEqual({
+        msg: "[SLEEP_NIGHT_ROUTE_VERSION]",
+        version: "sleep-night-resolution-v2",
+      });
+      assertSleepNightRouteTelemetryPrivacy(routeEvents[0]);
+      assertNoSentinelLeak(routeEvents);
+    } finally {
+      cap.restore();
+    }
+  });
+
+  it("emits one privacy-safe version event on authenticated sparse/no-data (404)", async () => {
+    mockLoad.mockResolvedValue(null);
+    const cap = captureInfoLogs();
+    try {
+      const res = await fetch(`${baseUrl}/users/me/sleep-night?day=${SENTINEL.day}`);
+      expect(res.status).toBe(404);
+      const routeEvents = sleepNightRouteEvents(cap.events);
+      expect(routeEvents).toHaveLength(1);
+      expect(routeEvents[0]).toEqual({
+        msg: "[SLEEP_NIGHT_ROUTE_VERSION]",
+        version: "sleep-night-resolution-v2",
+      });
+      assertSleepNightRouteTelemetryPrivacy(routeEvents[0]);
+      assertNoSentinelLeak(routeEvents);
+    } finally {
+      cap.restore();
+    }
+  });
+
+  it("emits no SleepNight route-version event on invalid day", async () => {
+    const cap = captureInfoLogs();
+    try {
+      const res = await fetch(`${baseUrl}/users/me/sleep-night?day=not-a-day`);
+      expect(res.status).toBe(400);
+      expect(sleepNightRouteEvents(cap.events)).toHaveLength(0);
+    } finally {
+      cap.restore();
+    }
+  });
+
+  it("emits no SleepNight route-version event when unauthenticated", async () => {
+    const cap = captureInfoLogs();
+    try {
+      const res = await fetch(`${unauthBaseUrl}/users/me/sleep-night?day=${SENTINEL.day}`);
+      expect(res.status).toBe(401);
+      expect(sleepNightRouteEvents(cap.events)).toHaveLength(0);
+    } finally {
+      cap.restore();
+    }
+  });
+
+  it("range route emits aggregate-only dayCount telemetry", async () => {
+    mockLoadRange.mockResolvedValue([]);
+    const cap = captureInfoLogs();
+    try {
+      const res = await fetch(
+        `${baseUrl}/users/me/sleep-nights?start=${SENTINEL.start}&end=${SENTINEL.end}`,
+      );
+      expect(res.status).toBe(200);
+      const routeEvents = sleepNightRouteEvents(cap.events);
+      expect(routeEvents).toHaveLength(1);
+      expect(routeEvents[0]).toEqual({
+        msg: "[SLEEP_NIGHT_RANGE_ROUTE]",
+        version: "sleep-night-range-v1",
+        dayCount: 3,
+      });
+      assertSleepNightRouteTelemetryPrivacy(routeEvents[0]);
+      assertNoSentinelLeak(routeEvents);
+    } finally {
+      cap.restore();
+    }
+  });
+});

--- a/services/api/src/routes/usersMe.ts
+++ b/services/api/src/routes/usersMe.ts
@@ -39,6 +39,10 @@ import { asyncHandler } from "../lib/asyncHandler";
 import { loadBodyFactsFromRawForApi } from "../lib/bodyFactsSynthesizeFromRaw";
 import type { RequestWithRid } from "../lib/logger";
 import { logger } from "../lib/logger";
+import {
+  logSleepNightRangeRouteTelemetry,
+  logSleepNightRouteVersionTelemetry,
+} from "../lib/sleepNightRouteTelemetry";
 import { dayQuerySchema, dayKeySchema } from "../types/day";
 import {
   dailyFactsDtoSchema,
@@ -2229,12 +2233,7 @@ router.get(
     const requestedDay = parseDay(req, res);
     if (!requestedDay) return;
 
-    logger.info({
-      msg: "[SLEEP_NIGHT_ROUTE_VERSION]",
-      version: "sleep-night-resolution-v2",
-      requestedDay,
-      uid,
-    });
+    logSleepNightRouteVersionTelemetry();
 
     const view = await loadSleepNightView(uid, requestedDay);
     if (!view) {
@@ -2297,11 +2296,7 @@ router.get(
       return;
     }
 
-    logger.info({
-      msg: "[SLEEP_NIGHT_RANGE_ROUTE]",
-      version: "sleep-night-range-v1",
-      dayCount,
-    });
+    logSleepNightRangeRouteTelemetry(dayCount);
 
     const nights = await loadSleepNightViewsForRange(uid, start, end);
     const out = {


### PR DESCRIPTION
## Summary

- removes user identity and exact-day metadata from SleepNight route telemetry;
- preserves the route-version marker only when operationally required;
- adds logger-capture privacy tests and source guards;
- leaves SleepNight behavior unchanged.

## Original blocker

- Timeline zero-traffic preflight found one existing-route telemetry privacy violation;
- Timeline route telemetry itself was clean;
- no traffic shift or Gateway config occurred.

## Functional parity

- response/status/auth/query behavior unchanged;
- no Firestore read/write change;
- no provider call;
- no Timeline product/OpenAPI change.

## Evidence

- focused SleepNight route + logger-capture + source-guard tests;
- full Jest suite (811 suites / 5054 tests);
- complete Code Check Gate;
- exact file scope limited to SleepNight telemetry source/tests/guards.

## Artifact impact

- `oli-api-00235-fiy` and digest `sha256:b1b5a760…` are superseded;
- preserve but do not cut over;
- corrected immutable image must be rebuilt after this PR is merged into `feat/timeline-v1`.

## Deployment

- no deployment in this PR;
- no Functions change;
- no Gateway change;
- no Firestore change.

Made with [Cursor](https://cursor.com)