### PR TITLE
fix(timeline): repair continuous feed chronology and workout truth

### DIFF
--- a/lib/data/workouts/workoutSessionReconciliation.ts
+++ b/lib/data/workouts/workoutSessionReconciliation.ts
@@ -2,8 +2,15 @@ import type { WorkoutHistoryItem } from "@/lib/data/workouts/parseWorkoutFromRaw
 import type { DayKey } from "@/lib/ui/calendar/types";
 import { formatWorkoutTitle } from "@/lib/data/workouts/workoutDisplay";
 import { classifyWorkoutHistoryItemEvidence } from "@/lib/data/workouts/workoutEligibility";
+import {
+  reconcileWorkoutSessionsCore,
+  type ReconcilableWorkoutRecord,
+  type ReconciledWorkoutSessionCore,
+  type WorkoutSessionFamily,
+  type WorkoutSessionType,
+} from "@/lib/domain/workouts/reconcileWorkoutSessionsCore";
 
-export type WorkoutSessionType = "strength" | "cardio" | "mixed" | "unknown";
+export type { WorkoutSessionType };
 
 export type WorkoutSessionSourceSummary = {
   source: string;
@@ -29,128 +36,60 @@ export type ReconciledWorkoutSession = {
   sourceCount: number;
 };
 
-const MERGE_GAP_MINUTES = 30;
-const START_PROXIMITY_MINUTES = 35;
-const DURATION_RATIO_TOLERANCE = 0.6;
-
-type NormalizedWindow = {
-  startMs: number | null;
-  endMs: number | null;
-};
-
-function toMs(iso: string | null | undefined): number | null {
-  if (!iso) return null;
-  const ms = Date.parse(iso);
-  return Number.isNaN(ms) ? null : ms;
-}
-
-function normalizeWindow(workout: WorkoutHistoryItem): NormalizedWindow {
-  const startMs = toMs(workout.start ?? workout.observedAt);
-  let endMs = toMs(workout.end);
-  if (endMs == null && startMs != null && typeof workout.durationMinutes === "number" && workout.durationMinutes > 0) {
-    endMs = startMs + Math.round(workout.durationMinutes * 60_000);
-  }
-  return { startMs, endMs };
-}
-
-function familyForWorkout(workout: WorkoutHistoryItem): "strength" | "cardio" | "unknown" {
+function familyForWorkout(workout: WorkoutHistoryItem): WorkoutSessionFamily {
   const kind = classifyWorkoutHistoryItemEvidence(workout);
   if (kind === "strength" || kind === "cardio") return kind;
   return "unknown";
 }
 
-function canMerge(
-  sessionStart: number | null,
-  sessionEnd: number | null,
-  workoutWindow: NormalizedWindow,
-): boolean {
-  const { startMs, endMs } = workoutWindow;
-  if (sessionStart == null || startMs == null) return false;
-  const left = sessionEnd ?? sessionStart;
-  const right = endMs ?? startMs;
-  const overlap = startMs <= left && right >= sessionStart;
-  if (overlap) return true;
-  const gapMs = Math.abs(startMs - left);
-  return gapMs <= MERGE_GAP_MINUTES * 60_000;
+function toReconcilable(workout: WorkoutHistoryItem): ReconcilableWorkoutRecord {
+  return {
+    id: workout.id,
+    sourceId: workout.sourceId,
+    ...(workout.rawKind ? { rawKind: workout.rawKind } : {}),
+    title: workout.title,
+    ...(workout.workoutType ? { workoutType: workout.workoutType } : {}),
+    start: workout.start,
+    end: workout.end,
+    observedAt: workout.observedAt,
+    durationMinutes: workout.durationMinutes,
+    calories: workout.calories,
+    family: familyForWorkout(workout),
+  };
 }
 
-function areFamiliesCompatible(
-  existingFamilies: Set<"strength" | "cardio" | "unknown">,
-  incoming: "strength" | "cardio" | "unknown",
-): boolean {
-  if (incoming === "unknown") return true;
-  if (existingFamilies.has("unknown")) return true;
-  if (incoming === "strength" && existingFamilies.has("cardio")) return false;
-  if (incoming === "cardio" && existingFamilies.has("strength")) return false;
-  return true;
-}
-
-function estimatedDurationMinutes(window: NormalizedWindow, fallback: number | null): number | null {
-  // When start === end (common on legacy manual strength_workout canonicals with no durationMinutes),
-  // do not invent a 1-minute duration — that blocks merging with a longer provider workout.
-  if (window.startMs != null && window.endMs != null && window.endMs > window.startMs) {
-    return Math.max(1, Math.round((window.endMs - window.startMs) / 60_000));
-  }
-  return fallback != null && Number.isFinite(fallback) && fallback > 0 ? fallback : null;
-}
-
-function isDurationCompatible(a: number | null, b: number | null): boolean {
-  if (a == null || b == null) return true;
-  const bigger = Math.max(a, b);
-  const smaller = Math.min(a, b);
-  if (bigger <= 0) return true;
-  return smaller / bigger >= 1 - DURATION_RATIO_TOLERANCE;
-}
-
-function mergeScore(
-  session: { start: number | null; end: number | null; workouts: WorkoutHistoryItem[] },
-  incomingWindow: NormalizedWindow,
-  incomingDuration: number | null,
-): number {
-  const incomingStart = incomingWindow.startMs;
-  if (incomingStart == null || session.start == null) return Number.POSITIVE_INFINITY;
-  const sessionDuration = estimatedDurationMinutes(
-    { startMs: session.start, endMs: session.end },
-    session.workouts[0]?.durationMinutes ?? null,
-  );
-  const startGap = Math.abs(incomingStart - session.start);
-  const endGap = Math.abs((incomingWindow.endMs ?? incomingStart) - (session.end ?? session.start));
-  if (!isDurationCompatible(sessionDuration, incomingDuration)) return Number.POSITIVE_INFINITY;
-  return startGap + endGap;
-}
-
-function chooseTitle(workouts: WorkoutHistoryItem[]): { title: string; source: ReconciledWorkoutSession["titleSource"] } {
-  const manual = workouts.find((w) => w.sourceId === "manual" && w.title.trim().length > 0);
-  if (manual) return { title: formatWorkoutTitle(manual.title), source: "manual" };
-  const provider = workouts.find((w) => w.title.trim().length > 0);
-  if (provider) return { title: formatWorkoutTitle(provider.title), source: "provider" };
-  return { title: "Workout", source: "fallback" };
-}
-
-function sessionTypeFromFamilies(families: Set<"strength" | "cardio" | "unknown">): WorkoutSessionType {
-  const hasStrength = families.has("strength");
-  const hasCardio = families.has("cardio");
-  if (hasStrength && hasCardio) return "mixed";
-  if (hasStrength) return "strength";
-  if (hasCardio) return "cardio";
-  return "unknown";
-}
-
-function getSessionDurationMinutes(workouts: WorkoutHistoryItem[]): number | null {
-  const manual = workouts.filter((w) => w.sourceId === "manual");
-  if (manual.length > 0) {
-    const sum = manual.reduce((acc, w) => {
-      if (typeof w.durationMinutes === "number" && Number.isFinite(w.durationMinutes) && w.durationMinutes > 0) {
-        return acc + w.durationMinutes;
-      }
-      return acc;
-    }, 0);
-    return sum > 0 ? sum : null;
-  }
-  const provider = workouts.find(
-    (w) => typeof w.durationMinutes === "number" && Number.isFinite(w.durationMinutes) && w.durationMinutes > 0,
-  );
-  return provider?.durationMinutes ?? null;
+function fromCore(
+  day: DayKey,
+  core: ReconciledWorkoutSessionCore,
+  byId: Map<string, WorkoutHistoryItem>,
+  index: number,
+): ReconciledWorkoutSession {
+  const workouts = core.memberIds
+    .map((id) => byId.get(id))
+    .filter((w): w is WorkoutHistoryItem => w != null);
+  // Preserve legacy indexed id shape used by session storage / menus.
+  const legacyId = `${day}:session:${index}:${workouts.map((w) => w.id).join("|")}`;
+  return {
+    id: legacyId,
+    day,
+    sessionType: core.sessionType,
+    title: formatWorkoutTitle(core.title),
+    titleSource: core.titleSource,
+    start: core.start,
+    end: core.end,
+    durationMinutes: core.durationMinutes,
+    calories: core.calories,
+    workouts,
+    sourceSummaries: workouts.map((w) => ({
+      source: w.sourceId,
+      rawEventId: w.id,
+      ...(w.workoutType ? { kind: w.workoutType } : {}),
+      ...(w.title ? { title: w.title } : {}),
+      ...(w.start ? { start: w.start } : {}),
+      ...(w.end ? { end: w.end } : {}),
+    })),
+    sourceCount: core.sourceCount,
+  };
 }
 
 export function reconcileWorkoutSessionsForDay(
@@ -158,90 +97,12 @@ export function reconcileWorkoutSessionsForDay(
   workouts: WorkoutHistoryItem[],
 ): ReconciledWorkoutSession[] {
   if (workouts.length === 0) return [];
-  const sorted = [...workouts].sort((a, b) => {
-    const sa = toMs(a.start ?? a.observedAt) ?? 0;
-    const sb = toMs(b.start ?? b.observedAt) ?? 0;
-    if (sa !== sb) return sa - sb;
-    return a.id.localeCompare(b.id);
-  });
-
-  const sessions: {
-    workouts: WorkoutHistoryItem[];
-    families: Set<"strength" | "cardio" | "unknown">;
-    start: number | null;
-    end: number | null;
-  }[] = [];
-
-  for (const workout of sorted) {
-    const family = familyForWorkout(workout);
-    const window = normalizeWindow(workout);
-    const incomingDuration = estimatedDurationMinutes(window, workout.durationMinutes);
-    let bestMatch: (typeof sessions)[number] | null = null;
-    let bestScore = Number.POSITIVE_INFINITY;
-    for (const candidate of sessions) {
-      if (!areFamiliesCompatible(candidate.families, family)) continue;
-      const closeByTime =
-        canMerge(candidate.start, candidate.end, window) ||
-        (candidate.start != null &&
-          window.startMs != null &&
-          Math.abs(window.startMs - candidate.start) <= START_PROXIMITY_MINUTES * 60_000);
-      if (!closeByTime) continue;
-      const score = mergeScore(candidate, window, incomingDuration);
-      if (score < bestScore) {
-        bestScore = score;
-        bestMatch = candidate;
-      }
-    }
-    if (bestMatch) {
-      bestMatch.workouts.push(workout);
-      bestMatch.families.add(family);
-      if (window.startMs != null) {
-        bestMatch.start = bestMatch.start == null ? window.startMs : Math.min(bestMatch.start, window.startMs);
-      }
-      if (window.endMs != null) {
-        bestMatch.end = bestMatch.end == null ? window.endMs : Math.max(bestMatch.end, window.endMs);
-      }
-    } else {
-      sessions.push({
-        workouts: [workout],
-        families: new Set([family]),
-        start: window.startMs,
-        end: window.endMs,
-      });
-    }
-  }
-
-  return sessions.map((s, index) => {
-    const startIso = s.start == null ? null : new Date(s.start).toISOString();
-    const endIso = s.end == null ? null : new Date(s.end).toISOString();
-    const title = chooseTitle(s.workouts);
-    const durationMinutes = getSessionDurationMinutes(s.workouts);
-    const calories = s.workouts
-      .map((w) => w.calories)
-      .find((c): c is number => typeof c === "number" && c >= 0) ?? null;
-
-    return {
-      id: `${day}:session:${index}:${s.workouts.map((w) => w.id).join("|")}`,
-      day,
-      sessionType: sessionTypeFromFamilies(s.families),
-      title: title.title,
-      titleSource: title.source,
-      start: startIso,
-      end: endIso,
-      durationMinutes,
-      calories,
-      workouts: s.workouts,
-      sourceSummaries: s.workouts.map((w) => ({
-        source: w.sourceId,
-        rawEventId: w.id,
-        ...(w.workoutType ? { kind: w.workoutType } : {}),
-        ...(w.title ? { title: w.title } : {}),
-        ...(w.start ? { start: w.start } : {}),
-        ...(w.end ? { end: w.end } : {}),
-      })),
-      sourceCount: new Set(s.workouts.map((w) => `${w.sourceId}:${w.id}`)).size,
-    };
-  });
+  const byId = new Map(workouts.map((w) => [w.id, w]));
+  const core = reconcileWorkoutSessionsCore(
+    day,
+    workouts.map(toReconcilable),
+  );
+  return core.map((session, index) => fromCore(day, session, byId, index));
 }
 
 export function deriveSessionTypeFlags(

--- a/lib/domain/workouts/__tests__/reconcileWorkoutSessionsCore.test.ts
+++ b/lib/domain/workouts/__tests__/reconcileWorkoutSessionsCore.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Pure shared workout session reconciliation contracts (synthetic data only).
+ */
+import {
+  familyFromWorkoutKind,
+  reconcileWorkoutSessionsCore,
+  type ReconcilableWorkoutRecord,
+} from "@/lib/domain/workouts/reconcileWorkoutSessionsCore";
+import { reconcileWorkoutSessionsForDay } from "@/lib/data/workouts/workoutSessionReconciliation";
+import type { WorkoutHistoryItem } from "@/lib/data/workouts/parseWorkoutFromRawEvent";
+
+function record(
+  overrides: Partial<ReconcilableWorkoutRecord> & Pick<ReconcilableWorkoutRecord, "id" | "family">,
+): ReconcilableWorkoutRecord {
+  return {
+    sourceId: overrides.sourceId ?? "apple_health",
+    title: overrides.title ?? null,
+    start: overrides.start ?? "2026-07-16T18:00:00.000Z",
+    end: overrides.end ?? "2026-07-16T19:00:00.000Z",
+    observedAt: overrides.observedAt ?? overrides.start ?? "2026-07-16T18:00:00.000Z",
+    durationMinutes: overrides.durationMinutes ?? 60,
+    calories: overrides.calories ?? null,
+    rawKind: overrides.rawKind ?? null,
+    ...overrides,
+  };
+}
+
+function historyItem(
+  overrides: Partial<WorkoutHistoryItem> & Pick<WorkoutHistoryItem, "id">,
+): WorkoutHistoryItem {
+  return {
+    observedAt: overrides.observedAt ?? "2026-07-16T18:00:00.000Z",
+    sourceId: overrides.sourceId ?? "apple_health",
+    title: overrides.title ?? "Workout",
+    start: overrides.start ?? "2026-07-16T18:00:00.000Z",
+    end: overrides.end ?? "2026-07-16T19:00:00.000Z",
+    durationMinutes: overrides.durationMinutes ?? 60,
+    calories: overrides.calories ?? null,
+    ...overrides,
+  };
+}
+
+describe("reconcileWorkoutSessionsCore", () => {
+  test("manual-only → one session", () => {
+    const sessions = reconcileWorkoutSessionsCore("2026-07-16", [
+      record({
+        id: "m1",
+        sourceId: "manual",
+        family: "strength",
+        rawKind: "strength_workout",
+        title: "Push",
+      }),
+    ]);
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]!.memberIds).toEqual(["m1"]);
+  });
+
+  test("Apple Health-only → one session", () => {
+    const sessions = reconcileWorkoutSessionsCore("2026-07-16", [
+      record({ id: "a1", family: "unknown", rawKind: "workout" }),
+    ]);
+    expect(sessions).toHaveLength(1);
+  });
+
+  test("matching manual + Apple Health → one merged session", () => {
+    // Legacy manual strength often has start===end and null duration — must still merge.
+    const sessions = reconcileWorkoutSessionsCore("2026-07-16", [
+      record({
+        id: "m1",
+        sourceId: "manual",
+        family: "strength",
+        rawKind: "strength_workout",
+        title: "Legs",
+        start: "2026-07-16T18:00:00.000Z",
+        end: "2026-07-16T18:00:00.000Z",
+        durationMinutes: null,
+      }),
+      record({
+        id: "a1",
+        family: "unknown",
+        rawKind: "workout",
+        start: "2026-07-16T18:02:00.000Z",
+        end: "2026-07-16T19:00:00.000Z",
+        durationMinutes: 58,
+      }),
+    ]);
+    expect(sessions).toHaveLength(1);
+    expect([...sessions[0]!.memberIds].sort()).toEqual(["a1", "m1"]);
+    expect(sessions[0]!.title).toBe("Legs");
+    expect(sessions[0]!.titleSource).toBe("manual");
+  });
+
+  test("strength_workout + workout kinds merge when times align", () => {
+    const sessions = reconcileWorkoutSessionsCore("2026-07-16", [
+      record({
+        id: "s1",
+        sourceId: "manual",
+        family: familyFromWorkoutKind("strength_workout"),
+        rawKind: "strength_workout",
+        start: "2026-07-16T18:00:00.000Z",
+        end: "2026-07-16T18:00:00.000Z",
+        durationMinutes: null,
+      }),
+      record({
+        id: "w1",
+        family: familyFromWorkoutKind("workout"),
+        rawKind: "workout",
+        start: "2026-07-16T18:10:00.000Z",
+        end: "2026-07-16T19:00:00.000Z",
+      }),
+    ]);
+    expect(sessions).toHaveLength(1);
+  });
+
+  test("two distinct sessions close in time stay separate when families conflict", () => {
+    const sessions = reconcileWorkoutSessionsCore("2026-07-16", [
+      record({
+        id: "s1",
+        family: "strength",
+        rawKind: "strength_workout",
+        start: "2026-07-16T18:00:00.000Z",
+        end: "2026-07-16T18:40:00.000Z",
+      }),
+      record({
+        id: "c1",
+        family: "cardio",
+        start: "2026-07-16T18:05:00.000Z",
+        end: "2026-07-16T18:45:00.000Z",
+      }),
+    ]);
+    expect(sessions).toHaveLength(2);
+  });
+
+  test("same title on far-apart sessions → two sessions", () => {
+    const sessions = reconcileWorkoutSessionsCore("2026-07-16", [
+      record({
+        id: "a",
+        family: "unknown",
+        title: "Run",
+        start: "2026-07-16T07:00:00.000Z",
+        end: "2026-07-16T07:30:00.000Z",
+      }),
+      record({
+        id: "b",
+        family: "unknown",
+        title: "Run",
+        start: "2026-07-16T18:00:00.000Z",
+        end: "2026-07-16T18:30:00.000Z",
+      }),
+    ]);
+    expect(sessions).toHaveLength(2);
+  });
+
+  test("source order does not change merged identity", () => {
+    const a = record({
+      id: "m1",
+      sourceId: "manual",
+      family: "strength",
+      rawKind: "strength_workout",
+      title: "Push",
+      start: "2026-07-16T18:00:00.000Z",
+      end: "2026-07-16T18:00:00.000Z",
+      durationMinutes: null,
+    });
+    const b = record({
+      id: "a1",
+      family: "unknown",
+      rawKind: "workout",
+      start: "2026-07-16T18:05:00.000Z",
+      end: "2026-07-16T19:00:00.000Z",
+    });
+    const forward = reconcileWorkoutSessionsCore("2026-07-16", [a, b]);
+    const reverse = reconcileWorkoutSessionsCore("2026-07-16", [b, a]);
+    expect(forward).toHaveLength(1);
+    expect(reverse).toHaveLength(1);
+    expect(forward[0]!.id).toBe(reverse[0]!.id);
+  });
+});
+
+describe("Workout module wrapper parity with core", () => {
+  test("same synthetic inputs yield one merged session with shared membership", () => {
+    const day = "2026-07-16" as const;
+    const manual = historyItem({
+      id: "m1",
+      sourceId: "manual",
+      rawKind: "strength_workout",
+      workoutType: "strength",
+      title: "Push",
+      start: "2026-07-16T18:00:00.000Z",
+      end: "2026-07-16T18:00:00.000Z",
+      durationMinutes: null,
+    });
+    const apple = historyItem({
+      id: "a1",
+      sourceId: "apple_health",
+      rawKind: "workout",
+      title: "Traditional Strength Training",
+      start: "2026-07-16T18:02:00.000Z",
+      end: "2026-07-16T19:00:00.000Z",
+      durationMinutes: 58,
+    });
+    const workoutSessions = reconcileWorkoutSessionsForDay(day, [manual, apple]);
+    const core = reconcileWorkoutSessionsCore(day, [
+      {
+        id: "m1",
+        sourceId: "manual",
+        rawKind: "strength_workout",
+        title: "Push",
+        start: "2026-07-16T18:00:00.000Z",
+        end: "2026-07-16T18:00:00.000Z",
+        durationMinutes: null,
+        calories: null,
+        family: "strength",
+      },
+      {
+        id: "a1",
+        sourceId: "apple_health",
+        rawKind: "workout",
+        title: "Traditional Strength Training",
+        start: "2026-07-16T18:02:00.000Z",
+        end: "2026-07-16T19:00:00.000Z",
+        durationMinutes: 58,
+        calories: null,
+        family: "unknown",
+      },
+    ]);
+    expect(workoutSessions).toHaveLength(1);
+    expect(core).toHaveLength(1);
+    expect(workoutSessions[0]!.workouts.map((w) => w.id).sort()).toEqual(
+      [...core[0]!.memberIds].sort(),
+    );
+  });
+});

--- a/lib/domain/workouts/reconcileWorkoutSessionsCore.ts
+++ b/lib/domain/workouts/reconcileWorkoutSessionsCore.ts
@@ -1,0 +1,289 @@
+/**
+ * Pure workout session reconciliation core.
+ * Shared by Workout module UI and Timeline feed normalization.
+ * No Firestore, no network, no React.
+ */
+
+export type WorkoutSessionFamily = "strength" | "cardio" | "unknown";
+
+export type ReconcilableWorkoutRecord = {
+  id: string;
+  sourceId: string;
+  /** Original raw/canonical kind when known (e.g. strength_workout). */
+  rawKind?: string | null;
+  title?: string | null;
+  workoutType?: "strength" | "cardio";
+  start: string | null;
+  end: string | null;
+  observedAt?: string | null;
+  durationMinutes?: number | null;
+  calories?: number | null;
+  family: WorkoutSessionFamily;
+};
+
+export type WorkoutSessionType = "strength" | "cardio" | "mixed" | "unknown";
+
+export type ReconciledWorkoutSessionCore = {
+  /** Stable across membership-preserving source-order changes. */
+  id: string;
+  day: string;
+  sessionType: WorkoutSessionType;
+  title: string;
+  titleSource: "user_override" | "manual" | "provider" | "fallback";
+  start: string | null;
+  end: string | null;
+  durationMinutes: number | null;
+  calories: number | null;
+  memberIds: readonly string[];
+  members: readonly ReconcilableWorkoutRecord[];
+  sourceCount: number;
+};
+
+const MERGE_GAP_MINUTES = 30;
+const START_PROXIMITY_MINUTES = 35;
+const DURATION_RATIO_TOLERANCE = 0.6;
+
+type NormalizedWindow = {
+  startMs: number | null;
+  endMs: number | null;
+};
+
+function toMs(iso: string | null | undefined): number | null {
+  if (!iso) return null;
+  const ms = Date.parse(iso);
+  return Number.isNaN(ms) ? null : ms;
+}
+
+function normalizeWindow(workout: ReconcilableWorkoutRecord): NormalizedWindow {
+  const startMs = toMs(workout.start ?? workout.observedAt);
+  let endMs = toMs(workout.end);
+  if (
+    endMs == null &&
+    startMs != null &&
+    typeof workout.durationMinutes === "number" &&
+    workout.durationMinutes > 0
+  ) {
+    endMs = startMs + Math.round(workout.durationMinutes * 60_000);
+  }
+  return { startMs, endMs };
+}
+
+function canMerge(
+  sessionStart: number | null,
+  sessionEnd: number | null,
+  workoutWindow: NormalizedWindow,
+): boolean {
+  const { startMs, endMs } = workoutWindow;
+  if (sessionStart == null || startMs == null) return false;
+  const left = sessionEnd ?? sessionStart;
+  const right = endMs ?? startMs;
+  const overlap = startMs <= left && right >= sessionStart;
+  if (overlap) return true;
+  const gapMs = Math.abs(startMs - left);
+  return gapMs <= MERGE_GAP_MINUTES * 60_000;
+}
+
+function areFamiliesCompatible(
+  existingFamilies: Set<WorkoutSessionFamily>,
+  incoming: WorkoutSessionFamily,
+): boolean {
+  if (incoming === "unknown") return true;
+  if (existingFamilies.has("unknown")) return true;
+  if (incoming === "strength" && existingFamilies.has("cardio")) return false;
+  if (incoming === "cardio" && existingFamilies.has("strength")) return false;
+  return true;
+}
+
+function estimatedDurationMinutes(
+  window: NormalizedWindow,
+  fallback: number | null | undefined,
+): number | null {
+  if (window.startMs != null && window.endMs != null && window.endMs > window.startMs) {
+    return Math.max(1, Math.round((window.endMs - window.startMs) / 60_000));
+  }
+  return fallback != null && Number.isFinite(fallback) && fallback > 0 ? fallback : null;
+}
+
+function isDurationCompatible(a: number | null, b: number | null): boolean {
+  if (a == null || b == null) return true;
+  const bigger = Math.max(a, b);
+  const smaller = Math.min(a, b);
+  if (bigger <= 0) return true;
+  return smaller / bigger >= 1 - DURATION_RATIO_TOLERANCE;
+}
+
+function mergeScore(
+  session: {
+    start: number | null;
+    end: number | null;
+    workouts: ReconcilableWorkoutRecord[];
+  },
+  incomingWindow: NormalizedWindow,
+  incomingDuration: number | null,
+): number {
+  const incomingStart = incomingWindow.startMs;
+  if (incomingStart == null || session.start == null) return Number.POSITIVE_INFINITY;
+  const sessionDuration = estimatedDurationMinutes(
+    { startMs: session.start, endMs: session.end },
+    session.workouts[0]?.durationMinutes ?? null,
+  );
+  const startGap = Math.abs(incomingStart - session.start);
+  const endGap = Math.abs((incomingWindow.endMs ?? incomingStart) - (session.end ?? session.start));
+  if (!isDurationCompatible(sessionDuration, incomingDuration)) return Number.POSITIVE_INFINITY;
+  return startGap + endGap;
+}
+
+function chooseTitle(workouts: readonly ReconcilableWorkoutRecord[]): {
+  title: string;
+  source: ReconciledWorkoutSessionCore["titleSource"];
+} {
+  const manual = workouts.find(
+    (w) => w.sourceId === "manual" && (w.title ?? "").trim().length > 0,
+  );
+  if (manual?.title) return { title: manual.title.trim(), source: "manual" };
+  const provider = workouts.find((w) => (w.title ?? "").trim().length > 0);
+  if (provider?.title) return { title: provider.title.trim(), source: "provider" };
+  if (workouts.some((w) => w.family === "strength" || w.rawKind === "strength_workout")) {
+    return { title: "Strength workout", source: "fallback" };
+  }
+  return { title: "Workout", source: "fallback" };
+}
+
+function sessionTypeFromFamilies(families: Set<WorkoutSessionFamily>): WorkoutSessionType {
+  const hasStrength = families.has("strength");
+  const hasCardio = families.has("cardio");
+  if (hasStrength && hasCardio) return "mixed";
+  if (hasStrength) return "strength";
+  if (hasCardio) return "cardio";
+  return "unknown";
+}
+
+function getSessionDurationMinutes(workouts: readonly ReconcilableWorkoutRecord[]): number | null {
+  const manual = workouts.filter((w) => w.sourceId === "manual");
+  if (manual.length > 0) {
+    const sum = manual.reduce((acc, w) => {
+      if (
+        typeof w.durationMinutes === "number" &&
+        Number.isFinite(w.durationMinutes) &&
+        w.durationMinutes > 0
+      ) {
+        return acc + w.durationMinutes;
+      }
+      return acc;
+    }, 0);
+    return sum > 0 ? sum : null;
+  }
+  const provider = workouts.find(
+    (w) =>
+      typeof w.durationMinutes === "number" &&
+      Number.isFinite(w.durationMinutes) &&
+      w.durationMinutes > 0,
+  );
+  return provider?.durationMinutes ?? null;
+}
+
+function stableSessionId(day: string, memberIds: readonly string[]): string {
+  const sorted = [...memberIds].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+  return `${day}:session:${sorted.join("|")}`;
+}
+
+/**
+ * Reconcile workout records for one calendar day into merged physical sessions.
+ * Deterministic for a given input set (independent of input array order).
+ */
+export function reconcileWorkoutSessionsCore(
+  day: string,
+  workouts: readonly ReconcilableWorkoutRecord[],
+): ReconciledWorkoutSessionCore[] {
+  if (workouts.length === 0) return [];
+  const sorted = [...workouts].sort((a, b) => {
+    const sa = toMs(a.start ?? a.observedAt) ?? 0;
+    const sb = toMs(b.start ?? b.observedAt) ?? 0;
+    if (sa !== sb) return sa - sb;
+    return a.id.localeCompare(b.id);
+  });
+
+  const sessions: {
+    workouts: ReconcilableWorkoutRecord[];
+    families: Set<WorkoutSessionFamily>;
+    start: number | null;
+    end: number | null;
+  }[] = [];
+
+  for (const workout of sorted) {
+    const family = workout.family;
+    const window = normalizeWindow(workout);
+    const incomingDuration = estimatedDurationMinutes(window, workout.durationMinutes);
+    let bestMatch: (typeof sessions)[number] | null = null;
+    let bestScore = Number.POSITIVE_INFINITY;
+    for (const candidate of sessions) {
+      if (!areFamiliesCompatible(candidate.families, family)) continue;
+      const closeByTime =
+        canMerge(candidate.start, candidate.end, window) ||
+        (candidate.start != null &&
+          window.startMs != null &&
+          Math.abs(window.startMs - candidate.start) <= START_PROXIMITY_MINUTES * 60_000);
+      if (!closeByTime) continue;
+      const score = mergeScore(candidate, window, incomingDuration);
+      if (score < bestScore) {
+        bestScore = score;
+        bestMatch = candidate;
+      }
+    }
+    if (bestMatch) {
+      bestMatch.workouts.push(workout);
+      bestMatch.families.add(family);
+      if (window.startMs != null) {
+        bestMatch.start =
+          bestMatch.start == null ? window.startMs : Math.min(bestMatch.start, window.startMs);
+      }
+      if (window.endMs != null) {
+        bestMatch.end =
+          bestMatch.end == null ? window.endMs : Math.max(bestMatch.end, window.endMs);
+      }
+    } else {
+      sessions.push({
+        workouts: [workout],
+        families: new Set([family]),
+        start: window.startMs,
+        end: window.endMs,
+      });
+    }
+  }
+
+  return sessions.map((s) => {
+    const startIso = s.start == null ? null : new Date(s.start).toISOString();
+    const endIso = s.end == null ? null : new Date(s.end).toISOString();
+    const title = chooseTitle(s.workouts);
+    const durationMinutes = getSessionDurationMinutes(s.workouts);
+    const calories =
+      s.workouts
+        .map((w) => w.calories)
+        .find((c): c is number => typeof c === "number" && c >= 0) ?? null;
+    const memberIds = s.workouts.map((w) => w.id);
+
+    return {
+      id: stableSessionId(day, memberIds),
+      day,
+      sessionType: sessionTypeFromFamilies(s.families),
+      title: title.title,
+      titleSource: title.source,
+      start: startIso,
+      end: endIso,
+      durationMinutes,
+      calories,
+      memberIds,
+      members: s.workouts,
+      sourceCount: new Set(s.workouts.map((w) => `${w.sourceId}:${w.id}`)).size,
+    };
+  });
+}
+
+/** Family from canonical/raw kind without requiring UI title classifiers. */
+export function familyFromWorkoutKind(
+  kind: string | null | undefined,
+): WorkoutSessionFamily {
+  if (kind === "strength_workout") return "strength";
+  if (kind === "workout") return "unknown";
+  return "unknown";
+}

--- a/lib/features/timeline/__tests__/timelineFeedOrder.test.ts
+++ b/lib/features/timeline/__tests__/timelineFeedOrder.test.ts
@@ -1,0 +1,77 @@
+// lib/features/timeline/__tests__/timelineFeedOrder.test.ts
+import type { TimelinePresentationItem } from "@oli/contracts";
+import {
+  canRequestOlderPage,
+  finalSectionDay,
+  finalSectionIndex,
+  groupSectionsAscending,
+  mergeFeedPageItems,
+  shouldLoadOlderFromEdge,
+} from "@/lib/features/timeline/timelineFeedOrder";
+
+function item(
+  id: string,
+  day: string,
+  dedupeKey: string,
+): TimelinePresentationItem {
+  return {
+    id,
+    kind: "nutrition",
+    day,
+    occurredAt: `${day}T10:00:00.000Z`,
+    timezone: "UTC",
+    title: id,
+    status: "ready",
+    source: "manual",
+    destination: `/(app)/nutrition/day/${day}`,
+    accessibilityLabel: id,
+    dedupeKey,
+    isSynthetic: false,
+    displayRole: "chronological_event",
+  };
+}
+
+describe("timelineFeedOrder", () => {
+  test("groupSectionsAscending orders oldest→newest with Today last", () => {
+    const page1 = [item("a", "2026-07-16", "a"), item("b", "2026-07-16", "b")];
+    const page2 = [item("c", "2026-07-15", "c"), item("d", "2026-07-14", "d")];
+    const merged = mergeFeedPageItems(page1, page2);
+    const sections = groupSectionsAscending(merged);
+    expect(sections.map((s) => s.day)).toEqual([
+      "2026-07-14",
+      "2026-07-15",
+      "2026-07-16",
+    ]);
+    expect(finalSectionDay(sections)).toBe("2026-07-16");
+    expect(finalSectionIndex(sections)).toBe(2);
+    expect(sections[2]?.data).toHaveLength(2);
+  });
+
+  test("mergeFeedPageItems drops duplicate dedupeKeys", () => {
+    const a = item("a", "2026-07-16", "nutrition:a");
+    const b = item("b", "2026-07-15", "canonical:b");
+    const merged = mergeFeedPageItems([a], [a, b]);
+    expect(merged.map((i) => i.dedupeKey)).toEqual(["nutrition:a", "canonical:b"]);
+  });
+
+  test("older-page gate is top-boundary only and blocks concurrent duplicates", () => {
+    const gate = {
+      hasMore: true,
+      nextCursor: "opaque",
+      loadingMore: false,
+      loading: false,
+    };
+    expect(shouldLoadOlderFromEdge({ edge: "start", gate })).toBe(true);
+    expect(shouldLoadOlderFromEdge({ edge: "end", gate })).toBe(false);
+    expect(canRequestOlderPage({ ...gate, nextCursor: null })).toBe(false);
+    expect(canRequestOlderPage({ ...gate, hasMore: false })).toBe(false);
+    expect(canRequestOlderPage({ ...gate, loadingMore: true })).toBe(false);
+    expect(canRequestOlderPage({ ...gate, loading: true })).toBe(false);
+  });
+
+  test("empty older page does not invent sections", () => {
+    const page1 = [item("a", "2026-07-16", "a")];
+    const merged = mergeFeedPageItems(page1, []);
+    expect(groupSectionsAscending(merged).map((s) => s.day)).toEqual(["2026-07-16"]);
+  });
+});

--- a/lib/features/timeline/__tests__/timelinePhysicalFeedRepair.guards.test.ts
+++ b/lib/features/timeline/__tests__/timelinePhysicalFeedRepair.guards.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Cross-boundary guards for the physical continuous-feed repair.
+ * Aggregate/source assertions only — no private runtime evidence.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+describe("timeline physical feed repair contracts", () => {
+  const root = join(__dirname, "..", "..", "..");
+
+  test("feed loads older history at the top boundary only", () => {
+    const list = readFileSync(join(root, "ui/timeline/TimelineFeedList.tsx"), "utf8");
+    const hook = readFileSync(join(root, "features/timeline/useTimelineFeed.ts"), "utf8");
+    expect(list).toContain("onStartReached");
+    expect(list).not.toMatch(/onEndReached\s*=/);
+    expect(list).toContain("maintainVisibleContentPosition");
+    expect(hook).toContain("loadOlder");
+    expect(hook).toContain("inFlightOlderCursorRef");
+    expect(hook).toContain("groupSectionsAscending");
+  });
+
+  test("feed and fallback share TimelineRailRow", () => {
+    const list = readFileSync(join(root, "ui/timeline/TimelineFeedList.tsx"), "utf8");
+    const rail = readFileSync(join(root, "ui/timeline/TimelineRail.tsx"), "utf8");
+    expect(list).toContain("TimelineRailRow");
+    expect(rail).toContain("TimelineRailRow");
+    expect(list).not.toContain("borderBottomWidth: StyleSheet.hairlineWidth");
+  });
+
+  test("Timeline normalizer reconciles workouts via shared core", () => {
+    const normalize = readFileSync(
+      join(root, "../services/api/src/lib/timeline/normalizeDay.ts"),
+      "utf8",
+    );
+    expect(normalize).toContain("reconcileWorkoutSessionsCore");
+    expect(normalize).toContain("buildReconciledWorkoutItems");
+    expect(normalize).toContain("workout_session:");
+    expect(normalize).toContain('ev.kind === "workout" || ev.kind === "strength_workout"');
+    expect(normalize).toContain("continue; // reconciled above");
+  });
+
+  test("no provider payload / raw URL telemetry in feed UI path", () => {
+    const list = readFileSync(join(root, "ui/timeline/TimelineFeedList.tsx"), "utf8");
+    const screen = readFileSync(join(root, "ui/timeline/TimelineFeedScreen.tsx"), "utf8");
+    const hook = readFileSync(join(root, "features/timeline/useTimelineFeed.ts"), "utf8");
+    for (const src of [list, screen, hook]) {
+      expect(src).not.toContain("NET_TRACE");
+      expect(src).not.toContain("providerPayload");
+      expect(src).not.toContain("rawPayload");
+      expect(src).not.toMatch(/console\.(log|debug|info)\([^)]*cursor/);
+    }
+  });
+});

--- a/lib/features/timeline/__tests__/useTimelineFeed.merge.test.ts
+++ b/lib/features/timeline/__tests__/useTimelineFeed.merge.test.ts
@@ -2,33 +2,10 @@
 // Pure merge/group behavior for the feed hook (no Auth/Firebase).
 
 import type { TimelinePresentationItem } from "@oli/contracts";
-
-function mergeItems(
-  prev: TimelinePresentationItem[],
-  next: TimelinePresentationItem[],
-): TimelinePresentationItem[] {
-  const seen = new Set(prev.map((i) => i.dedupeKey));
-  const out = [...prev];
-  for (const item of next) {
-    if (seen.has(item.dedupeKey)) continue;
-    seen.add(item.dedupeKey);
-    out.push(item);
-  }
-  return out;
-}
-
-function groupSections(items: TimelinePresentationItem[]) {
-  const order: string[] = [];
-  const map = new Map<string, TimelinePresentationItem[]>();
-  for (const item of items) {
-    if (!map.has(item.day)) {
-      map.set(item.day, []);
-      order.push(item.day);
-    }
-    map.get(item.day)!.push(item);
-  }
-  return order.map((day) => ({ day, data: map.get(day)! }));
-}
+import {
+  groupSectionsAscending,
+  mergeFeedPageItems,
+} from "@/lib/features/timeline/timelineFeedOrder";
 
 function item(
   id: string,
@@ -53,14 +30,14 @@ function item(
 }
 
 describe("timeline feed merge helpers", () => {
-  test("mergeItems drops duplicate dedupeKeys", () => {
+  test("mergeFeedPageItems drops duplicate dedupeKeys", () => {
     const a = item("a", "2026-07-16", "nutrition:a");
     const b = item("b", "2026-07-15", "canonical:b");
-    const merged = mergeItems([a], [a, b]);
+    const merged = mergeFeedPageItems([a], [a, b]);
     expect(merged.map((i) => i.dedupeKey)).toEqual(["nutrition:a", "canonical:b"]);
   });
 
-  test("groupSections preserves first-seen day order with Today first and older below", () => {
+  test("groupSectionsAscending places Today/newest last for chat-style chronology", () => {
     const page1 = [
       item("a", "2026-07-16", "a"),
       item("b", "2026-07-16", "b"),
@@ -69,14 +46,14 @@ describe("timeline feed merge helpers", () => {
       item("c", "2026-07-15", "c"),
       item("d", "2026-07-14", "d"),
     ];
-    const merged = mergeItems(page1, page2);
-    const sections = groupSections(merged);
+    const merged = mergeFeedPageItems(page1, page2);
+    const sections = groupSectionsAscending(merged);
     expect(sections.map((s) => s.day)).toEqual([
-      "2026-07-16",
-      "2026-07-15",
       "2026-07-14",
+      "2026-07-15",
+      "2026-07-16",
     ]);
-    expect(sections[0]?.data).toHaveLength(2);
+    expect(sections[sections.length - 1]?.data).toHaveLength(2);
   });
 
   test("refetch omits optional opts under exactOptionalPropertyTypes", () => {
@@ -87,21 +64,29 @@ describe("timeline feed merge helpers", () => {
     expect(src).not.toMatch(/append:\s*false,\s*opts,/);
   });
 
-  test("request-budget contract: one feed client, guarded loadMore, no per-day fan-out", () => {
+  test("request-budget contract: one feed client, guarded loadOlder, no per-day fan-out", () => {
     const { readFileSync } = require("node:fs") as typeof import("node:fs");
     const { join } = require("node:path") as typeof import("node:path");
     const hook = readFileSync(join(__dirname, "..", "useTimelineFeed.ts"), "utf8");
+    const list = readFileSync(
+      join(__dirname, "..", "..", "..", "ui", "timeline", "TimelineFeedList.tsx"),
+      "utf8",
+    );
     const screen = readFileSync(
       join(__dirname, "..", "..", "..", "ui", "timeline", "TimelineDayScreen.tsx"),
       "utf8",
     );
     expect(hook).toContain("import { getTimelineFeed }");
     expect(hook).toContain("await getTimelineFeed(token,");
-    expect(hook).toContain("if (!hasMore || !nextCursor || loadingMore || loading) return");
-    expect(hook).toContain("setAnchorDayState");
-    expect(hook).toContain("returnToToday");
+    expect(hook).toContain("loadOlder");
+    expect(hook).toContain("canRequestOlderPage");
+    expect(hook).toContain("inFlightOlderCursorRef");
+    expect(hook).toContain("groupSectionsAscending");
     expect(hook).not.toContain("getRawEvents");
     expect(hook).not.toContain("oura");
+    expect(list).toContain("onStartReached");
+    expect(list).not.toContain("onEndReached=");
+    expect(list).toContain("maintainVisibleContentPosition");
     expect(screen).toContain('EXPO_PUBLIC_TIMELINE_FEED === "1"');
     expect(screen).not.toMatch(/EXPO_PUBLIC_TIMELINE_FEED\s*=\s*["']1["']/);
   });

--- a/lib/features/timeline/timelineFeedOrder.ts
+++ b/lib/features/timeline/timelineFeedOrder.ts
@@ -1,0 +1,81 @@
+/**
+ * Pure Timeline continuous-feed ordering helpers.
+ * Server pages remain day-descending (anchor/newest first) for the opaque cursor contract.
+ * Display sections are derived ascending (oldest → newest) so Today sits at the bottom.
+ */
+
+import type { TimelinePresentationItem } from "@oli/contracts";
+
+export type TimelineFeedSection = {
+  day: string;
+  data: TimelinePresentationItem[];
+};
+
+/** Append a newer older-history page while dropping duplicate dedupeKeys. */
+export function mergeFeedPageItems(
+  prev: readonly TimelinePresentationItem[],
+  next: readonly TimelinePresentationItem[],
+): TimelinePresentationItem[] {
+  const seen = new Set(prev.map((i) => i.dedupeKey));
+  const out = [...prev];
+  for (const item of next) {
+    if (seen.has(item.dedupeKey)) continue;
+    seen.add(item.dedupeKey);
+    out.push(item);
+  }
+  return out;
+}
+
+/**
+ * Group items into day sections ordered oldest → newest.
+ * Within each day, preserve first-seen item order (server within-day ascending).
+ */
+export function groupSectionsAscending(
+  items: readonly TimelinePresentationItem[],
+): TimelineFeedSection[] {
+  const map = new Map<string, TimelinePresentationItem[]>();
+  for (const item of items) {
+    const bucket = map.get(item.day);
+    if (bucket) {
+      bucket.push(item);
+    } else {
+      map.set(item.day, [item]);
+    }
+  }
+  const days = [...map.keys()].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+  return days.map((day) => ({ day, data: map.get(day)! }));
+}
+
+/** Index of the final/current (newest) section — target for cold open and Return to Today. */
+export function finalSectionIndex(sections: readonly TimelineFeedSection[]): number {
+  return Math.max(0, sections.length - 1);
+}
+
+export function finalSectionDay(sections: readonly TimelineFeedSection[]): string | null {
+  if (sections.length === 0) return null;
+  return sections[sections.length - 1]!.day;
+}
+
+export type OlderPageRequestGate = {
+  hasMore: boolean;
+  nextCursor: string | null;
+  loadingMore: boolean;
+  loading: boolean;
+};
+
+/** True when one older cursor page may be requested (top-boundary only). */
+export function canRequestOlderPage(gate: OlderPageRequestGate): boolean {
+  return gate.hasMore && gate.nextCursor != null && !gate.loadingMore && !gate.loading;
+}
+
+/**
+ * Decide whether a SectionList edge callback may request older history.
+ * Older history loads at the top only — never from the bottom/end edge.
+ */
+export function shouldLoadOlderFromEdge(args: {
+  edge: "start" | "end";
+  gate: OlderPageRequestGate;
+}): boolean {
+  if (args.edge !== "start") return false;
+  return canRequestOlderPage(args.gate);
+}

--- a/lib/features/timeline/useTimelineFeed.ts
+++ b/lib/features/timeline/useTimelineFeed.ts
@@ -1,6 +1,7 @@
 // lib/features/timeline/useTimelineFeed.ts
 // Cursor-accumulating Timeline feed hook. Issues GET /users/me/timeline-feed only.
 // Resets on user switch / anchor change. Does not call multi-day /timeline aggregates.
+// Display sections are ascending (oldest→newest); older pages load via top-boundary only.
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useIsFocused } from "@react-navigation/native";
@@ -9,11 +10,14 @@ import type { FailureKind, GetOptions } from "@/lib/api/http";
 import { getTimelineFeed } from "@/lib/api/usersMe";
 import { useAuth } from "@/lib/auth/AuthProvider";
 import { getTodayDayKey } from "@/lib/time/dayKey";
+import {
+  canRequestOlderPage,
+  groupSectionsAscending,
+  mergeFeedPageItems,
+  type TimelineFeedSection,
+} from "@/lib/features/timeline/timelineFeedOrder";
 
-export type TimelineFeedSection = {
-  day: string;
-  data: TimelinePresentationItem[];
-};
+export type { TimelineFeedSection };
 
 export type UseTimelineFeedStatus =
   | { status: "partial" }
@@ -30,38 +34,14 @@ export type UseTimelineFeedStatus =
 export type UseTimelineFeedResult = {
   anchorDay: string;
   status: UseTimelineFeedStatus;
+  /** Increments on hard reset (anchor / return-to-today / user switch / refetch). */
+  listGeneration: number;
   setAnchorDay: (day: string) => void;
   returnToToday: () => void;
-  loadMore: () => void;
+  /** Load one older cursor page (top-boundary). */
+  loadOlder: () => void;
   refetch: (opts?: GetOptions) => void;
 };
-
-function groupSections(items: TimelinePresentationItem[]): TimelineFeedSection[] {
-  const order: string[] = [];
-  const map = new Map<string, TimelinePresentationItem[]>();
-  for (const item of items) {
-    if (!map.has(item.day)) {
-      map.set(item.day, []);
-      order.push(item.day);
-    }
-    map.get(item.day)!.push(item);
-  }
-  return order.map((day) => ({ day, data: map.get(day)! }));
-}
-
-function mergeItems(
-  prev: TimelinePresentationItem[],
-  next: TimelinePresentationItem[],
-): TimelinePresentationItem[] {
-  const seen = new Set(prev.map((i) => i.dedupeKey));
-  const out = [...prev];
-  for (const item of next) {
-    if (seen.has(item.dedupeKey)) continue;
-    seen.add(item.dedupeKey);
-    out.push(item);
-  }
-  return out;
-}
 
 export function useTimelineFeed(initialAnchor?: string): UseTimelineFeedResult {
   const isFocused = useIsFocused();
@@ -75,6 +55,7 @@ export function useTimelineFeed(initialAnchor?: string): UseTimelineFeedResult {
   const [hasMore, setHasMore] = useState(false);
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
+  const [listGeneration, setListGeneration] = useState(0);
   const [error, setError] = useState<{
     error: string;
     requestId: string | null;
@@ -85,6 +66,12 @@ export function useTimelineFeed(initialAnchor?: string): UseTimelineFeedResult {
   const uidRef = useRef(user?.uid ?? null);
   const anchorRef = useRef(anchorDay);
   anchorRef.current = anchorDay;
+  const loadingMoreRef = useRef(false);
+  const inFlightOlderCursorRef = useRef<string | null>(null);
+
+  const bumpListGeneration = useCallback(() => {
+    setListGeneration((g) => g + 1);
+  }, []);
 
   // User-switch reset
   useEffect(() => {
@@ -97,8 +84,11 @@ export function useTimelineFeed(initialAnchor?: string): UseTimelineFeedResult {
       setError(null);
       setAnchorDayState(today);
       genRef.current += 1;
+      inFlightOlderCursorRef.current = null;
+      loadingMoreRef.current = false;
+      bumpListGeneration();
     }
-  }, [user?.uid, today]);
+  }, [user?.uid, today, bumpListGeneration]);
 
   const fetchPage = useCallback(
     async (args: {
@@ -109,8 +99,10 @@ export function useTimelineFeed(initialAnchor?: string): UseTimelineFeedResult {
     }) => {
       if (!isFocused || initializing) return;
       const gen = ++genRef.current;
-      if (args.append) setLoadingMore(true);
-      else {
+      if (args.append) {
+        loadingMoreRef.current = true;
+        setLoadingMore(true);
+      } else {
         setLoading(true);
         setError(null);
       }
@@ -150,7 +142,7 @@ export function useTimelineFeed(initialAnchor?: string): UseTimelineFeedResult {
         }
 
         const page: TimelineFeedResponseDto = result.json;
-        setItems((prev) => (args.append ? mergeItems(prev, page.items) : page.items));
+        setItems((prev) => (args.append ? mergeFeedPageItems(prev, page.items) : page.items));
         setNextCursor(page.nextCursor);
         setHasMore(page.hasMore);
         setError(null);
@@ -165,6 +157,10 @@ export function useTimelineFeed(initialAnchor?: string): UseTimelineFeedResult {
         if (gen === genRef.current) {
           setLoading(false);
           setLoadingMore(false);
+          loadingMoreRef.current = false;
+          if (args.append) {
+            inFlightOlderCursorRef.current = null;
+          }
         }
       }
     },
@@ -176,26 +172,46 @@ export function useTimelineFeed(initialAnchor?: string): UseTimelineFeedResult {
     void fetchPage({ anchor: anchorDay, append: false });
   }, [anchorDay, fetchPage, initializing, isFocused]);
 
-  const setAnchorDay = useCallback((day: string) => {
-    if (!/^\d{4}-\d{2}-\d{2}$/.test(day)) return;
-    setItems([]);
-    setNextCursor(null);
-    setHasMore(false);
-    setAnchorDayState(day);
-  }, []);
+  const setAnchorDay = useCallback(
+    (day: string) => {
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(day)) return;
+      setItems([]);
+      setNextCursor(null);
+      setHasMore(false);
+      inFlightOlderCursorRef.current = null;
+      setAnchorDayState(day);
+      bumpListGeneration();
+    },
+    [bumpListGeneration],
+  );
 
   const returnToToday = useCallback(() => {
     setItems([]);
     setNextCursor(null);
     setHasMore(false);
+    inFlightOlderCursorRef.current = null;
     setAnchorDayState(today);
-  }, [today]);
+    bumpListGeneration();
+  }, [today, bumpListGeneration]);
 
-  const loadMore = useCallback(() => {
-    if (!hasMore || !nextCursor || loadingMore || loading) return;
+  const loadOlder = useCallback(() => {
+    const cursor = nextCursor;
+    if (
+      !canRequestOlderPage({
+        hasMore,
+        nextCursor: cursor,
+        loadingMore: loadingMoreRef.current || loadingMore,
+        loading,
+      })
+    ) {
+      return;
+    }
+    if (!cursor) return;
+    if (inFlightOlderCursorRef.current === cursor) return;
+    inFlightOlderCursorRef.current = cursor;
     void fetchPage({
       anchor: anchorRef.current,
-      cursor: nextCursor,
+      cursor,
       append: true,
     });
   }, [fetchPage, hasMore, loading, loadingMore, nextCursor]);
@@ -204,6 +220,8 @@ export function useTimelineFeed(initialAnchor?: string): UseTimelineFeedResult {
     (opts?: GetOptions) => {
       setItems([]);
       setNextCursor(null);
+      inFlightOlderCursorRef.current = null;
+      bumpListGeneration();
       // exactOptionalPropertyTypes: omit `opts` when absent (do not pass undefined).
       void fetchPage({
         anchor: anchorRef.current,
@@ -211,7 +229,7 @@ export function useTimelineFeed(initialAnchor?: string): UseTimelineFeedResult {
         ...(opts !== undefined ? { opts } : {}),
       });
     },
-    [fetchPage],
+    [fetchPage, bumpListGeneration],
   );
 
   let status: UseTimelineFeedStatus;
@@ -227,7 +245,7 @@ export function useTimelineFeed(initialAnchor?: string): UseTimelineFeedResult {
   } else {
     status = {
       status: "ready",
-      sections: groupSections(items),
+      sections: groupSectionsAscending(items),
       items,
       hasMore,
       loadingMore,
@@ -238,9 +256,10 @@ export function useTimelineFeed(initialAnchor?: string): UseTimelineFeedResult {
   return {
     anchorDay,
     status,
+    listGeneration,
     setAnchorDay,
     returnToToday,
-    loadMore,
+    loadOlder,
     refetch,
   };
 }

--- a/lib/ui/timeline/TimelineEventCard.tsx
+++ b/lib/ui/timeline/TimelineEventCard.tsx
@@ -2,7 +2,6 @@
 // Single elevated timeline row card (icon + title + subtitle). Presentational only.
 import { Pressable, StyleSheet, Text, View } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
-import type { TimelineDayItem } from "@/lib/features/timeline/types";
 import { elevatedCardSurfaceStyle } from "@/lib/ui/theme/elevatedCardSurface";
 import { SYSTEM_ACCENT } from "@/lib/ui/theme/systemAccent";
 import {
@@ -12,23 +11,42 @@ import {
   UI_TEXT_TERTIARY_LABEL,
 } from "@/lib/ui/theme/uiTokens";
 
-export type TimelineEventCardProps = {
-  item: TimelineDayItem;
-  /** Pre-formatted local time, e.g. "7:20 AM". Used for the accessibility label. */
-  timeLabel: string;
-  onPress: (item: TimelineDayItem) => void;
+export type TimelineEventCardModel = {
+  title: string;
+  subtitle?: string;
+  icon: string;
+  accessibilityLabel: string;
 };
 
-export function TimelineEventCard({ item, timeLabel, onPress }: TimelineEventCardProps) {
+export type TimelineEventCardProps = {
+  item: TimelineEventCardModel;
+  /** Pre-formatted local time, e.g. "7:20 AM". Used for the accessibility label. */
+  timeLabel: string;
+  onPress: () => void;
+  /** When false, omit chevron and disable press affordance. */
+  actionable?: boolean;
+};
+
+export function TimelineEventCard({
+  item,
+  timeLabel,
+  onPress,
+  actionable = true,
+}: TimelineEventCardProps) {
   const accessibilityLabel = [timeLabel, item.accessibilityLabel]
     .filter((s) => s && s.length > 0)
     .join(", ");
 
   return (
     <Pressable
-      style={({ pressed }) => [styles.card, pressed && styles.cardPressed]}
-      onPress={() => onPress(item)}
-      accessibilityRole="button"
+      style={({ pressed }) => [
+        styles.card,
+        actionable && pressed && styles.cardPressed,
+        !actionable && styles.cardStatic,
+      ]}
+      onPress={actionable ? onPress : undefined}
+      disabled={!actionable}
+      accessibilityRole={actionable ? "button" : "text"}
       accessibilityLabel={accessibilityLabel}
     >
       <View style={styles.iconWrap}>
@@ -44,7 +62,9 @@ export function TimelineEventCard({ item, timeLabel, onPress }: TimelineEventCar
           </Text>
         ) : null}
       </View>
-      <Ionicons name="chevron-forward" size={16} color={UI_TEXT_TERTIARY_LABEL} />
+      {actionable ? (
+        <Ionicons name="chevron-forward" size={16} color={UI_TEXT_TERTIARY_LABEL} />
+      ) : null}
     </Pressable>
   );
 }
@@ -58,9 +78,11 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
     paddingHorizontal: 14,
     borderRadius: UI_GROUPED_CARD_RADIUS,
+    minHeight: 44,
     ...elevatedCardSurfaceStyle,
   },
   cardPressed: { opacity: 0.7 },
+  cardStatic: {},
   iconWrap: {
     width: 32,
     height: 32,

--- a/lib/ui/timeline/TimelineFeedList.tsx
+++ b/lib/ui/timeline/TimelineFeedList.tsx
@@ -1,6 +1,7 @@
 // lib/ui/timeline/TimelineFeedList.tsx
-// Continuous SectionList feed with sticky day headers.
-import { useCallback, useMemo } from "react";
+// Continuous SectionList feed: oldest→newest sections, Today at bottom,
+// older history loaded at the top boundary with visible-position preservation.
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import {
   ActivityIndicator,
   Pressable,
@@ -9,10 +10,13 @@ import {
   StyleSheet,
   Text,
   View,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
   type SectionListRenderItemInfo,
 } from "react-native";
 import type { TimelinePresentationItem } from "@oli/contracts";
-import type { TimelineFeedSection } from "@/lib/features/timeline/useTimelineFeed";
+import type { TimelineFeedSection } from "@/lib/features/timeline/timelineFeedOrder";
+import { finalSectionIndex } from "@/lib/features/timeline/timelineFeedOrder";
 import { TimelineDaySectionHeader } from "@/lib/ui/timeline/TimelineDaySectionHeader";
 import { UI_TEXT_MUTED, UI_TEXT_PRIMARY, UI_TEXT_SECONDARY } from "@/lib/ui/theme/uiTokens";
 import { SYSTEM_ACCENT } from "@/lib/ui/theme/systemAccent";
@@ -21,11 +25,14 @@ import { getTodayDayKey } from "@/lib/time/dayKey";
 export type TimelineFeedListProps = {
   sections: TimelineFeedSection[];
   onPressItem: (item: TimelinePresentationItem) => void;
-  onEndReached: () => void;
+  /** Top-boundary older-history load (not bottom). */
+  onStartReached: () => void;
   loadingMore: boolean;
   refreshing: boolean;
   onRefresh: () => void;
   contentBottomPadding: number;
+  /** Bumps on hard reset so initial scroll-to-newest re-runs. */
+  listGeneration: number;
   paginationError?: string | null;
   onRetryPage?: () => void;
 };
@@ -42,15 +49,98 @@ function formatTime(iso: string): string {
 export function TimelineFeedList({
   sections,
   onPressItem,
-  onEndReached,
+  onStartReached,
   loadingMore,
   refreshing,
   onRefresh,
   contentBottomPadding,
+  listGeneration,
   paginationError,
   onRetryPage,
 }: TimelineFeedListProps) {
   const today = useMemo(() => getTodayDayKey(), []);
+  const listRef = useRef<SectionList<TimelinePresentationItem, TimelineFeedSection>>(null);
+  const didInitialScrollRef = useRef(false);
+  const startReachedArmedRef = useRef(false);
+  const lastStartReachedAtRef = useRef(0);
+  const armTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearArmTimer = useCallback(() => {
+    if (armTimerRef.current) {
+      clearTimeout(armTimerRef.current);
+      armTimerRef.current = null;
+    }
+  }, []);
+
+  const armStartReached = useCallback(() => {
+    clearArmTimer();
+    armTimerRef.current = setTimeout(() => {
+      startReachedArmedRef.current = true;
+      armTimerRef.current = null;
+    }, 400);
+  }, [clearArmTimer]);
+
+  useEffect(() => {
+    didInitialScrollRef.current = false;
+    startReachedArmedRef.current = false;
+    clearArmTimer();
+  }, [listGeneration, clearArmTimer]);
+
+  useEffect(() => () => clearArmTimer(), [clearArmTimer]);
+
+  const scrollToNewest = useCallback(
+    (animated: boolean) => {
+      if (sections.length === 0) return;
+      const sectionIndex = finalSectionIndex(sections);
+      const last = sections[sectionIndex];
+      const itemIndex = Math.max(0, (last?.data.length ?? 1) - 1);
+      try {
+        listRef.current?.scrollToLocation({
+          sectionIndex,
+          itemIndex,
+          animated,
+          viewPosition: 1,
+        });
+      } catch {
+        // SectionList may throw if layout is not ready; contentSizeChange retries once.
+      }
+    },
+    [sections],
+  );
+
+  useEffect(() => {
+    if (didInitialScrollRef.current) return;
+    if (sections.length === 0) return;
+    const id = requestAnimationFrame(() => {
+      scrollToNewest(false);
+      didInitialScrollRef.current = true;
+      armStartReached();
+    });
+    return () => cancelAnimationFrame(id);
+  }, [sections, scrollToNewest, listGeneration, armStartReached]);
+
+  const onContentSizeChange = useCallback(() => {
+    if (didInitialScrollRef.current) return;
+    if (sections.length === 0) return;
+    scrollToNewest(false);
+    didInitialScrollRef.current = true;
+    armStartReached();
+  }, [scrollToNewest, sections.length, armStartReached]);
+
+  const handleStartReached = useCallback(() => {
+    if (!startReachedArmedRef.current) return;
+    if (loadingMore) return;
+    const now = Date.now();
+    if (now - lastStartReachedAtRef.current < 600) return;
+    lastStartReachedAtRef.current = now;
+    onStartReached();
+  }, [loadingMore, onStartReached]);
+
+  const onScroll = useCallback((e: NativeSyntheticEvent<NativeScrollEvent>) => {
+    if (e.nativeEvent.contentOffset.y < 80) {
+      startReachedArmedRef.current = true;
+    }
+  }, []);
 
   const renderItem = useCallback(
     ({ item }: SectionListRenderItemInfo<TimelinePresentationItem, TimelineFeedSection>) => {
@@ -94,39 +184,52 @@ export function TimelineFeedList({
     [],
   );
 
-  const ListFooter = useMemo(() => {
+  const ListHeader = useMemo(() => {
     if (paginationError) {
       return (
-        <Pressable onPress={onRetryPage} style={styles.footer} accessibilityRole="button">
-          <Text style={styles.footerError}>{paginationError}</Text>
-          <Text style={styles.footerRetry}>Tap to retry</Text>
+        <Pressable onPress={onRetryPage} style={styles.edge} accessibilityRole="button">
+          <Text style={styles.edgeError}>{paginationError}</Text>
+          <Text style={styles.edgeRetry}>Tap to retry</Text>
         </Pressable>
       );
     }
     if (loadingMore) {
       return (
-        <View style={styles.footer}>
+        <View style={styles.edge}>
           <ActivityIndicator color={UI_TEXT_MUTED} />
         </View>
       );
     }
-    return <View style={{ height: 8 }} />;
+    return <View style={{ height: 4 }} />;
   }, [loadingMore, onRetryPage, paginationError]);
 
   return (
     <SectionList
+      ref={listRef}
       sections={sections}
       keyExtractor={keyExtractor}
       renderItem={renderItem}
       renderSectionHeader={renderSectionHeader}
       stickySectionHeadersEnabled
-      onEndReached={onEndReached}
-      onEndReachedThreshold={0.4}
+      onStartReached={handleStartReached}
+      onStartReachedThreshold={0.2}
+      onScroll={onScroll}
+      scrollEventThrottle={16}
+      onContentSizeChange={onContentSizeChange}
+      maintainVisibleContentPosition={{
+        minIndexForVisible: 0,
+        autoscrollToTopThreshold: 24,
+      }}
       refreshControl={
         <RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor="#8E8E93" />
       }
       contentContainerStyle={{ paddingBottom: contentBottomPadding }}
-      ListFooterComponent={ListFooter}
+      ListHeaderComponent={ListHeader}
+      ListFooterComponent={<View style={{ height: 8 }} />}
+      initialNumToRender={16}
+      maxToRenderPerBatch={12}
+      windowSize={7}
+      removeClippedSubviews
     />
   );
 }
@@ -146,7 +249,7 @@ const styles = StyleSheet.create({
   summary: { marginTop: 2, fontSize: 14, color: UI_TEXT_SECONDARY },
   status: { marginTop: 2, fontSize: 12, color: UI_TEXT_MUTED, textTransform: "capitalize" },
   time: { fontSize: 13, color: UI_TEXT_MUTED, paddingTop: 2 },
-  footer: { paddingVertical: 16, alignItems: "center" },
-  footerError: { color: UI_TEXT_SECONDARY, fontSize: 14 },
-  footerRetry: { marginTop: 4, color: SYSTEM_ACCENT, fontSize: 14, fontWeight: "600" },
+  edge: { paddingVertical: 16, alignItems: "center" },
+  edgeError: { color: UI_TEXT_SECONDARY, fontSize: 14 },
+  edgeRetry: { marginTop: 4, color: SYSTEM_ACCENT, fontSize: 14, fontWeight: "600" },
 });

--- a/lib/ui/timeline/TimelineFeedList.tsx
+++ b/lib/ui/timeline/TimelineFeedList.tsx
@@ -1,6 +1,7 @@
 // lib/ui/timeline/TimelineFeedList.tsx
 // Continuous SectionList feed: oldest→newest sections, Today at bottom,
 // older history loaded at the top boundary with visible-position preservation.
+// Shares TimelineRailRow with the single-day fallback.
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import {
   ActivityIndicator,
@@ -18,7 +19,10 @@ import type { TimelinePresentationItem } from "@oli/contracts";
 import type { TimelineFeedSection } from "@/lib/features/timeline/timelineFeedOrder";
 import { finalSectionIndex } from "@/lib/features/timeline/timelineFeedOrder";
 import { TimelineDaySectionHeader } from "@/lib/ui/timeline/TimelineDaySectionHeader";
-import { UI_TEXT_MUTED, UI_TEXT_PRIMARY, UI_TEXT_SECONDARY } from "@/lib/ui/theme/uiTokens";
+import { TimelineRailRow } from "@/lib/ui/timeline/TimelineRailRow";
+import { formatTimelineTimeLabel } from "@/lib/ui/timeline/TimelineRail";
+import { timelinePresentationIcon } from "@/lib/ui/timeline/timelinePresentationIcon";
+import { UI_TEXT_MUTED, UI_TEXT_SECONDARY } from "@/lib/ui/theme/uiTokens";
 import { SYSTEM_ACCENT } from "@/lib/ui/theme/systemAccent";
 import { getTodayDayKey } from "@/lib/time/dayKey";
 
@@ -36,15 +40,6 @@ export type TimelineFeedListProps = {
   paginationError?: string | null;
   onRetryPage?: () => void;
 };
-
-function formatTime(iso: string): string {
-  const t = Date.parse(iso);
-  if (!Number.isFinite(t)) return "";
-  return new Date(t).toLocaleTimeString(undefined, {
-    hour: "numeric",
-    minute: "2-digit",
-  });
-}
 
 export function TimelineFeedList({
   sections,
@@ -143,25 +138,29 @@ export function TimelineFeedList({
   }, []);
 
   const renderItem = useCallback(
-    ({ item }: SectionListRenderItemInfo<TimelinePresentationItem, TimelineFeedSection>) => {
-      const time =
-        item.displayRole === "day_context" ? "" : formatTime(item.occurredAt);
+    ({
+      item,
+      index,
+      section,
+    }: SectionListRenderItemInfo<TimelinePresentationItem, TimelineFeedSection>) => {
+      const isContext = item.displayRole === "day_context";
+      const timeLabel = isContext ? "" : formatTimelineTimeLabel(item.occurredAt);
+      const subtitle =
+        item.summary ??
+        (item.status !== "ready" ? item.status : undefined);
       return (
-        <Pressable
-          onPress={() => onPressItem(item)}
-          accessibilityRole="button"
+        <TimelineRailRow
+          timeLabel={timeLabel}
+          title={item.title}
+          {...(subtitle ? { subtitle } : {})}
+          icon={timelinePresentationIcon(item.kind)}
           accessibilityLabel={item.accessibilityLabel}
-          style={styles.row}
-        >
-          <View style={styles.rowMain}>
-            <Text style={styles.title}>{item.title}</Text>
-            {item.summary ? <Text style={styles.summary}>{item.summary}</Text> : null}
-            {item.status !== "ready" ? (
-              <Text style={styles.status}>{item.status}</Text>
-            ) : null}
-          </View>
-          {time ? <Text style={styles.time}>{time}</Text> : null}
-        </Pressable>
+          actionable
+          isFirstInSegment={index === 0}
+          isLastInSegment={index === section.data.length - 1}
+          onPress={() => onPressItem(item)}
+          testID={`timeline-feed-row-${item.dedupeKey}`}
+        />
       );
     },
     [onPressItem],
@@ -235,20 +234,6 @@ export function TimelineFeedList({
 }
 
 const styles = StyleSheet.create({
-  row: {
-    flexDirection: "row",
-    alignItems: "flex-start",
-    paddingVertical: 12,
-    paddingHorizontal: 4,
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: "#E5E5EA",
-    minHeight: 44,
-  },
-  rowMain: { flex: 1, paddingRight: 12 },
-  title: { fontSize: 16, fontWeight: "600", color: UI_TEXT_PRIMARY },
-  summary: { marginTop: 2, fontSize: 14, color: UI_TEXT_SECONDARY },
-  status: { marginTop: 2, fontSize: 12, color: UI_TEXT_MUTED, textTransform: "capitalize" },
-  time: { fontSize: 13, color: UI_TEXT_MUTED, paddingTop: 2 },
   edge: { paddingVertical: 16, alignItems: "center" },
   edgeError: { color: UI_TEXT_SECONDARY, fontSize: 14 },
   edgeRetry: { marginTop: 4, color: SYSTEM_ACCENT, fontSize: 14, fontWeight: "600" },

--- a/lib/ui/timeline/TimelineFeedScreen.tsx
+++ b/lib/ui/timeline/TimelineFeedScreen.tsx
@@ -82,11 +82,12 @@ export function TimelineFeedScreen({ initialDay }: TimelineFeedScreenProps) {
             <TimelineFeedList
               sections={feed.status.sections}
               onPressItem={onPressItem}
-              onEndReached={feed.loadMore}
+              onStartReached={feed.loadOlder}
               loadingMore={feed.status.loadingMore}
               refreshing={refreshing}
               onRefresh={onRefresh}
               contentBottomPadding={listBottomPad}
+              listGeneration={feed.listGeneration}
             />
           )}
         </View>

--- a/lib/ui/timeline/TimelineRail.tsx
+++ b/lib/ui/timeline/TimelineRail.tsx
@@ -2,11 +2,9 @@
 // Vertical timeline rail: time label + connector dot + event card per item.
 // Virtualized via FlatList; this component owns the day's scroll + pull-to-refresh.
 import type { ReactElement } from "react";
-import { FlatList, StyleSheet, Text, View, type RefreshControlProps } from "react-native";
+import { FlatList, View, type RefreshControlProps } from "react-native";
 import type { TimelineDayItem } from "@/lib/features/timeline/types";
-import { TimelineEventCard } from "@/lib/ui/timeline/TimelineEventCard";
-import { SYSTEM_ACCENT } from "@/lib/ui/theme/systemAccent";
-import { UI_BORDER_HAIRLINE, UI_TEXT_TERTIARY_LABEL } from "@/lib/ui/theme/uiTokens";
+import { TimelineRailRow } from "@/lib/ui/timeline/TimelineRailRow";
 
 export function formatTimelineTimeLabel(iso: string): string {
   const d = new Date(iso);
@@ -36,30 +34,18 @@ export function TimelineRail({
       {...(refreshControl ? { refreshControl } : {})}
       {...(ListHeaderComponent ? { ListHeaderComponent } : {})}
       renderItem={({ item, index }) => (
-        <View style={styles.row}>
-          <View style={styles.timeColumn}>
-            <Text style={styles.timeText}>{formatTimelineTimeLabel(item.timestamp)}</Text>
-          </View>
-          <View style={styles.railColumn}>
-            <View
-              style={[
-                styles.railLine,
-                index === 0 && styles.railLineTopHidden,
-                index === items.length - 1 && styles.railLineBottomHidden,
-              ]}
-            />
-            <View style={styles.railDot} />
-          </View>
-          <View style={styles.cardColumn}>
-            <TimelineEventCard
-              item={item}
-              timeLabel={formatTimelineTimeLabel(item.timestamp)}
-              onPress={onPressItem}
-            />
-          </View>
-        </View>
+        <TimelineRailRow
+          timeLabel={formatTimelineTimeLabel(item.timestamp)}
+          title={item.title}
+          {...(item.subtitle ? { subtitle: item.subtitle } : {})}
+          icon={item.icon}
+          accessibilityLabel={item.accessibilityLabel}
+          actionable
+          isFirstInSegment={index === 0}
+          isLastInSegment={index === items.length - 1}
+          onPress={() => onPressItem(item)}
+        />
       )}
-      ItemSeparatorComponent={() => <View style={styles.separator} />}
       ListFooterComponent={<View style={{ height: contentBottomPadding }} />}
       initialNumToRender={16}
       maxToRenderPerBatch={12}
@@ -69,40 +55,3 @@ export function TimelineRail({
     />
   );
 }
-
-const TIME_COL_WIDTH = 64;
-const RAIL_COL_WIDTH = 20;
-const DOT_SIZE = 10;
-
-const styles = StyleSheet.create({
-  row: { flexDirection: "row", alignItems: "stretch" },
-  timeColumn: {
-    width: TIME_COL_WIDTH,
-    paddingTop: 16,
-    alignItems: "flex-end",
-    paddingRight: 8,
-  },
-  timeText: { fontSize: 12, fontWeight: "600", color: UI_TEXT_TERTIARY_LABEL },
-  railColumn: {
-    width: RAIL_COL_WIDTH,
-    alignItems: "center",
-  },
-  railLine: {
-    position: "absolute",
-    top: 0,
-    bottom: 0,
-    width: 2,
-    backgroundColor: UI_BORDER_HAIRLINE,
-  },
-  railLineTopHidden: { top: 22 },
-  railLineBottomHidden: { bottom: "50%" },
-  railDot: {
-    width: DOT_SIZE,
-    height: DOT_SIZE,
-    borderRadius: DOT_SIZE / 2,
-    backgroundColor: SYSTEM_ACCENT,
-    marginTop: 18,
-  },
-  cardColumn: { flex: 1, paddingVertical: 4 },
-  separator: { height: 8 },
-});

--- a/lib/ui/timeline/TimelineRailRow.tsx
+++ b/lib/ui/timeline/TimelineRailRow.tsx
@@ -1,0 +1,103 @@
+// lib/ui/timeline/TimelineRailRow.tsx
+// Shared time + rail + card row used by single-day TimelineRail and continuous feed.
+import { StyleSheet, Text, View } from "react-native";
+import { TimelineEventCard } from "@/lib/ui/timeline/TimelineEventCard";
+import { SYSTEM_ACCENT } from "@/lib/ui/theme/systemAccent";
+import { UI_BORDER_HAIRLINE, UI_TEXT_TERTIARY_LABEL } from "@/lib/ui/theme/uiTokens";
+
+export type TimelineRailRowProps = {
+  timeLabel: string;
+  title: string;
+  subtitle?: string;
+  icon: string;
+  accessibilityLabel: string;
+  actionable?: boolean;
+  isFirstInSegment: boolean;
+  isLastInSegment: boolean;
+  onPress: () => void;
+  testID?: string;
+};
+
+export function TimelineRailRow({
+  timeLabel,
+  title,
+  subtitle,
+  icon,
+  accessibilityLabel,
+  actionable = true,
+  isFirstInSegment,
+  isLastInSegment,
+  onPress,
+  testID,
+}: TimelineRailRowProps) {
+  return (
+    <View style={styles.row} testID={testID}>
+      <View style={styles.timeColumn} importantForAccessibility="no">
+        <Text style={styles.timeText}>{timeLabel}</Text>
+      </View>
+      <View
+        style={styles.railColumn}
+        importantForAccessibility="no"
+        accessibilityElementsHidden
+      >
+        <View
+          style={[
+            styles.railLine,
+            isFirstInSegment && styles.railLineTopHidden,
+            isLastInSegment && styles.railLineBottomHidden,
+          ]}
+        />
+        <View style={styles.railDot} />
+      </View>
+      <View style={styles.cardColumn}>
+        <TimelineEventCard
+          item={{
+            title,
+            icon,
+            accessibilityLabel,
+            ...(subtitle ? { subtitle } : {}),
+          }}
+          timeLabel={timeLabel}
+          onPress={onPress}
+          actionable={actionable}
+        />
+      </View>
+    </View>
+  );
+}
+
+const TIME_COL_WIDTH = 64;
+const RAIL_COL_WIDTH = 20;
+const DOT_SIZE = 10;
+
+const styles = StyleSheet.create({
+  row: { flexDirection: "row", alignItems: "stretch", marginBottom: 8 },
+  timeColumn: {
+    width: TIME_COL_WIDTH,
+    paddingTop: 16,
+    alignItems: "flex-end",
+    paddingRight: 8,
+  },
+  timeText: { fontSize: 12, fontWeight: "600", color: UI_TEXT_TERTIARY_LABEL },
+  railColumn: {
+    width: RAIL_COL_WIDTH,
+    alignItems: "center",
+  },
+  railLine: {
+    position: "absolute",
+    top: 0,
+    bottom: 0,
+    width: 2,
+    backgroundColor: UI_BORDER_HAIRLINE,
+  },
+  railLineTopHidden: { top: 22 },
+  railLineBottomHidden: { bottom: "50%" },
+  railDot: {
+    width: DOT_SIZE,
+    height: DOT_SIZE,
+    borderRadius: DOT_SIZE / 2,
+    backgroundColor: SYSTEM_ACCENT,
+    marginTop: 18,
+  },
+  cardColumn: { flex: 1, paddingVertical: 4 },
+});

--- a/lib/ui/timeline/__tests__/TimelineEventCard.test.tsx
+++ b/lib/ui/timeline/__tests__/TimelineEventCard.test.tsx
@@ -4,20 +4,11 @@ import renderer, { act } from "react-test-renderer";
 import { Pressable } from "react-native";
 
 import { TimelineEventCard } from "@/lib/ui/timeline/TimelineEventCard";
-import type { TimelineDayItem } from "@/lib/features/timeline/types";
 
-const ITEM: TimelineDayItem = {
-  id: "n1",
-  day: "2026-06-10",
-  timestamp: "2026-06-10T07:25:00.000Z",
-  sortKey: "2026-06-10T07:25:00.000Z#n1",
+const ITEM = {
   title: "Coffee",
   subtitle: "Breakfast · 5 kcal",
-  sourceType: "caffeine",
-  sourceId: "n1",
   icon: "cafe-outline",
-  href: "/(app)/nutrition/day/2026-06-10",
-  isPassive: false,
   accessibilityLabel: "Coffee, Breakfast · 5 kcal",
 };
 
@@ -38,7 +29,7 @@ describe("TimelineEventCard", () => {
     expect((pressable.props as { accessibilityRole?: string }).accessibilityRole).toBe("button");
   });
 
-  it("calls onPress with the item", () => {
+  it("calls onPress when pressed", () => {
     const onPress = jest.fn();
     let tree!: renderer.ReactTestRenderer;
     act(() => {
@@ -50,6 +41,23 @@ describe("TimelineEventCard", () => {
     act(() => {
       (tree.root.findByType(Pressable).props as { onPress: () => void }).onPress();
     });
-    expect(onPress).toHaveBeenCalledWith(ITEM);
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("omits chevron and press when not actionable", () => {
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(
+        <TimelineEventCard
+          item={ITEM}
+          timeLabel=""
+          onPress={jest.fn()}
+          actionable={false}
+        />,
+      );
+    });
+    const pressable = tree.root.findByType(Pressable);
+    expect((pressable.props as { disabled?: boolean }).disabled).toBe(true);
+    expect((pressable.props as { accessibilityRole?: string }).accessibilityRole).toBe("text");
   });
 });

--- a/lib/ui/timeline/__tests__/TimelineFeedList.dayHeaders.test.tsx
+++ b/lib/ui/timeline/__tests__/TimelineFeedList.dayHeaders.test.tsx
@@ -36,16 +36,17 @@ describe("TimelineFeedList day section headers", () => {
         <OliThemeProvider mode="dark">
           <TimelineFeedList
             sections={[
-              { day: "2026-07-16", data: [item("2026-07-16", "a")] },
-              { day: "2026-07-15", data: [item("2026-07-15", "b")] },
               { day: "2026-07-14", data: [] },
+              { day: "2026-07-15", data: [item("2026-07-15", "b")] },
+              { day: "2026-07-16", data: [item("2026-07-16", "a")] },
             ]}
             onPressItem={jest.fn()}
-            onEndReached={jest.fn()}
+            onStartReached={jest.fn()}
             loadingMore={false}
             refreshing={false}
             onRefresh={jest.fn()}
             contentBottomPadding={40}
+            listGeneration={0}
           />
         </OliThemeProvider>,
       );
@@ -58,10 +59,12 @@ describe("TimelineFeedList day section headers", () => {
     expect(typeof sectionList.props.renderSectionHeader).toBe("function");
     expect(sectionList.props.sections).toHaveLength(3);
     expect(sectionList.props.sections.map((s: { day: string }) => s.day)).toEqual([
-      "2026-07-16",
-      "2026-07-15",
       "2026-07-14",
+      "2026-07-15",
+      "2026-07-16",
     ]);
+    expect(sectionList.props.onStartReached).toEqual(expect.any(Function));
+    expect(sectionList.props.onEndReached).toBeUndefined();
     // Section data contains events only — no duplicate date rows.
     for (const section of sectionList.props.sections as {
       day: string;

--- a/lib/ui/timeline/__tests__/TimelineFeedList.railParity.test.tsx
+++ b/lib/ui/timeline/__tests__/TimelineFeedList.railParity.test.tsx
@@ -1,0 +1,93 @@
+// lib/ui/timeline/__tests__/TimelineFeedList.railParity.test.tsx
+import React from "react";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import renderer, { act } from "react-test-renderer";
+import type { TimelinePresentationItem } from "@oli/contracts";
+import { TimelineFeedList } from "@/lib/ui/timeline/TimelineFeedList";
+import { TimelineRailRow } from "@/lib/ui/timeline/TimelineRailRow";
+import { OliThemeProvider } from "@/lib/ui/theme/OliThemeContext";
+
+jest.mock("@/lib/time/dayKey", () => ({
+  getTodayDayKey: () => "2026-07-16",
+}));
+
+function item(
+  overrides: Partial<TimelinePresentationItem> &
+    Pick<TimelinePresentationItem, "id" | "kind" | "day" | "occurredAt">,
+): TimelinePresentationItem {
+  return {
+    timezone: "UTC",
+    title: overrides.title ?? overrides.kind,
+    status: "ready",
+    source: "manual",
+    destination: "/(app)/(tabs)/timeline/2026-07-16",
+    accessibilityLabel: overrides.title ?? overrides.kind,
+    dedupeKey: overrides.dedupeKey ?? overrides.id,
+    isSynthetic: false,
+    displayRole: overrides.displayRole ?? "chronological_event",
+    ...overrides,
+  };
+}
+
+describe("TimelineFeedList rail/card parity", () => {
+  it("renders TimelineRailRow instead of plain divider rows", () => {
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(
+        <OliThemeProvider mode="dark">
+          <TimelineFeedList
+            sections={[
+              {
+                day: "2026-07-16",
+                data: [
+                  item({
+                    id: "sleep",
+                    kind: "sleep_context",
+                    day: "2026-07-16",
+                    occurredAt: "2026-07-16T07:00:00.000Z",
+                    displayRole: "day_context",
+                    title: "Sleep",
+                  }),
+                  item({
+                    id: "meal",
+                    kind: "nutrition",
+                    day: "2026-07-16",
+                    occurredAt: "2026-07-16T12:00:00.000Z",
+                    title: "Lunch",
+                  }),
+                ],
+              },
+            ]}
+            onPressItem={jest.fn()}
+            onStartReached={jest.fn()}
+            loadingMore={false}
+            refreshing={false}
+            onRefresh={jest.fn()}
+            contentBottomPadding={40}
+            listGeneration={0}
+          />
+        </OliThemeProvider>,
+      );
+    });
+
+    const rows = tree.root.findAllByType(TimelineRailRow);
+    expect(rows.length).toBeGreaterThanOrEqual(2);
+    const context = rows.find((r) => r.props.title === "Sleep");
+    expect(context?.props.timeLabel).toBe("");
+    const meal = rows.find((r) => r.props.title === "Lunch");
+    expect(meal?.props.timeLabel.length).toBeGreaterThan(0);
+  });
+
+  it("source uses shared rail row and no hairline-only feed row", () => {
+    const src = readFileSync(join(__dirname, "..", "TimelineFeedList.tsx"), "utf8");
+    const rail = readFileSync(join(__dirname, "..", "TimelineRail.tsx"), "utf8");
+    expect(src).toContain("TimelineRailRow");
+    expect(src).toContain("timelinePresentationIcon");
+    expect(src).not.toContain("borderBottomWidth: StyleSheet.hairlineWidth");
+    expect(rail).toContain("TimelineRailRow");
+    expect(src).toContain("onStartReached");
+    expect(src).toContain("stickySectionHeadersEnabled");
+    expect(src).toContain("contentBottomPadding");
+  });
+});

--- a/lib/ui/timeline/timelinePresentationIcon.ts
+++ b/lib/ui/timeline/timelinePresentationIcon.ts
@@ -1,0 +1,25 @@
+// lib/ui/timeline/timelinePresentationIcon.ts
+// Map Timeline presentation kinds to the established Ionicons set.
+import type { TimelinePresentationKind } from "@oli/contracts";
+
+const KIND_ICONS: Record<TimelinePresentationKind, string> = {
+  sleep_context: "moon-outline",
+  recovery_context: "heart-outline",
+  sleep_start: "moon-outline",
+  sleep_wake: "sunny-outline",
+  nutrition: "restaurant-outline",
+  caffeine: "cafe-outline",
+  incomplete: "create-outline",
+  workout_strength: "barbell-outline",
+  workout_cardio: "bicycle-outline",
+  workout: "fitness-outline",
+  steps: "walk-outline",
+  weight: "body-outline",
+  insight: "bulb-outline",
+  activity_live: "walk-outline",
+  activity_final: "walk-outline",
+};
+
+export function timelinePresentationIcon(kind: TimelinePresentationKind): string {
+  return KIND_ICONS[kind] ?? "ellipse-outline";
+}

--- a/services/api/src/lib/timeline/__tests__/normalizeDay.test.ts
+++ b/services/api/src/lib/timeline/__tests__/normalizeDay.test.ts
@@ -178,6 +178,93 @@ describe("normalizeTimelineDay", () => {
     expect(items.some((i) => i.kind === "steps")).toBe(false);
   });
 
+  test("merges matching strength_workout + workout into one presentation item", () => {
+    const items = normalizeTimelineDay({
+      day: "2026-07-16",
+      todayDay: "2026-07-16",
+      nowIso: "2026-07-16T20:00:00.000Z",
+      events: [
+        {
+          id: "m1",
+          userId: "u",
+          sourceId: "manual",
+          kind: "strength_workout",
+          start: "2026-07-16T18:00:00.000Z",
+          end: "2026-07-16T18:00:00.000Z",
+          day: "2026-07-16",
+          timezone: "UTC",
+          createdAt: "2026-07-16T18:00:00.000Z",
+          updatedAt: "2026-07-16T18:00:00.000Z",
+          schemaVersion: 1,
+        },
+        {
+          id: "a1",
+          userId: "u",
+          sourceId: "apple_health",
+          kind: "workout",
+          start: "2026-07-16T18:02:00.000Z",
+          end: "2026-07-16T19:00:00.000Z",
+          day: "2026-07-16",
+          timezone: "UTC",
+          createdAt: "2026-07-16T19:00:00.000Z",
+          updatedAt: "2026-07-16T19:00:00.000Z",
+          schemaVersion: 1,
+        },
+      ],
+      readiness: { connected: false, score: null },
+    });
+    const workouts = items.filter(
+      (i) =>
+        i.kind === "workout" ||
+        i.kind === "workout_strength" ||
+        i.kind === "workout_cardio",
+    );
+    expect(workouts).toHaveLength(1);
+    expect(workouts[0]!.dedupeKey).toBe("workout_session:a1|m1");
+    expect(workouts[0]!.id).toContain("m1");
+    expect(workouts[0]!.id).toContain("a1");
+    expect(JSON.stringify(workouts[0])).not.toMatch(/providerPayload|rawPayload/);
+  });
+
+  test("keeps two far-apart same-kind workouts distinct", () => {
+    const items = normalizeTimelineDay({
+      day: "2026-07-16",
+      todayDay: "2026-07-16",
+      nowIso: "2026-07-16T20:00:00.000Z",
+      events: [
+        {
+          id: "w1",
+          userId: "u",
+          sourceId: "apple_health",
+          kind: "workout",
+          start: "2026-07-16T07:00:00.000Z",
+          end: "2026-07-16T07:30:00.000Z",
+          day: "2026-07-16",
+          timezone: "UTC",
+          createdAt: "2026-07-16T07:30:00.000Z",
+          updatedAt: "2026-07-16T07:30:00.000Z",
+          schemaVersion: 1,
+        },
+        {
+          id: "w2",
+          userId: "u",
+          sourceId: "apple_health",
+          kind: "workout",
+          start: "2026-07-16T18:00:00.000Z",
+          end: "2026-07-16T18:30:00.000Z",
+          day: "2026-07-16",
+          timezone: "UTC",
+          createdAt: "2026-07-16T18:30:00.000Z",
+          updatedAt: "2026-07-16T18:30:00.000Z",
+          schemaVersion: 1,
+        },
+      ],
+      readiness: { connected: false, score: null },
+    });
+    const workouts = items.filter((i) => i.kind === "workout");
+    expect(workouts).toHaveLength(2);
+  });
+
   test("skips canonical steps and emits historical activity_final", () => {
     const items = normalizeTimelineDay({
       day: "2026-07-15",

--- a/services/api/src/lib/timeline/normalizeDay.ts
+++ b/services/api/src/lib/timeline/normalizeDay.ts
@@ -14,6 +14,10 @@ import {
   type TimelinePresentationSource,
 } from "@oli/contracts";
 
+import {
+  familyFromWorkoutKind,
+  reconcileWorkoutSessionsCore,
+} from "@/lib/domain/workouts/reconcileWorkoutSessionsCore";
 import { dedupeTimelineFeedItems } from "./dedupe";
 import { sortTimelineFeedItems } from "./order";
 
@@ -296,22 +300,79 @@ const CANONICAL_KIND_MAP: Record<
   string,
   { kind: TimelinePresentationItem["kind"]; title: string; destination: (day: string) => string } | undefined
 > = {
-  strength_workout: {
-    kind: "workout_strength",
-    title: "Strength workout",
-    destination: (d) => `/(app)/workouts/day/${d}`,
-  },
-  workout: {
-    kind: "workout",
-    title: "Workout",
-    destination: (d) => `/(app)/workouts/day/${d}`,
-  },
   weight: {
     kind: "weight",
     title: "Weight",
     destination: (d) => `/(app)/body/day/${d}`,
   },
 };
+
+function presentationKindForSession(
+  sessionType: "strength" | "cardio" | "mixed" | "unknown",
+): TimelinePresentationItem["kind"] {
+  if (sessionType === "strength") return "workout_strength";
+  if (sessionType === "cardio") return "workout_cardio";
+  return "workout";
+}
+
+function buildReconciledWorkoutItems(
+  day: string,
+  timezone: string,
+  events: readonly CanonicalEventListItem[],
+): TimelinePresentationItem[] {
+  const candidates = events.filter(
+    (ev) => ev.kind === "workout" || ev.kind === "strength_workout",
+  );
+  if (candidates.length === 0) return [];
+
+  const records = candidates
+    .filter((ev) => Number.isFinite(Date.parse(ev.start)))
+    .map((ev) => ({
+      id: ev.id,
+      sourceId: ev.sourceId,
+      rawKind: ev.kind,
+      title: null as string | null,
+      start: ev.start,
+      end: ev.end,
+      observedAt: ev.start,
+      durationMinutes:
+        Number.isFinite(Date.parse(ev.end)) && Date.parse(ev.end) > Date.parse(ev.start)
+          ? Math.max(1, Math.round((Date.parse(ev.end) - Date.parse(ev.start)) / 60_000))
+          : null,
+      calories: null as number | null,
+      family: familyFromWorkoutKind(ev.kind),
+    }));
+
+  const sessions = reconcileWorkoutSessionsCore(day, records);
+  return sessions.map((session) => {
+    const kind = presentationKindForSession(session.sessionType);
+    const title =
+      session.sessionType === "strength"
+        ? "Strength workout"
+        : session.sessionType === "cardio"
+          ? "Cardio workout"
+          : session.title || "Workout";
+    const occurredAt = session.start ?? records[0]!.start;
+    const tz =
+      candidates.find((c) => session.memberIds.includes(c.id))?.timezone || timezone;
+    const hasManual = session.members.some((m) => m.sourceId === "manual");
+    return {
+      id: session.id,
+      kind,
+      day,
+      occurredAt,
+      timezone: tz,
+      title,
+      status: "ready" as const,
+      source: hasManual ? ("manual" as const) : ("device" as const),
+      destination: `/(app)/workouts/day/${day}`,
+      accessibilityLabel: title,
+      dedupeKey: `workout_session:${[...session.memberIds].sort().join("|")}`,
+      isSynthetic: false,
+      displayRole: "chronological_event" as const,
+    };
+  });
+}
 
 function buildCanonicalItems(
   day: string,
@@ -320,11 +381,14 @@ function buildCanonicalItems(
   skipSleep: boolean,
 ): TimelinePresentationItem[] {
   const out: TimelinePresentationItem[] = [];
+  out.push(...buildReconciledWorkoutItems(day, timezone, events));
+
   for (const ev of events) {
     if (ev.kind === "nutrition") continue;
     if (ev.kind === "steps") continue; // forbid midnight Steps fabrication
     if (ev.kind === "sleep" && skipSleep) continue;
     if (ev.kind === "hrv") continue; // recovery context covers readiness
+    if (ev.kind === "workout" || ev.kind === "strength_workout") continue; // reconciled above
     const map = CANONICAL_KIND_MAP[ev.kind];
     if (!map) continue;
     if (!Number.isFinite(Date.parse(ev.start))) continue;

--- a/services/api/tsconfig.json
+++ b/services/api/tsconfig.json
@@ -15,7 +15,11 @@
     "skipLibCheck": true
   },
   "references": [{ "path": "../../lib/contracts/tsconfig.json" }],
-  "include": ["src/**/*.ts", "../../lib/labs/**/*.ts"],
+  "include": [
+    "src/**/*.ts",
+    "../../lib/labs/**/*.ts",
+    "../../lib/domain/workouts/reconcileWorkoutSessionsCore.ts"
+  ],
   "exclude": [
     "node_modules",
     "dist",


### PR DESCRIPTION
## Summary

- makes Timeline chronology messaging-style;
- renders older days above and Today/newest at the bottom;
- loads older history upward while preserving visible position;
- restores the established rail/card design;
- reuses canonical Workout merged-session truth;
- prevents manual/watch duplicates without collapsing distinct sessions.

## Physical blocker

- feed attach passed;
- initial continuous-feed physical matrix failed on chronology direction,
  visual parity, and duplicate Workout truth;
- local feed flag was restored to unset;
- backend remained healthy and unchanged.

## Architecture

- no UI-only duplicate hiding;
- Workout reconciliation occurs at the canonical/backend presentation boundary;
- no raw-history hydration on mobile;
- no per-day/per-item fan-out;
- pagination remains bounded and opaque;
- no Firestore write/provider call/backfill.

## Evidence

- focused chronology, visual parity, Workout reconciliation, and source-guard tests;
- full Code Check Gate (typecheck, lint, invariants, trust boundary, Jest, API/Functions builds, iOS export, Expo Doctor);
- exact files in the repair commits;
- OpenAPI hash unchanged (`0f232559a343c542130113a8a5392a4280c98b5490640da4d0b68fa3abca2084`).

## Deployment

Derived from the exact repair diff:

- mobile source update required;
- Cloud Run rebuild/revision required (Timeline `normalizeDay` + shared domain merger);
- Gateway config change not required (OpenAPI unchanged);
- Functions not required;
- Firestore rules/indexes not required;
- migration/backfill not required.

## Unverified

- corrected live physical chronology;
- corrected live rail/card feed;
- corrected live Workout uniqueness;
- busy-day physical continuation;
- physical account switching;
- VoiceOver;
- Dynamic Type;
- light mode;
- post-repair request budget on device.

## Safety

- no deployment;
- no traffic shift;
- no Gateway change;
- no Firestore mutation;
- no backfill;
- no user creation;
- PR #187 remains draft.


Made with [Cursor](https://cursor.com)