### PR TITLE
fix(api): make Timeline workout core Cloud Run resolvable

### DIFF
--- a/services/api/package.json
+++ b/services/api/package.json
@@ -6,10 +6,12 @@
   "type": "commonjs",
   "scripts": {
     "dev": "node scripts/bundle-workout-day-summary-rebuild.mjs && node scripts/write-workout-summary-rebuild-bundle-checksum.mjs && node -r ts-node/register/transpile-only src/server.ts",
-    "build": "node scripts/bundle-workout-day-summary-rebuild.mjs && node scripts/write-workout-summary-rebuild-bundle-checksum.mjs && tsc -b tsconfig.json && node scripts/copy-workout-summary-rebuild-bundle-to-dist.mjs",
+    "build": "node scripts/bundle-workout-day-summary-rebuild.mjs && node scripts/write-workout-summary-rebuild-bundle-checksum.mjs && tsc -b tsconfig.json && node scripts/copy-workout-summary-rebuild-bundle-to-dist.mjs && node scripts/assert-runtime-module-resolution.mjs && node scripts/smoke-emitted-timeline-normalize.mjs",
     "bundle:workout-summary-rebuild": "node scripts/bundle-workout-day-summary-rebuild.mjs",
     "bundle:workout-summary-rebuild:checksum": "node scripts/write-workout-summary-rebuild-bundle-checksum.mjs",
     "verify:workout-summary-rebuild-bundle": "node scripts/verify-workout-summary-rebuild-bundle.mjs",
+    "check:runtime-module-resolution": "node scripts/assert-runtime-module-resolution.mjs",
+    "smoke:emitted-timeline-normalize": "node scripts/smoke-emitted-timeline-normalize.mjs",
     "start": "node dist/services/api/src/server.js",
     "typecheck": "tsc --noEmit"
   },

--- a/services/api/scripts/assert-runtime-module-resolution-lib.cjs
+++ b/services/api/scripts/assert-runtime-module-resolution-lib.cjs
@@ -1,0 +1,57 @@
+/**
+ * Shared scanner for unresolved `@/` runtime aliases in emitted API JS.
+ * CommonJS so Jest and the .mjs CLI both consume one implementation.
+ */
+const { readdirSync, readFileSync, statSync, existsSync } = require("node:fs");
+const { join, relative } = require("node:path");
+
+/** Match require("@/..."), require.resolve("@/..."), import("@/...") */
+const UNRESOLVED_ALIAS_RE =
+  /(?:require\.resolve|require|import)\(\s*(['"])@\/[^'"]*\1\s*\)/g;
+
+function shouldScan(filePath) {
+  const parts = filePath.split(/[/\\]/);
+  if (parts.includes("__tests__")) return false;
+  if (filePath.endsWith(".test.js") || filePath.endsWith(".spec.js")) return false;
+  if (filePath.endsWith(".js.map")) return false;
+  return filePath.endsWith(".js");
+}
+
+function walk(dir, out = []) {
+  if (!existsSync(dir)) return out;
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    const st = statSync(full);
+    if (st.isDirectory()) walk(full, out);
+    else if (shouldScan(full)) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * @param {string} root
+ * @returns {{ file: string, count: number }[]}
+ */
+function findUnresolvedRuntimeAliases(root) {
+  const files = walk(root).sort((a, b) => a.localeCompare(b));
+  const hits = [];
+  for (const file of files) {
+    const text = readFileSync(file, "utf8");
+    const stripped = text
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/(^|[^:])\/\/.*$/gm, "$1");
+    const matches = stripped.match(UNRESOLVED_ALIAS_RE);
+    if (matches && matches.length > 0) {
+      hits.push({
+        file: relative(root, file) || file,
+        count: matches.length,
+      });
+    }
+  }
+  return hits;
+}
+
+module.exports = {
+  findUnresolvedRuntimeAliases,
+  UNRESOLVED_ALIAS_RE,
+};

--- a/services/api/scripts/assert-runtime-module-resolution.mjs
+++ b/services/api/scripts/assert-runtime-module-resolution.mjs
@@ -6,56 +6,17 @@
  * Scans services/api/dist production JS (excludes __tests__ and *.test.js).
  * Reports only file paths and counts — never file contents or env values.
  */
-import { readdirSync, readFileSync, statSync, existsSync } from "node:fs";
-import { join, relative, resolve } from "node:path";
+import { createRequire } from "node:module";
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const require = createRequire(import.meta.url);
+const { findUnresolvedRuntimeAliases } = require("./assert-runtime-module-resolution-lib.cjs");
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 const apiRoot = resolve(__dirname, "..");
 const distRoot = resolve(apiRoot, "dist");
-
-/** Match require("@/..."), require.resolve("@/..."), import("@/...") */
-const UNRESOLVED_ALIAS_RE =
-  /(?:require\.resolve|require|import)\(\s*(['"])@\/[^'"]*\1\s*\)/g;
-
-function shouldScan(filePath) {
-  const parts = filePath.split(/[/\\]/);
-  if (parts.includes("__tests__")) return false;
-  if (filePath.endsWith(".test.js") || filePath.endsWith(".spec.js")) return false;
-  if (filePath.endsWith(".js.map")) return false;
-  return filePath.endsWith(".js");
-}
-
-function walk(dir, out = []) {
-  if (!existsSync(dir)) return out;
-  for (const name of readdirSync(dir)) {
-    const full = join(dir, name);
-    const st = statSync(full);
-    if (st.isDirectory()) walk(full, out);
-    else if (shouldScan(full)) out.push(full);
-  }
-  return out;
-}
-
-export function findUnresolvedRuntimeAliases(root = distRoot) {
-  const files = walk(root).sort((a, b) => a.localeCompare(b));
-  const hits = [];
-  for (const file of files) {
-    const text = readFileSync(file, "utf8");
-    // Strip block and line comments to reduce source-map / comment false positives.
-    const stripped = text
-      .replace(/\/\*[\s\S]*?\*\//g, "")
-      .replace(/(^|[^:])\/\/.*$/gm, "$1");
-    const matches = stripped.match(UNRESOLVED_ALIAS_RE);
-    if (matches && matches.length > 0) {
-      hits.push({
-        file: relative(root, file) || file,
-        count: matches.length,
-      });
-    }
-  }
-  return hits;
-}
 
 function main() {
   if (!existsSync(distRoot)) {
@@ -79,10 +40,4 @@ function main() {
   );
 }
 
-const isDirect =
-  process.argv[1] &&
-  resolve(process.argv[1]) === fileURLToPath(import.meta.url);
-
-if (isDirect) {
-  main();
-}
+main();

--- a/services/api/scripts/assert-runtime-module-resolution.mjs
+++ b/services/api/scripts/assert-runtime-module-resolution.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/**
+ * Fail-closed guard: Cloud Run-reachable emitted API JavaScript must not retain
+ * unresolved TypeScript path aliases (`@/...`).
+ *
+ * Scans services/api/dist production JS (excludes __tests__ and *.test.js).
+ * Reports only file paths and counts — never file contents or env values.
+ */
+import { readdirSync, readFileSync, statSync, existsSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const apiRoot = resolve(__dirname, "..");
+const distRoot = resolve(apiRoot, "dist");
+
+/** Match require("@/..."), require.resolve("@/..."), import("@/...") */
+const UNRESOLVED_ALIAS_RE =
+  /(?:require\.resolve|require|import)\(\s*(['"])@\/[^'"]*\1\s*\)/g;
+
+function shouldScan(filePath) {
+  const parts = filePath.split(/[/\\]/);
+  if (parts.includes("__tests__")) return false;
+  if (filePath.endsWith(".test.js") || filePath.endsWith(".spec.js")) return false;
+  if (filePath.endsWith(".js.map")) return false;
+  return filePath.endsWith(".js");
+}
+
+function walk(dir, out = []) {
+  if (!existsSync(dir)) return out;
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    const st = statSync(full);
+    if (st.isDirectory()) walk(full, out);
+    else if (shouldScan(full)) out.push(full);
+  }
+  return out;
+}
+
+export function findUnresolvedRuntimeAliases(root = distRoot) {
+  const files = walk(root).sort((a, b) => a.localeCompare(b));
+  const hits = [];
+  for (const file of files) {
+    const text = readFileSync(file, "utf8");
+    // Strip block and line comments to reduce source-map / comment false positives.
+    const stripped = text
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/(^|[^:])\/\/.*$/gm, "$1");
+    const matches = stripped.match(UNRESOLVED_ALIAS_RE);
+    if (matches && matches.length > 0) {
+      hits.push({
+        file: relative(root, file) || file,
+        count: matches.length,
+      });
+    }
+  }
+  return hits;
+}
+
+function main() {
+  if (!existsSync(distRoot)) {
+    console.error(
+      "assert-runtime-module-resolution: missing dist/ — run API build first",
+    );
+    process.exit(1);
+  }
+  const hits = findUnresolvedRuntimeAliases(distRoot);
+  if (hits.length > 0) {
+    console.error(
+      `assert-runtime-module-resolution: FAIL — ${hits.length} file(s) retain unresolved @/ runtime alias(es)`,
+    );
+    for (const h of hits) {
+      console.error(`  ${h.file} (${h.count})`);
+    }
+    process.exit(1);
+  }
+  console.log(
+    "assert-runtime-module-resolution: OK (no unresolved @/ aliases in Cloud Run-reachable emitted JS)",
+  );
+}
+
+const isDirect =
+  process.argv[1] &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isDirect) {
+  main();
+}

--- a/services/api/scripts/smoke-emitted-timeline-normalize.mjs
+++ b/services/api/scripts/smoke-emitted-timeline-normalize.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+/**
+ * Load the emitted Timeline normalizer under Node (same layout as Cloud Run).
+ * No network, secrets, or server listen — module-resolution proof only.
+ */
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const apiRoot = resolve(__dirname, "..");
+const normalizeDayJs = join(
+  apiRoot,
+  "dist/services/api/src/lib/timeline/normalizeDay.js",
+);
+
+if (!existsSync(normalizeDayJs)) {
+  console.error(
+    "smoke-emitted-timeline-normalize: missing emitted normalizeDay.js — run API build first",
+  );
+  process.exit(1);
+}
+
+const require = createRequire(import.meta.url);
+try {
+  require(normalizeDayJs);
+  console.log("smoke-emitted-timeline-normalize: OK");
+} catch (err) {
+  const code = err && typeof err === "object" && "code" in err ? err.code : "ERROR";
+  console.error(`smoke-emitted-timeline-normalize: FAIL (${code})`);
+  process.exit(1);
+}

--- a/services/api/src/lib/__tests__/assertRuntimeModuleResolution.test.ts
+++ b/services/api/src/lib/__tests__/assertRuntimeModuleResolution.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Synthetic fixture tests for the Cloud Run runtime module-resolution guard.
+ */
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const SCRIPT = join(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "scripts",
+  "assert-runtime-module-resolution.mjs",
+);
+
+async function loadFinder() {
+  const mod = await import(SCRIPT);
+  return mod.findUnresolvedRuntimeAliases as (root?: string) => {
+    file: string;
+    count: number;
+  }[];
+}
+
+describe("assert-runtime-module-resolution", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "oli-runtime-alias-"));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("flags CommonJS require(\"@/...\")", async () => {
+    const find = await loadFinder();
+    writeFileSync(join(root, "bad.js"), 'const x = require("@/lib/foo");\n');
+    const hits = find(root);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.file).toBe("bad.js");
+  });
+
+  test("flags require.resolve(\"@/...\")", async () => {
+    const find = await loadFinder();
+    writeFileSync(join(root, "bad.js"), 'require.resolve("@/lib/foo");\n');
+    expect(find(root)).toHaveLength(1);
+  });
+
+  test("flags dynamic import(\"@/...\")", async () => {
+    const find = await loadFinder();
+    writeFileSync(join(root, "bad.js"), 'import("@/lib/foo");\n');
+    expect(find(root)).toHaveLength(1);
+  });
+
+  test("allows relative require", async () => {
+    const find = await loadFinder();
+    writeFileSync(join(root, "ok.js"), 'require("../../lib/domain/workouts/core");\n');
+    expect(find(root)).toHaveLength(0);
+  });
+
+  test("allows npm scoped packages", async () => {
+    const find = await loadFinder();
+    writeFileSync(join(root, "ok.js"), 'require("@oli/contracts");\n');
+    expect(find(root)).toHaveLength(0);
+  });
+
+  test("ignores aliases inside block comments", async () => {
+    const find = await loadFinder();
+    writeFileSync(
+      join(root, "ok.js"),
+      "/* require(\"@/lib/foo\") */\nrequire(\"./relative\");\n",
+    );
+    expect(find(root)).toHaveLength(0);
+  });
+
+  test("skips __tests__ directories", async () => {
+    const find = await loadFinder();
+    mkdirSync(join(root, "__tests__"), { recursive: true });
+    writeFileSync(join(root, "__tests__", "bad.js"), 'require("@/lib/foo");\n');
+    writeFileSync(join(root, "ok.js"), 'require("./x");\n');
+    expect(find(root)).toHaveLength(0);
+  });
+
+  test("reports deterministic file ordering", async () => {
+    const find = await loadFinder();
+    writeFileSync(join(root, "z.js"), 'require("@/z");\n');
+    writeFileSync(join(root, "a.js"), 'require("@/a");\n');
+    const hits = find(root);
+    expect(hits.map((h) => h.file)).toEqual(["a.js", "z.js"]);
+  });
+});

--- a/services/api/src/lib/__tests__/assertRuntimeModuleResolution.test.ts
+++ b/services/api/src/lib/__tests__/assertRuntimeModuleResolution.test.ts
@@ -5,22 +5,8 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
-const SCRIPT = join(
-  __dirname,
-  "..",
-  "..",
-  "..",
-  "scripts",
-  "assert-runtime-module-resolution.mjs",
-);
-
-async function loadFinder() {
-  const mod = await import(SCRIPT);
-  return mod.findUnresolvedRuntimeAliases as (root?: string) => {
-    file: string;
-    count: number;
-  }[];
-}
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { findUnresolvedRuntimeAliases } = require("../../../scripts/assert-runtime-module-resolution-lib.cjs");
 
 describe("assert-runtime-module-resolution", () => {
   let root: string;
@@ -33,60 +19,52 @@ describe("assert-runtime-module-resolution", () => {
     rmSync(root, { recursive: true, force: true });
   });
 
-  test("flags CommonJS require(\"@/...\")", async () => {
-    const find = await loadFinder();
+  test("flags CommonJS require(\"@/...\")", () => {
     writeFileSync(join(root, "bad.js"), 'const x = require("@/lib/foo");\n');
-    const hits = find(root);
+    const hits = findUnresolvedRuntimeAliases(root);
     expect(hits).toHaveLength(1);
     expect(hits[0]?.file).toBe("bad.js");
   });
 
-  test("flags require.resolve(\"@/...\")", async () => {
-    const find = await loadFinder();
+  test("flags require.resolve(\"@/...\")", () => {
     writeFileSync(join(root, "bad.js"), 'require.resolve("@/lib/foo");\n');
-    expect(find(root)).toHaveLength(1);
+    expect(findUnresolvedRuntimeAliases(root)).toHaveLength(1);
   });
 
-  test("flags dynamic import(\"@/...\")", async () => {
-    const find = await loadFinder();
+  test("flags dynamic import(\"@/...\")", () => {
     writeFileSync(join(root, "bad.js"), 'import("@/lib/foo");\n');
-    expect(find(root)).toHaveLength(1);
+    expect(findUnresolvedRuntimeAliases(root)).toHaveLength(1);
   });
 
-  test("allows relative require", async () => {
-    const find = await loadFinder();
+  test("allows relative require", () => {
     writeFileSync(join(root, "ok.js"), 'require("../../lib/domain/workouts/core");\n');
-    expect(find(root)).toHaveLength(0);
+    expect(findUnresolvedRuntimeAliases(root)).toHaveLength(0);
   });
 
-  test("allows npm scoped packages", async () => {
-    const find = await loadFinder();
+  test("allows npm scoped packages", () => {
     writeFileSync(join(root, "ok.js"), 'require("@oli/contracts");\n');
-    expect(find(root)).toHaveLength(0);
+    expect(findUnresolvedRuntimeAliases(root)).toHaveLength(0);
   });
 
-  test("ignores aliases inside block comments", async () => {
-    const find = await loadFinder();
+  test("ignores aliases inside block comments", () => {
     writeFileSync(
       join(root, "ok.js"),
       "/* require(\"@/lib/foo\") */\nrequire(\"./relative\");\n",
     );
-    expect(find(root)).toHaveLength(0);
+    expect(findUnresolvedRuntimeAliases(root)).toHaveLength(0);
   });
 
-  test("skips __tests__ directories", async () => {
-    const find = await loadFinder();
+  test("skips __tests__ directories", () => {
     mkdirSync(join(root, "__tests__"), { recursive: true });
     writeFileSync(join(root, "__tests__", "bad.js"), 'require("@/lib/foo");\n');
     writeFileSync(join(root, "ok.js"), 'require("./x");\n');
-    expect(find(root)).toHaveLength(0);
+    expect(findUnresolvedRuntimeAliases(root)).toHaveLength(0);
   });
 
-  test("reports deterministic file ordering", async () => {
-    const find = await loadFinder();
+  test("reports deterministic file ordering", () => {
     writeFileSync(join(root, "z.js"), 'require("@/z");\n');
     writeFileSync(join(root, "a.js"), 'require("@/a");\n');
-    const hits = find(root);
-    expect(hits.map((h) => h.file)).toEqual(["a.js", "z.js"]);
+    const hits = findUnresolvedRuntimeAliases(root);
+    expect(hits.map((h: { file: string }) => h.file)).toEqual(["a.js", "z.js"]);
   });
 });

--- a/services/api/src/lib/timeline/__tests__/normalizeDay.emitSafeImport.test.ts
+++ b/services/api/src/lib/timeline/__tests__/normalizeDay.emitSafeImport.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Source + wiring guards for Cloud Run-safe Timeline workout-core imports.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+describe("Timeline API emit-safe workout core import", () => {
+  const apiRoot = join(__dirname, "..", "..", "..");
+  const normalizeSrc = join(apiRoot, "src/lib/timeline/normalizeDay.ts");
+  const packageJson = join(apiRoot, "package.json");
+
+  test("normalizeDay imports shared core via emit-safe relative specifier", () => {
+    const src = readFileSync(normalizeSrc, "utf8");
+    expect(src).toContain("reconcileWorkoutSessionsCore");
+    expect(src).toContain(
+      'from "../../../../../lib/domain/workouts/reconcileWorkoutSessionsCore"',
+    );
+    expect(src).not.toMatch(
+      /from\s+["']@\/lib\/domain\/workouts\/reconcileWorkoutSessionsCore["']/,
+    );
+    // Does not duplicate merger inline.
+    expect(src).not.toContain("MERGE_GAP_MINUTES");
+    expect(src).not.toContain("START_PROXIMITY_MINUTES");
+  });
+
+  test("API build invokes runtime-resolution and emitted-normalize smoke", () => {
+    const pkg = JSON.parse(readFileSync(packageJson, "utf8")) as {
+      scripts: Record<string, string>;
+    };
+    expect(pkg.scripts.build).toContain("assert-runtime-module-resolution.mjs");
+    expect(pkg.scripts.build).toContain("smoke-emitted-timeline-normalize.mjs");
+    expect(pkg.scripts["check:runtime-module-resolution"]).toContain(
+      "assert-runtime-module-resolution.mjs",
+    );
+  });
+});

--- a/services/api/src/lib/timeline/__tests__/normalizeDay.emitSafeImport.test.ts
+++ b/services/api/src/lib/timeline/__tests__/normalizeDay.emitSafeImport.test.ts
@@ -5,7 +5,8 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 describe("Timeline API emit-safe workout core import", () => {
-  const apiRoot = join(__dirname, "..", "..", "..");
+  // __dirname = services/api/src/lib/timeline/__tests__
+  const apiRoot = join(__dirname, "..", "..", "..", "..");
   const normalizeSrc = join(apiRoot, "src/lib/timeline/normalizeDay.ts");
   const packageJson = join(apiRoot, "package.json");
 

--- a/services/api/src/lib/timeline/normalizeDay.ts
+++ b/services/api/src/lib/timeline/normalizeDay.ts
@@ -17,7 +17,7 @@ import {
 import {
   familyFromWorkoutKind,
   reconcileWorkoutSessionsCore,
-} from "@/lib/domain/workouts/reconcileWorkoutSessionsCore";
+} from "../../../../../lib/domain/workouts/reconcileWorkoutSessionsCore";
 import { dedupeTimelineFeedItems } from "./dedupe";
 import { sortTimelineFeedItems } from "./order";
 


### PR DESCRIPTION
## Summary

- replaces the unresolved Cloud Run runtime alias with an emit-safe module
  reference;
- preserves the single shared workout reconciliation implementation;
- adds an emitted-JavaScript unresolved-alias guard;
- adds a direct emitted-module load smoke;
- causes API builds to fail before image creation when a reachable alias
  remains.

## Original failure

- source, TypeScript, Jest, and image build passed;
- zero-traffic revision `oli-api-00238-qac` exited at startup;
- compiled Timeline normalization retained `require("@/...")`;
- startup probe failed;
- no traffic or Gateway change occurred.

## Functional parity

- no workout reconciliation logic change;
- no Timeline chronology/design change;
- no DTO/OpenAPI change;
- no auth/query/cursor change;
- no provider call;
- no Firestore write;
- no migration/backfill.

## Evidence

- emitted alias count before/after;
- emitted module-load proof;
- repeated runtime-guard passes;
- local Docker proof when available;
- focused tests;
- complete Code Check Gate;
- exact file scope.

## Artifact impact

Superseded:
- image digest `sha256:c6b84068…`;
- revision `oli-api-00238-qac`;
- tag `timeline-feed-repair-9932f23`.

Treatment:
- preserve at 0%;
- do not cut over;
- do not delete.

A new immutable image and zero-traffic revision are required after this PR is
merged into `feat/timeline-v1`.

## Deployment

Required:
- Cloud Run API rebuild/revision.

Not required:
- Gateway config;
- Firebase Functions;
- Firestore rules/indexes;
- migration;
- backfill;
- mobile bundle change.

## Safety

- no deployment in this PR;
- live API remains `oli-api-00236-muz`;
- current Timeline Gateway remains attached;
- feed flag remains unset;
- PR #187 remains draft.

Made with [Cursor](https://cursor.com)