### PR TITLE
fix(timeline): restore current-day and calendar continuity

### DIFF
--- a/docs/audits/2026-07-18-timeline-viewport-calendar-continuity.md
+++ b/docs/audits/2026-07-18-timeline-viewport-calendar-continuity.md
@@ -1,0 +1,47 @@
+# Timeline viewport and calendar continuity repair — 2026-07-18
+
+Aggregate-only classification after failed physical feed attach on Timeline v1.
+
+## Failed physical observations (booleans only)
+
+| Gate | Result |
+| --- | --- |
+| Feed attach | PASS |
+| Initial current-day positioning | FAIL |
+| Sticky date-header contract | FAIL |
+| Calendar newer-history continuity | FAIL |
+| Rail/card design (visible sample) | PASS |
+| Redbox | NONE |
+| Blank screen | NONE |
+| Visible backend error | NONE |
+
+Local experimental feed flag restored to unset after classification.
+Physical capture artifacts were not retained in Git.
+
+## Root causes
+
+1. **Initial viewport:** cold-open scroll armed without a reliable content/layout readiness barrier and without bounded `onScrollToIndexFailed` retry, so the list could remain at the oldest offset.
+2. **Sticky header:** continuous feed `SectionList` used sticky section headers while inline day headings already rendered, producing a redundant pinned date under the page title.
+3. **Calendar continuity:** calendar selection replaced the Today-rooted page set with an anchor-at-D older window, discarding newer days below D.
+
+## Repair strategy
+
+Client-only:
+
+- intentional scroll targets (`newest` | `day`) with layout/content readiness and bounded retries;
+- `stickySectionHeadersEnabled={false}` with inline `TimelineDaySectionHeader` retained;
+- `jumpToDay` keeps Today as the data anchor, scrolls when D is loaded, otherwise appends bounded older pages (cap 10) without discarding newer history.
+
+No additive bidirectional API/OpenAPI change.
+
+## Deployment classification
+
+- Mobile: REQUIRED
+- Cloud Run / Gateway / Functions / Firestore / migration / backfill: NOT REQUIRED
+
+## Unverified on device after repair
+
+- cold open lands on Today
+- non-sticky inline headings
+- historical calendar continuity
+- prepend stability, request budget, account-switch isolation, VoiceOver, Dynamic Type, light mode

--- a/lib/features/timeline/__tests__/timelineCalendarContinuity.test.ts
+++ b/lib/features/timeline/__tests__/timelineCalendarContinuity.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Calendar-jump continuity: selecting D must keep newer days toward Today.
+ * Client-only strategy: Today-rooted pages + bounded older append.
+ */
+import type { TimelinePresentationItem } from "@oli/contracts";
+import {
+  groupSectionsAscending,
+  mergeFeedPageItems,
+} from "@/lib/features/timeline/timelineFeedOrder";
+import {
+  MAX_ENSURE_DAY_OLDER_PAGES,
+  canRequestEnsureDayPage,
+  dayIsLoaded,
+  resolveScrollLocation,
+} from "@/lib/features/timeline/timelineFeedScrollIntent";
+
+function item(day: string, id: string): TimelinePresentationItem {
+  return {
+    id,
+    kind: "nutrition",
+    day,
+    occurredAt: `${day}T12:00:00.000Z`,
+    timezone: "UTC",
+    title: id,
+    status: "ready",
+    source: "manual",
+    destination: `/(app)/nutrition/day/${day}`,
+    accessibilityLabel: id,
+    dedupeKey: id,
+    isSynthetic: false,
+    displayRole: "chronological_event",
+  };
+}
+
+describe("timeline calendar continuity (client-only ensure-day)", () => {
+  const today = "2026-07-16";
+  const loaded = groupSectionsAscending([
+    item("2026-07-14", "d2"),
+    item("2026-07-15", "d1"),
+    item("2026-07-16", "today"),
+  ]);
+
+  test("selecting loaded D issues zero network need and scrolls to D", () => {
+    expect(dayIsLoaded(loaded, "2026-07-15")).toBe(true);
+    const loc = resolveScrollLocation(loaded, {
+      id: 1,
+      mode: "day",
+      day: "2026-07-15",
+    });
+    expect(loc?.sectionIndex).toBe(1);
+    expect(loc?.viewPosition).toBe(0);
+  });
+
+  test("D-1 remains above and D+1/Today remain below after selecting D", () => {
+    expect(loaded.map((s) => s.day)).toEqual([
+      "2026-07-14",
+      "2026-07-15",
+      "2026-07-16",
+    ]);
+    const dIndex = loaded.findIndex((s) => s.day === "2026-07-15");
+    expect(loaded[dIndex - 1]?.day).toBe("2026-07-14");
+    expect(loaded[dIndex + 1]?.day).toBe(today);
+  });
+
+  test("appending older pages preserves already-loaded newer history", () => {
+    const todayPage = [item("2026-07-16", "today"), item("2026-07-15", "d1")];
+    const olderPage = [
+      item("2026-07-14", "d2"),
+      item("2026-07-13", "d3"),
+      item("2026-07-12", "target"),
+    ];
+    const merged = mergeFeedPageItems(todayPage, olderPage);
+    const sections = groupSectionsAscending(merged);
+    expect(sections.map((s) => s.day)).toEqual([
+      "2026-07-12",
+      "2026-07-13",
+      "2026-07-14",
+      "2026-07-15",
+      "2026-07-16",
+    ]);
+    expect(dayIsLoaded(sections, "2026-07-12")).toBe(true);
+    expect(dayIsLoaded(sections, today)).toBe(true);
+    // No duplicate day or item
+    expect(new Set(sections.map((s) => s.day)).size).toBe(sections.length);
+    expect(new Set(merged.map((i) => i.dedupeKey)).size).toBe(merged.length);
+  });
+
+  test("ensure-day budget is page-capped (not one request per day)", () => {
+    expect(MAX_ENSURE_DAY_OLDER_PAGES).toBe(10);
+    let pages = 0;
+    while (
+      canRequestEnsureDayPage({
+        pagesRequested: pages,
+        maxPages: MAX_ENSURE_DAY_OLDER_PAGES,
+        hasMore: true,
+        targetLoaded: false,
+      })
+    ) {
+      pages += 1;
+    }
+    expect(pages).toBe(10);
+  });
+
+  test("Return to Today targets newest section without needing page discard", () => {
+    const loc = resolveScrollLocation(loaded, { id: 9, mode: "newest" });
+    expect(loc?.sectionIndex).toBe(loaded.length - 1);
+    expect(loaded[loc!.sectionIndex]?.day).toBe(today);
+  });
+});

--- a/lib/features/timeline/__tests__/timelineFeedScrollIntent.test.ts
+++ b/lib/features/timeline/__tests__/timelineFeedScrollIntent.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Pure scroll-intent / ensure-day budget tests for Timeline continuous feed.
+ */
+import {
+  MAX_ENSURE_DAY_OLDER_PAGES,
+  MAX_FEED_SCROLL_RETRIES,
+  canRequestEnsureDayPage,
+  dayIsLoaded,
+  resolveScrollLocation,
+  sectionIndexForDay,
+} from "@/lib/features/timeline/timelineFeedScrollIntent";
+import {
+  finalSectionIndex,
+  groupSectionsAscending,
+} from "@/lib/features/timeline/timelineFeedOrder";
+import type { TimelinePresentationItem } from "@oli/contracts";
+
+function item(day: string, id: string): TimelinePresentationItem {
+  return {
+    id,
+    kind: "nutrition",
+    day,
+    occurredAt: `${day}T12:00:00.000Z`,
+    timezone: "UTC",
+    title: id,
+    status: "ready",
+    source: "manual",
+    destination: `/(app)/nutrition/day/${day}`,
+    accessibilityLabel: id,
+    dedupeKey: id,
+    isSynthetic: false,
+    displayRole: "chronological_event",
+  };
+}
+
+describe("timelineFeedScrollIntent", () => {
+  const sections = groupSectionsAscending([
+    item("2026-07-14", "a"),
+    item("2026-07-15", "b"),
+    item("2026-07-16", "c"),
+    item("2026-07-16", "d"),
+  ]);
+
+  test("newest intent targets final section last item near bottom", () => {
+    const loc = resolveScrollLocation(sections, { id: 1, mode: "newest" });
+    expect(loc).toEqual({
+      sectionIndex: finalSectionIndex(sections),
+      itemIndex: 1,
+      viewPosition: 1,
+    });
+  });
+
+  test("day intent targets section header near top", () => {
+    const loc = resolveScrollLocation(sections, {
+      id: 2,
+      mode: "day",
+      day: "2026-07-15",
+    });
+    expect(loc).toEqual({
+      sectionIndex: 1,
+      itemIndex: 0,
+      viewPosition: 0,
+    });
+  });
+
+  test("day intent returns null until the day is loaded", () => {
+    expect(
+      resolveScrollLocation(sections, { id: 3, mode: "day", day: "2026-07-10" }),
+    ).toBeNull();
+    expect(dayIsLoaded(sections, "2026-07-14")).toBe(true);
+    expect(dayIsLoaded(sections, "2026-07-10")).toBe(false);
+    expect(sectionIndexForDay(sections, "2026-07-16")).toBe(2);
+  });
+
+  test("ensure-day budget is bounded and stops when loaded or exhausted", () => {
+    expect(MAX_FEED_SCROLL_RETRIES).toBeGreaterThan(0);
+    expect(MAX_ENSURE_DAY_OLDER_PAGES).toBe(10);
+    expect(
+      canRequestEnsureDayPage({
+        pagesRequested: 0,
+        maxPages: 10,
+        hasMore: true,
+        targetLoaded: false,
+      }),
+    ).toBe(true);
+    expect(
+      canRequestEnsureDayPage({
+        pagesRequested: 10,
+        maxPages: 10,
+        hasMore: true,
+        targetLoaded: false,
+      }),
+    ).toBe(false);
+    expect(
+      canRequestEnsureDayPage({
+        pagesRequested: 2,
+        maxPages: 10,
+        hasMore: false,
+        targetLoaded: false,
+      }),
+    ).toBe(false);
+    expect(
+      canRequestEnsureDayPage({
+        pagesRequested: 2,
+        maxPages: 10,
+        hasMore: true,
+        targetLoaded: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/lib/features/timeline/__tests__/timelineViewportCalendarContinuity.guards.test.ts
+++ b/lib/features/timeline/__tests__/timelineViewportCalendarContinuity.guards.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Source guards for current-day viewport and calendar newer-history continuity.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+describe("timeline viewport and calendar continuity contracts", () => {
+  const root = join(__dirname, "..", "..", "..");
+
+  test("sticky section headers are disabled on the continuous feed list", () => {
+    const list = readFileSync(join(root, "ui/timeline/TimelineFeedList.tsx"), "utf8");
+    expect(list).toContain("stickySectionHeadersEnabled={false}");
+    expect(list).toContain("TimelineDaySectionHeader");
+    expect(list).toContain("onScrollToIndexFailed");
+    expect(list).toContain("onScrollBeginDrag");
+    expect(list).toContain("MAX_FEED_SCROLL_RETRIES");
+    expect(list).not.toMatch(/stickySectionHeadersEnabled\s*$/m);
+  });
+
+  test("calendar selection uses jumpToDay without replacing newer history", () => {
+    const hook = readFileSync(join(root, "features/timeline/useTimelineFeed.ts"), "utf8");
+    const screen = readFileSync(join(root, "ui/timeline/TimelineFeedScreen.tsx"), "utf8");
+    expect(hook).toContain("jumpToDay");
+    expect(hook).toContain("MAX_ENSURE_DAY_OLDER_PAGES");
+    expect(hook).toContain("dayIsLoaded");
+    expect(hook).toContain("anchorDay: today");
+    expect(hook).not.toMatch(/setAnchorDayState\(day\)/);
+    expect(screen).toContain("feed.jumpToDay");
+    expect(screen).not.toContain("feed.setAnchorDay");
+    expect(screen).toContain("selectedDay={feed.selectedDay}");
+  });
+
+  test("Return to Today re-targets newest without discarding loaded pages", () => {
+    const hook = readFileSync(join(root, "features/timeline/useTimelineFeed.ts"), "utf8");
+    const returnBlock = hook.slice(hook.indexOf("const returnToToday"), hook.indexOf("const refetch"));
+    expect(returnBlock).toContain('mode: "newest"');
+    expect(returnBlock).not.toContain("setItems([])");
+  });
+
+  test("no request-per-day or unbounded ensure loop", () => {
+    const hook = readFileSync(join(root, "features/timeline/useTimelineFeed.ts"), "utf8");
+    const intent = readFileSync(
+      join(root, "features/timeline/timelineFeedScrollIntent.ts"),
+      "utf8",
+    );
+    expect(intent).toContain("MAX_ENSURE_DAY_OLDER_PAGES = 10");
+    expect(hook).toContain("canRequestEnsureDayPage");
+    expect(hook).not.toMatch(/for\s*\(\s*let\s+d\s*=/);
+    expect(hook).not.toContain("getTimelineDay");
+  });
+});

--- a/lib/features/timeline/timelineFeedScrollIntent.ts
+++ b/lib/features/timeline/timelineFeedScrollIntent.ts
@@ -1,0 +1,87 @@
+/**
+ * Pure Timeline feed scroll-intent helpers.
+ * Keeps cold-open / Return-to-Today / calendar-jump targeting out of render paths.
+ */
+
+import type { TimelineFeedSection } from "@/lib/features/timeline/timelineFeedOrder";
+import { finalSectionIndex } from "@/lib/features/timeline/timelineFeedOrder";
+
+export type FeedScrollMode = "newest" | "day";
+
+export type FeedScrollTarget = {
+  /** Monotonic id; each intentional reset gets a new id. */
+  id: number;
+  mode: FeedScrollMode;
+  /** Required when mode === "day". */
+  day?: string;
+};
+
+export type ScrollLocationTarget = {
+  sectionIndex: number;
+  itemIndex: number;
+  /** 0 = align section near top (calendar jump); 1 = align near bottom (Today). */
+  viewPosition: number;
+};
+
+/** Bounded retries for SectionList scrollToLocation / onScrollToIndexFailed. */
+export const MAX_FEED_SCROLL_RETRIES = 8;
+
+/** Max sequential older-page loads while ensuring a calendar day is present. */
+export const MAX_ENSURE_DAY_OLDER_PAGES = 10;
+
+export function sectionIndexForDay(
+  sections: readonly TimelineFeedSection[],
+  day: string,
+): number {
+  return sections.findIndex((s) => s.day === day);
+}
+
+export function resolveScrollLocation(
+  sections: readonly TimelineFeedSection[],
+  target: FeedScrollTarget,
+): ScrollLocationTarget | null {
+  if (sections.length === 0) return null;
+  if (target.mode === "newest") {
+    const sectionIndex = finalSectionIndex(sections);
+    const last = sections[sectionIndex];
+    return {
+      sectionIndex,
+      itemIndex: Math.max(0, (last?.data.length ?? 1) - 1),
+      viewPosition: 1,
+    };
+  }
+  const day = target.day;
+  if (!day) return null;
+  const sectionIndex = sectionIndexForDay(sections, day);
+  if (sectionIndex < 0) return null;
+  return {
+    sectionIndex,
+    itemIndex: 0,
+    viewPosition: 0,
+  };
+}
+
+export function dayIsLoaded(
+  sections: readonly TimelineFeedSection[],
+  day: string,
+): boolean {
+  return sectionIndexForDay(sections, day) >= 0;
+}
+
+export type EnsureDayBudget = {
+  pagesRequested: number;
+  maxPages: number;
+  hasMore: boolean;
+  targetLoaded: boolean;
+};
+
+/** Whether another older page may be requested while seeking a calendar day. */
+export function canRequestEnsureDayPage(budget: EnsureDayBudget): boolean {
+  if (budget.targetLoaded) return false;
+  if (!budget.hasMore) return false;
+  return budget.pagesRequested < budget.maxPages;
+}
+
+export function nextEnsureDayPageCount(pagesRequested: number): number {
+  return pagesRequested + 1;
+}

--- a/lib/features/timeline/useTimelineFeed.ts
+++ b/lib/features/timeline/useTimelineFeed.ts
@@ -1,9 +1,9 @@
 // lib/features/timeline/useTimelineFeed.ts
 // Cursor-accumulating Timeline feed hook. Issues GET /users/me/timeline-feed only.
-// Resets on user switch / anchor change. Does not call multi-day /timeline aggregates.
-// Display sections are ascending (oldest→newest); older pages load via top-boundary only.
+// Resets on user switch / hard refetch. Display sections are ascending (oldest→newest);
+// older pages load via top-boundary only. Calendar jumps keep the Today-rooted pages.
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useIsFocused } from "@react-navigation/native";
 import type { TimelineFeedResponseDto, TimelinePresentationItem } from "@oli/contracts";
 import type { FailureKind, GetOptions } from "@/lib/api/http";
@@ -16,6 +16,13 @@ import {
   mergeFeedPageItems,
   type TimelineFeedSection,
 } from "@/lib/features/timeline/timelineFeedOrder";
+import {
+  MAX_ENSURE_DAY_OLDER_PAGES,
+  canRequestEnsureDayPage,
+  dayIsLoaded,
+  nextEnsureDayPageCount,
+  type FeedScrollTarget,
+} from "@/lib/features/timeline/timelineFeedScrollIntent";
 
 export type { TimelineFeedSection };
 
@@ -32,22 +39,31 @@ export type UseTimelineFeedStatus =
     };
 
 export type UseTimelineFeedResult = {
+  /** Data-fetch anchor — stays on Today for continuous-feed continuity. */
   anchorDay: string;
+  /** Calendar highlight / jump focus (may differ from data anchor). */
+  selectedDay: string;
   status: UseTimelineFeedStatus;
-  /** Increments on hard reset (anchor / return-to-today / user switch / refetch). */
-  listGeneration: number;
-  setAnchorDay: (day: string) => void;
+  /** Intentional scroll target for the list (cold open / Return to Today / calendar). */
+  scrollTarget: FeedScrollTarget;
+  onScrollTargetSettled: (id: number) => void;
+  /** Calendar jump: scroll when loaded; otherwise load bounded older pages without discarding newer. */
+  jumpToDay: (day: string) => void;
   returnToToday: () => void;
   /** Load one older cursor page (top-boundary). */
   loadOlder: () => void;
   refetch: (opts?: GetOptions) => void;
+  ensuringDay: boolean;
+  ensureDayError: string | null;
 };
 
 export function useTimelineFeed(initialAnchor?: string): UseTimelineFeedResult {
   const isFocused = useIsFocused();
   const { user, initializing, getIdToken } = useAuth();
   const today = getTodayDayKey();
-  const [anchorDay, setAnchorDayState] = useState(() =>
+  // Continuous feed always fetches from Today; initialAnchor only seeds selectedDay.
+  const [anchorDay] = useState(today);
+  const [selectedDay, setSelectedDay] = useState(() =>
     initialAnchor && /^\d{4}-\d{2}-\d{2}$/.test(initialAnchor) ? initialAnchor : today,
   );
   const [items, setItems] = useState<TimelinePresentationItem[]>([]);
@@ -55,7 +71,12 @@ export function useTimelineFeed(initialAnchor?: string): UseTimelineFeedResult {
   const [hasMore, setHasMore] = useState(false);
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
-  const [listGeneration, setListGeneration] = useState(0);
+  const [ensuringDay, setEnsuringDay] = useState(false);
+  const [ensureDayError, setEnsureDayError] = useState<string | null>(null);
+  const [scrollTarget, setScrollTarget] = useState<FeedScrollTarget>({
+    id: 1,
+    mode: "newest",
+  });
   const [error, setError] = useState<{
     error: string;
     requestId: string | null;
@@ -64,13 +85,25 @@ export function useTimelineFeed(initialAnchor?: string): UseTimelineFeedResult {
 
   const genRef = useRef(0);
   const uidRef = useRef(user?.uid ?? null);
-  const anchorRef = useRef(anchorDay);
-  anchorRef.current = anchorDay;
   const loadingMoreRef = useRef(false);
   const inFlightOlderCursorRef = useRef<string | null>(null);
+  const scrollIdRef = useRef(1);
+  const ensureGenRef = useRef(0);
+  const ensureTargetDayRef = useRef<string | null>(null);
+  const itemsRef = useRef(items);
+  itemsRef.current = items;
+  const hasMoreRef = useRef(hasMore);
+  hasMoreRef.current = hasMore;
+  const nextCursorRef = useRef(nextCursor);
+  nextCursorRef.current = nextCursor;
 
-  const bumpListGeneration = useCallback(() => {
-    setListGeneration((g) => g + 1);
+  const bumpScrollTarget = useCallback((partial: Omit<FeedScrollTarget, "id">) => {
+    scrollIdRef.current += 1;
+    setScrollTarget({ id: scrollIdRef.current, ...partial });
+  }, []);
+
+  const onScrollTargetSettled = useCallback(() => {
+    // Settled markers live in the list; no-op hook side for now.
   }, []);
 
   // User-switch reset
@@ -82,17 +115,20 @@ export function useTimelineFeed(initialAnchor?: string): UseTimelineFeedResult {
       setNextCursor(null);
       setHasMore(false);
       setError(null);
-      setAnchorDayState(today);
+      setSelectedDay(today);
+      setEnsureDayError(null);
+      setEnsuringDay(false);
+      ensureGenRef.current += 1;
+      ensureTargetDayRef.current = null;
       genRef.current += 1;
       inFlightOlderCursorRef.current = null;
       loadingMoreRef.current = false;
-      bumpListGeneration();
+      bumpScrollTarget({ mode: "newest" });
     }
-  }, [user?.uid, today, bumpListGeneration]);
+  }, [user?.uid, today, bumpScrollTarget]);
 
   const fetchPage = useCallback(
     async (args: {
-      anchor: string;
       cursor?: string | null;
       append: boolean;
       opts?: GetOptions;
@@ -124,7 +160,7 @@ export function useTimelineFeed(initialAnchor?: string): UseTimelineFeedResult {
         }
 
         const result = await getTimelineFeed(token, {
-          anchorDay: args.anchor,
+          anchorDay: today,
           ...(args.cursor ? { cursor: args.cursor } : {}),
           limit: 50,
           ...(args.opts?.cacheBust ? { cacheBust: args.opts.cacheBust } : {}),
@@ -164,35 +200,13 @@ export function useTimelineFeed(initialAnchor?: string): UseTimelineFeedResult {
         }
       }
     },
-    [getIdToken, initializing, isFocused, user],
+    [getIdToken, initializing, isFocused, today, user],
   );
 
   useEffect(() => {
     if (!isFocused || initializing) return;
-    void fetchPage({ anchor: anchorDay, append: false });
-  }, [anchorDay, fetchPage, initializing, isFocused]);
-
-  const setAnchorDay = useCallback(
-    (day: string) => {
-      if (!/^\d{4}-\d{2}-\d{2}$/.test(day)) return;
-      setItems([]);
-      setNextCursor(null);
-      setHasMore(false);
-      inFlightOlderCursorRef.current = null;
-      setAnchorDayState(day);
-      bumpListGeneration();
-    },
-    [bumpListGeneration],
-  );
-
-  const returnToToday = useCallback(() => {
-    setItems([]);
-    setNextCursor(null);
-    setHasMore(false);
-    inFlightOlderCursorRef.current = null;
-    setAnchorDayState(today);
-    bumpListGeneration();
-  }, [today, bumpListGeneration]);
+    void fetchPage({ append: false });
+  }, [fetchPage, initializing, isFocused]);
 
   const loadOlder = useCallback(() => {
     const cursor = nextCursor;
@@ -210,27 +224,102 @@ export function useTimelineFeed(initialAnchor?: string): UseTimelineFeedResult {
     if (inFlightOlderCursorRef.current === cursor) return;
     inFlightOlderCursorRef.current = cursor;
     void fetchPage({
-      anchor: anchorRef.current,
       cursor,
       append: true,
     });
   }, [fetchPage, hasMore, loading, loadingMore, nextCursor]);
 
+  const jumpToDay = useCallback(
+    (day: string) => {
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(day)) return;
+      setSelectedDay(day);
+      setEnsureDayError(null);
+
+      const sections = groupSectionsAscending(itemsRef.current);
+      if (dayIsLoaded(sections, day)) {
+        bumpScrollTarget({ mode: "day", day });
+        return;
+      }
+
+      // Bounded ensure-day-loaded: keep Today-rooted pages, append older until found.
+      const ensureGen = ++ensureGenRef.current;
+      ensureTargetDayRef.current = day;
+      setEnsuringDay(true);
+      bumpScrollTarget({ mode: "day", day });
+
+      void (async () => {
+        let pagesRequested = 0;
+        try {
+          while (ensureGen === ensureGenRef.current) {
+            const currentSections = groupSectionsAscending(itemsRef.current);
+            if (dayIsLoaded(currentSections, day)) {
+              bumpScrollTarget({ mode: "day", day });
+              return;
+            }
+            if (
+              !canRequestEnsureDayPage({
+                pagesRequested,
+                maxPages: MAX_ENSURE_DAY_OLDER_PAGES,
+                hasMore: hasMoreRef.current,
+                targetLoaded: false,
+              })
+            ) {
+              setEnsureDayError("That day is not in the loaded Timeline range yet.");
+              return;
+            }
+            const cursor = nextCursorRef.current;
+            if (!cursor) {
+              setEnsureDayError("That day is not in the loaded Timeline range yet.");
+              return;
+            }
+            if (inFlightOlderCursorRef.current === cursor) {
+              return;
+            }
+            inFlightOlderCursorRef.current = cursor;
+            pagesRequested = nextEnsureDayPageCount(pagesRequested);
+            await fetchPage({ cursor, append: true });
+            if (ensureGen !== ensureGenRef.current) return;
+          }
+        } finally {
+          if (ensureGen === ensureGenRef.current) {
+            setEnsuringDay(false);
+            ensureTargetDayRef.current = null;
+          }
+        }
+      })();
+    },
+    [bumpScrollTarget, fetchPage],
+  );
+
+  const returnToToday = useCallback(() => {
+    ensureGenRef.current += 1;
+    ensureTargetDayRef.current = null;
+    setEnsuringDay(false);
+    setEnsureDayError(null);
+    setSelectedDay(today);
+    // Keep loaded pages; only re-target the newest section.
+    bumpScrollTarget({ mode: "newest" });
+  }, [today, bumpScrollTarget]);
+
   const refetch = useCallback(
     (opts?: GetOptions) => {
+      ensureGenRef.current += 1;
+      ensureTargetDayRef.current = null;
+      setEnsuringDay(false);
+      setEnsureDayError(null);
       setItems([]);
       setNextCursor(null);
       inFlightOlderCursorRef.current = null;
-      bumpListGeneration();
-      // exactOptionalPropertyTypes: omit `opts` when absent (do not pass undefined).
+      bumpScrollTarget({ mode: "newest" });
       void fetchPage({
-        anchor: anchorRef.current,
         append: false,
         ...(opts !== undefined ? { opts } : {}),
       });
     },
-    [fetchPage, bumpListGeneration],
+    [fetchPage, bumpScrollTarget],
   );
+
+  const sections = useMemo(() => groupSectionsAscending(items), [items]);
 
   let status: UseTimelineFeedStatus;
   if (error && items.length === 0) {
@@ -245,21 +334,25 @@ export function useTimelineFeed(initialAnchor?: string): UseTimelineFeedResult {
   } else {
     status = {
       status: "ready",
-      sections: groupSectionsAscending(items),
+      sections,
       items,
       hasMore,
-      loadingMore,
+      loadingMore: loadingMore || ensuringDay,
       isEmpty: items.length === 0,
     };
   }
 
   return {
     anchorDay,
+    selectedDay,
     status,
-    listGeneration,
-    setAnchorDay,
+    scrollTarget,
+    onScrollTargetSettled,
+    jumpToDay,
     returnToToday,
     loadOlder,
     refetch,
+    ensuringDay,
+    ensureDayError,
   };
 }

--- a/lib/ui/timeline/TimelineFeedList.tsx
+++ b/lib/ui/timeline/TimelineFeedList.tsx
@@ -17,7 +17,11 @@ import {
 } from "react-native";
 import type { TimelinePresentationItem } from "@oli/contracts";
 import type { TimelineFeedSection } from "@/lib/features/timeline/timelineFeedOrder";
-import { finalSectionIndex } from "@/lib/features/timeline/timelineFeedOrder";
+import {
+  MAX_FEED_SCROLL_RETRIES,
+  resolveScrollLocation,
+  type FeedScrollTarget,
+} from "@/lib/features/timeline/timelineFeedScrollIntent";
 import { TimelineDaySectionHeader } from "@/lib/ui/timeline/TimelineDaySectionHeader";
 import { TimelineRailRow } from "@/lib/ui/timeline/TimelineRailRow";
 import { formatTimelineTimeLabel } from "@/lib/ui/timeline/TimelineRail";
@@ -35,8 +39,13 @@ export type TimelineFeedListProps = {
   refreshing: boolean;
   onRefresh: () => void;
   contentBottomPadding: number;
-  /** Bumps on hard reset so initial scroll-to-newest re-runs. */
-  listGeneration: number;
+  /**
+   * Intentional scroll target. New `id` arms one bounded scroll attempt
+   * (cold open, Return to Today, or calendar jump).
+   */
+  scrollTarget: FeedScrollTarget;
+  /** Fired once the target is applied or abandoned after bounded retries / user drag. */
+  onScrollTargetSettled?: (id: number) => void;
   paginationError?: string | null;
   onRetryPage?: () => void;
 };
@@ -49,16 +58,21 @@ export function TimelineFeedList({
   refreshing,
   onRefresh,
   contentBottomPadding,
-  listGeneration,
+  scrollTarget,
+  onScrollTargetSettled,
   paginationError,
   onRetryPage,
 }: TimelineFeedListProps) {
   const today = useMemo(() => getTodayDayKey(), []);
   const listRef = useRef<SectionList<TimelinePresentationItem, TimelineFeedSection>>(null);
-  const didInitialScrollRef = useRef(false);
   const startReachedArmedRef = useRef(false);
   const lastStartReachedAtRef = useRef(0);
   const armTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingTargetIdRef = useRef<number | null>(null);
+  const retryCountRef = useRef(0);
+  const userDragCancelRef = useRef(false);
+  const layoutReadyRef = useRef(false);
+  const settledIdsRef = useRef(new Set<number>());
 
   const clearArmTimer = useCallback(() => {
     if (armTimerRef.current) {
@@ -75,52 +89,110 @@ export function TimelineFeedList({
     }, 400);
   }, [clearArmTimer]);
 
-  useEffect(() => {
-    didInitialScrollRef.current = false;
-    startReachedArmedRef.current = false;
-    clearArmTimer();
-  }, [listGeneration, clearArmTimer]);
-
   useEffect(() => () => clearArmTimer(), [clearArmTimer]);
 
-  const scrollToNewest = useCallback(
-    (animated: boolean) => {
-      if (sections.length === 0) return;
-      const sectionIndex = finalSectionIndex(sections);
-      const last = sections[sectionIndex];
-      const itemIndex = Math.max(0, (last?.data.length ?? 1) - 1);
-      try {
-        listRef.current?.scrollToLocation({
-          sectionIndex,
-          itemIndex,
-          animated,
-          viewPosition: 1,
-        });
-      } catch {
-        // SectionList may throw if layout is not ready; contentSizeChange retries once.
-      }
+  const markSettled = useCallback(
+    (id: number) => {
+      if (settledIdsRef.current.has(id)) return;
+      settledIdsRef.current.add(id);
+      pendingTargetIdRef.current = null;
+      retryCountRef.current = 0;
+      userDragCancelRef.current = false;
+      armStartReached();
+      onScrollTargetSettled?.(id);
     },
-    [sections],
+    [armStartReached, onScrollTargetSettled],
   );
 
-  useEffect(() => {
-    if (didInitialScrollRef.current) return;
+  const attemptScroll = useCallback(() => {
+    const id = pendingTargetIdRef.current;
+    if (id == null) return;
+    if (userDragCancelRef.current) {
+      markSettled(id);
+      return;
+    }
+    if (!layoutReadyRef.current) return;
     if (sections.length === 0) return;
+
+    const location = resolveScrollLocation(sections, scrollTarget);
+    if (!location) {
+      // Day not loaded yet — keep pending; ensureDayLoaded will grow sections.
+      return;
+    }
+    if (retryCountRef.current >= MAX_FEED_SCROLL_RETRIES) {
+      markSettled(id);
+      return;
+    }
+    retryCountRef.current += 1;
+    try {
+      listRef.current?.scrollToLocation({
+        sectionIndex: location.sectionIndex,
+        itemIndex: location.itemIndex,
+        animated: false,
+        viewPosition: location.viewPosition,
+      });
+    } catch {
+      // Layout not ready; onScrollToIndexFailed / contentSizeChange retries.
+    }
+  }, [markSettled, scrollTarget, sections]);
+
+  // Arm a new intentional target.
+  useEffect(() => {
+    if (settledIdsRef.current.has(scrollTarget.id)) return;
+    pendingTargetIdRef.current = scrollTarget.id;
+    retryCountRef.current = 0;
+    userDragCancelRef.current = false;
+    startReachedArmedRef.current = false;
+    clearArmTimer();
+    // Attempt after paint when content already measured.
     const id = requestAnimationFrame(() => {
-      scrollToNewest(false);
-      didInitialScrollRef.current = true;
-      armStartReached();
+      attemptScroll();
     });
     return () => cancelAnimationFrame(id);
-  }, [sections, scrollToNewest, listGeneration, armStartReached]);
+  }, [scrollTarget.id, scrollTarget.mode, scrollTarget.day, attemptScroll, clearArmTimer]);
 
+  // Retry when content size changes (sections grew or first layout).
   const onContentSizeChange = useCallback(() => {
-    if (didInitialScrollRef.current) return;
-    if (sections.length === 0) return;
-    scrollToNewest(false);
-    didInitialScrollRef.current = true;
-    armStartReached();
-  }, [scrollToNewest, sections.length, armStartReached]);
+    layoutReadyRef.current = true;
+    attemptScroll();
+  }, [attemptScroll]);
+
+  const onScrollToIndexFailed = useCallback(() => {
+    const id = pendingTargetIdRef.current;
+    if (id == null) return;
+    if (retryCountRef.current >= MAX_FEED_SCROLL_RETRIES) {
+      markSettled(id);
+      return;
+    }
+    // Short deferred retry without device-speed timeouts.
+    requestAnimationFrame(() => {
+      attemptScroll();
+    });
+  }, [attemptScroll, markSettled]);
+
+  // Treat a successful scroll frame as settled once we have retried at least once
+  // or content was ready and we issued a scroll. Use content-size + one rAF settle.
+  useEffect(() => {
+    const id = pendingTargetIdRef.current;
+    if (id == null) return;
+    if (userDragCancelRef.current) {
+      markSettled(id);
+      return;
+    }
+    const location = resolveScrollLocation(sections, scrollTarget);
+    if (!location) return;
+    if (!layoutReadyRef.current) return;
+    // After a successful scrollToLocation call path, settle on next frame when
+    // retries have started (or first attempt with layout ready).
+    if (retryCountRef.current >= 1) {
+      const raf = requestAnimationFrame(() => {
+        if (pendingTargetIdRef.current === id && !userDragCancelRef.current) {
+          markSettled(id);
+        }
+      });
+      return () => cancelAnimationFrame(raf);
+    }
+  }, [sections, scrollTarget, markSettled]);
 
   const handleStartReached = useCallback(() => {
     if (!startReachedArmedRef.current) return;
@@ -136,6 +208,13 @@ export function TimelineFeedList({
       startReachedArmedRef.current = true;
     }
   }, []);
+
+  const onScrollBeginDrag = useCallback(() => {
+    if (pendingTargetIdRef.current != null) {
+      userDragCancelRef.current = true;
+      markSettled(pendingTargetIdRef.current);
+    }
+  }, [markSettled]);
 
   const renderItem = useCallback(
     ({
@@ -171,7 +250,6 @@ export function TimelineFeedList({
       <TimelineDaySectionHeader
         dayKey={section.day}
         todayDayKey={today}
-        sticky
         testID={`timeline-feed-section-header-${section.day}`}
       />
     ),
@@ -209,12 +287,14 @@ export function TimelineFeedList({
       keyExtractor={keyExtractor}
       renderItem={renderItem}
       renderSectionHeader={renderSectionHeader}
-      stickySectionHeadersEnabled
+      stickySectionHeadersEnabled={false}
       onStartReached={handleStartReached}
       onStartReachedThreshold={0.2}
       onScroll={onScroll}
+      onScrollBeginDrag={onScrollBeginDrag}
       scrollEventThrottle={16}
       onContentSizeChange={onContentSizeChange}
+      onScrollToIndexFailed={onScrollToIndexFailed}
       maintainVisibleContentPosition={{
         minIndexForVisible: 0,
         autoscrollToTopThreshold: 24,

--- a/lib/ui/timeline/TimelineFeedScreen.tsx
+++ b/lib/ui/timeline/TimelineFeedScreen.tsx
@@ -1,7 +1,7 @@
 // lib/ui/timeline/TimelineFeedScreen.tsx
 // Continuous Timeline feed UI (requires EXPO_PUBLIC_TIMELINE_FEED=1 + live API).
 import { useCallback, useMemo, useState } from "react";
-import { ScrollView, StyleSheet, View } from "react-native";
+import { ScrollView, StyleSheet, Text, View } from "react-native";
 import { useRouter } from "expo-router";
 import type { TimelinePresentationItem } from "@oli/contracts";
 import { ScreenContainer, ErrorState, LoadingState } from "@/lib/ui/ScreenStates";
@@ -14,7 +14,7 @@ import { TimelineEmptyState } from "@/lib/ui/timeline/TimelineEmptyState";
 import { TimelineCalendarButton } from "@/lib/ui/timeline/TimelineCalendarButton";
 import { TimelineCalendarSheet } from "@/lib/ui/timeline/TimelineCalendarSheet";
 import { TimelineDaySectionHeader } from "@/lib/ui/timeline/TimelineDaySectionHeader";
-import { UI_APP_SCREEN_BG, UI_TAB_ROOT_INSET } from "@/lib/ui/theme/uiTokens";
+import { UI_APP_SCREEN_BG, UI_TAB_ROOT_INSET, UI_TEXT_SECONDARY } from "@/lib/ui/theme/uiTokens";
 
 export type TimelineFeedScreenProps = {
   initialDay?: string;
@@ -64,7 +64,7 @@ export function TimelineFeedScreen({ initialDay }: TimelineFeedScreenProps) {
             />
           ) : feed.status.isEmpty ? (
             <ScrollView
-              key={`feed-empty:${feed.anchorDay}`}
+              key={`feed-empty:${feed.selectedDay}`}
               style={styles.contentFill}
               contentContainerStyle={[
                 styles.emptyScrollContent,
@@ -72,31 +72,39 @@ export function TimelineFeedScreen({ initialDay }: TimelineFeedScreenProps) {
               ]}
             >
               <TimelineDaySectionHeader
-                dayKey={feed.anchorDay}
+                dayKey={feed.selectedDay}
                 todayDayKey={today}
                 testID="timeline-day-section-header"
               />
-              <TimelineEmptyState isToday={feed.anchorDay === today} />
+              <TimelineEmptyState isToday={feed.selectedDay === today} />
             </ScrollView>
           ) : (
-            <TimelineFeedList
-              sections={feed.status.sections}
-              onPressItem={onPressItem}
-              onStartReached={feed.loadOlder}
-              loadingMore={feed.status.loadingMore}
-              refreshing={refreshing}
-              onRefresh={onRefresh}
-              contentBottomPadding={listBottomPad}
-              listGeneration={feed.listGeneration}
-            />
+            <>
+              {feed.ensureDayError ? (
+                <Text style={styles.ensureError} accessibilityRole="text">
+                  {feed.ensureDayError}
+                </Text>
+              ) : null}
+              <TimelineFeedList
+                sections={feed.status.sections}
+                onPressItem={onPressItem}
+                onStartReached={feed.loadOlder}
+                loadingMore={feed.status.loadingMore}
+                refreshing={refreshing}
+                onRefresh={onRefresh}
+                contentBottomPadding={listBottomPad}
+                scrollTarget={feed.scrollTarget}
+                onScrollTargetSettled={feed.onScrollTargetSettled}
+              />
+            </>
           )}
         </View>
       </View>
       <TimelineCalendarSheet
         visible={calendarOpen}
-        selectedDay={feed.anchorDay}
+        selectedDay={feed.selectedDay}
         onSelectDay={(next) => {
-          feed.setAnchorDay(next);
+          feed.jumpToDay(next);
           setCalendarOpen(false);
         }}
         onCancel={() => setCalendarOpen(false)}
@@ -114,4 +122,10 @@ const styles = StyleSheet.create({
   content: { flex: 1, paddingHorizontal: UI_TAB_ROOT_INSET, paddingTop: 4 },
   contentFill: { flex: 1 },
   emptyScrollContent: { flexGrow: 1 },
+  ensureError: {
+    color: UI_TEXT_SECONDARY,
+    fontSize: 13,
+    textAlign: "center",
+    paddingVertical: 6,
+  },
 });

--- a/lib/ui/timeline/__tests__/TimelineFeedList.dayHeaders.test.tsx
+++ b/lib/ui/timeline/__tests__/TimelineFeedList.dayHeaders.test.tsx
@@ -28,8 +28,10 @@ function item(day: string, id: string): TimelinePresentationItem {
   };
 }
 
+const scrollTarget = { id: 1, mode: "newest" as const };
+
 describe("TimelineFeedList day section headers", () => {
-  it("enables sticky section headers and uses one header component per day", () => {
+  it("disables sticky section headers and keeps one inline header per day", () => {
     let tree!: renderer.ReactTestRenderer;
     act(() => {
       tree = renderer.create(
@@ -46,17 +48,19 @@ describe("TimelineFeedList day section headers", () => {
             refreshing={false}
             onRefresh={jest.fn()}
             contentBottomPadding={40}
-            listGeneration={0}
+            scrollTarget={scrollTarget}
           />
         </OliThemeProvider>,
       );
     });
 
     const sectionList = tree.root.find(
-      (n) => n.props?.stickySectionHeadersEnabled === true,
+      (n) => n.props?.stickySectionHeadersEnabled === false,
     );
-    expect(sectionList.props.stickySectionHeadersEnabled).toBe(true);
+    expect(sectionList.props.stickySectionHeadersEnabled).toBe(false);
     expect(typeof sectionList.props.renderSectionHeader).toBe("function");
+    expect(typeof sectionList.props.onScrollToIndexFailed).toBe("function");
+    expect(typeof sectionList.props.onScrollBeginDrag).toBe("function");
     expect(sectionList.props.sections).toHaveLength(3);
     expect(sectionList.props.sections.map((s: { day: string }) => s.day)).toEqual([
       "2026-07-14",
@@ -65,7 +69,6 @@ describe("TimelineFeedList day section headers", () => {
     ]);
     expect(sectionList.props.onStartReached).toEqual(expect.any(Function));
     expect(sectionList.props.onEndReached).toBeUndefined();
-    // Section data contains events only — no duplicate date rows.
     for (const section of sectionList.props.sections as {
       day: string;
       data: TimelinePresentationItem[];
@@ -73,6 +76,9 @@ describe("TimelineFeedList day section headers", () => {
       expect(section.data.every((row) => row.day === section.day)).toBe(true);
       expect(section.data.every((row) => row.kind != null)).toBe(true);
     }
+    act(() => {
+      tree.unmount();
+    });
   });
 
   it("formats Today / abbreviated weekday headings for feed section days", () => {
@@ -105,7 +111,6 @@ describe("TimelineFeedList day section headers", () => {
           <TimelineDaySectionHeader
             dayKey="2026-07-14"
             todayDayKey="2026-07-16"
-            sticky
             testID="timeline-feed-section-header-2026-07-14"
           />
         </OliThemeProvider>,
@@ -120,14 +125,17 @@ describe("TimelineFeedList day section headers", () => {
     ).toBe("Tuesday, July 14, 2026");
   });
 
-  it("uses TimelineDaySectionHeader from source and keeps sticky headers enabled", () => {
+  it("uses TimelineDaySectionHeader and keeps sticky headers disabled", () => {
     const src = require("node:fs").readFileSync(
       require("node:path").join(__dirname, "..", "TimelineFeedList.tsx"),
       "utf8",
     );
     expect(src).toContain("TimelineDaySectionHeader");
-    expect(src).toContain("stickySectionHeadersEnabled");
+    expect(src).toContain("stickySectionHeadersEnabled={false}");
     expect(src).toContain("renderSectionHeader");
+    expect(src).toContain("onScrollToIndexFailed");
+    expect(src).toContain("onScrollBeginDrag");
     expect(src).not.toContain("formatSectionLabel");
+    expect(src).not.toMatch(/stickySectionHeadersEnabled\s*\n/);
   });
 });

--- a/lib/ui/timeline/__tests__/TimelineFeedList.railParity.test.tsx
+++ b/lib/ui/timeline/__tests__/TimelineFeedList.railParity.test.tsx
@@ -65,7 +65,7 @@ describe("TimelineFeedList rail/card parity", () => {
             refreshing={false}
             onRefresh={jest.fn()}
             contentBottomPadding={40}
-            listGeneration={0}
+            scrollTarget={{ id: 1, mode: "newest" }}
           />
         </OliThemeProvider>,
       );
@@ -77,6 +77,9 @@ describe("TimelineFeedList rail/card parity", () => {
     expect(context?.props.timeLabel).toBe("");
     const meal = rows.find((r) => r.props.title === "Lunch");
     expect(meal?.props.timeLabel.length).toBeGreaterThan(0);
+    act(() => {
+      tree.unmount();
+    });
   });
 
   it("source uses shared rail row and no hairline-only feed row", () => {
@@ -87,7 +90,8 @@ describe("TimelineFeedList rail/card parity", () => {
     expect(src).not.toContain("borderBottomWidth: StyleSheet.hairlineWidth");
     expect(rail).toContain("TimelineRailRow");
     expect(src).toContain("onStartReached");
-    expect(src).toContain("stickySectionHeadersEnabled");
+    expect(src).toContain("stickySectionHeadersEnabled={false}");
     expect(src).toContain("contentBottomPadding");
+    expect(src).toContain("scrollTarget");
   });
 });

--- a/lib/ui/timeline/__tests__/TimelineFeedList.scrollPosition.test.tsx
+++ b/lib/ui/timeline/__tests__/TimelineFeedList.scrollPosition.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * Deterministic scroll-intent wiring on TimelineFeedList (no device layout).
+ */
+import React from "react";
+import renderer, { act } from "react-test-renderer";
+import type { TimelinePresentationItem } from "@oli/contracts";
+import { TimelineFeedList } from "@/lib/ui/timeline/TimelineFeedList";
+import { OliThemeProvider } from "@/lib/ui/theme/OliThemeContext";
+import { MAX_FEED_SCROLL_RETRIES } from "@/lib/features/timeline/timelineFeedScrollIntent";
+
+jest.mock("@/lib/time/dayKey", () => ({
+  getTodayDayKey: () => "2026-07-16",
+}));
+
+function item(day: string, id: string): TimelinePresentationItem {
+  return {
+    id,
+    kind: "nutrition",
+    day,
+    occurredAt: `${day}T12:00:00.000Z`,
+    timezone: "UTC",
+    title: id,
+    status: "ready",
+    source: "manual",
+    destination: `/(app)/nutrition/day/${day}`,
+    accessibilityLabel: id,
+    dedupeKey: id,
+    isSynthetic: false,
+    displayRole: "chronological_event",
+  };
+}
+
+const sections = [
+  { day: "2026-07-14", data: [item("2026-07-14", "a")] },
+  { day: "2026-07-15", data: [item("2026-07-15", "b")] },
+  { day: "2026-07-16", data: [item("2026-07-16", "c"), item("2026-07-16", "d")] },
+];
+
+describe("TimelineFeedList scroll positioning", () => {
+  it("exposes bounded scroll retry contract and content-size handler", () => {
+    expect(MAX_FEED_SCROLL_RETRIES).toBe(8);
+
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(
+        <OliThemeProvider mode="dark">
+          <TimelineFeedList
+            sections={sections}
+            onPressItem={jest.fn()}
+            onStartReached={jest.fn()}
+            loadingMore={false}
+            refreshing={false}
+            onRefresh={jest.fn()}
+            contentBottomPadding={48}
+            scrollTarget={{ id: 1, mode: "newest" }}
+          />
+        </OliThemeProvider>,
+      );
+    });
+
+    const list = tree.root.find(
+      (n) => n.props?.stickySectionHeadersEnabled === false,
+    );
+    expect(typeof list.props.onContentSizeChange).toBe("function");
+    expect(typeof list.props.onScrollToIndexFailed).toBe("function");
+    expect(typeof list.props.onScrollBeginDrag).toBe("function");
+    expect(list.props.contentContainerStyle).toEqual(
+      expect.objectContaining({ paddingBottom: 48 }),
+    );
+    act(() => {
+      tree.unmount();
+    });
+  });
+
+  it("does not render a separate fixed active-day header beside the list", () => {
+    const src = require("node:fs").readFileSync(
+      require("node:path").join(__dirname, "..", "TimelineFeedList.tsx"),
+      "utf8",
+    );
+    expect(src).not.toMatch(/activeDay|pinnedDay|stickyDate|headerDateLabel/);
+    expect(src).toContain("stickySectionHeadersEnabled={false}");
+  });
+});


### PR DESCRIPTION
## Summary

- reliably opens Timeline at the current/newest section;
- removes the redundant sticky day heading while preserving inline dates;
- calendar selection positions the chosen day without truncating newer
  history;
- preserves bounded pagination and Return to Today.

## Physical blocker

- feed attached successfully;
- rail/card design loaded;
- backend remained healthy;
- initial viewport landed on a prior day;
- a pinned older date was redundant;
- calendar selection ended history at the selected day;
- local feed flag was restored to unset.

## Architecture

Client-only bounded ensure-day-loaded:

- data fetch anchor stays on Today;
- selecting already-loaded D scrolls with zero network;
- selecting unloaded D appends older cursor pages until D is present, the
  older cursor ends, or a strict 10-page cap is reached;
- every already-loaded newer section is retained;
- no request per day;
- no request per item;
- no write/provider call/backfill;
- no duplicate day/item;
- auth-scoped state resets on user switch;
- no raw history hydration;
- no additive bidirectional API/OpenAPI change.

## Evidence

- focused scroll-intent, sticky-header, calendar-continuity, and source-guard tests;
- full Code Check Gate (typecheck, lint, invariants, Jest 821/5100, API/functions builds, iOS export);
- request budgets remain page-capped;
- exact file scope is mobile Timeline + audit only;
- deployment classification: mobile REQUIRED; Cloud Run/Gateway/Functions/Firestore NOT REQUIRED.

## Deployment

- Mobile: REQUIRED
- Cloud Run: NOT REQUIRED
- Gateway/OpenAPI: NOT REQUIRED (OpenAPI SHA-256 unchanged)
- Functions: NOT REQUIRED
- Firestore rules/indexes: NOT REQUIRED
- Migration/backfill: NOT REQUIRED

## Unverified

- repaired initial viewport on device;
- non-sticky inline headings on device;
- historical calendar continuity on device;
- prepend stability;
- physical request budget;
- account-switch isolation;
- VoiceOver;
- Dynamic Type;
- light mode.

## Safety

- no deployment;
- live API remains 00239;
- current Timeline Gateway remains attached;
- local feed flag restored to unset;
- PR #187 remains draft.

Made with [Cursor](https://cursor.com)