### PR TITLE
fix(timeline): enforce Daily Timeline action truth

### DIFF
--- a/docs/product/timeline-daily-v1-contract.md
+++ b/docs/product/timeline-daily-v1-contract.md
@@ -144,8 +144,8 @@ Daily Timeline v1 ships on the existing `useTimelineDay` composition (Option A)
 with these constraints:
 
 - request budget: the existing focused single-day hooks only (events, bounded
-  raw nutrition/incomplete, sleep night, daily facts, insights) — no continuous
-  feed cursor loop;
+  raw nutrition/incomplete, sleep night, daily facts, readiness, insights) — no
+  continuous feed cursor loop;
 - raw payloads are parsed only inside `buildTimelineDayVm` and never rendered;
 - continuous `getTimelineFeed` is not used by the shipping tab;
 - server normalize/reconcile remain retained for platform/Timeline v2;

--- a/lib/features/timeline/__tests__/buildTimelineDayVm.test.ts
+++ b/lib/features/timeline/__tests__/buildTimelineDayVm.test.ts
@@ -2,6 +2,7 @@
 import {
   buildDailyTimelineContext,
   buildTimelineDayVm,
+  isDailyTimelineAggregateAction,
   isMidnightFabricatedStepsItem,
 } from "@/lib/features/timeline/buildTimelineDayVm";
 import type {
@@ -238,16 +239,29 @@ describe("buildTimelineDayVm", () => {
     expect(missing.every((r) => r.valueLabel == null)).toBe(true);
   });
 
-  it("drops midnight fabricated Steps from chronological actions", () => {
+  it("drops all aggregate Steps from chronological actions", () => {
     const vm = buildTimelineDayVm({
       day: DAY,
       events: [
         canonical({ id: "st1", kind: "steps", start: `${DAY}T00:00:00.000Z` }),
+        canonical({ id: "st2", kind: "steps", start: `${DAY}T15:30:00.000Z` }),
         canonical({ id: "w1", kind: "workout", start: `${DAY}T09:00:00.000Z` }),
       ],
+      dailyFacts: {
+        schemaVersion: 1,
+        userId: "u1",
+        date: DAY,
+        computedAt: `${DAY}T23:00:00.000Z`,
+        activity: { steps: 8000 },
+      } as never,
     });
     expect(vm.items.find((i) => i.sourceType === "steps")).toBeUndefined();
+    expect(vm.items.find((i) => i.sourceType === "activity")).toBeUndefined();
+    expect(vm.items.find((i) => i.title === "Steps")).toBeUndefined();
     expect(vm.items.find((i) => i.id === "w1")).toBeDefined();
+    expect(vm.context.find((r) => r.kind === "activity")?.valueLabel).toMatch(/8,000 steps/);
+    expect(isDailyTimelineAggregateAction({ kind: "steps" })).toBe(true);
+    expect(isDailyTimelineAggregateAction({ kind: "activity_final" })).toBe(true);
     expect(
       isMidnightFabricatedStepsItem({
         id: "x",
@@ -263,6 +277,47 @@ describe("buildTimelineDayVm", () => {
         accessibilityLabel: "Steps",
       }),
     ).toBe(true);
+  });
+
+  it("keeps one Activity representation in context only", () => {
+    const vm = buildTimelineDayVm({
+      day: DAY,
+      events: [canonical({ id: "st1", kind: "steps", start: `${DAY}T00:00:00.000Z` })],
+      dailyFacts: {
+        schemaVersion: 1,
+        userId: "u1",
+        date: DAY,
+        computedAt: `${DAY}T23:00:00.000Z`,
+        activity: { steps: 1200 },
+      } as never,
+      insights: [insight("mov1", `${DAY}T14:00:00.000Z`)],
+    });
+    const activityish = vm.items.filter(
+      (i) =>
+        i.sourceType === "steps" ||
+        i.sourceType === "activity" ||
+        i.title === "Steps" ||
+        i.title === "Activity",
+    );
+    expect(activityish).toHaveLength(0);
+    expect(vm.context.filter((r) => r.kind === "activity")).toHaveLength(1);
+    expect(vm.items.find((i) => i.title === "Good sleep")).toBeDefined();
+  });
+
+  it("treats missing Activity as unavailable and trusted zero as zero", () => {
+    const missing = buildDailyTimelineContext({ day: DAY });
+    expect(missing.find((r) => r.kind === "activity")?.availability).toBe("unavailable");
+    const zero = buildDailyTimelineContext({
+      day: DAY,
+      dailyFacts: {
+        schemaVersion: 1,
+        userId: "u1",
+        date: DAY,
+        computedAt: `${DAY}T23:00:00.000Z`,
+        activity: { steps: 0 },
+      } as never,
+    });
+    expect(zero.find((r) => r.kind === "activity")?.valueLabel).toMatch(/0 steps/);
   });
 
   it("always includes three context rows on the view model", () => {

--- a/lib/features/timeline/__tests__/buildTimelineDayVm.test.ts
+++ b/lib/features/timeline/__tests__/buildTimelineDayVm.test.ts
@@ -9,6 +9,7 @@ import type {
   CanonicalEventListItem,
   InsightDto,
   RawEventListItem,
+  ReadinessViewDto,
   SleepNightViewDto,
 } from "@oli/contracts";
 
@@ -91,14 +92,26 @@ function sleepNight(endedAt: string, totalSleepMinutes?: number): SleepNightView
   };
 }
 
-function insight(id: string, createdAt: string): InsightDto {
+function readiness(score: number | null, overrides?: Partial<ReadinessViewDto>): ReadinessViewDto {
+  return {
+    requestedDay: DAY,
+    resolvedDay: DAY,
+    isFallback: false,
+    day: DAY,
+    sourceId: "oura",
+    score,
+    ...overrides,
+  };
+}
+
+function insight(id: string, createdAt: string, title = "Good sleep"): InsightDto {
   return {
     schemaVersion: 1,
     id,
     userId: "u1",
     date: DAY,
     kind: "sleep",
-    title: "Good sleep",
+    title,
     message: "You slept well",
     severity: "info",
     evidence: [],
@@ -146,13 +159,13 @@ describe("buildTimelineDayVm", () => {
     });
 
     const ids = vm.items.map((i) => i.id);
-    expect(ids).toContain("w1");
+    expect(ids).toContain(`${DAY}:session:w1`);
     expect(ids).toContain("n1");
     expect(ids).toContain("i1");
 
     const nutrition = vm.items.find((i) => i.id === "n1");
     expect(nutrition?.isPassive).toBe(false);
-    const workout = vm.items.find((i) => i.id === "w1");
+    const workout = vm.items.find((i) => i.id === `${DAY}:session:w1`);
     expect(workout?.isPassive).toBe(true);
   });
 
@@ -208,6 +221,24 @@ describe("buildTimelineDayVm", () => {
     expect(vm.summary).toEqual({ steps: 8000, totalKcal: 2100, sleepMinutes: 465 });
   });
 
+  it("orders nutrition chronologically with wake and incomplete", () => {
+    const vm = buildTimelineDayVm({
+      day: DAY,
+      rawItems: [
+        rawNutrition("n2", `${DAY}T13:00:00.000Z`, { foodLabel: "Lunch" }),
+        rawIncomplete("i1", `${DAY}T11:00:00.000Z`),
+        rawNutrition("n1", `${DAY}T08:00:00.000Z`, { foodLabel: "Breakfast" }),
+      ],
+      sleepNight: sleepNight(`${DAY}T07:00:00.000Z`, 420),
+    });
+    expect(vm.items.map((i) => i.id)).toEqual([
+      `sleep_wake:${DAY}`,
+      "n1",
+      "i1",
+      "n2",
+    ]);
+  });
+
   it("skips items with unparseable timestamps", () => {
     const vm = buildTimelineDayVm({
       day: DAY,
@@ -228,10 +259,12 @@ describe("buildTimelineDayVm", () => {
         activity: { steps: 0 },
         recovery: { hrvRmssd: 42 },
       } as never,
+      readinessView: readiness(78),
     });
     expect(context.map((r) => r.kind)).toEqual(["sleep", "recovery", "activity"]);
     expect(context[0]?.availability).toBe("available");
     expect(context[1]?.availability).toBe("available");
+    expect(context[1]?.valueLabel).toBe("Score 78");
     expect(context[2]?.availability).toBe("available");
     expect(context[2]?.valueLabel).toMatch(/0 steps/);
     const missing = buildDailyTimelineContext({ day: DAY });
@@ -258,7 +291,7 @@ describe("buildTimelineDayVm", () => {
     expect(vm.items.find((i) => i.sourceType === "steps")).toBeUndefined();
     expect(vm.items.find((i) => i.sourceType === "activity")).toBeUndefined();
     expect(vm.items.find((i) => i.title === "Steps")).toBeUndefined();
-    expect(vm.items.find((i) => i.id === "w1")).toBeDefined();
+    expect(vm.items.find((i) => i.id === `${DAY}:session:w1`)).toBeDefined();
     expect(vm.context.find((r) => r.kind === "activity")?.valueLabel).toMatch(/8,000 steps/);
     expect(isDailyTimelineAggregateAction({ kind: "steps" })).toBe(true);
     expect(isDailyTimelineAggregateAction({ kind: "activity_final" })).toBe(true);
@@ -290,7 +323,7 @@ describe("buildTimelineDayVm", () => {
         computedAt: `${DAY}T23:00:00.000Z`,
         activity: { steps: 1200 },
       } as never,
-      insights: [insight("mov1", `${DAY}T14:00:00.000Z`)],
+      insights: [insight("mov1", `${DAY}T14:00:00.000Z`, "Movement insight")],
     });
     const activityish = vm.items.filter(
       (i) =>
@@ -301,7 +334,7 @@ describe("buildTimelineDayVm", () => {
     );
     expect(activityish).toHaveLength(0);
     expect(vm.context.filter((r) => r.kind === "activity")).toHaveLength(1);
-    expect(vm.items.find((i) => i.title === "Good sleep")).toBeDefined();
+    expect(vm.items.find((i) => i.title === "Movement insight")).toBeDefined();
   });
 
   it("treats missing Activity as unavailable and trusted zero as zero", () => {
@@ -324,5 +357,210 @@ describe("buildTimelineDayVm", () => {
     const vm = buildTimelineDayVm({ day: DAY });
     expect(vm.context).toHaveLength(3);
   });
+});
 
+describe("Daily Timeline Recovery score contract", () => {
+  it("displays exact-day readiness score", () => {
+    const context = buildDailyTimelineContext({
+      day: DAY,
+      readinessView: readiness(82),
+    });
+    const recovery = context.find((r) => r.kind === "recovery");
+    expect(recovery?.valueLabel).toBe("Score 82");
+    expect(recovery?.availability).toBe("available");
+    expect(recovery?.accessibilityLabel).toBe("Recovery, Score 82");
+  });
+
+  it("shows unavailable when score is missing", () => {
+    const context = buildDailyTimelineContext({
+      day: DAY,
+      readinessView: readiness(null),
+    });
+    const recovery = context.find((r) => r.kind === "recovery");
+    expect(recovery?.valueLabel).toBeUndefined();
+    expect(recovery?.availability).toBe("unavailable");
+    expect(recovery?.accessibilityLabel).toBe("Recovery, unavailable");
+  });
+
+  it("does not substitute HRV/RHR for the score", () => {
+    const context = buildDailyTimelineContext({
+      day: DAY,
+      dailyFacts: {
+        schemaVersion: 1,
+        userId: "u1",
+        date: DAY,
+        computedAt: `${DAY}T23:00:00.000Z`,
+        recovery: { hrvRmssd: 55, restingHeartRate: 48 },
+      } as never,
+      sleepNight: {
+        ...sleepNight(`${DAY}T07:00:00.000Z`),
+        sleepNight: {
+          ...sleepNight(`${DAY}T07:00:00.000Z`).sleepNight,
+          averageHrvMs: 60,
+          lowestHeartRateBpm: 50,
+        },
+      },
+    });
+    const recovery = context.find((r) => r.kind === "recovery");
+    expect(recovery?.valueLabel).toBeUndefined();
+    expect(recovery?.availability).toBe("unavailable");
+    expect(JSON.stringify(recovery)).not.toMatch(/HRV|RHR|hrv|restingHeartRate/i);
+  });
+
+  it("keeps score zero when valid", () => {
+    const recovery = buildDailyTimelineContext({
+      day: DAY,
+      readinessView: readiness(0),
+    }).find((r) => r.kind === "recovery");
+    expect(recovery?.valueLabel).toBe("Score 0");
+    expect(recovery?.availability).toBe("available");
+  });
+
+  it("rejects fallback and mismatched-day readiness", () => {
+    expect(
+      buildDailyTimelineContext({
+        day: DAY,
+        readinessView: readiness(90, { isFallback: true }),
+      }).find((r) => r.kind === "recovery")?.availability,
+    ).toBe("unavailable");
+    expect(
+      buildDailyTimelineContext({
+        day: DAY,
+        readinessView: readiness(90, { resolvedDay: "2026-06-09" }),
+      }).find((r) => r.kind === "recovery")?.availability,
+    ).toBe("unavailable");
+  });
+
+  it("does not pass vendor contributor payloads into context rows", () => {
+    const context = buildDailyTimelineContext({
+      day: DAY,
+      readinessView: readiness(70, {
+        contributors: { hrv_balance: 80, resting_heart_rate: 90 },
+      }),
+    });
+    const serialized = JSON.stringify(context);
+    expect(serialized).not.toContain("contributors");
+    expect(serialized).not.toContain("hrv_balance");
+    expect(serialized).not.toContain("resting_heart_rate");
+  });
+});
+
+describe("Daily Timeline workout reconciliation", () => {
+  it("merges matching manual/watch representations into one action", () => {
+    const vm = buildTimelineDayVm({
+      day: DAY,
+      events: [
+        canonical({
+          id: "watch-1",
+          kind: "workout",
+          sourceId: "apple_health",
+          start: `${DAY}T09:00:00.000Z`,
+          end: `${DAY}T09:45:00.000Z`,
+        }),
+        canonical({
+          id: "manual-1",
+          kind: "strength_workout",
+          sourceId: "manual",
+          start: `${DAY}T09:05:00.000Z`,
+          end: `${DAY}T09:50:00.000Z`,
+        }),
+      ],
+    });
+    const workouts = vm.items.filter(
+      (i) =>
+        i.sourceType === "workout" ||
+        i.sourceType === "workout_strength" ||
+        i.sourceType === "workout_cardio",
+    );
+    expect(workouts).toHaveLength(1);
+    expect(workouts[0]?.title).toBe("Strength workout");
+    expect(workouts[0]?.id).toBe(`${DAY}:session:manual-1|watch-1`);
+    expect(JSON.stringify(workouts[0])).not.toContain("memberIds");
+  });
+
+  it("is order-independent for the same source pair", () => {
+    const forward = buildTimelineDayVm({
+      day: DAY,
+      events: [
+        canonical({
+          id: "a",
+          kind: "workout",
+          sourceId: "apple_health",
+          start: `${DAY}T10:00:00.000Z`,
+          end: `${DAY}T10:40:00.000Z`,
+        }),
+        canonical({
+          id: "b",
+          kind: "strength_workout",
+          sourceId: "manual",
+          start: `${DAY}T10:02:00.000Z`,
+          end: `${DAY}T10:42:00.000Z`,
+        }),
+      ],
+    });
+    const reverse = buildTimelineDayVm({
+      day: DAY,
+      events: [
+        canonical({
+          id: "b",
+          kind: "strength_workout",
+          sourceId: "manual",
+          start: `${DAY}T10:02:00.000Z`,
+          end: `${DAY}T10:42:00.000Z`,
+        }),
+        canonical({
+          id: "a",
+          kind: "workout",
+          sourceId: "apple_health",
+          start: `${DAY}T10:00:00.000Z`,
+          end: `${DAY}T10:40:00.000Z`,
+        }),
+      ],
+    });
+    expect(forward.items.map((i) => i.id)).toEqual(reverse.items.map((i) => i.id));
+  });
+
+  it("keeps distant same-title sessions distinct", () => {
+    const vm = buildTimelineDayVm({
+      day: DAY,
+      events: [
+        canonical({
+          id: "m1",
+          kind: "workout",
+          sourceId: "manual",
+          start: `${DAY}T08:00:00.000Z`,
+          end: `${DAY}T08:40:00.000Z`,
+        }),
+        canonical({
+          id: "m2",
+          kind: "workout",
+          sourceId: "manual",
+          start: `${DAY}T18:00:00.000Z`,
+          end: `${DAY}T18:40:00.000Z`,
+        }),
+      ],
+    });
+    expect(vm.items.filter((i) => i.sourceType.startsWith("workout"))).toHaveLength(2);
+  });
+
+  it("keeps chronologically ordered reconciled actions among other items", () => {
+    const vm = buildTimelineDayVm({
+      day: DAY,
+      events: [
+        canonical({
+          id: "w1",
+          kind: "workout",
+          start: `${DAY}T12:00:00.000Z`,
+          end: `${DAY}T12:30:00.000Z`,
+        }),
+      ],
+      rawItems: [rawNutrition("n1", `${DAY}T09:00:00.000Z`, { foodLabel: "Breakfast" })],
+      insights: [insight("i1", `${DAY}T15:00:00.000Z`)],
+    });
+    expect(vm.items.map((i) => i.id)).toEqual([
+      "n1",
+      `${DAY}:session:w1`,
+      "insight:i1",
+    ]);
+  });
 });

--- a/lib/features/timeline/__tests__/timelineDailyActionTruth.guards.test.ts
+++ b/lib/features/timeline/__tests__/timelineDailyActionTruth.guards.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Source guards: Daily Timeline action truth — aggregate Steps, Recovery score,
+ * workout reconciliation via shared core.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { isDailyTimelineAggregateAction } from "@/lib/features/timeline/isDailyTimelineAggregateAction";
+
+describe("Daily Timeline action truth guards", () => {
+  const root = join(__dirname, "..", "..", "..", "..");
+
+  test("VM excludes aggregate Steps/activity_final and reconciles workouts via shared core", () => {
+    const vm = readFileSync(join(root, "lib/features/timeline/buildTimelineDayVm.ts"), "utf8");
+    const adapter = readFileSync(
+      join(root, "lib/features/timeline/reconcileDailyTimelineWorkoutActions.ts"),
+      "utf8",
+    );
+    expect(vm).toContain("isDailyTimelineAggregateAction");
+    expect(vm).toContain("buildReconciledDailyTimelineWorkoutItems");
+    expect(vm).toContain("exactDayReadinessScore");
+    expect(vm).not.toMatch(/recoveryValue = `HRV/);
+    expect(vm).not.toMatch(/hrvRmssd/);
+    expect(adapter).toContain("reconcileWorkoutSessionsCore");
+    expect(adapter).not.toMatch(/title-only|titleOnly|dedupeByTitle/);
+  });
+
+  test("predicate treats steps and activity_final as aggregates", () => {
+    expect(isDailyTimelineAggregateAction({ kind: "steps" })).toBe(true);
+    expect(isDailyTimelineAggregateAction({ kind: "activity_final" })).toBe(true);
+    expect(isDailyTimelineAggregateAction({ sourceType: "steps" })).toBe(true);
+    expect(isDailyTimelineAggregateAction({ sourceType: "activity" })).toBe(true);
+    expect(isDailyTimelineAggregateAction({ kind: "workout" })).toBe(false);
+    expect(isDailyTimelineAggregateAction({ sourceType: "insight" })).toBe(false);
+  });
+
+  test("useTimelineDay wires exact-day readiness without feed or provider pull", () => {
+    const hook = readFileSync(join(root, "lib/features/timeline/useTimelineDay.ts"), "utf8");
+    expect(hook).toContain("useReadinessView");
+    expect(hook).toContain("readinessView");
+    expect(hook).not.toContain("getTimelineFeed");
+    expect(hook).not.toContain("pullNow");
+    expect(hook).not.toContain("EXPO_PUBLIC_TIMELINE_FEED");
+  });
+
+  test("shipping screen does not special-case Steps or Recovery proxies", () => {
+    const screen = readFileSync(join(root, "lib/ui/timeline/TimelineDayScreen.tsx"), "utf8");
+    const card = readFileSync(join(root, "lib/ui/timeline/DailyTimelineContextCard.tsx"), "utf8");
+    expect(screen).not.toContain("isMidnightFabricatedStepsItem");
+    expect(screen).not.toContain("hrvRmssd");
+    expect(card).not.toContain("hrvRmssd");
+    expect(card).not.toContain("restingHeartRate");
+  });
+});

--- a/lib/features/timeline/__tests__/timelineDailyCompleteness.guards.test.ts
+++ b/lib/features/timeline/__tests__/timelineDailyCompleteness.guards.test.ts
@@ -35,7 +35,7 @@ describe("Daily Timeline selected-day completeness guards", () => {
     expect(TIMELINE_DAY_RAW_EVENTS_MAX_ITEMS).toBe(
       TIMELINE_DAY_RAW_EVENTS_PAGE_SIZE * TIMELINE_DAY_MAX_PAGES_PER_FAMILY,
     );
-    expect(TIMELINE_DAY_WORST_CASE_SELECTED_DAY_REQUESTS).toBeLessThanOrEqual(23);
+    expect(TIMELINE_DAY_WORST_CASE_SELECTED_DAY_REQUESTS).toBeLessThanOrEqual(24);
   });
 
   test("collector enforces cursor cycle and page cap reasons", () => {

--- a/lib/features/timeline/__tests__/timelineDailyV1.shipping.guards.test.ts
+++ b/lib/features/timeline/__tests__/timelineDailyV1.shipping.guards.test.ts
@@ -41,5 +41,6 @@ describe("Daily Timeline v1 shipping path", () => {
     expect(hook).toContain("fetchTimelineDayRawEventsPages");
     expect(hook).toContain("useSleepNight");
     expect(hook).toContain("useDailyFacts");
+    expect(hook).toContain("useReadinessView");
   });
 });

--- a/lib/features/timeline/__tests__/useTimelineDay.completeness.test.tsx
+++ b/lib/features/timeline/__tests__/useTimelineDay.completeness.test.tsx
@@ -46,6 +46,13 @@ jest.mock("@/lib/data/useInsights", () => ({
   }),
 }));
 
+jest.mock("@/lib/data/useReadinessView", () => ({
+  useReadinessView: () => ({
+    status: "missing",
+    refetch: jest.fn(),
+  }),
+}));
+
 import { useTimelineDay } from "@/lib/features/timeline/useTimelineDay";
 
 const DAY = "2026-07-16";

--- a/lib/features/timeline/buildTimelineDayVm.ts
+++ b/lib/features/timeline/buildTimelineDayVm.ts
@@ -10,6 +10,7 @@ import {
   type RawEventListItem,
   type SleepNightViewDto,
 } from "@oli/contracts";
+import { isDailyTimelineAggregateAction } from "@/lib/features/timeline/isDailyTimelineAggregateAction";
 import { resolveTimelineItemHref } from "@/lib/features/timeline/resolveTimelineItemHref";
 import type {
   TimelineDayContextRow,
@@ -27,6 +28,8 @@ export type BuildTimelineDayVmInput = {
   dailyFacts?: DailyFactsDto | null;
   insights?: readonly InsightDto[];
 };
+
+export { isDailyTimelineAggregateAction } from "@/lib/features/timeline/isDailyTimelineAggregateAction";
 
 const ICONS: Record<TimelineSourceType, string> = {
   sleep_wake: "sunny-outline",
@@ -219,6 +222,8 @@ function buildCanonicalItems(
   for (const ev of events) {
     if (ev.kind === "nutrition") continue; // raw nutrition events are the source of truth for meals
     if (ev.kind === "sleep" && skipSleep) continue;
+    // Aggregates belong in Daily context only — never as chronological actions.
+    if (isDailyTimelineAggregateAction({ kind: ev.kind })) continue;
     const map = CANONICAL_KIND_MAP[ev.kind];
     const meta = map ?? { sourceType: "unknown" as const, title: ev.kind };
     if (!Number.isFinite(Date.parse(ev.start))) continue;
@@ -268,9 +273,12 @@ function formatDurationMinutesLabel(minutes: number): string {
   return `${m}m`;
 }
 
-/** True when a Steps item is a midnight-anchored fabrication (not a real timed action). */
+/**
+ * Legacy midnight Steps detector. Daily Timeline now excludes all aggregate Steps
+ * via {@link isDailyTimelineAggregateAction}; this remains for focused regression tests.
+ */
 export function isMidnightFabricatedStepsItem(item: TimelineDayItem): boolean {
-  if (item.sourceType !== "steps") return false;
+  if (!isDailyTimelineAggregateAction(item)) return false;
   const ms = Date.parse(item.timestamp);
   if (!Number.isFinite(ms)) return false;
   const d = new Date(ms);
@@ -405,7 +413,7 @@ export function buildTimelineDayVm(input: BuildTimelineDayVmInput): TimelineDayV
   ];
   if (wake) merged.push(wake);
 
-  const items = sortItems(merged).filter((item) => !isMidnightFabricatedStepsItem(item));
+  const items = sortItems(merged).filter((item) => !isDailyTimelineAggregateAction(item));
   const context = buildDailyTimelineContext({
     day,
     ...(input.sleepNight !== undefined ? { sleepNight: input.sleepNight } : {}),

--- a/lib/features/timeline/buildTimelineDayVm.ts
+++ b/lib/features/timeline/buildTimelineDayVm.ts
@@ -8,9 +8,12 @@ import {
   type DailyFactsDto,
   type InsightDto,
   type RawEventListItem,
+  type ReadinessViewDto,
   type SleepNightViewDto,
 } from "@oli/contracts";
+import { normalizeOuraScore0to100 } from "@/lib/format/ouraScore";
 import { isDailyTimelineAggregateAction } from "@/lib/features/timeline/isDailyTimelineAggregateAction";
+import { buildReconciledDailyTimelineWorkoutItems } from "@/lib/features/timeline/reconcileDailyTimelineWorkoutActions";
 import { resolveTimelineItemHref } from "@/lib/features/timeline/resolveTimelineItemHref";
 import type {
   TimelineDayContextRow,
@@ -26,6 +29,8 @@ export type BuildTimelineDayVmInput = {
   rawItems?: readonly RawEventListItem[];
   sleepNight?: SleepNightViewDto | null;
   dailyFacts?: DailyFactsDto | null;
+  /** Exact-day readiness view; proxy HRV/RHR must never substitute for the score. */
+  readinessView?: ReadinessViewDto | null;
   insights?: readonly InsightDto[];
 };
 
@@ -224,6 +229,8 @@ function buildCanonicalItems(
     if (ev.kind === "sleep" && skipSleep) continue;
     // Aggregates belong in Daily context only — never as chronological actions.
     if (isDailyTimelineAggregateAction({ kind: ev.kind })) continue;
+    // Workouts are emitted once via shared session reconciliation.
+    if (ev.kind === "workout" || ev.kind === "strength_workout") continue;
     const map = CANONICAL_KIND_MAP[ev.kind];
     const meta = map ?? { sourceType: "unknown" as const, title: ev.kind };
     if (!Number.isFinite(Date.parse(ev.start))) continue;
@@ -285,10 +292,21 @@ export function isMidnightFabricatedStepsItem(item: TimelineDayItem): boolean {
   return d.getUTCHours() === 0 && d.getUTCMinutes() === 0 && d.getUTCSeconds() === 0;
 }
 
+function exactDayReadinessScore(
+  day: string,
+  readinessView: ReadinessViewDto | null | undefined,
+): number | null {
+  if (!readinessView) return null;
+  if (readinessView.isFallback === true) return null;
+  if (readinessView.requestedDay !== day || readinessView.resolvedDay !== day) return null;
+  return normalizeOuraScore0to100(readinessView.score);
+}
+
 export function buildDailyTimelineContext(input: {
   day: string;
   sleepNight?: SleepNightViewDto | null;
   dailyFacts?: DailyFactsDto | null;
+  readinessView?: ReadinessViewDto | null;
 }): TimelineDayContextRow[] {
   const { day } = input;
   const night = input.sleepNight?.sleepNight;
@@ -321,21 +339,11 @@ export function buildDailyTimelineContext(input: {
     icon: "moon-outline",
   };
 
-  const hrv =
-    (typeof facts?.recovery?.hrvRmssd === "number" ? facts.recovery.hrvRmssd : undefined) ??
-    (typeof night?.averageHrvMs === "number" ? night.averageHrvMs : undefined);
-  const rhr =
-    (typeof facts?.recovery?.restingHeartRate === "number"
-      ? facts.recovery.restingHeartRate
-      : undefined) ??
-    (typeof night?.lowestHeartRateBpm === "number" ? night.lowestHeartRateBpm : undefined);
-  let recoveryValue: string | undefined;
-  if (typeof hrv === "number" && Number.isFinite(hrv)) {
-    recoveryValue = `HRV ${Math.round(hrv)} ms`;
-    if (typeof rhr === "number") recoveryValue = `${recoveryValue} · RHR ${Math.round(rhr)}`;
-  } else if (typeof rhr === "number" && Number.isFinite(rhr)) {
-    recoveryValue = `RHR ${Math.round(rhr)}`;
-  }
+  // Recovery contract: exact-day readiness score, otherwise unavailable.
+  // Never substitute HRV / RHR / contributors for the score in context.
+  const recoveryScore = exactDayReadinessScore(day, input.readinessView);
+  const recoveryValue =
+    recoveryScore != null ? `Score ${recoveryScore}` : undefined;
   const recoveryAvailable = recoveryValue != null;
   const recovery: TimelineDayContextRow = {
     kind: "recovery",
@@ -409,6 +417,7 @@ export function buildTimelineDayVm(input: BuildTimelineDayVmInput): TimelineDayV
     ...buildNutritionItems(day, rawItems),
     ...buildIncompleteItems(day, rawItems),
     ...buildCanonicalItems(day, events, wake != null),
+    ...buildReconciledDailyTimelineWorkoutItems(day, events),
     ...buildInsightItems(day, insights),
   ];
   if (wake) merged.push(wake);
@@ -418,6 +427,7 @@ export function buildTimelineDayVm(input: BuildTimelineDayVmInput): TimelineDayV
     day,
     ...(input.sleepNight !== undefined ? { sleepNight: input.sleepNight } : {}),
     ...(input.dailyFacts !== undefined ? { dailyFacts: input.dailyFacts } : {}),
+    ...(input.readinessView !== undefined ? { readinessView: input.readinessView } : {}),
   });
 
   return {

--- a/lib/features/timeline/isDailyTimelineAggregateAction.ts
+++ b/lib/features/timeline/isDailyTimelineAggregateAction.ts
@@ -1,0 +1,18 @@
+// Pure predicate: day-level Activity/Steps aggregates are context-only, never chronological actions.
+
+import type { TimelineSourceType } from "@/lib/features/timeline/types";
+
+type AggregateCandidate = {
+  sourceType?: TimelineSourceType;
+  kind?: string;
+};
+
+/**
+ * True when an event/item is a day-level Activity or Steps aggregate that belongs
+ * only in Daily Timeline context — not as a chronological rail action.
+ */
+export function isDailyTimelineAggregateAction(item: AggregateCandidate): boolean {
+  if (item.kind === "steps" || item.kind === "activity_final") return true;
+  if (item.sourceType === "steps" || item.sourceType === "activity") return true;
+  return false;
+}

--- a/lib/features/timeline/reconcileDailyTimelineWorkoutActions.ts
+++ b/lib/features/timeline/reconcileDailyTimelineWorkoutActions.ts
@@ -1,0 +1,103 @@
+// Pure adapter: Daily Timeline workout events → shared reconcileWorkoutSessionsCore → actions.
+// No Firestore, no network. Matching uses the shared core (not title equality alone).
+
+import type { CanonicalEventListItem } from "@oli/contracts";
+import {
+  familyFromWorkoutKind,
+  reconcileWorkoutSessionsCore,
+  type ReconcilableWorkoutRecord,
+  type WorkoutSessionType,
+} from "@/lib/domain/workouts/reconcileWorkoutSessionsCore";
+import { resolveTimelineItemHref } from "@/lib/features/timeline/resolveTimelineItemHref";
+import type { TimelineDayItem, TimelineSourceType } from "@/lib/features/timeline/types";
+
+const ICONS: Record<"workout_strength" | "workout_cardio" | "workout", string> = {
+  workout_strength: "barbell-outline",
+  workout_cardio: "bicycle-outline",
+  workout: "fitness-outline",
+};
+
+function durationMinutes(start: string, end: string): number | null {
+  const s = Date.parse(start);
+  const e = Date.parse(end);
+  if (!Number.isFinite(s) || !Number.isFinite(e) || e <= s) return null;
+  return Math.max(1, Math.round((e - s) / 60_000));
+}
+
+function sourceTypeForSession(sessionType: WorkoutSessionType): TimelineSourceType {
+  if (sessionType === "strength") return "workout_strength";
+  if (sessionType === "cardio") return "workout_cardio";
+  return "workout";
+}
+
+function toReconcilable(ev: CanonicalEventListItem): ReconcilableWorkoutRecord {
+  return {
+    id: ev.id,
+    sourceId: ev.sourceId,
+    rawKind: ev.kind,
+    title: null,
+    start: ev.start,
+    end: ev.end,
+    observedAt: ev.start,
+    durationMinutes: durationMinutes(ev.start, ev.end),
+    calories: null,
+    family: familyFromWorkoutKind(ev.kind),
+  };
+}
+
+/**
+ * Reconcile workout / strength_workout canonical events for one day into unique
+ * Daily Timeline action items. Matching manual/watch pairs become one action.
+ */
+export function buildReconciledDailyTimelineWorkoutItems(
+  day: string,
+  events: readonly CanonicalEventListItem[],
+): TimelineDayItem[] {
+  const candidates = events.filter(
+    (ev) =>
+      (ev.kind === "workout" || ev.kind === "strength_workout") &&
+      Number.isFinite(Date.parse(ev.start)),
+  );
+  if (candidates.length === 0) return [];
+
+  const byId = new Map(candidates.map((ev) => [ev.id, ev]));
+  const sessions = reconcileWorkoutSessionsCore(day, candidates.map(toReconcilable));
+
+  return sessions.map((session) => {
+    const sourceType = sourceTypeForSession(session.sessionType);
+    const primary =
+      session.members.find((m) => m.sourceId === "manual") ?? session.members[0]!;
+    const primaryEvent = byId.get(primary.id) ?? candidates[0]!;
+    const timestamp = session.start ?? primaryEvent.start;
+    const title = session.title;
+    const href = resolveTimelineItemHref({
+      sourceType,
+      day,
+      canonicalEventId: primary.id,
+    });
+    return {
+      id: session.id,
+      day,
+      timestamp,
+      sortKey: `${timestamp}#${session.id}`,
+      title,
+      sourceType,
+      sourceId: primary.sourceId,
+      icon: ICONS[sourceType as keyof typeof ICONS],
+      href,
+      isPassive: primary.sourceId !== "manual",
+      accessibilityLabel: title,
+    };
+  });
+}
+
+/** True when a Daily Timeline action is workout-like (must go through reconciliation). */
+export function isDailyTimelineWorkoutAction(
+  item: Pick<TimelineDayItem, "sourceType">,
+): boolean {
+  return (
+    item.sourceType === "workout" ||
+    item.sourceType === "workout_strength" ||
+    item.sourceType === "workout_cardio"
+  );
+}

--- a/lib/features/timeline/timelineDayPageLimits.ts
+++ b/lib/features/timeline/timelineDayPageLimits.ts
@@ -17,9 +17,9 @@ export const TIMELINE_DAY_RAW_EVENTS_MAX_ITEMS =
   TIMELINE_DAY_RAW_EVENTS_PAGE_SIZE * TIMELINE_DAY_MAX_PAGES_PER_FAMILY;
 
 /**
- * Ordinary selected day (no nextCursor): 1 events + 1 raw + sleep + facts + insights.
- * Worst case with full continuation: 10 + 10 + 3 context reads.
+ * Ordinary selected day (no nextCursor): 1 events + 1 raw + sleep + facts + readiness + insights.
+ * Worst case with full continuation: 10 + 10 + 4 context reads.
  */
-export const TIMELINE_DAY_ORDINARY_SELECTED_DAY_REQUESTS = 5 as const;
+export const TIMELINE_DAY_ORDINARY_SELECTED_DAY_REQUESTS = 6 as const;
 export const TIMELINE_DAY_WORST_CASE_SELECTED_DAY_REQUESTS =
-  TIMELINE_DAY_MAX_PAGES_PER_FAMILY * 2 + 3;
+  TIMELINE_DAY_MAX_PAGES_PER_FAMILY * 2 + 4;

--- a/lib/features/timeline/useTimelineDay.ts
+++ b/lib/features/timeline/useTimelineDay.ts
@@ -10,6 +10,7 @@ import { useAuth } from "@/lib/auth/AuthProvider";
 import { useSleepNight } from "@/lib/hooks/useSleepNight";
 import { useDailyFacts } from "@/lib/data/useDailyFacts";
 import { useInsights } from "@/lib/data/useInsights";
+import { useReadinessView } from "@/lib/data/useReadinessView";
 import { buildTimelineDayVm } from "@/lib/features/timeline/buildTimelineDayVm";
 import { fetchTimelineDayEventsPages } from "@/lib/features/timeline/fetchTimelineDayEventsPages";
 import { fetchTimelineDayRawEventsPages } from "@/lib/features/timeline/fetchTimelineDayRawEventsPages";
@@ -55,6 +56,7 @@ function buildVm(args: {
   raw: readonly RawEventListItem[];
   sleepView: ReturnType<typeof useSleepNight>["view"];
   facts: ReturnType<typeof useDailyFacts>;
+  readiness: ReturnType<typeof useReadinessView>;
   insights: ReturnType<typeof useInsights>;
 }): TimelineDayVm {
   return buildTimelineDayVm({
@@ -63,6 +65,7 @@ function buildVm(args: {
     rawItems: args.raw,
     ...(args.sleepView ? { sleepNight: args.sleepView } : {}),
     ...(args.facts.status === "ready" ? { dailyFacts: args.facts.data } : {}),
+    ...(args.readiness.status === "ready" ? { readinessView: args.readiness.data } : {}),
     ...(args.insights.status === "ready" ? { insights: args.insights.data.items } : {}),
   });
 }
@@ -80,6 +83,7 @@ export function useTimelineDay(day: string): UseTimelineDayResult {
 
   const sleep = useSleepNight(day, { enabled });
   const facts = useDailyFacts(day, { enabled });
+  const readiness = useReadinessView(day);
   const insights = useInsights(day);
 
   const generationRef = useRef(0);
@@ -165,16 +169,18 @@ export function useTimelineDay(day: string): UseTimelineDayResult {
 
   const sleepRefetch = sleep.refetch;
   const factsRefetch = facts.refetch;
+  const readinessRefetch = readiness.refetch;
   const insightsRefetch = insights.refetch;
 
   const refetchAll = useCallback(
     (opts?: GetOptions) => {
       sleepRefetch(opts);
       factsRefetch(opts);
+      readinessRefetch(opts);
       insightsRefetch(opts);
       void loadHistory(opts);
     },
-    [sleepRefetch, factsRefetch, insightsRefetch, loadHistory],
+    [sleepRefetch, factsRefetch, readinessRefetch, insightsRefetch, loadHistory],
   );
 
   const { status, completeness } = useMemo((): {
@@ -232,6 +238,7 @@ export function useTimelineDay(day: string): UseTimelineDayResult {
       raw: raw.completeness === "error" ? [] : raw.items,
       sleepView: sleep.view,
       facts,
+      readiness,
       insights,
     });
 
@@ -252,7 +259,7 @@ export function useTimelineDay(day: string): UseTimelineDayResult {
       },
       completeness: { state: "unproven", reason },
     };
-  }, [valid, authError, historySettling, history, day, sleep.view, facts, insights]);
+  }, [valid, authError, historySettling, history, day, sleep.view, facts, readiness, insights]);
 
   return { day, status, completeness, refetchAll };
 }


### PR DESCRIPTION
## Summary
- removes aggregate/midnight Steps from chronological Daily Timeline actions
- keeps one Activity context representation (context only; no duplicate Steps action)
- displays Recovery as exact-day readiness score or honest unavailable (no HRV/RHR proxy substitution)
- applies existing `reconcileWorkoutSessionsCore` to Daily Timeline workout/strength rows so matching manual/watch sessions render once; distinct sessions remain distinct
- no backend/API/OpenAPI change; mobile-only view-model / composition repair
- physical retest required before merging Daily (#192) or feature (#187)

## Test plan
- [ ] Exact-head CI green on this PR
- [ ] Code review of Activity filter, Recovery score mapping, workout adapter
- [ ] After merge into Daily branch: bounded physical Daily Timeline truth matrix (A5/A6/Recovery/A7)
- [ ] Do not merge #192 or #187 until physical matrix passes


Made with [Cursor](https://cursor.com)