### PR TITLE
feat(program): relocate weekly progress from dash

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,15 @@ EXPO_PUBLIC_BACKEND_BASE_URL=https://<your-gateway-host>.uc.gateway.dev
 # Required when BACKEND_BASE_URL is a *.uc.gateway.dev host (consumer API key on query param ?key=)
 EXPO_PUBLIC_GATEWAY_API_KEY=
 
+# Optional client feature toggles (non-secret; baked into the JS bundle at Metro/EAS
+# build or update time — changing them requires a new native/dev-client reload or a
+# new EAS Update / app binary that embeds the value. Not a remote server kill switch.)
+# EXPO_PUBLIC_DASH_WEEKLY_PROGRESS_RELOCATION=1
+#   Dash Phase 1 — Weekly Progress relocation.
+#   unset or "1" → enabled: Weekly Progress mounted under Program; absent from Dash.
+#   "0"          → rollback: legacy Weekly Fitness mounted under Dash; absent from Program.
+#   Any other value behaves as enabled (same as unset/"1").
+
 # Optional dev-only diagnostics (never enable in production builds you ship)
 # EXPO_PUBLIC_DEBUG_API_BASE_URL=1   # logs EXPO_PUBLIC_BACKEND_BASE_URL once per authed request
 # EXPO_PUBLIC_DEBUG_DATA_LOGS=1      # high-volume per-day cache/rollup diagnostics (dev only)

--- a/app/(app)/(tabs)/__tests__/dash-accessibility.test.tsx
+++ b/app/(app)/(tabs)/__tests__/dash-accessibility.test.tsx
@@ -4,6 +4,7 @@
 import React, { act } from "react";
 import renderer from "react-test-renderer";
 
+import { setDashWeeklyProgressRelocationEnabledForTests } from "@/lib/data/dash/dashWeeklyProgressRelocation";
 
 const mockUseTodayHealthHero = jest.fn();
 jest.mock("@/lib/hooks/useTodayHealthHero", () => ({
@@ -170,6 +171,7 @@ function findPressablesWithLabel(
 
 describe("Dash accessibility", () => {
   beforeEach(() => {
+    setDashWeeklyProgressRelocationEnabledForTests(true);
     mockUseTodayHealthHero.mockReset();
     mockUseTodayHealthHero.mockReturnValue({
       energyLoading: false,
@@ -220,6 +222,10 @@ describe("Dash accessibility", () => {
     });
   });
 
+  afterEach(() => {
+    setDashWeeklyProgressRelocationEnabledForTests(null);
+  });
+
   it("exposes accessibilityLabel on settings initial button", () => {
     let test!: renderer.ReactTestRenderer;
     act(() => {
@@ -251,7 +257,7 @@ describe("Dash accessibility", () => {
     expect(rootViews.length).toBeGreaterThanOrEqual(1);
   });
 
-  it("removes Sleep/Recovery summary and renders Weekly Fitness as first content card", () => {
+  it("removes Sleep/Recovery summary; Body Composition is first when relocation is enabled", () => {
     let test!: renderer.ReactTestRenderer;
     act(() => {
       test = renderer.create(<DashScreen />);
@@ -271,7 +277,7 @@ describe("Dash accessibility", () => {
     /** Body Composition card row is present. */
     expect(text).toContain("159.3 lb");
     expect(text).toContain("Body Composition");
-    expect(text).toContain("Weekly Fitness");
+    expect(text).not.toContain("Weekly Fitness");
     /** Daily Energy still renders. */
     expect(text).toContain("Daily Energy");
     expect(text).toContain("Daily Nutrition");
@@ -280,15 +286,13 @@ describe("Dash accessibility", () => {
     /** Legacy hero row used plain "Sleep" / "Recovery" labels; dedicated card uses "Daily Sleep". */
     expect(text).not.toContain("Last night summary");
 
-    /** Weekly Fitness first; then Body, Energy, Sleep, Readiness, Nutrition. */
-    const idxWeeklyFitness = text.indexOf("Weekly Fitness");
+    /** Body first when Weekly Progress is relocated; then Energy, Sleep, Readiness, Nutrition. */
     const idxBody = text.indexOf("Body Composition");
     const idxEnergy = text.indexOf("Daily Energy");
     const idxSleepCard = text.indexOf("Daily Sleep");
     const idxReadiness = text.indexOf("Oura Readiness");
     const idxNutrition = text.indexOf("Daily Nutrition");
-    expect(idxWeeklyFitness).toBeGreaterThan(-1);
-    expect(idxBody).toBeGreaterThan(idxWeeklyFitness);
+    expect(idxBody).toBeGreaterThan(-1);
     expect(idxEnergy).toBeGreaterThan(idxBody);
     expect(idxSleepCard).toBeGreaterThan(idxEnergy);
     expect(idxReadiness).toBeGreaterThan(idxSleepCard);

--- a/app/(app)/(tabs)/__tests__/dash-composition.test.tsx
+++ b/app/(app)/(tabs)/__tests__/dash-composition.test.tsx
@@ -1,8 +1,11 @@
 // app/(app)/(tabs)/__tests__/dash-composition.test.tsx
-// Command Center clean baseline: Today progress removed; six retained cards in order.
+// Command Center clean baseline: Today progress removed; state cards retained on Dash.
+// Weekly Fitness is on Dash only when relocation is disabled (rollback).
 
 import React, { act } from "react";
 import renderer from "react-test-renderer";
+
+import { setDashWeeklyProgressRelocationEnabledForTests } from "@/lib/data/dash/dashWeeklyProgressRelocation";
 
 const mockUseTodayHealthHero = jest.fn();
 jest.mock("@/lib/hooks/useTodayHealthHero", () => ({
@@ -159,6 +162,7 @@ function countOccurrences(haystack: string, needle: string): number {
 
 describe("Dash composition clean baseline", () => {
   beforeEach(() => {
+    setDashWeeklyProgressRelocationEnabledForTests(true);
     mockUseTodayHealthHero.mockReset();
     mockUseTodayHealthHero.mockReturnValue({
       energyLoading: false,
@@ -174,7 +178,11 @@ describe("Dash composition clean baseline", () => {
     });
   });
 
-  it("removes Today progress hero/card and keeps six retained cards in order", () => {
+  afterEach(() => {
+    setDashWeeklyProgressRelocationEnabledForTests(null);
+  });
+
+  it("removes Today progress hero/card and keeps state cards in order (relocation enabled)", () => {
     let test!: renderer.ReactTestRenderer;
     act(() => {
       test = renderer.create(<DashScreen />);
@@ -191,32 +199,44 @@ describe("Dash composition clean baseline", () => {
     expect(test.root.findAll((n) => (n.props as { testID?: string }).testID === "today-progress-card")).toHaveLength(0);
     expect(test.root.findAll((n) => (n.props as { testID?: string }).testID === "today-health-hero")).toHaveLength(0);
 
-    expect(text).toContain("Weekly Fitness");
+    expect(text).not.toContain("Weekly Fitness");
+    expect(text).not.toContain("Weekly Progress");
     expect(text).toContain("Body Composition");
     expect(text).toContain("Daily Energy");
     expect(text).toContain("Daily Sleep");
     expect(text).toContain("Oura Readiness");
     expect(text).toContain("Daily Nutrition");
 
-    expect(countOccurrences(text, "Weekly Fitness")).toBe(1);
     expect(countOccurrences(text, "Body Composition")).toBe(1);
     expect(countOccurrences(text, "Daily Energy")).toBe(1);
     expect(countOccurrences(text, "Daily Sleep")).toBe(1);
     expect(countOccurrences(text, "Oura Readiness")).toBe(1);
     expect(countOccurrences(text, "Daily Nutrition")).toBe(1);
 
-    const idxWeekly = text.indexOf("Weekly Fitness");
     const idxBody = text.indexOf("Body Composition");
     const idxEnergy = text.indexOf("Daily Energy");
     const idxSleep = text.indexOf("Daily Sleep");
     const idxReadiness = text.indexOf("Oura Readiness");
     const idxNutrition = text.indexOf("Daily Nutrition");
-    expect(idxWeekly).toBeGreaterThan(-1);
-    expect(idxBody).toBeGreaterThan(idxWeekly);
+    expect(idxBody).toBeGreaterThan(-1);
     expect(idxEnergy).toBeGreaterThan(idxBody);
     expect(idxSleep).toBeGreaterThan(idxEnergy);
     expect(idxReadiness).toBeGreaterThan(idxSleep);
     expect(idxNutrition).toBeGreaterThan(idxReadiness);
+  });
+
+  it("rollback: restores Weekly Fitness as first Dash card when relocation is disabled", () => {
+    setDashWeeklyProgressRelocationEnabledForTests(false);
+    let test!: renderer.ReactTestRenderer;
+    act(() => {
+      test = renderer.create(<DashScreen />);
+    });
+    const text = collectAllText(test);
+    expect(text).toContain("Weekly Fitness");
+    const idxWeekly = text.indexOf("Weekly Fitness");
+    const idxBody = text.indexOf("Body Composition");
+    expect(idxWeekly).toBeGreaterThan(-1);
+    expect(idxBody).toBeGreaterThan(idxWeekly);
   });
 
   it("sleep hero can show score without duplicating readiness card", () => {

--- a/app/(app)/(tabs)/__tests__/dash-provenance.test.tsx
+++ b/app/(app)/(tabs)/__tests__/dash-provenance.test.tsx
@@ -4,6 +4,7 @@
 import React, { act } from "react";
 import renderer from "react-test-renderer";
 
+import { setDashWeeklyProgressRelocationEnabledForTests } from "@/lib/data/dash/dashWeeklyProgressRelocation";
 
 const mockUseTodayHealthHero = jest.fn();
 jest.mock("@/lib/hooks/useTodayHealthHero", () => ({
@@ -150,6 +151,7 @@ function countDashIconPlaceholders(root: renderer.ReactTestInstance): number {
 
 describe("Dash provenance", () => {
   beforeEach(() => {
+    setDashWeeklyProgressRelocationEnabledForTests(true);
     mockUseTodayHealthHero.mockReset();
     mockUseTodayHealthHero.mockReturnValue({
       energyLoading: false,
@@ -176,6 +178,10 @@ describe("Dash provenance", () => {
         message: "No sleep data logged for this day.",
       },
     });
+  });
+
+  afterEach(() => {
+    setDashWeeklyProgressRelocationEnabledForTests(null);
   });
 
   it("shows Oli Fitness tab title and Body Composition + Daily Energy sections", () => {
@@ -215,7 +221,7 @@ describe("Dash provenance", () => {
     expect(text).toContain("NEAT");
     expect(text).toContain("Cardio");
     expect(text).toContain("Strength");
-    expect(text).toContain("Weekly Fitness");
+    expect(text).not.toContain("Weekly Fitness");
     expect(text).not.toContain("Progress to goal");
     expect(text).toContain("Daily Nutrition");
     expect(text).toContain("Oura Readiness");

--- a/app/(app)/(tabs)/__tests__/dash-recap.test.tsx
+++ b/app/(app)/(tabs)/__tests__/dash-recap.test.tsx
@@ -4,6 +4,8 @@
 import React, { act } from "react";
 import renderer from "react-test-renderer";
 
+import { setDashWeeklyProgressRelocationEnabledForTests } from "@/lib/data/dash/dashWeeklyProgressRelocation";
+
 
 jest.mock("react-native", () => ({
   View: "View",
@@ -172,10 +174,15 @@ function collectAllText(test: renderer.ReactTestRenderer): string {
 
 describe("Dash Daily Energy card", () => {
   beforeEach(() => {
+    setDashWeeklyProgressRelocationEnabledForTests(true);
     mockUseTodayHealthHero.mockReset();
   });
 
-  it("renders Weekly Fitness first and removes Sleep/Recovery summary", () => {
+  afterEach(() => {
+    setDashWeeklyProgressRelocationEnabledForTests(null);
+  });
+
+  it("renders Body Composition first (relocation) and removes Sleep/Recovery summary", () => {
     mockUseTodayHealthHero.mockReturnValue({
       energyLoading: false,
       energyError: null,
@@ -211,8 +218,8 @@ describe("Dash Daily Energy card", () => {
     expect(text).not.toContain("Track, understand, and improve every part of your health.");
     expect(text).not.toContain("Good afternoon");
     expect(text).not.toContain("Today's Progress");
-    /** Weekly Fitness + remaining cards. */
-    expect(text).toContain("Weekly Fitness");
+    /** Weekly Fitness relocated off Dash by default. */
+    expect(text).not.toContain("Weekly Fitness");
     expect(text).toContain("Body Composition");
     expect(text).toContain("159.3 lb");
     expect(text).toContain("BMI");
@@ -229,15 +236,13 @@ describe("Dash Daily Energy card", () => {
     expect(text).toContain("Daily Sleep");
     expect(text).toContain("Oura Readiness");
 
-    /** Weekly Fitness first; then Body, Energy, Sleep, Readiness, Nutrition. */
-    const idxWeeklyFitness = text.indexOf("Weekly Fitness");
+    /** Body first; then Energy, Sleep, Readiness, Nutrition. */
     const idxBody = text.indexOf("Body Composition");
     const idxEnergy = text.indexOf("Daily Energy");
     const idxSleep = text.indexOf("Daily Sleep");
     const idxReadiness = text.indexOf("Oura Readiness");
     const idxNutrition = text.indexOf("Daily Nutrition");
-    expect(idxWeeklyFitness).toBeGreaterThan(-1);
-    expect(idxBody).toBeGreaterThan(idxWeeklyFitness);
+    expect(idxBody).toBeGreaterThan(-1);
     expect(idxEnergy).toBeGreaterThan(idxBody);
     expect(idxSleep).toBeGreaterThan(idxEnergy);
     expect(idxReadiness).toBeGreaterThan(idxSleep);

--- a/app/(app)/(tabs)/__tests__/program-home.test.tsx
+++ b/app/(app)/(tabs)/__tests__/program-home.test.tsx
@@ -3,6 +3,12 @@ import fs from "node:fs";
 import path from "node:path";
 import renderer from "react-test-renderer";
 
+import {
+  setDashWeeklyProgressRelocationEnabledForTests,
+  WEEKLY_PROGRESS_CONSUMER_TITLE,
+  WEEKLY_PROGRESS_SUPPORTING_COPY,
+} from "@/lib/data/dash/dashWeeklyProgressRelocation";
+
 const mockPush = jest.fn();
 
 jest.mock("expo-router", () => ({
@@ -27,12 +33,31 @@ jest.mock("@/lib/preferences/PreferencesProvider", () => ({
   }),
 }));
 
+jest.mock("@/lib/auth/AuthProvider", () => ({
+  useAuth: () => ({ user: { uid: "t1" }, initializing: false, getIdToken: jest.fn() }),
+}));
+
+jest.mock("@/lib/data/dash/useWeeklyFitnessCard", () => ({
+  useWeeklyFitnessCard: () => ({
+    loading: false,
+    error: null,
+    model: null,
+    goalsHref: "/(app)/fitness-goals",
+  }),
+}));
+
 jest.mock("react-native", () => ({
   View: "View",
   Text: "Text",
   Pressable: "Pressable",
   ScrollView: "ScrollView",
-  StyleSheet: { create: (s: unknown) => s },
+  StyleSheet: { create: (s: unknown) => s, hairlineWidth: 1 },
+}));
+
+jest.mock("react-native-svg", () => ({
+  __esModule: true,
+  default: "Svg",
+  Circle: "Circle",
 }));
 
 import ProgramScreen from "../program";
@@ -40,6 +65,11 @@ import { UI_TEXT_PRIMARY } from "@/lib/ui/theme/uiTokens";
 
 beforeEach(() => {
   mockPush.mockClear();
+  setDashWeeklyProgressRelocationEnabledForTests(true);
+});
+
+afterEach(() => {
+  setDashWeeklyProgressRelocationEnabledForTests(null);
 });
 
 function renderProgram(): renderer.ReactTestRenderer {
@@ -50,11 +80,44 @@ function renderProgram(): renderer.ReactTestRenderer {
   return test;
 }
 
+function collectText(test: renderer.ReactTestRenderer): string {
+  const nodes = test.root.findAllByType("Text");
+  const parts: string[] = [];
+  for (const n of nodes) {
+    for (const child of n.children) {
+      if (typeof child === "string" || typeof child === "number") parts.push(String(child));
+    }
+  }
+  return parts.join(" ");
+}
+
 describe("Program tab", () => {
   it("renders the Program header title", () => {
     const test = renderProgram();
     const str = JSON.stringify(test.toJSON());
     expect(str).toContain("Program");
+  });
+
+  it("renders Weekly Progress when relocation is enabled", () => {
+    const test = renderProgram();
+    const text = collectText(test);
+    expect(text).toContain(WEEKLY_PROGRESS_CONSUMER_TITLE);
+    expect(text).toContain(WEEKLY_PROGRESS_SUPPORTING_COPY);
+    expect(test.root.findByProps({ testID: "program-weekly-progress-section" })).toBeTruthy();
+    expect(text).not.toMatch(/adherence/i);
+    expect(text).not.toMatch(/health score/i);
+  });
+
+  it("omits Weekly Progress when relocation is disabled", () => {
+    setDashWeeklyProgressRelocationEnabledForTests(false);
+    const test = renderProgram();
+    const text = collectText(test);
+    expect(text).not.toContain(WEEKLY_PROGRESS_CONSUMER_TITLE);
+    expect(
+      test.root.findAll(
+        (n) => (n.props as { testID?: string }).testID === "program-weekly-progress-section",
+      ),
+    ).toHaveLength(0);
   });
 
   it("renders the + button instead of the settings gear", () => {
@@ -96,11 +159,12 @@ describe("Program tab", () => {
     expect(test.root.findByProps({ testID: "program-category-activity" })).toBeTruthy();
   });
 
-  it("renders the empty state when no current programs exist", () => {
+  it("renders the empty state when no current programs exist alongside Weekly Progress", () => {
     const test = renderProgram();
     expect(test.root.findByProps({ testID: "program-current-empty" })).toBeTruthy();
     const str = JSON.stringify(test.toJSON());
     expect(str).toContain("No active programs yet");
+    expect(str).toContain(WEEKLY_PROGRESS_CONSUMER_TITLE);
     expect(str).not.toContain("Saved Programs");
     expect(str).not.toContain("Shared Programs");
   });
@@ -112,5 +176,6 @@ describe("Program tab", () => {
     expect(src).not.toMatch(/from\s+["'][^"']*firebase[^"']*["']/i);
     expect(src).not.toMatch(/from\s+["'][^"']*lib\/api\/http["']/);
     expect(src).not.toMatch(/apiGet[A-Za-z]*\s*\(/);
+    expect(src).not.toContain("useWeeklyFitnessCard");
   });
 });

--- a/app/(app)/(tabs)/__tests__/weekly-progress-relocation.test.tsx
+++ b/app/(app)/(tabs)/__tests__/weekly-progress-relocation.test.tsx
@@ -1,0 +1,343 @@
+// app/(app)/(tabs)/__tests__/weekly-progress-relocation.test.tsx
+// Phase 1: Weekly Progress relocation between Dash and Program (feature-flagged).
+
+import React, { act } from "react";
+import fs from "node:fs";
+import path from "node:path";
+import renderer from "react-test-renderer";
+
+import {
+  setDashWeeklyProgressRelocationEnabledForTests,
+  WEEKLY_PROGRESS_CONSUMER_TITLE,
+  WEEKLY_PROGRESS_SUPPORTING_COPY,
+} from "@/lib/data/dash/dashWeeklyProgressRelocation";
+import { WEEKLY_FITNESS_ROUTES } from "@/lib/data/dash/weeklyFitnessRoutes";
+
+const mockUseWeeklyFitnessCard = jest.fn();
+
+jest.mock("@/lib/data/dash/useWeeklyFitnessCard", () => ({
+  useWeeklyFitnessCard: (...args: unknown[]) => mockUseWeeklyFitnessCard(...args),
+}));
+
+const mockUseTodayHealthHero = jest.fn();
+jest.mock("@/lib/hooks/useTodayHealthHero", () => ({
+  useTodayHealthHero: (...args: unknown[]) => mockUseTodayHealthHero(...args),
+}));
+
+jest.mock("@/lib/hooks/useDailyReadinessCard", () => ({
+  useDailyReadinessCard: () => ({
+    vm: { status: "missing", day: "2026-05-11", message: "No current-day readiness signal is available yet." },
+    refetch: jest.fn(),
+  }),
+}));
+
+jest.mock("@/lib/auth/AuthProvider", () => ({
+  useAuth: () => ({ user: { uid: "t1" }, initializing: false, getIdToken: jest.fn() }),
+}));
+
+jest.mock("@/components/navigation/ManageNavigationContext", () => ({
+  useManageNavigation: () => ({
+    manageVisible: false,
+    menuAnchor: null,
+    openManage: jest.fn(),
+    closeManage: jest.fn(),
+  }),
+}));
+
+jest.mock("@/lib/data/profile/useUserProfileMain", () => ({
+  useUserProfileMain: () => ({ state: { status: "missing" } }),
+}));
+
+jest.mock("@/lib/data/dash/useBodyCompositionDashCard", () => ({
+  useBodyCompositionDashCard: () => ({
+    loading: false,
+    error: null,
+    hasUser: true,
+    goalsHref: "/(app)/body/settings",
+    built: {
+      tag: "ready" as const,
+      weightPrimaryLabel: "159.3 lb",
+      readingAsOfLabel: "As of today",
+      rows: [],
+      cardAccessibilityLabel: "Body composition card.",
+    },
+  }),
+}));
+
+jest.mock("@/lib/data/dash/useDailyNutritionCard", () => ({
+  useDailyNutritionCard: () => ({
+    model: {
+      calorieLabel: "1,850 kcal",
+      hasAnyNutrition: true,
+      rows: [
+        { key: "protein", label: "Protein", valueLabel: "142 g" },
+        { key: "carbs", label: "Carbs", valueLabel: "210 g" },
+        { key: "fat", label: "Fat", valueLabel: "64 g" },
+      ] as const,
+    },
+    loading: false,
+    error: null,
+  }),
+}));
+
+jest.mock("@/lib/preferences/PreferencesProvider", () => ({
+  usePreferences: () => ({
+    state: { preferences: {} },
+  }),
+}));
+
+jest.mock("@/lib/ui/navigation/useFloatingTabBarScrollPadding", () => ({
+  useFloatingTabBarScrollPadding: (extra: number) => extra + 0,
+}));
+
+jest.mock("react-native", () => ({
+  View: "View",
+  Text: "Text",
+  Pressable: "Pressable",
+  Modal: "Modal",
+  ScrollView: "ScrollView",
+  ActivityIndicator: "ActivityIndicator",
+  StyleSheet: { create: (s: unknown) => s, hairlineWidth: 1 },
+  Easing: {
+    out: (e: (t: number) => number) => e,
+    cubic: (t: number) => t * t * t,
+    inOut: (fn: (t: number) => number) => fn,
+    quad: (t: number) => t * t,
+  },
+  Animated: {
+    View: "Animated.View",
+    Value: function (initial: number) {
+      return {
+        _value: initial,
+        interpolate: () => "0%",
+        setValue: jest.fn(),
+      };
+    },
+    timing: function () {
+      return { start: jest.fn() };
+    },
+    sequence: () => ({ start: jest.fn() }),
+    loop: () => ({ start: jest.fn(), stop: jest.fn() }),
+  },
+}));
+
+jest.mock("react-native-safe-area-context", () => ({
+  SafeAreaView: "SafeAreaView",
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+const mockPush = jest.fn();
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ push: mockPush }),
+  useFocusEffect: (cb: () => void) => cb(),
+}));
+
+jest.mock("@expo/vector-icons", () => ({
+  Ionicons: () => require("react").createElement("View", { "data-testid": "icon" }),
+}));
+
+jest.mock("react-native-svg", () => ({
+  __esModule: true,
+  default: "Svg",
+  Circle: "Circle",
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const DashScreen = require("../dash").default;
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const ProgramScreen = require("../program").default;
+
+function collectAllText(test: renderer.ReactTestRenderer): string {
+  const nodes = test.root.findAllByType("Text");
+  const parts: string[] = [];
+  for (const n of nodes) {
+    for (const child of n.children) {
+      if (typeof child === "string" || typeof child === "number") parts.push(String(child));
+    }
+  }
+  return parts.join(" ");
+}
+
+const sampleModel = {
+  weeklyProgress: {
+    percent: null as number | null,
+    label: "—",
+    subtitle: "Weekly Progress",
+    accessibilityLabel: "Weekly Progress, unavailable, not enough contributors. Button.",
+    href: WEEKLY_FITNESS_ROUTES.goalsEditor,
+    testID: "weekly-fitness-hero-weekly-progress",
+  },
+  bodyComposition: {
+    percent: 81,
+    label: "81",
+    subtitle: "Body Composition Score",
+    accessibilityLabel:
+      "Body Composition Score, 81, progress toward your selected body composition goal. Button.",
+    href: WEEKLY_FITNESS_ROUTES.bodyComposition,
+    testID: "weekly-fitness-hero-body-composition",
+  },
+  metrics: [
+    {
+      key: "activity" as const,
+      label: "Activity",
+      valueLabel: "No activity data",
+      accessibilityLabel: "Activity, No activity data, button.",
+      progress01: null,
+      hasProgress: false,
+      barColor: "#888",
+      href: WEEKLY_FITNESS_ROUTES.activity,
+    },
+    {
+      key: "strength" as const,
+      label: "Strength",
+      valueLabel: "2 workouts",
+      accessibilityLabel: "Strength, 2 workouts, button.",
+      progress01: 0.4,
+      hasProgress: true,
+      barColor: "#888",
+      href: WEEKLY_FITNESS_ROUTES.strength,
+    },
+  ],
+  weeklyProgressScore0to100: null as number | null,
+  bodyCompositionScore0to100: 81,
+  eligibleWeeklyProgressCount: 1,
+};
+
+describe("Weekly Progress relocation", () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+    mockUseWeeklyFitnessCard.mockReset();
+    mockUseWeeklyFitnessCard.mockReturnValue({
+      loading: false,
+      error: null,
+      model: sampleModel,
+      goalsHref: WEEKLY_FITNESS_ROUTES.goalsEditor,
+    });
+    mockUseTodayHealthHero.mockReset();
+    mockUseTodayHealthHero.mockReturnValue({
+      energyLoading: false,
+      energyError: null,
+      energy: undefined,
+      sleepCardVm: {
+        status: "missing",
+        day: "2026-05-11",
+        message: "No sleep data logged for this day.",
+      },
+      exactDayRestingHeartRateBpm: null,
+      refetch: jest.fn(),
+    });
+  });
+
+  afterEach(() => {
+    setDashWeeklyProgressRelocationEnabledForTests(null);
+  });
+
+  it("enabled: Program shows Weekly Progress; Dash does not; hook mounts once", () => {
+    setDashWeeklyProgressRelocationEnabledForTests(true);
+
+    let dash!: renderer.ReactTestRenderer;
+    let program!: renderer.ReactTestRenderer;
+    act(() => {
+      dash = renderer.create(<DashScreen />);
+      program = renderer.create(<ProgramScreen />);
+    });
+
+    const dashText = collectAllText(dash);
+    const programText = collectAllText(program);
+
+    expect(dashText).not.toContain("Weekly Fitness");
+    expect(dashText).not.toContain(WEEKLY_PROGRESS_CONSUMER_TITLE);
+    expect(dashText).toContain("Body Composition");
+    expect(dashText).toContain("Daily Energy");
+
+    expect(programText).toContain(WEEKLY_PROGRESS_CONSUMER_TITLE);
+    expect(programText).toContain(WEEKLY_PROGRESS_SUPPORTING_COPY);
+    expect(programText).toContain("No active programs yet");
+    expect(programText).not.toMatch(/adherence/i);
+    expect(programText).not.toMatch(/health score/i);
+    expect(program.root.findByProps({ testID: "program-weekly-progress-section" })).toBeTruthy();
+    expect(
+      program.root.findAll(
+        (n) =>
+          (n.props as { accessibilityLabel?: string }).accessibilityLabel === "Weekly Progress card",
+      ).length,
+    ).toBeGreaterThanOrEqual(1);
+
+    expect(mockUseWeeklyFitnessCard).toHaveBeenCalledTimes(1);
+  });
+
+  it("enabled: insufficient contributors keep score unavailable (null), body goal unchanged", () => {
+    setDashWeeklyProgressRelocationEnabledForTests(true);
+    let program!: renderer.ReactTestRenderer;
+    act(() => {
+      program = renderer.create(<ProgramScreen />);
+    });
+    const text = collectAllText(program);
+    expect(sampleModel.weeklyProgressScore0to100).toBeNull();
+    expect(text).toContain("Body Composition Score");
+    expect(text).toContain("81");
+    // Hero percent label for unavailable weekly progress is em dash, not a fabricated 0.
+    expect(text).toContain("—");
+    expect(text).not.toMatch(/Weekly Progress, 0 percent/i);
+  });
+
+  it("enabled: row navigation destinations remain valid", () => {
+    setDashWeeklyProgressRelocationEnabledForTests(true);
+    let program!: renderer.ReactTestRenderer;
+    act(() => {
+      program = renderer.create(<ProgramScreen />);
+    });
+    const strengthRow = program.root.findByProps({ testID: "weekly-fitness-row-strength" });
+    act(() => {
+      (strengthRow.props.onPress as () => void)();
+    });
+    expect(mockPush).toHaveBeenCalledWith(WEEKLY_FITNESS_ROUTES.strength);
+  });
+
+  it("disabled: Dash restores Weekly Fitness; Program does not duplicate the card", () => {
+    setDashWeeklyProgressRelocationEnabledForTests(false);
+
+    let dash!: renderer.ReactTestRenderer;
+    let program!: renderer.ReactTestRenderer;
+    act(() => {
+      dash = renderer.create(<DashScreen />);
+      program = renderer.create(<ProgramScreen />);
+    });
+
+    const dashText = collectAllText(dash);
+    const programText = collectAllText(program);
+
+    expect(dashText).toContain("Weekly Fitness");
+    expect(dashText).toContain("Body Composition");
+    expect(programText).not.toContain(WEEKLY_PROGRESS_CONSUMER_TITLE);
+    expect(program.root.findAll((n) => (n.props as { testID?: string }).testID === "program-weekly-progress-section")).toHaveLength(0);
+    expect(programText).toContain("No active programs yet");
+    expect(mockUseWeeklyFitnessCard).toHaveBeenCalledTimes(1);
+  });
+
+  it("source guards: screens do not call Firebase/API; only the host imports the heavy hook", () => {
+    const dashSrc = fs.readFileSync(path.join(__dirname, "..", "dash.tsx"), "utf8");
+    const programSrc = fs.readFileSync(path.join(__dirname, "..", "program.tsx"), "utf8");
+    const hostSrc = fs.readFileSync(
+      path.join(__dirname, "../../../../lib/ui/dash/WeeklyFitnessCardHost.tsx"),
+      "utf8",
+    );
+
+    for (const src of [dashSrc, programSrc]) {
+      expect(src).not.toMatch(/\bfetch\s*\(/);
+      expect(src).not.toMatch(/from\s+["'][^"']*firebase[^"']*["']/i);
+      expect(src).not.toMatch(/from\s+["'][^"']*lib\/api\/http["']/);
+      expect(src).not.toMatch(/apiGet[A-Za-z]*\s*\(/);
+      expect(src).not.toContain("useWeeklyFitnessCard");
+    }
+    expect(hostSrc).toContain("useWeeklyFitnessCard");
+    expect(dashSrc).toContain("WeeklyFitnessCardHost");
+    expect(programSrc).toContain("WeeklyFitnessCardHost");
+  });
+
+  it("does not modify Timeline sources", () => {
+    // Provenance guard for this suite: Timeline paths must stay untouched by this feature file set.
+    const timelineDir = path.join(__dirname, "..", "timeline");
+    expect(fs.existsSync(timelineDir)).toBe(true);
+  });
+});

--- a/app/(app)/(tabs)/dash.tsx
+++ b/app/(app)/(tabs)/dash.tsx
@@ -1,5 +1,7 @@
 // app/(app)/(tabs)/dash.tsx
-// Oli — Dash: header + retained module cards (Weekly Fitness first).
+// Oli — Dash: header + retained module cards (current health/fitness state).
+// Weekly Fitness / Weekly Progress placement is controlled by
+// `isDashWeeklyProgressRelocationEnabled` (Program when enabled; Dash when disabled).
 import React from "react";
 import { ScrollView, View, StyleSheet } from "react-native";
 import { useFocusEffect, useRouter } from "expo-router";
@@ -10,7 +12,7 @@ import { useFloatingTabBarScrollPadding } from "@/lib/ui/navigation/useFloatingT
 import { useAuth } from "@/lib/auth/AuthProvider";
 import { useBodyCompositionDashCard } from "@/lib/data/dash/useBodyCompositionDashCard";
 import { useDailyNutritionCard } from "@/lib/data/dash/useDailyNutritionCard";
-import { useWeeklyFitnessCard } from "@/lib/data/dash/useWeeklyFitnessCard";
+import { isDashWeeklyProgressRelocationEnabled } from "@/lib/data/dash/dashWeeklyProgressRelocation";
 import { useTodayHealthHero } from "@/lib/hooks/useTodayHealthHero";
 import { useDailyReadinessCard } from "@/lib/hooks/useDailyReadinessCard";
 import { BodyCompositionCard } from "@/lib/ui/dash/BodyCompositionCard";
@@ -18,7 +20,7 @@ import { DailyEnergyCard } from "@/lib/ui/dash/DailyEnergyCard";
 import { DailyReadinessCard } from "@/lib/ui/dash/DailyReadinessCard";
 import { DailySleepCard } from "@/lib/ui/dash/DailySleepCard";
 import { DailyNutritionCard } from "@/lib/ui/dash/DailyNutritionCard";
-import { WeeklyFitnessCard } from "@/lib/ui/dash/WeeklyFitnessCard";
+import { WeeklyFitnessCardHost } from "@/lib/ui/dash/WeeklyFitnessCardHost";
 import { getTodayDayKeyLocal } from "@/lib/ui/calendar/dateUtils";
 
 export default function DashScreen() {
@@ -26,6 +28,7 @@ export default function DashScreen() {
   const scrollPaddingBottom = useFloatingTabBarScrollPadding(40);
   const { user } = useAuth();
   const todayKey = getTodayDayKeyLocal();
+  const showWeeklyFitnessOnDash = !isDashWeeklyProgressRelocationEnabled();
   const {
     energy,
     energyLoading,
@@ -38,7 +41,6 @@ export default function DashScreen() {
     enabled: Boolean(user),
     exactDayRestingHeartRateBpm,
   });
-  const weeklyFitness = useWeeklyFitnessCard();
   const bodyComposition = useBodyCompositionDashCard();
   const dailyNutrition = useDailyNutritionCard(todayKey);
 
@@ -60,13 +62,7 @@ export default function DashScreen() {
           showsVerticalScrollIndicator={false}
         >
           <View style={styles.stacksSection}>
-            <WeeklyFitnessCard
-              loading={weeklyFitness.loading}
-              error={weeklyFitness.error}
-              model={weeklyFitness.model}
-              goalsHref={weeklyFitness.goalsHref}
-              hasUser={user != null}
-            />
+            {showWeeklyFitnessOnDash ? <WeeklyFitnessCardHost /> : null}
             <BodyCompositionCard
               loading={bodyComposition.loading}
               error={bodyComposition.error}

--- a/app/(app)/(tabs)/program.tsx
+++ b/app/(app)/(tabs)/program.tsx
@@ -1,5 +1,5 @@
 // app/(app)/(tabs)/program.tsx
-// Oli — Program: tab root showing plan category cards + current programs.
+// Oli — Program: weekly target progress + plan category cards + current programs.
 import React, { useMemo } from "react";
 import { ScrollView, View, StyleSheet } from "react-native";
 import { ScreenContainer } from "@/lib/ui/ScreenStates";
@@ -8,11 +8,17 @@ import { UI_APP_SCREEN_BG, UI_TAB_ROOT_INSET } from "@/lib/ui/theme/uiTokens";
 import { useFloatingTabBarScrollPadding } from "@/lib/ui/navigation/useFloatingTabBarScrollPadding";
 import type { ProgramSummary } from "@/lib/data/program/types";
 import { buildProgramCategoryCards } from "@/lib/data/program/buildProgramCategoryCards";
+import {
+  WEEKLY_PROGRESS_CONSUMER_TITLE,
+  WEEKLY_PROGRESS_SUPPORTING_COPY,
+  isDashWeeklyProgressRelocationEnabled,
+} from "@/lib/data/dash/dashWeeklyProgressRelocation";
 import { usePreferences } from "@/lib/preferences/PreferencesProvider";
 import { resolveWeeklyFitnessGoals } from "@/lib/preferences/weeklyFitnessGoals";
 import { ProgramAddButton } from "@/lib/ui/program/ProgramAddButton";
 import { ProgramCategoryCards } from "@/lib/ui/program/ProgramCategoryCards";
 import { ProgramCurrentScreen } from "@/lib/ui/program/ProgramCurrentScreen";
+import { WeeklyFitnessCardHost } from "@/lib/ui/dash/WeeklyFitnessCardHost";
 
 export default function ProgramScreen() {
   const scrollPaddingBottom = useFloatingTabBarScrollPadding(40);
@@ -22,6 +28,7 @@ export default function ProgramScreen() {
     [prefState.preferences, prefState.preferences.weeklyFitnessGoals?.updatedAt],
   );
   const categoryCards = useMemo(() => buildProgramCategoryCards(goals), [goals]);
+  const showWeeklyProgress = isDashWeeklyProgressRelocationEnabled();
 
   // v1: no program document persistence yet — active programs list stays empty.
   const currentPrograms: ProgramSummary[] = [];
@@ -35,6 +42,15 @@ export default function ProgramScreen() {
           contentContainerStyle={[styles.content, { paddingBottom: scrollPaddingBottom }]}
           showsVerticalScrollIndicator={false}
         >
+          {showWeeklyProgress ? (
+            <View testID="program-weekly-progress-section" accessibilityLabel="Weekly progress section">
+              <WeeklyFitnessCardHost
+                title={WEEKLY_PROGRESS_CONSUMER_TITLE}
+                subtitle={WEEKLY_PROGRESS_SUPPORTING_COPY}
+                cardAccessibilityLabel="Weekly Progress card"
+              />
+            </View>
+          ) : null}
           <ProgramCategoryCards cards={categoryCards} />
           <ProgramCurrentScreen programs={currentPrograms} embedded />
         </ScrollView>

--- a/lib/data/dash/__tests__/dashWeeklyProgressRelocation.test.ts
+++ b/lib/data/dash/__tests__/dashWeeklyProgressRelocation.test.ts
@@ -39,6 +39,15 @@ describe("dashWeeklyProgressRelocation flag", () => {
     expect(isDashWeeklyProgressRelocationEnabled()).toBe(true);
   });
 
+  it("treats unexpected env values as enabled (same as default)", () => {
+    process.env[DASH_WEEKLY_PROGRESS_RELOCATION_ENV_KEY] = "false";
+    expect(isDashWeeklyProgressRelocationEnabled()).toBe(true);
+    process.env[DASH_WEEKLY_PROGRESS_RELOCATION_ENV_KEY] = "2";
+    expect(isDashWeeklyProgressRelocationEnabled()).toBe(true);
+    process.env[DASH_WEEKLY_PROGRESS_RELOCATION_ENV_KEY] = "";
+    expect(isDashWeeklyProgressRelocationEnabled()).toBe(true);
+  });
+
   it("test override wins over env", () => {
     process.env[DASH_WEEKLY_PROGRESS_RELOCATION_ENV_KEY] = "0";
     setDashWeeklyProgressRelocationEnabledForTests(true);

--- a/lib/data/dash/__tests__/dashWeeklyProgressRelocation.test.ts
+++ b/lib/data/dash/__tests__/dashWeeklyProgressRelocation.test.ts
@@ -1,0 +1,64 @@
+import {
+  DASH_WEEKLY_PROGRESS_RELOCATION_ENV_KEY,
+  DASH_WEEKLY_PROGRESS_RELOCATION_FLAG_ID,
+  WEEKLY_FITNESS_CONSUMER_TITLE,
+  WEEKLY_PROGRESS_CONSUMER_TITLE,
+  WEEKLY_PROGRESS_SUPPORTING_COPY,
+  isDashWeeklyProgressRelocationEnabled,
+  setDashWeeklyProgressRelocationEnabledForTests,
+} from "../dashWeeklyProgressRelocation";
+
+describe("dashWeeklyProgressRelocation flag", () => {
+  const prevEnv = process.env[DASH_WEEKLY_PROGRESS_RELOCATION_ENV_KEY];
+
+  afterEach(() => {
+    setDashWeeklyProgressRelocationEnabledForTests(null);
+    if (prevEnv === undefined) {
+      delete process.env[DASH_WEEKLY_PROGRESS_RELOCATION_ENV_KEY];
+    } else {
+      process.env[DASH_WEEKLY_PROGRESS_RELOCATION_ENV_KEY] = prevEnv;
+    }
+  });
+
+  it("exposes the conceptual product flag id", () => {
+    expect(DASH_WEEKLY_PROGRESS_RELOCATION_FLAG_ID).toBe("dashWeeklyProgressRelocation");
+  });
+
+  it("defaults to enabled (Program placement)", () => {
+    delete process.env[DASH_WEEKLY_PROGRESS_RELOCATION_ENV_KEY];
+    expect(isDashWeeklyProgressRelocationEnabled()).toBe(true);
+  });
+
+  it("disables when env override is 0 (Dash rollback)", () => {
+    process.env[DASH_WEEKLY_PROGRESS_RELOCATION_ENV_KEY] = "0";
+    expect(isDashWeeklyProgressRelocationEnabled()).toBe(false);
+  });
+
+  it("enables when env override is 1", () => {
+    process.env[DASH_WEEKLY_PROGRESS_RELOCATION_ENV_KEY] = "1";
+    expect(isDashWeeklyProgressRelocationEnabled()).toBe(true);
+  });
+
+  it("test override wins over env", () => {
+    process.env[DASH_WEEKLY_PROGRESS_RELOCATION_ENV_KEY] = "0";
+    setDashWeeklyProgressRelocationEnabledForTests(true);
+    expect(isDashWeeklyProgressRelocationEnabled()).toBe(true);
+    setDashWeeklyProgressRelocationEnabledForTests(false);
+    expect(isDashWeeklyProgressRelocationEnabled()).toBe(false);
+  });
+
+  it("keeps consumer copy free of adherence/health-classification claims", () => {
+    const surfaces = [
+      WEEKLY_PROGRESS_CONSUMER_TITLE,
+      WEEKLY_PROGRESS_SUPPORTING_COPY,
+      WEEKLY_FITNESS_CONSUMER_TITLE,
+    ].join(" ");
+    expect(surfaces).not.toMatch(/adherence/i);
+    expect(surfaces).not.toMatch(/active program completion/i);
+    expect(surfaces).not.toMatch(/health score/i);
+    expect(surfaces).not.toMatch(/fitness level/i);
+    expect(surfaces).not.toMatch(/medical/i);
+    expect(WEEKLY_PROGRESS_CONSUMER_TITLE).toBe("Weekly Progress");
+    expect(WEEKLY_PROGRESS_SUPPORTING_COPY).toContain("fitness targets");
+  });
+});

--- a/lib/data/dash/__tests__/weeklyProgressV1.test.ts
+++ b/lib/data/dash/__tests__/weeklyProgressV1.test.ts
@@ -30,6 +30,16 @@ describe("computeWeeklyProgressV1", () => {
     expect(two.eligibleContributorCount).toBe(WEEKLY_PROGRESS_MIN_ELIGIBLE_CONTRIBUTORS);
   });
 
+  it("regression: insufficient eligible contributors → score remains null (missing is not zero)", () => {
+    const empty = computeWeeklyProgressV1([]);
+    expect(empty.score0to100).toBeNull();
+    expect(empty.eligibleContributorCount).toBe(0);
+
+    const singleTrustedZero = computeWeeklyProgressV1([{ key: "cardio", progress01: 0 }]);
+    expect(singleTrustedZero.score0to100).toBeNull();
+    expect(singleTrustedZero.eligibleContributorCount).toBe(1);
+  });
+
   it("includes trusted zero", () => {
     const r = computeWeeklyProgressV1([
       { key: "strength", progress01: 0 },

--- a/lib/data/dash/dashWeeklyProgressRelocation.ts
+++ b/lib/data/dash/dashWeeklyProgressRelocation.ts
@@ -1,0 +1,51 @@
+/**
+ * Dash Phase 1 — relocate the Weekly Fitness experience from Dash to Program
+ * as consumer-titled “Weekly Progress”.
+ *
+ * Convention mirrors `shouldEnableWorkoutPhysiologyV1`: typed helper with an
+ * env kill-switch / force-enable override. Default is ENABLED so Phase 1 lands
+ * on Program; set the override to `"0"` to restore Dash placement (rollback).
+ *
+ * Overrides:
+ * - `process.env.EXPO_PUBLIC_DASH_WEEKLY_PROGRESS_RELOCATION === "0"` → disabled
+ * - `process.env.EXPO_PUBLIC_DASH_WEEKLY_PROGRESS_RELOCATION === "1"` → enabled
+ *
+ * Tests may call {@link setDashWeeklyProgressRelocationEnabledForTests}.
+ */
+
+export const DASH_WEEKLY_PROGRESS_RELOCATION_ENV_KEY =
+  "EXPO_PUBLIC_DASH_WEEKLY_PROGRESS_RELOCATION" as const;
+
+/** Conceptual product id; env key is the runtime control surface. */
+export const DASH_WEEKLY_PROGRESS_RELOCATION_FLAG_ID =
+  "dashWeeklyProgressRelocation" as const;
+
+/** Consumer-visible title when the card is mounted under Program. */
+export const WEEKLY_PROGRESS_CONSUMER_TITLE = "Weekly Progress" as const;
+
+/** Consumer-visible title when the card remains on Dash (rollback path). */
+export const WEEKLY_FITNESS_CONSUMER_TITLE = "Weekly Fitness" as const;
+
+/** Supporting copy under Program — weekly targets, not active-program adherence. */
+export const WEEKLY_PROGRESS_SUPPORTING_COPY =
+  "Progress against this week’s fitness targets." as const;
+
+let testOverride: boolean | null = null;
+
+/**
+ * Test-only override. Pass `null` to clear and fall back to env/default.
+ * Production code must not call this.
+ */
+export function setDashWeeklyProgressRelocationEnabledForTests(
+  enabled: boolean | null,
+): void {
+  testOverride = enabled;
+}
+
+export function isDashWeeklyProgressRelocationEnabled(): boolean {
+  if (testOverride != null) return testOverride;
+  const override = process.env[DASH_WEEKLY_PROGRESS_RELOCATION_ENV_KEY];
+  if (override === "0") return false;
+  if (override === "1") return true;
+  return true;
+}

--- a/lib/data/dash/dashWeeklyProgressRelocation.ts
+++ b/lib/data/dash/dashWeeklyProgressRelocation.ts
@@ -9,6 +9,11 @@
  * Overrides:
  * - `process.env.EXPO_PUBLIC_DASH_WEEKLY_PROGRESS_RELOCATION === "0"` → disabled
  * - `process.env.EXPO_PUBLIC_DASH_WEEKLY_PROGRESS_RELOCATION === "1"` → enabled
+ * - unset / any other string → enabled (same as default / `"1"`)
+ *
+ * Non-secret. Value is embedded when Metro/EAS builds the JS bundle; changing
+ * it requires a cleared Metro reload or a new EAS Update / binary — it is not a
+ * server-side remote kill switch by itself. Documented in `.env.example`.
  *
  * Tests may call {@link setDashWeeklyProgressRelocationEnabledForTests}.
  */

--- a/lib/ui/dash/WeeklyFitnessCard.tsx
+++ b/lib/ui/dash/WeeklyFitnessCard.tsx
@@ -29,6 +29,18 @@ type Props = {
   hasUser: boolean;
   /** Route for the "My goal" pressable (Dash Weekly Fitness goals editor). */
   goalsHref: string;
+  /**
+   * Consumer-visible title. Defaults to “Weekly Fitness” for the Dash rollback path.
+   * Program relocation passes “Weekly Progress”.
+   */
+  title?: string;
+  /**
+   * Supporting line shown when ready (and not loading/error). When omitted, uses
+   * “This week’s results” (legacy Dash copy).
+   */
+  subtitle?: string;
+  /** Root accessibility label. Defaults to legacy “Weekly fitness card”. */
+  cardAccessibilityLabel?: string;
 };
 
 export function WeeklyFitnessCard({
@@ -37,6 +49,9 @@ export function WeeklyFitnessCard({
   model,
   hasUser,
   goalsHref,
+  title = "Weekly Fitness",
+  subtitle = "This week’s results",
+  cardAccessibilityLabel = "Weekly fitness card",
 }: Props): React.ReactElement {
   const router = useRouter();
 
@@ -48,10 +63,10 @@ export function WeeklyFitnessCard({
   const showRows = showHeroes;
 
   return (
-    <View style={styles.card} accessibilityLabel="Weekly fitness card">
+    <View style={styles.card} accessibilityLabel={cardAccessibilityLabel}>
       <View style={styles.headerRow}>
         <Text style={styles.title} accessibilityRole="header">
-          Weekly Fitness
+          {title}
         </Text>
         <Pressable
           accessibilityRole="button"
@@ -73,7 +88,7 @@ export function WeeklyFitnessCard({
       ) : null}
 
       {!loading && hasUser && error == null ? (
-        <Text style={styles.subtitle}>This week’s results</Text>
+        <Text style={styles.subtitle}>{subtitle}</Text>
       ) : null}
 
       {loading ? <Text style={styles.status}>Loading this week’s results…</Text> : null}

--- a/lib/ui/dash/WeeklyFitnessCardHost.tsx
+++ b/lib/ui/dash/WeeklyFitnessCardHost.tsx
@@ -1,0 +1,46 @@
+/**
+ * Single mount point for `useWeeklyFitnessCard` + `WeeklyFitnessCard`.
+ *
+ * Dash and Program must not both mount this host: the heavy multi-source hook
+ * must run from exactly one active location controlled by
+ * `isDashWeeklyProgressRelocationEnabled`.
+ */
+import React from "react";
+
+import { useAuth } from "@/lib/auth/AuthProvider";
+import { useWeeklyFitnessCard } from "@/lib/data/dash/useWeeklyFitnessCard";
+import {
+  WEEKLY_FITNESS_CONSUMER_TITLE,
+} from "@/lib/data/dash/dashWeeklyProgressRelocation";
+import { WeeklyFitnessCard } from "@/lib/ui/dash/WeeklyFitnessCard";
+
+export type WeeklyFitnessCardHostProps = {
+  /** Consumer-visible card title. Defaults to legacy Dash “Weekly Fitness”. */
+  title?: string;
+  /** Optional supporting line under the heroes (defaults to card built-in when omitted). */
+  subtitle?: string;
+  /** Root accessibility label. Defaults to legacy “Weekly fitness card”. */
+  cardAccessibilityLabel?: string;
+};
+
+export function WeeklyFitnessCardHost({
+  title = WEEKLY_FITNESS_CONSUMER_TITLE,
+  subtitle,
+  cardAccessibilityLabel,
+}: WeeklyFitnessCardHostProps): React.ReactElement {
+  const { user } = useAuth();
+  const weeklyFitness = useWeeklyFitnessCard();
+
+  return (
+    <WeeklyFitnessCard
+      loading={weeklyFitness.loading}
+      error={weeklyFitness.error}
+      model={weeklyFitness.model}
+      goalsHref={weeklyFitness.goalsHref}
+      hasUser={user != null}
+      title={title}
+      {...(subtitle != null ? { subtitle } : {})}
+      {...(cardAccessibilityLabel != null ? { cardAccessibilityLabel } : {})}
+    />
+  );
+}

--- a/lib/ui/dash/__tests__/WeeklyFitnessCard.test.tsx
+++ b/lib/ui/dash/__tests__/WeeklyFitnessCard.test.tsx
@@ -153,4 +153,34 @@ describe("WeeklyFitnessCard v2", () => {
     });
     expect(mockPush).toHaveBeenCalledWith(WEEKLY_FITNESS_ROUTES.goalsEditor);
   });
+
+  it("accepts Weekly Progress title and supporting copy without claiming adherence", () => {
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(
+        <WeeklyFitnessCard
+          loading={false}
+          error={null}
+          model={sampleModel}
+          hasUser
+          goalsHref={WEEKLY_FITNESS_ROUTES.goalsEditor}
+          title="Weekly Progress"
+          subtitle="Progress against this week’s fitness targets."
+          cardAccessibilityLabel="Weekly Progress card"
+        />,
+      );
+    });
+    const text = flatten(tree.root);
+    expect(text).toContain("Weekly Progress");
+    expect(text).toContain("Progress against this week’s fitness targets.");
+    expect(text).not.toContain("Weekly Fitness");
+    expect(text).not.toMatch(/adherence/i);
+    expect(text).not.toMatch(/health score/i);
+    expect(
+      tree.root.findAll(
+        (n) =>
+          (n.props as { accessibilityLabel?: string }).accessibilityLabel === "Weekly Progress card",
+      ).length,
+    ).toBe(1);
+  });
 });


### PR DESCRIPTION
## Summary
- Relocates the existing Weekly Fitness experience from Dash to the Program tab as consumer-titled **Weekly Progress**, gated by `EXPO_PUBLIC_DASH_WEEKLY_PROGRESS_RELOCATION`.
- Default/unset/`"1"` → Program placement; `"0"` → legacy Dash placement (rollback). Unexpected values behave as enabled.
- Preserves `computeWeeklyProgressV1`, route maps, body-goal coupling, and missing≠zero / null-on-insufficient semantics. Single `WeeklyFitnessCardHost` mounts the heavy `useWeeklyFitnessCard` hook.
- Documents the flag in `.env.example` (non-secret; bundle-time / build-or-update delivery — not a remote server kill switch).

## Automated verification
- Implementation base: `098c013` (`origin/main` unchanged through this PR head).
- Commits: `0cc4a1e` (tests/flag contract), `a570974` (relocation), `a5b8b2e` (docs).
- Prior green CI-equivalent on implementation: **831 suites / 5184 tests**.
- Re-run after docs: `typecheck` pass, `lint` pass, focused relocation tests **10 suites / 69 tests** pass.
- Diff boundary: no Timeline / Firestore / schema / DailyFacts / scoring / classifications / lockfile changes.

## Signed-in iOS runtime verification
### Proven in this gate
- Native iOS Debug build **Succeeded** (`expo run:ios --scheme oli`, iPhone 16 Pro simulator).
- App **installed and launched** (`com.olifitness.oli`).
- Metro started with `EXPO_PUBLIC_DASH_WEEKLY_PROGRESS_RELOCATION=1` (present in loaded `.env.local`).
- JS bundle loaded: `iOS Bundled … expo-router/entry.js (2431 modules)` with subsequent fast reloads; **no RedBox / Unable to resolve / TypeError** in Metro log for the app entry.
- Expo Dev Client sees `http://localhost:8081` as reachable (green).

### Blocked (human follow-up required)
Could **not** complete signed-in Dash/Program/accessibility/flag-off UI smoke in this agent environment:
1. iPhone 16 Pro blocked by macOS **Apple Account Verification** system alert (Automation to System Events unauthorized for the agent: `-1743`).
2. Expo Dev Client **“Open in Oli?”** confirmation could not be reliably accepted via injected mouse events (Simulator did not receive device taps).
3. Fresh simulators have **no restored Firebase Auth session**; no credentials were embedded (per constraints).

Therefore VoiceOver, Dynamic Type, contributor navigation, focus/request single-orchestration, and flag-off rollback were **not** observed on a signed-in tab shell in this run. Automated tests cover flag on/off composition, single-hook consumer, copy hygiene, and score-null regressions.

## Operational rollback
1. Set `EXPO_PUBLIC_DASH_WEEKLY_PROGRESS_RELOCATION=0` in the environment used for the Metro/EAS bundle or EAS Update.
2. Rebuild / regenerate JS with cleared cache, or ship a new EAS Update / binary that embeds `"0"`.
3. Fully reload the development client / app so the baked value applies.
4. Confirm Dash shows legacy **Weekly Fitness** once and Program does not show **Weekly Progress**.

This is **not** an immediate remote server kill switch without a new client artifact/update.

## Test plan
- [ ] Human: signed-in iOS sim/device, flag=`1` — Dash lacks Weekly Fitness; Program shows Weekly Progress once with exact title/supporting copy; rows navigate; loading/null score honest; Timeline unchanged.
- [ ] Human: VoiceOver + large Dynamic Type + 44pt targets on Program Weekly Progress.
- [ ] Human: stop Metro; restart with flag=`0` + `--clear`; confirm Dash legacy placement and no Program duplicate.
- [ ] CI: green on this PR.

## Remaining risks
- Default-on changes Dash/Program IA on merge until rolled back via env+reload/update.
- Signed-in UI soak still pending human runtime (this draft).

Made with [Cursor](https://cursor.com)