### PR TITLE
feat(dash): add daily monitor foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,14 @@ EXPO_PUBLIC_GATEWAY_API_KEY=
 #   unset or "1" → enabled: Weekly Progress mounted under Program; absent from Dash.
 #   "0"          → rollback: legacy Weekly Fitness mounted under Dash; absent from Program.
 #   Any other value behaves as enabled (same as unset/"1").
+#
+# EXPO_PUBLIC_DASH_DAILY_MONITOR_FOUNDATION=1
+#   Dash Phase 2C — Daily Monitor foundation.
+#   unset or "1" → enabled candidate (Daily Monitor only when Weekly Progress relocation is also enabled).
+#   "0"          → rollback: legacy Dash presentation (post–Phase 1 or full legacy depending on relocation).
+#   Any other value behaves as enabled (same as unset/"1").
+#   When Daily Monitor is ON and Weekly Progress relocation is OFF, the app falls back to legacy Dash
+#   (no Daily Monitor + Weekly Fitness hybrid). Non-secret; baked into the JS bundle — not a remote kill switch.
 
 # Optional dev-only diagnostics (never enable in production builds you ship)
 # EXPO_PUBLIC_DEBUG_API_BASE_URL=1   # logs EXPO_PUBLIC_BACKEND_BASE_URL once per authed request

--- a/app/(app)/(tabs)/__tests__/dash-accessibility.test.tsx
+++ b/app/(app)/(tabs)/__tests__/dash-accessibility.test.tsx
@@ -5,6 +5,7 @@ import React, { act } from "react";
 import renderer from "react-test-renderer";
 
 import { setDashWeeklyProgressRelocationEnabledForTests } from "@/lib/data/dash/dashWeeklyProgressRelocation";
+import { setDashDailyMonitorFoundationEnabledForTests } from "@/lib/data/dash/dashDailyMonitorFoundation";
 
 const mockUseTodayHealthHero = jest.fn();
 jest.mock("@/lib/hooks/useTodayHealthHero", () => ({
@@ -40,6 +41,7 @@ const mockUseBodyCompositionDashCard = jest.fn(() => ({
   error: null,
   hasUser: true,
   goalsHref: "/(app)/body/settings",
+    overviewDay: "2026-05-11",
   built: {
     tag: "ready" as const,
     weightPrimaryLabel: "159.3 lb",
@@ -171,6 +173,7 @@ function findPressablesWithLabel(
 
 describe("Dash accessibility", () => {
   beforeEach(() => {
+    setDashDailyMonitorFoundationEnabledForTests(false);
     setDashWeeklyProgressRelocationEnabledForTests(true);
     mockUseTodayHealthHero.mockReset();
     mockUseTodayHealthHero.mockReturnValue({
@@ -190,6 +193,7 @@ describe("Dash accessibility", () => {
       error: null,
       hasUser: true,
       goalsHref: "/(app)/body/settings",
+    overviewDay: "2026-05-11",
       built: {
         tag: "ready" as const,
         weightPrimaryLabel: "159.3 lb",
@@ -224,6 +228,7 @@ describe("Dash accessibility", () => {
 
   afterEach(() => {
     setDashWeeklyProgressRelocationEnabledForTests(null);
+    setDashDailyMonitorFoundationEnabledForTests(null);
   });
 
   it("exposes accessibilityLabel on settings initial button", () => {

--- a/app/(app)/(tabs)/__tests__/dash-composition.test.tsx
+++ b/app/(app)/(tabs)/__tests__/dash-composition.test.tsx
@@ -5,6 +5,7 @@
 import React, { act } from "react";
 import renderer from "react-test-renderer";
 
+import { setDashDailyMonitorFoundationEnabledForTests } from "@/lib/data/dash/dashDailyMonitorFoundation";
 import { setDashWeeklyProgressRelocationEnabledForTests } from "@/lib/data/dash/dashWeeklyProgressRelocation";
 
 const mockUseTodayHealthHero = jest.fn();
@@ -42,6 +43,7 @@ jest.mock("@/lib/data/dash/useBodyCompositionDashCard", () => ({
     error: null,
     hasUser: true,
     goalsHref: "/(app)/body/settings",
+    overviewDay: "2026-05-11",
     built: {
       tag: "ready" as const,
       weightPrimaryLabel: "159.3 lb",
@@ -162,6 +164,7 @@ function countOccurrences(haystack: string, needle: string): number {
 
 describe("Dash composition clean baseline", () => {
   beforeEach(() => {
+    setDashDailyMonitorFoundationEnabledForTests(false);
     setDashWeeklyProgressRelocationEnabledForTests(true);
     mockUseTodayHealthHero.mockReset();
     mockUseTodayHealthHero.mockReturnValue({
@@ -180,6 +183,7 @@ describe("Dash composition clean baseline", () => {
 
   afterEach(() => {
     setDashWeeklyProgressRelocationEnabledForTests(null);
+    setDashDailyMonitorFoundationEnabledForTests(null);
   });
 
   it("removes Today progress hero/card and keeps state cards in order (relocation enabled)", () => {

--- a/app/(app)/(tabs)/__tests__/dash-provenance.test.tsx
+++ b/app/(app)/(tabs)/__tests__/dash-provenance.test.tsx
@@ -5,6 +5,7 @@ import React, { act } from "react";
 import renderer from "react-test-renderer";
 
 import { setDashWeeklyProgressRelocationEnabledForTests } from "@/lib/data/dash/dashWeeklyProgressRelocation";
+import { setDashDailyMonitorFoundationEnabledForTests } from "@/lib/data/dash/dashDailyMonitorFoundation";
 
 const mockUseTodayHealthHero = jest.fn();
 jest.mock("@/lib/hooks/useTodayHealthHero", () => ({
@@ -41,6 +42,7 @@ jest.mock("@/lib/data/dash/useBodyCompositionDashCard", () => ({
     error: null,
     hasUser: true,
     goalsHref: "/(app)/body/settings",
+    overviewDay: "2026-05-11",
     built: {
       tag: "ready" as const,
       weightPrimaryLabel: "159.3 lb",
@@ -151,6 +153,7 @@ function countDashIconPlaceholders(root: renderer.ReactTestInstance): number {
 
 describe("Dash provenance", () => {
   beforeEach(() => {
+    setDashDailyMonitorFoundationEnabledForTests(false);
     setDashWeeklyProgressRelocationEnabledForTests(true);
     mockUseTodayHealthHero.mockReset();
     mockUseTodayHealthHero.mockReturnValue({
@@ -182,6 +185,7 @@ describe("Dash provenance", () => {
 
   afterEach(() => {
     setDashWeeklyProgressRelocationEnabledForTests(null);
+    setDashDailyMonitorFoundationEnabledForTests(null);
   });
 
   it("shows Oli Fitness tab title and Body Composition + Daily Energy sections", () => {

--- a/app/(app)/(tabs)/__tests__/dash-recap.test.tsx
+++ b/app/(app)/(tabs)/__tests__/dash-recap.test.tsx
@@ -236,7 +236,7 @@ describe("Dash Daily Energy card", () => {
     expect(text).toContain("2,120–2,480 kcal");
     expect(text).toContain("BMR");
     expect(text).toContain("NEAT");
-    expect(text).toContain("Estimated");
+    expect(text).not.toContain("Estimated");
     expect(text).not.toContain("Estimated burn today");
     expect(text).not.toContain("Confidence");
     expect(text).toContain("Daily Sleep");

--- a/app/(app)/(tabs)/__tests__/dash-recap.test.tsx
+++ b/app/(app)/(tabs)/__tests__/dash-recap.test.tsx
@@ -5,6 +5,7 @@ import React, { act } from "react";
 import renderer from "react-test-renderer";
 
 import { setDashWeeklyProgressRelocationEnabledForTests } from "@/lib/data/dash/dashWeeklyProgressRelocation";
+import { setDashDailyMonitorFoundationEnabledForTests } from "@/lib/data/dash/dashDailyMonitorFoundation";
 
 
 jest.mock("react-native", () => ({
@@ -92,6 +93,7 @@ const mockUseBodyCompositionDashCard = jest.fn(() => ({
   error: null,
   hasUser: true,
   goalsHref: "/(app)/body/settings",
+    overviewDay: "2026-05-11",
   built: {
     tag: "ready" as const,
     weightPrimaryLabel: "159.3 lb",
@@ -174,12 +176,14 @@ function collectAllText(test: renderer.ReactTestRenderer): string {
 
 describe("Dash Daily Energy card", () => {
   beforeEach(() => {
+    setDashDailyMonitorFoundationEnabledForTests(false);
     setDashWeeklyProgressRelocationEnabledForTests(true);
     mockUseTodayHealthHero.mockReset();
   });
 
   afterEach(() => {
     setDashWeeklyProgressRelocationEnabledForTests(null);
+    setDashDailyMonitorFoundationEnabledForTests(null);
   });
 
   it("renders Body Composition first (relocation) and removes Sleep/Recovery summary", () => {

--- a/app/(app)/(tabs)/__tests__/dash-recap.test.tsx
+++ b/app/(app)/(tabs)/__tests__/dash-recap.test.tsx
@@ -236,7 +236,9 @@ describe("Dash Daily Energy card", () => {
     expect(text).toContain("2,120–2,480 kcal");
     expect(text).toContain("BMR");
     expect(text).toContain("NEAT");
-    expect(text).toContain("Confidence");
+    expect(text).toContain("Estimated");
+    expect(text).toContain("Estimated burn today");
+    expect(text).not.toContain("Confidence");
     expect(text).toContain("Daily Sleep");
     expect(text).toContain("Oura Readiness");
 

--- a/app/(app)/(tabs)/__tests__/dash-recap.test.tsx
+++ b/app/(app)/(tabs)/__tests__/dash-recap.test.tsx
@@ -237,7 +237,7 @@ describe("Dash Daily Energy card", () => {
     expect(text).toContain("BMR");
     expect(text).toContain("NEAT");
     expect(text).toContain("Estimated");
-    expect(text).toContain("Estimated burn today");
+    expect(text).not.toContain("Estimated burn today");
     expect(text).not.toContain("Confidence");
     expect(text).toContain("Daily Sleep");
     expect(text).toContain("Oura Readiness");

--- a/app/(app)/(tabs)/__tests__/tabs-navigation.test.tsx
+++ b/app/(app)/(tabs)/__tests__/tabs-navigation.test.tsx
@@ -145,6 +145,12 @@ jest.mock("expo-router", () => {
 });
 
 import { UI_APP_SCREEN_BG } from "@/lib/ui/theme/uiTokens";
+import {
+  DAILY_MONITOR_TAB_A11Y_LABEL,
+  DAILY_MONITOR_TAB_TITLE,
+  setDashDailyMonitorFoundationEnabledForTests,
+} from "@/lib/data/dash/dashDailyMonitorFoundation";
+import { setDashWeeklyProgressRelocationEnabledForTests } from "@/lib/data/dash/dashWeeklyProgressRelocation";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const layoutModule = require("../_layout");
@@ -170,6 +176,11 @@ function findTabs(test: renderer.ReactTestRenderer): { name: string; title: stri
 }
 
 describe("TabsLayout", () => {
+  afterEach(() => {
+    setDashDailyMonitorFoundationEnabledForTests(null);
+    setDashWeeklyProgressRelocationEnabledForTests(null);
+  });
+
   it("has initialRouteName dash", () => {
     let test!: renderer.ReactTestRenderer;
 
@@ -181,7 +192,10 @@ describe("TabsLayout", () => {
     expect(tabsNode.props["data-initial-route"]).toBe("dash");
   });
 
-  it("registers four primary tabs in order (Dash, Timeline, Program, Library)", () => {
+  it("registers four primary tabs in order (route identity preserved)", () => {
+    setDashDailyMonitorFoundationEnabledForTests(true);
+    setDashWeeklyProgressRelocationEnabledForTests(true);
+
     let test!: renderer.ReactTestRenderer;
 
     act(() => {
@@ -193,7 +207,43 @@ describe("TabsLayout", () => {
     expect(names).toEqual(["dash", "timeline", "program", "library"]);
 
     const primaryTitles = tabs.map((t) => t.title);
-    expect(primaryTitles).toEqual(["Dash", "Timeline", "Program", "Library"]);
+    expect(primaryTitles).toEqual([
+      DAILY_MONITOR_TAB_TITLE,
+      "Timeline",
+      "Program",
+      "Library",
+    ]);
+  });
+
+  it("uses legacy Dash tab title when Daily Monitor experience is inactive", () => {
+    setDashDailyMonitorFoundationEnabledForTests(false);
+    setDashWeeklyProgressRelocationEnabledForTests(true);
+
+    let test!: renderer.ReactTestRenderer;
+    act(() => {
+      test = renderer.create(<TabsLayout />);
+    });
+
+    expect(findTabs(test).map((t) => t.title)).toEqual([
+      "Dash",
+      "Timeline",
+      "Program",
+      "Library",
+    ]);
+  });
+
+  it("exposes Daily Monitor accessibility label while keeping route name dash", () => {
+    setDashDailyMonitorFoundationEnabledForTests(true);
+    setDashWeeklyProgressRelocationEnabledForTests(true);
+    // Re-require is unnecessary; layout reads flags at render time.
+    let test!: renderer.ReactTestRenderer;
+    act(() => {
+      test = renderer.create(<TabsLayout />);
+    });
+    const dash = findTabs(test).find((t) => t.name === "dash");
+    expect(dash?.name).toBe("dash");
+    expect(dash?.title).toBe(DAILY_MONITOR_TAB_TITLE);
+    expect(DAILY_MONITOR_TAB_A11Y_LABEL).toBe("Daily Monitor");
   });
 
   it("does not register Profile as a bottom nav tab", () => {

--- a/app/(app)/(tabs)/__tests__/weekly-progress-relocation.test.tsx
+++ b/app/(app)/(tabs)/__tests__/weekly-progress-relocation.test.tsx
@@ -11,6 +11,7 @@ import {
   WEEKLY_PROGRESS_CONSUMER_TITLE,
   WEEKLY_PROGRESS_SUPPORTING_COPY,
 } from "@/lib/data/dash/dashWeeklyProgressRelocation";
+import { setDashDailyMonitorFoundationEnabledForTests } from "@/lib/data/dash/dashDailyMonitorFoundation";
 import { WEEKLY_FITNESS_ROUTES } from "@/lib/data/dash/weeklyFitnessRoutes";
 
 const mockUseWeeklyFitnessCard = jest.fn();
@@ -54,6 +55,7 @@ jest.mock("@/lib/data/dash/useBodyCompositionDashCard", () => ({
     error: null,
     hasUser: true,
     goalsHref: "/(app)/body/settings",
+    overviewDay: "2026-05-11",
     built: {
       tag: "ready" as const,
       weightPrimaryLabel: "159.3 lb",
@@ -205,6 +207,7 @@ const sampleModel = {
 
 describe("Weekly Progress relocation", () => {
   beforeEach(() => {
+    setDashDailyMonitorFoundationEnabledForTests(false);
     mockPush.mockClear();
     mockUseWeeklyFitnessCard.mockReset();
     mockUseWeeklyFitnessCard.mockReturnValue({
@@ -230,6 +233,7 @@ describe("Weekly Progress relocation", () => {
 
   afterEach(() => {
     setDashWeeklyProgressRelocationEnabledForTests(null);
+    setDashDailyMonitorFoundationEnabledForTests(null);
   });
 
   it("enabled: Program shows Weekly Progress; Dash does not; hook mounts once", () => {
@@ -318,12 +322,16 @@ describe("Weekly Progress relocation", () => {
   it("source guards: screens do not call Firebase/API; only the host imports the heavy hook", () => {
     const dashSrc = fs.readFileSync(path.join(__dirname, "..", "dash.tsx"), "utf8");
     const programSrc = fs.readFileSync(path.join(__dirname, "..", "program.tsx"), "utf8");
+    const legacyDashHostSrc = fs.readFileSync(
+      path.join(__dirname, "../../../../components/dashboard/LegacyDashHost.tsx"),
+      "utf8",
+    );
     const hostSrc = fs.readFileSync(
       path.join(__dirname, "../../../../lib/ui/dash/WeeklyFitnessCardHost.tsx"),
       "utf8",
     );
 
-    for (const src of [dashSrc, programSrc]) {
+    for (const src of [dashSrc, programSrc, legacyDashHostSrc]) {
       expect(src).not.toMatch(/\bfetch\s*\(/);
       expect(src).not.toMatch(/from\s+["'][^"']*firebase[^"']*["']/i);
       expect(src).not.toMatch(/from\s+["'][^"']*lib\/api\/http["']/);
@@ -331,7 +339,8 @@ describe("Weekly Progress relocation", () => {
       expect(src).not.toContain("useWeeklyFitnessCard");
     }
     expect(hostSrc).toContain("useWeeklyFitnessCard");
-    expect(dashSrc).toContain("WeeklyFitnessCardHost");
+    expect(dashSrc).toContain("LegacyDashHost");
+    expect(legacyDashHostSrc).toContain("WeeklyFitnessCardHost");
     expect(programSrc).toContain("WeeklyFitnessCardHost");
   });
 

--- a/app/(app)/(tabs)/_layout.tsx
+++ b/app/(app)/(tabs)/_layout.tsx
@@ -9,6 +9,13 @@ import {
   ManageNavigationProvider,
   useManageNavigation,
 } from "@/components/navigation/ManageNavigationContext";
+import {
+  DAILY_MONITOR_TAB_A11Y_LABEL,
+  DAILY_MONITOR_TAB_TITLE,
+  isDashDailyMonitorFoundationEnabled,
+} from "@/lib/data/dash/dashDailyMonitorFoundation";
+import { isDashWeeklyProgressRelocationEnabled } from "@/lib/data/dash/dashWeeklyProgressRelocation";
+import { resolveDashExperienceMode } from "@/lib/data/dash/resolveDashExperienceMode";
 import { UI_APP_SCREEN_BG, UI_NAV_TAB_ICON_ACTIVE, UI_NAV_TAB_ICON_INACTIVE } from "@/lib/ui/theme/uiTokens";
 import { ThemeProvider } from "@react-navigation/native";
 import { createOliTabNavigationTheme } from "@/lib/ui/theme/oliTheme";
@@ -57,6 +64,13 @@ function OliTabBar(props: BottomTabBarProps) {
 
 function TabsLayoutInner() {
   const tabTheme = useMemo(() => createOliTabNavigationTheme(), []);
+  const dashExperience = resolveDashExperienceMode({
+    dailyMonitorEnabled: isDashDailyMonitorFoundationEnabled(),
+    weeklyProgressRelocationEnabled: isDashWeeklyProgressRelocationEnabled(),
+  });
+  const dashTabTitle = dashExperience === "daily_monitor" ? DAILY_MONITOR_TAB_TITLE : "Dash";
+  const dashTabA11y =
+    dashExperience === "daily_monitor" ? DAILY_MONITOR_TAB_A11Y_LABEL : "Dash";
 
   return (
     <View style={{ flex: 1, backgroundColor: UI_APP_SCREEN_BG }}>
@@ -65,8 +79,8 @@ function TabsLayoutInner() {
           <Tabs.Screen
             name="dash"
             options={{
-              title: "Dash",
-              tabBarAccessibilityLabel: "Dash",
+              title: dashTabTitle,
+              tabBarAccessibilityLabel: dashTabA11y,
               tabBarIcon: ({ color, size, focused }) => (
                 <Ionicons name={focused ? "home" : "home-outline"} size={size ?? 24} color={color} />
               ),

--- a/app/(app)/(tabs)/dash.tsx
+++ b/app/(app)/(tabs)/dash.tsx
@@ -1,106 +1,19 @@
 // app/(app)/(tabs)/dash.tsx
-// Oli — Dash: header + retained module cards (current health/fitness state).
-// Weekly Fitness / Weekly Progress placement is controlled by
-// `isDashWeeklyProgressRelocationEnabled` (Program when enabled; Dash when disabled).
+// Oli — Dash tab: Daily Monitor (Phase 2C) or legacy Dash composition.
+// Only one experience host mounts so inactive-host hooks never run.
 import React from "react";
-import { ScrollView, View, StyleSheet } from "react-native";
-import { useFocusEffect, useRouter } from "expo-router";
+
+import { resolveDashExperienceModeFromFlags } from "@/lib/data/dash/resolveDashExperienceMode";
+import { DailyMonitorHost } from "@/components/dashboard/DailyMonitorHost";
+import { LegacyDashHost } from "@/components/dashboard/LegacyDashHost";
 import { ScreenContainer } from "@/lib/ui/ScreenStates";
-import { DashScreenHeader } from "@/components/dashboard/DashScreenHeader";
-import { UI_APP_SCREEN_BG, UI_TAB_ROOT_INSET } from "@/lib/ui/theme/uiTokens";
-import { useFloatingTabBarScrollPadding } from "@/lib/ui/navigation/useFloatingTabBarScrollPadding";
-import { useAuth } from "@/lib/auth/AuthProvider";
-import { useBodyCompositionDashCard } from "@/lib/data/dash/useBodyCompositionDashCard";
-import { useDailyNutritionCard } from "@/lib/data/dash/useDailyNutritionCard";
-import { isDashWeeklyProgressRelocationEnabled } from "@/lib/data/dash/dashWeeklyProgressRelocation";
-import { useTodayHealthHero } from "@/lib/hooks/useTodayHealthHero";
-import { useDailyReadinessCard } from "@/lib/hooks/useDailyReadinessCard";
-import { BodyCompositionCard } from "@/lib/ui/dash/BodyCompositionCard";
-import { DailyEnergyCard } from "@/lib/ui/dash/DailyEnergyCard";
-import { DailyReadinessCard } from "@/lib/ui/dash/DailyReadinessCard";
-import { DailySleepCard } from "@/lib/ui/dash/DailySleepCard";
-import { DailyNutritionCard } from "@/lib/ui/dash/DailyNutritionCard";
-import { WeeklyFitnessCardHost } from "@/lib/ui/dash/WeeklyFitnessCardHost";
-import { getTodayDayKeyLocal } from "@/lib/ui/calendar/dateUtils";
 
 export default function DashScreen() {
-  const router = useRouter();
-  const scrollPaddingBottom = useFloatingTabBarScrollPadding(40);
-  const { user } = useAuth();
-  const todayKey = getTodayDayKeyLocal();
-  const showWeeklyFitnessOnDash = !isDashWeeklyProgressRelocationEnabled();
-  const {
-    energy,
-    energyLoading,
-    energyError,
-    sleepCardVm,
-    exactDayRestingHeartRateBpm,
-    refetch,
-  } = useTodayHealthHero(todayKey);
-  const readinessCard = useDailyReadinessCard(todayKey, {
-    enabled: Boolean(user),
-    exactDayRestingHeartRateBpm,
-  });
-  const bodyComposition = useBodyCompositionDashCard();
-  const dailyNutrition = useDailyNutritionCard(todayKey);
-
-  useFocusEffect(
-    React.useCallback(() => {
-      refetch({ cacheBust: "dashEnergyFocus" });
-      readinessCard.refetch({ cacheBust: "dashReadinessFocus" });
-    }, [refetch, readinessCard.refetch]),
-  );
+  const mode = resolveDashExperienceModeFromFlags();
 
   return (
     <ScreenContainer padded={false}>
-      <View style={styles.root}>
-        <DashScreenHeader />
-        <ScrollView
-          style={styles.scrollView}
-          contentContainerStyle={[styles.scroll, { paddingBottom: scrollPaddingBottom }]}
-          keyboardShouldPersistTaps="handled"
-          showsVerticalScrollIndicator={false}
-        >
-          <View style={styles.stacksSection}>
-            {showWeeklyFitnessOnDash ? <WeeklyFitnessCardHost /> : null}
-            <BodyCompositionCard
-              loading={bodyComposition.loading}
-              error={bodyComposition.error}
-              hasUser={bodyComposition.hasUser}
-              goalsHref={bodyComposition.goalsHref}
-              built={bodyComposition.built}
-            />
-
-            <DailyEnergyCard energy={energy} loading={energyLoading} error={energyError} />
-            <DailySleepCard vm={sleepCardVm} />
-            <DailyReadinessCard vm={readinessCard.vm} />
-            <DailyNutritionCard
-              model={dailyNutrition.model}
-              loading={dailyNutrition.loading}
-              error={dailyNutrition.error}
-              onPress={() => router.push("/(app)/nutrition")}
-            />
-          </View>
-        </ScrollView>
-      </View>
+      {mode === "daily_monitor" ? <DailyMonitorHost /> : <LegacyDashHost />}
     </ScreenContainer>
   );
 }
-
-const styles = StyleSheet.create({
-  root: {
-    flex: 1,
-    backgroundColor: UI_APP_SCREEN_BG,
-  },
-  scrollView: {
-    flex: 1,
-    backgroundColor: UI_APP_SCREEN_BG,
-  },
-  scroll: {
-    paddingHorizontal: UI_TAB_ROOT_INSET,
-    paddingTop: 0,
-    flexGrow: 1,
-    backgroundColor: UI_APP_SCREEN_BG,
-  },
-  stacksSection: {},
-});

--- a/components/dashboard/DailyMonitorHost.tsx
+++ b/components/dashboard/DailyMonitorHost.tsx
@@ -15,6 +15,8 @@ import {
 import { buildDailyMonitorViewModel } from "@/lib/data/dash/buildDailyMonitorViewModel";
 import { useBodyCompositionDashCard } from "@/lib/data/dash/useBodyCompositionDashCard";
 import { useDailyNutritionCard } from "@/lib/data/dash/useDailyNutritionCard";
+import { useDailyMonitorActivityCard } from "@/lib/data/dash/useDailyMonitorActivityCard";
+import { useDailyMonitorSessionCards } from "@/lib/data/dash/useDailyMonitorSessionCards";
 import {
   resolveBodyCompositionMonitorPresence,
   resolveEnergyMonitorPresence,
@@ -32,6 +34,11 @@ import { DailyEnergyCard } from "@/lib/ui/dash/DailyEnergyCard";
 import { DailyNutritionCard } from "@/lib/ui/dash/DailyNutritionCard";
 import { DailyReadinessCard } from "@/lib/ui/dash/DailyReadinessCard";
 import { DailySleepCard } from "@/lib/ui/dash/DailySleepCard";
+import {
+  DailyMonitorActivityCard,
+  DailyMonitorCardioCard,
+  DailyMonitorWorkoutCard,
+} from "@/lib/ui/dash/DailyMonitorDomainCards";
 import { useFloatingTabBarScrollPadding } from "@/lib/ui/navigation/useFloatingTabBarScrollPadding";
 import { EmptyState, ErrorState } from "@/lib/ui/ScreenStates";
 import {
@@ -65,9 +72,14 @@ export function DailyMonitorHost(): React.ReactElement {
   });
   const bodyComposition = useBodyCompositionDashCard();
   const dailyNutrition = useDailyNutritionCard(dayKey);
+  const activityCard = useDailyMonitorActivityCard(dayKey);
+  const sessionCards = useDailyMonitorSessionCards(dayKey);
 
   const sleepPresence = resolveSleepMonitorPresence(sleepCardVm);
   const readinessPresence = resolveReadinessMonitorPresence(readinessCard.vm);
+  const activityPresence = activityCard.presence;
+  const workoutPresence = sessionCards.workoutPresence;
+  const cardioPresence = sessionCards.cardioPresence;
   const energyPresence = resolveEnergyMonitorPresence({
     energy,
     loading: energyLoading,
@@ -97,6 +109,9 @@ export function DailyMonitorHost(): React.ReactElement {
         domains: [
           { domainId: "sleep", presence: sleepPresence },
           { domainId: "readiness", presence: readinessPresence },
+          { domainId: "activity", presence: activityPresence },
+          { domainId: "workout", presence: workoutPresence },
+          { domainId: "cardio", presence: cardioPresence },
           { domainId: "energy", presence: energyPresence },
           { domainId: "nutrition", presence: nutritionPresence },
           { domainId: "body_composition", presence: bodyPresence },
@@ -108,6 +123,9 @@ export function DailyMonitorHost(): React.ReactElement {
       user,
       sleepPresence,
       readinessPresence,
+      activityPresence,
+      workoutPresence,
+      cardioPresence,
       energyPresence,
       nutritionPresence,
       bodyPresence,
@@ -115,8 +133,9 @@ export function DailyMonitorHost(): React.ReactElement {
   );
 
   const onRetry = useCallback(() => {
-    refetch({ cacheBust: `dailyMonitorRetry:${Date.now()}` });
-    readinessCard.refetch({ cacheBust: `dailyMonitorRetry:${Date.now()}` });
+    const bust = `dailyMonitorRetry:${Date.now()}`;
+    refetch({ cacheBust: bust });
+    readinessCard.refetch({ cacheBust: bust });
   }, [refetch, readinessCard.refetch]);
 
   useFocusEffect(
@@ -128,6 +147,9 @@ export function DailyMonitorHost(): React.ReactElement {
 
   const showSleep = presenceCreatesMainStackCard(sleepPresence);
   const showReadiness = presenceCreatesMainStackCard(readinessPresence);
+  const showActivity = presenceCreatesMainStackCard(activityPresence);
+  const showWorkout = presenceCreatesMainStackCard(workoutPresence);
+  const showCardio = presenceCreatesMainStackCard(cardioPresence);
   const showEnergy = presenceCreatesMainStackCard(energyPresence);
   const showNutrition = presenceCreatesMainStackCard(nutritionPresence);
   const showBody = presenceCreatesMainStackCard(bodyPresence);
@@ -206,7 +228,7 @@ export function DailyMonitorHost(): React.ReactElement {
         ) : null}
 
         {monitorVm.sections.map((section) => (
-          <View key={section.id} style={styles.section} accessibilityRole="header">
+          <View key={section.id} style={styles.section}>
             <Text
               style={styles.sectionTitle}
               accessibilityRole="header"
@@ -225,14 +247,31 @@ export function DailyMonitorHost(): React.ReactElement {
             {section.domainIds.includes("readiness") && showReadiness ? (
               <DailyReadinessCard vm={readinessCard.vm} title="Readiness" />
             ) : null}
+            {section.domainIds.includes("activity") && showActivity && activityCard.model != null ? (
+              <DailyMonitorActivityCard model={activityCard.model} href={activityCard.href} />
+            ) : null}
+            {section.domainIds.includes("workout") &&
+            showWorkout &&
+            sessionCards.workoutModel != null ? (
+              <DailyMonitorWorkoutCard
+                model={sessionCards.workoutModel}
+                href={sessionCards.workoutHref}
+              />
+            ) : null}
+            {section.domainIds.includes("cardio") &&
+            showCardio &&
+            sessionCards.cardioModel != null ? (
+              <DailyMonitorCardioCard
+                model={sessionCards.cardioModel}
+                href={sessionCards.cardioHref}
+              />
+            ) : null}
             {section.domainIds.includes("energy") && showEnergy ? (
               <DailyEnergyCard
                 energy={energy}
                 loading={false}
                 error={
-                  energyPresence === "refresh_error_with_cached_day_evidence"
-                    ? energyError
-                    : null
+                  energyPresence === "refresh_error_with_cached_day_evidence" ? energyError : null
                 }
                 title="Energy Expenditure"
               />
@@ -253,7 +292,6 @@ export function DailyMonitorHost(): React.ReactElement {
                 hasUser={bodyComposition.hasUser}
                 goalsHref={bodyComposition.goalsHref}
                 built={bodyComposition.built}
-                /** Same-day reading — omit prior-day “As of …” carry-forward copy. */
                 suppressAsOfLabel
               />
             ) : null}

--- a/components/dashboard/DailyMonitorHost.tsx
+++ b/components/dashboard/DailyMonitorHost.tsx
@@ -75,7 +75,7 @@ export function DailyMonitorHost(): React.ReactElement {
   const bodyComposition = useBodyCompositionDashCard();
   const dailyNutrition = useDailyNutritionCard(dayKey);
   const activityCard = useDailyMonitorActivityCard(dayKey);
-  const sessionCards = useDailyMonitorSessionCards(dayKey);
+  const sessionCards = useDailyMonitorSessionCards(dayKey, energy);
   const stressCard = useDailyMonitorStressCard(dayKey);
 
   const sleepPresence = resolveSleepMonitorPresence(sleepCardVm);

--- a/components/dashboard/DailyMonitorHost.tsx
+++ b/components/dashboard/DailyMonitorHost.tsx
@@ -1,0 +1,312 @@
+/**
+ * Daily Monitor host — presence-driven current-day cards only (Phase 2C).
+ */
+
+import React, { useCallback, useMemo } from "react";
+import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+import { useFocusEffect, useRouter } from "expo-router";
+
+import { DashScreenHeader } from "@/components/dashboard/DashScreenHeader";
+import { useAuth } from "@/lib/auth/AuthProvider";
+import {
+  DAILY_MONITOR_SCREEN_TITLE,
+} from "@/lib/data/dash/dashDailyMonitorFoundation";
+import { buildDailyMonitorViewModel } from "@/lib/data/dash/buildDailyMonitorViewModel";
+import { useBodyCompositionDashCard } from "@/lib/data/dash/useBodyCompositionDashCard";
+import { useDailyNutritionCard } from "@/lib/data/dash/useDailyNutritionCard";
+import {
+  resolveBodyCompositionMonitorPresence,
+  resolveEnergyMonitorPresence,
+  resolveNutritionMonitorPresence,
+  resolveReadinessMonitorPresence,
+  resolveSleepMonitorPresence,
+} from "@/lib/data/dash/resolveDailyMonitorDomainPresence";
+import { presenceCreatesMainStackCard } from "@/lib/data/dash/dailyMonitorPresence";
+import { useCurrentLocalDayKey } from "@/lib/hooks/useCurrentLocalDayKey";
+import { useDailyReadinessCard } from "@/lib/hooks/useDailyReadinessCard";
+import { useTodayHealthHero } from "@/lib/hooks/useTodayHealthHero";
+import { formatDayKeyStackNavTitle } from "@/lib/ui/calendar/dayKeyDisplayFormat";
+import { BodyCompositionCard } from "@/lib/ui/dash/BodyCompositionCard";
+import { DailyEnergyCard } from "@/lib/ui/dash/DailyEnergyCard";
+import { DailyNutritionCard } from "@/lib/ui/dash/DailyNutritionCard";
+import { DailyReadinessCard } from "@/lib/ui/dash/DailyReadinessCard";
+import { DailySleepCard } from "@/lib/ui/dash/DailySleepCard";
+import { useFloatingTabBarScrollPadding } from "@/lib/ui/navigation/useFloatingTabBarScrollPadding";
+import { EmptyState, ErrorState } from "@/lib/ui/ScreenStates";
+import {
+  UI_APP_SCREEN_BG,
+  UI_BORDER_HAIRLINE,
+  UI_CARD_SURFACE,
+  UI_TAB_ROOT_INSET,
+  UI_TEXT_MUTED,
+  UI_TEXT_PRIMARY,
+  UI_TEXT_SECONDARY,
+} from "@/lib/ui/theme/uiTokens";
+
+export function DailyMonitorHost(): React.ReactElement {
+  const router = useRouter();
+  const scrollPaddingBottom = useFloatingTabBarScrollPadding(40);
+  const { user } = useAuth();
+  const { dayKey } = useCurrentLocalDayKey();
+  const dateLabel = useMemo(() => formatDayKeyStackNavTitle(dayKey), [dayKey]);
+
+  const {
+    energy,
+    energyLoading,
+    energyError,
+    sleepCardVm,
+    exactDayRestingHeartRateBpm,
+    refetch,
+  } = useTodayHealthHero(dayKey);
+  const readinessCard = useDailyReadinessCard(dayKey, {
+    enabled: Boolean(user),
+    exactDayRestingHeartRateBpm,
+  });
+  const bodyComposition = useBodyCompositionDashCard();
+  const dailyNutrition = useDailyNutritionCard(dayKey);
+
+  const sleepPresence = resolveSleepMonitorPresence(sleepCardVm);
+  const readinessPresence = resolveReadinessMonitorPresence(readinessCard.vm);
+  const energyPresence = resolveEnergyMonitorPresence({
+    energy,
+    loading: energyLoading,
+    error: energyError,
+    requestedDay: dayKey,
+  });
+  const nutritionPresence = resolveNutritionMonitorPresence({
+    model: dailyNutrition.model,
+    loading: dailyNutrition.loading,
+    error: dailyNutrition.error,
+  });
+  const bodyPresence = resolveBodyCompositionMonitorPresence({
+    requestedDay: dayKey,
+    overviewDay: bodyComposition.overviewDay,
+    seriesLoading: bodyComposition.loading,
+    seriesError: bodyComposition.error,
+    hasUser: bodyComposition.hasUser,
+    built: bodyComposition.built,
+  });
+
+  const monitorVm = useMemo(
+    () =>
+      buildDailyMonitorViewModel({
+        requestedDay: dayKey,
+        dateLabel,
+        signedOut: !user,
+        domains: [
+          { domainId: "sleep", presence: sleepPresence },
+          { domainId: "readiness", presence: readinessPresence },
+          { domainId: "energy", presence: energyPresence },
+          { domainId: "nutrition", presence: nutritionPresence },
+          { domainId: "body_composition", presence: bodyPresence },
+        ],
+      }),
+    [
+      dayKey,
+      dateLabel,
+      user,
+      sleepPresence,
+      readinessPresence,
+      energyPresence,
+      nutritionPresence,
+      bodyPresence,
+    ],
+  );
+
+  const onRetry = useCallback(() => {
+    refetch({ cacheBust: `dailyMonitorRetry:${Date.now()}` });
+    readinessCard.refetch({ cacheBust: `dailyMonitorRetry:${Date.now()}` });
+  }, [refetch, readinessCard.refetch]);
+
+  useFocusEffect(
+    React.useCallback(() => {
+      refetch({ cacheBust: "dailyMonitorFocus" });
+      readinessCard.refetch({ cacheBust: "dailyMonitorFocus" });
+    }, [refetch, readinessCard.refetch]),
+  );
+
+  const showSleep = presenceCreatesMainStackCard(sleepPresence);
+  const showReadiness = presenceCreatesMainStackCard(readinessPresence);
+  const showEnergy = presenceCreatesMainStackCard(energyPresence);
+  const showNutrition = presenceCreatesMainStackCard(nutritionPresence);
+  const showBody = presenceCreatesMainStackCard(bodyPresence);
+
+  return (
+    <View style={styles.root} testID="daily-monitor-host">
+      <DashScreenHeader
+        title={DAILY_MONITOR_SCREEN_TITLE}
+        dateLabel={dateLabel}
+        accessibilityLabel={`${DAILY_MONITOR_SCREEN_TITLE}. ${dateLabel}`}
+      />
+      <ScrollView
+        style={styles.scrollView}
+        contentContainerStyle={[styles.scroll, { paddingBottom: scrollPaddingBottom }]}
+        keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator={false}
+      >
+        {monitorVm.showPartialRefreshBanner ? (
+          <View
+            style={styles.banner}
+            accessibilityRole="text"
+            accessibilityLabel="Some data couldn't be refreshed."
+          >
+            <Text style={styles.bannerText}>Some data couldn{"\u2019"}t be refreshed.</Text>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Retry refresh"
+              onPress={onRetry}
+              style={styles.bannerRetry}
+              hitSlop={8}
+            >
+              <Text style={styles.bannerRetryText}>Retry</Text>
+            </Pressable>
+          </View>
+        ) : null}
+
+        {monitorVm.screenStatus === "loading" ? (
+          <Text style={styles.status} accessibilityRole="text">
+            Loading Daily Monitor{"\u2026"}
+          </Text>
+        ) : null}
+
+        {monitorVm.screenStatus === "error" ? (
+          <ErrorState
+            variant="inline"
+            title="Couldn't load today's data"
+            message={monitorVm.errorMessage ?? "Please try again."}
+            onRetry={onRetry}
+          />
+        ) : null}
+
+        {monitorVm.screenStatus === "empty" ? (
+          <EmptyState
+            title={monitorVm.emptyTitle ?? "No health data is available for today yet."}
+            description={
+              monitorVm.emptySubtitle ??
+              "Data will appear as devices sync or you add entries."
+            }
+          />
+        ) : null}
+
+        {monitorVm.sections.map((section) => (
+          <View key={section.id} style={styles.section} accessibilityRole="header">
+            <Text
+              style={styles.sectionTitle}
+              accessibilityRole="header"
+              accessibilityLabel={section.title}
+            >
+              {section.title}
+            </Text>
+            {section.domainIds.includes("sleep") && showSleep ? (
+              <DailySleepCard
+                vm={sleepCardVm}
+                title="Sleep"
+                scoreCaption="Oura Sleep Score"
+                cardAccessibilityLabel="Sleep card"
+              />
+            ) : null}
+            {section.domainIds.includes("readiness") && showReadiness ? (
+              <DailyReadinessCard vm={readinessCard.vm} title="Readiness" />
+            ) : null}
+            {section.domainIds.includes("energy") && showEnergy ? (
+              <DailyEnergyCard
+                energy={energy}
+                loading={false}
+                error={
+                  energyPresence === "refresh_error_with_cached_day_evidence"
+                    ? energyError
+                    : null
+                }
+                title="Energy Expenditure"
+              />
+            ) : null}
+            {section.domainIds.includes("nutrition") && showNutrition ? (
+              <DailyNutritionCard
+                model={dailyNutrition.model}
+                loading={false}
+                error={null}
+                title="Nutrition"
+                onPress={() => router.push("/(app)/nutrition")}
+              />
+            ) : null}
+            {section.domainIds.includes("body_composition") && showBody ? (
+              <BodyCompositionCard
+                loading={false}
+                error={null}
+                hasUser={bodyComposition.hasUser}
+                goalsHref={bodyComposition.goalsHref}
+                built={bodyComposition.built}
+                /** Same-day reading — omit prior-day “As of …” carry-forward copy. */
+                suppressAsOfLabel
+              />
+            ) : null}
+          </View>
+        ))}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: UI_APP_SCREEN_BG,
+  },
+  scrollView: {
+    flex: 1,
+    backgroundColor: UI_APP_SCREEN_BG,
+  },
+  scroll: {
+    paddingHorizontal: UI_TAB_ROOT_INSET,
+    paddingTop: 0,
+    flexGrow: 1,
+    backgroundColor: UI_APP_SCREEN_BG,
+  },
+  section: {
+    marginTop: 8,
+  },
+  sectionTitle: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: UI_TEXT_SECONDARY,
+    letterSpacing: 0.2,
+    marginTop: 12,
+    marginBottom: 4,
+    textTransform: "uppercase",
+  },
+  status: {
+    marginTop: 24,
+    textAlign: "center",
+    color: UI_TEXT_MUTED,
+    fontSize: 15,
+  },
+  banner: {
+    marginTop: 8,
+    padding: 12,
+    borderRadius: 10,
+    backgroundColor: UI_CARD_SURFACE,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: UI_BORDER_HAIRLINE,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 12,
+    minHeight: 44,
+  },
+  bannerText: {
+    flex: 1,
+    color: UI_TEXT_PRIMARY,
+    fontSize: 14,
+  },
+  bannerRetry: {
+    minHeight: 44,
+    minWidth: 44,
+    justifyContent: "center",
+    paddingHorizontal: 8,
+  },
+  bannerRetryText: {
+    color: UI_TEXT_PRIMARY,
+    fontWeight: "600",
+    fontSize: 14,
+  },
+});

--- a/components/dashboard/DailyMonitorHost.tsx
+++ b/components/dashboard/DailyMonitorHost.tsx
@@ -300,7 +300,6 @@ export function DailyMonitorHost(): React.ReactElement {
                 loading={false}
                 error={null}
                 hasUser={bodyComposition.hasUser}
-                goalsHref={bodyComposition.goalsHref}
                 built={bodyComposition.built}
                 suppressAsOfLabel
               />

--- a/components/dashboard/DailyMonitorHost.tsx
+++ b/components/dashboard/DailyMonitorHost.tsx
@@ -9,6 +9,7 @@ import { useFocusEffect, useRouter } from "expo-router";
 import { DashScreenHeader } from "@/components/dashboard/DashScreenHeader";
 import { useAuth } from "@/lib/auth/AuthProvider";
 import {
+  DAILY_MONITOR_APP_HEADER_TITLE,
   DAILY_MONITOR_SCREEN_TITLE,
 } from "@/lib/data/dash/dashDailyMonitorFoundation";
 import { buildDailyMonitorViewModel } from "@/lib/data/dash/buildDailyMonitorViewModel";
@@ -134,9 +135,8 @@ export function DailyMonitorHost(): React.ReactElement {
   return (
     <View style={styles.root} testID="daily-monitor-host">
       <DashScreenHeader
-        title={DAILY_MONITOR_SCREEN_TITLE}
-        dateLabel={dateLabel}
-        accessibilityLabel={`${DAILY_MONITOR_SCREEN_TITLE}. ${dateLabel}`}
+        title={DAILY_MONITOR_APP_HEADER_TITLE}
+        accessibilityLabel={DAILY_MONITOR_APP_HEADER_TITLE}
       />
       <ScrollView
         style={styles.scrollView}
@@ -144,6 +144,23 @@ export function DailyMonitorHost(): React.ReactElement {
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
       >
+        <View
+          style={styles.pageIntro}
+          accessible
+          accessibilityLabel={`${DAILY_MONITOR_SCREEN_TITLE}. ${dateLabel}`}
+        >
+          <Text
+            style={styles.pageTitle}
+            accessibilityRole="header"
+            testID="daily-monitor-page-title"
+          >
+            {DAILY_MONITOR_SCREEN_TITLE}
+          </Text>
+          <Text style={styles.pageDate} accessibilityRole="text" testID="daily-monitor-page-date">
+            {dateLabel}
+          </Text>
+        </View>
+
         {monitorVm.showPartialRefreshBanner ? (
           <View
             style={styles.banner}
@@ -261,6 +278,22 @@ const styles = StyleSheet.create({
     paddingTop: 0,
     flexGrow: 1,
     backgroundColor: UI_APP_SCREEN_BG,
+  },
+  pageIntro: {
+    marginTop: 4,
+    marginBottom: 8,
+  },
+  pageTitle: {
+    fontSize: 28,
+    fontWeight: "700",
+    color: UI_TEXT_PRIMARY,
+    letterSpacing: 0.1,
+  },
+  pageDate: {
+    marginTop: 4,
+    fontSize: 15,
+    fontWeight: "500",
+    color: UI_TEXT_SECONDARY,
   },
   section: {
     marginTop: 8,

--- a/components/dashboard/DailyMonitorHost.tsx
+++ b/components/dashboard/DailyMonitorHost.tsx
@@ -17,6 +17,7 @@ import { useBodyCompositionDashCard } from "@/lib/data/dash/useBodyCompositionDa
 import { useDailyNutritionCard } from "@/lib/data/dash/useDailyNutritionCard";
 import { useDailyMonitorActivityCard } from "@/lib/data/dash/useDailyMonitorActivityCard";
 import { useDailyMonitorSessionCards } from "@/lib/data/dash/useDailyMonitorSessionCards";
+import { useDailyMonitorStressCard } from "@/lib/data/dash/useDailyMonitorStressCard";
 import {
   resolveBodyCompositionMonitorPresence,
   resolveEnergyMonitorPresence,
@@ -37,6 +38,7 @@ import { DailySleepCard } from "@/lib/ui/dash/DailySleepCard";
 import {
   DailyMonitorActivityCard,
   DailyMonitorCardioCard,
+  DailyMonitorStressCard,
   DailyMonitorWorkoutCard,
 } from "@/lib/ui/dash/DailyMonitorDomainCards";
 import { useFloatingTabBarScrollPadding } from "@/lib/ui/navigation/useFloatingTabBarScrollPadding";
@@ -74,9 +76,11 @@ export function DailyMonitorHost(): React.ReactElement {
   const dailyNutrition = useDailyNutritionCard(dayKey);
   const activityCard = useDailyMonitorActivityCard(dayKey);
   const sessionCards = useDailyMonitorSessionCards(dayKey);
+  const stressCard = useDailyMonitorStressCard(dayKey);
 
   const sleepPresence = resolveSleepMonitorPresence(sleepCardVm);
   const readinessPresence = resolveReadinessMonitorPresence(readinessCard.vm);
+  const stressPresence = stressCard.presence;
   const activityPresence = activityCard.presence;
   const workoutPresence = sessionCards.workoutPresence;
   const cardioPresence = sessionCards.cardioPresence;
@@ -109,6 +113,7 @@ export function DailyMonitorHost(): React.ReactElement {
         domains: [
           { domainId: "sleep", presence: sleepPresence },
           { domainId: "readiness", presence: readinessPresence },
+          { domainId: "stress", presence: stressPresence },
           { domainId: "activity", presence: activityPresence },
           { domainId: "workout", presence: workoutPresence },
           { domainId: "cardio", presence: cardioPresence },
@@ -123,6 +128,7 @@ export function DailyMonitorHost(): React.ReactElement {
       user,
       sleepPresence,
       readinessPresence,
+      stressPresence,
       activityPresence,
       workoutPresence,
       cardioPresence,
@@ -147,6 +153,7 @@ export function DailyMonitorHost(): React.ReactElement {
 
   const showSleep = presenceCreatesMainStackCard(sleepPresence);
   const showReadiness = presenceCreatesMainStackCard(readinessPresence);
+  const showStress = presenceCreatesMainStackCard(stressPresence);
   const showActivity = presenceCreatesMainStackCard(activityPresence);
   const showWorkout = presenceCreatesMainStackCard(workoutPresence);
   const showCardio = presenceCreatesMainStackCard(cardioPresence);
@@ -246,6 +253,9 @@ export function DailyMonitorHost(): React.ReactElement {
             ) : null}
             {section.domainIds.includes("readiness") && showReadiness ? (
               <DailyReadinessCard vm={readinessCard.vm} title="Readiness" />
+            ) : null}
+            {section.domainIds.includes("stress") && showStress && stressCard.model != null ? (
+              <DailyMonitorStressCard model={stressCard.model} href={stressCard.href} />
             ) : null}
             {section.domainIds.includes("activity") && showActivity && activityCard.model != null ? (
               <DailyMonitorActivityCard model={activityCard.model} href={activityCard.href} />

--- a/components/dashboard/DashScreenHeader.tsx
+++ b/components/dashboard/DashScreenHeader.tsx
@@ -3,21 +3,48 @@ import { StyleSheet, Text, View } from "react-native";
 
 import { ManageMenuTriggerButton } from "@/components/navigation/ManageMenuTriggerButton";
 import { UserInitialSettingsButton } from "@/lib/ui/UserInitialSettingsButton";
-import { UI_APP_SCREEN_BG, UI_TAB_ROOT_INSET, UI_TEXT_PRIMARY } from "@/lib/ui/theme/uiTokens";
+import {
+  UI_APP_SCREEN_BG,
+  UI_TAB_ROOT_INSET,
+  UI_TEXT_PRIMARY,
+  UI_TEXT_SECONDARY,
+} from "@/lib/ui/theme/uiTokens";
 
-const TITLE = "Oli Fitness";
+const DEFAULT_TITLE = "Oli Fitness";
 
-export function DashScreenHeader(): React.ReactElement {
+export type DashScreenHeaderProps = {
+  /** Consumer screen title. Defaults to legacy “Oli Fitness”. */
+  title?: string;
+  /** Optional current-day label shown under the title (Daily Monitor). */
+  dateLabel?: string | null;
+  /** Combined accessibility label for title (+ date when present). */
+  accessibilityLabel?: string;
+};
+
+export function DashScreenHeader({
+  title = DEFAULT_TITLE,
+  dateLabel = null,
+  accessibilityLabel,
+}: DashScreenHeaderProps = {}): React.ReactElement {
+  const a11y =
+    accessibilityLabel ??
+    (dateLabel != null && dateLabel.length > 0 ? `${title}. ${dateLabel}` : title);
+
   return (
-    <View style={styles.wrap} testID="dash-screen-header">
+    <View style={styles.wrap} testID="dash-screen-header" accessibilityLabel={a11y}>
       <View style={styles.row}>
         <View style={styles.leftCluster}>
           <ManageMenuTriggerButton />
         </View>
         <View style={styles.titleLayer} pointerEvents="none">
           <Text style={styles.title} numberOfLines={1} accessibilityRole="header">
-            {TITLE}
+            {title}
           </Text>
+          {dateLabel != null && dateLabel.length > 0 ? (
+            <Text style={styles.dateLabel} numberOfLines={1} accessibilityRole="text">
+              {dateLabel}
+            </Text>
+          ) : null}
         </View>
         <View style={styles.rightCluster}>
           <UserInitialSettingsButton />
@@ -57,6 +84,13 @@ const styles = StyleSheet.create({
     fontWeight: "600",
     color: UI_TEXT_PRIMARY,
     letterSpacing: 0.15,
+    textAlign: "center",
+  },
+  dateLabel: {
+    marginTop: 2,
+    fontSize: 13,
+    fontWeight: "500",
+    color: UI_TEXT_SECONDARY,
     textAlign: "center",
   },
   rightCluster: {

--- a/components/dashboard/DashScreenHeader.tsx
+++ b/components/dashboard/DashScreenHeader.tsx
@@ -15,7 +15,7 @@ const DEFAULT_TITLE = "Oli Fitness";
 export type DashScreenHeaderProps = {
   /** Consumer screen title. Defaults to legacy “Oli Fitness”. */
   title?: string;
-  /** Optional current-day label shown under the title (Daily Monitor). */
+  /** Optional subtitle under the title. Daily Monitor keeps date in page content instead. */
   dateLabel?: string | null;
   /** Combined accessibility label for title (+ date when present). */
   accessibilityLabel?: string;

--- a/components/dashboard/LegacyDashHost.tsx
+++ b/components/dashboard/LegacyDashHost.tsx
@@ -1,0 +1,106 @@
+/**
+ * Legacy Dash composition host (post–Phase 1 / Phase 2C rollback).
+ * Preserves empty-card behavior and current card order. Not modernized.
+ */
+
+import React from "react";
+import { ScrollView, View, StyleSheet } from "react-native";
+import { useFocusEffect, useRouter } from "expo-router";
+
+import { DashScreenHeader } from "@/components/dashboard/DashScreenHeader";
+import { useAuth } from "@/lib/auth/AuthProvider";
+import { useBodyCompositionDashCard } from "@/lib/data/dash/useBodyCompositionDashCard";
+import { useDailyNutritionCard } from "@/lib/data/dash/useDailyNutritionCard";
+import { isDashWeeklyProgressRelocationEnabled } from "@/lib/data/dash/dashWeeklyProgressRelocation";
+import { LEGACY_DASH_SCREEN_TITLE } from "@/lib/data/dash/dashDailyMonitorFoundation";
+import { useTodayHealthHero } from "@/lib/hooks/useTodayHealthHero";
+import { useDailyReadinessCard } from "@/lib/hooks/useDailyReadinessCard";
+import { BodyCompositionCard } from "@/lib/ui/dash/BodyCompositionCard";
+import { DailyEnergyCard } from "@/lib/ui/dash/DailyEnergyCard";
+import { DailyReadinessCard } from "@/lib/ui/dash/DailyReadinessCard";
+import { DailySleepCard } from "@/lib/ui/dash/DailySleepCard";
+import { DailyNutritionCard } from "@/lib/ui/dash/DailyNutritionCard";
+import { WeeklyFitnessCardHost } from "@/lib/ui/dash/WeeklyFitnessCardHost";
+import { useFloatingTabBarScrollPadding } from "@/lib/ui/navigation/useFloatingTabBarScrollPadding";
+import { UI_APP_SCREEN_BG, UI_TAB_ROOT_INSET } from "@/lib/ui/theme/uiTokens";
+import { getTodayDayKeyLocal } from "@/lib/ui/calendar/dateUtils";
+
+export function LegacyDashHost(): React.ReactElement {
+  const router = useRouter();
+  const scrollPaddingBottom = useFloatingTabBarScrollPadding(40);
+  const { user } = useAuth();
+  const todayKey = getTodayDayKeyLocal();
+  const showWeeklyFitnessOnDash = !isDashWeeklyProgressRelocationEnabled();
+  const {
+    energy,
+    energyLoading,
+    energyError,
+    sleepCardVm,
+    exactDayRestingHeartRateBpm,
+    refetch,
+  } = useTodayHealthHero(todayKey);
+  const readinessCard = useDailyReadinessCard(todayKey, {
+    enabled: Boolean(user),
+    exactDayRestingHeartRateBpm,
+  });
+  const bodyComposition = useBodyCompositionDashCard();
+  const dailyNutrition = useDailyNutritionCard(todayKey);
+
+  useFocusEffect(
+    React.useCallback(() => {
+      refetch({ cacheBust: "dashEnergyFocus" });
+      readinessCard.refetch({ cacheBust: "dashReadinessFocus" });
+    }, [refetch, readinessCard.refetch]),
+  );
+
+  return (
+    <View style={styles.root}>
+      <DashScreenHeader title={LEGACY_DASH_SCREEN_TITLE} />
+      <ScrollView
+        style={styles.scrollView}
+        contentContainerStyle={[styles.scroll, { paddingBottom: scrollPaddingBottom }]}
+        keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator={false}
+      >
+        <View style={styles.stacksSection}>
+          {showWeeklyFitnessOnDash ? <WeeklyFitnessCardHost /> : null}
+          <BodyCompositionCard
+            loading={bodyComposition.loading}
+            error={bodyComposition.error}
+            hasUser={bodyComposition.hasUser}
+            goalsHref={bodyComposition.goalsHref}
+            built={bodyComposition.built}
+          />
+
+          <DailyEnergyCard energy={energy} loading={energyLoading} error={energyError} />
+          <DailySleepCard vm={sleepCardVm} />
+          <DailyReadinessCard vm={readinessCard.vm} />
+          <DailyNutritionCard
+            model={dailyNutrition.model}
+            loading={dailyNutrition.loading}
+            error={dailyNutrition.error}
+            onPress={() => router.push("/(app)/nutrition")}
+          />
+        </View>
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: UI_APP_SCREEN_BG,
+  },
+  scrollView: {
+    flex: 1,
+    backgroundColor: UI_APP_SCREEN_BG,
+  },
+  scroll: {
+    paddingHorizontal: UI_TAB_ROOT_INSET,
+    paddingTop: 0,
+    flexGrow: 1,
+    backgroundColor: UI_APP_SCREEN_BG,
+  },
+  stacksSection: {},
+});

--- a/components/dashboard/LegacyDashHost.tsx
+++ b/components/dashboard/LegacyDashHost.tsx
@@ -68,7 +68,6 @@ export function LegacyDashHost(): React.ReactElement {
             loading={bodyComposition.loading}
             error={bodyComposition.error}
             hasUser={bodyComposition.hasUser}
-            goalsHref={bodyComposition.goalsHref}
             built={bodyComposition.built}
           />
 

--- a/components/dashboard/__tests__/DailyMonitorHost.hierarchy.test.tsx
+++ b/components/dashboard/__tests__/DailyMonitorHost.hierarchy.test.tsx
@@ -13,7 +13,11 @@ import {
 import { allowConsoleForThisTest } from "../../../scripts/test/consoleGuard";
 
 jest.mock("@/lib/auth/AuthProvider", () => ({
-  useAuth: () => ({ user: { uid: "u1" }, initializing: false }),
+  useAuth: () => ({
+    user: { uid: "u1" },
+    initializing: false,
+    getIdToken: jest.fn(async () => "test-token"),
+  }),
 }));
 
 jest.mock("@/lib/hooks/useCurrentLocalDayKey", () => ({
@@ -61,6 +65,35 @@ jest.mock("@/lib/data/dash/useDailyNutritionCard", () => ({
   }),
 }));
 
+const mockActivityHook = jest.fn(() => ({
+  presence: "absent_no_day_evidence" as const,
+  model: null,
+  href: "/(app)/activity" as const,
+}));
+const mockSessionHook = jest.fn(() => ({
+  workoutPresence: "absent_no_day_evidence" as const,
+  workoutModel: null,
+  workoutHref: "/(app)/workouts" as const,
+  cardioPresence: "absent_no_day_evidence" as const,
+  cardioModel: null,
+  cardioHref: "/(app)/cardio" as const,
+}));
+const mockStressHook = jest.fn(() => ({
+  presence: "absent_no_day_evidence" as const,
+  model: null,
+  href: "/(app)/recovery/stress" as const,
+}));
+
+jest.mock("@/lib/data/dash/useDailyMonitorActivityCard", () => ({
+  useDailyMonitorActivityCard: (...args: unknown[]) => mockActivityHook(...args),
+}));
+jest.mock("@/lib/data/dash/useDailyMonitorSessionCards", () => ({
+  useDailyMonitorSessionCards: (...args: unknown[]) => mockSessionHook(...args),
+}));
+jest.mock("@/lib/data/dash/useDailyMonitorStressCard", () => ({
+  useDailyMonitorStressCard: (...args: unknown[]) => mockStressHook(...args),
+}));
+
 jest.mock("@/lib/ui/navigation/useFloatingTabBarScrollPadding", () => ({
   useFloatingTabBarScrollPadding: () => 120,
 }));
@@ -106,6 +139,12 @@ function collectText(root: renderer.ReactTestInstance): string {
 }
 
 describe("Daily Monitor header hierarchy", () => {
+  beforeEach(() => {
+    mockActivityHook.mockClear();
+    mockSessionHook.mockClear();
+    mockStressHook.mockClear();
+  });
+
   it("uses Oli in the fixed header and Daily Monitor + date in page content", async () => {
     allowConsoleForThisTest({ error: [/not wrapped in act/] });
     let tree!: renderer.ReactTestRenderer;
@@ -153,11 +192,19 @@ describe("Daily Monitor header hierarchy", () => {
       .join(" ");
     expect(headerJoined).not.toContain("Daily Monitor");
     expect(headerJoined).not.toContain("Mon Jul 20");
+
+    expect(mockActivityHook).toHaveBeenCalled();
+    expect(mockSessionHook).toHaveBeenCalled();
+    expect(mockStressHook).toHaveBeenCalled();
     tree.unmount();
   });
 
-  it("preserves legacy Oli Fitness header and does not show Monitor page intro", async () => {
+  it("preserves legacy Oli Fitness header and does not mount Monitor-only domain hooks", async () => {
     allowConsoleForThisTest({ error: [/not wrapped in act/] });
+    mockActivityHook.mockClear();
+    mockSessionHook.mockClear();
+    mockStressHook.mockClear();
+
     let tree!: renderer.ReactTestRenderer;
     await act(async () => {
       tree = renderer.create(React.createElement(LegacyDashHost));
@@ -175,6 +222,9 @@ describe("Daily Monitor header hierarchy", () => {
     expect(headerTexts).toContain(LEGACY_DASH_SCREEN_TITLE);
     expect(headerTexts.join(" ")).not.toContain("Daily Monitor");
     expect(tree.root.findAllByProps({ testID: "daily-monitor-page-title" })).toHaveLength(0);
+    expect(mockActivityHook).not.toHaveBeenCalled();
+    expect(mockSessionHook).not.toHaveBeenCalled();
+    expect(mockStressHook).not.toHaveBeenCalled();
     tree.unmount();
   });
 });

--- a/components/dashboard/__tests__/DailyMonitorHost.hierarchy.test.tsx
+++ b/components/dashboard/__tests__/DailyMonitorHost.hierarchy.test.tsx
@@ -1,0 +1,180 @@
+/**
+ * Mode A header hierarchy: fixed header is Oli; Daily Monitor title/date live in scroll content.
+ */
+
+import React, { act } from "react";
+import renderer from "react-test-renderer";
+
+import {
+  DAILY_MONITOR_APP_HEADER_TITLE,
+  DAILY_MONITOR_SCREEN_TITLE,
+  LEGACY_DASH_SCREEN_TITLE,
+} from "@/lib/data/dash/dashDailyMonitorFoundation";
+import { allowConsoleForThisTest } from "../../../scripts/test/consoleGuard";
+
+jest.mock("@/lib/auth/AuthProvider", () => ({
+  useAuth: () => ({ user: { uid: "u1" }, initializing: false }),
+}));
+
+jest.mock("@/lib/hooks/useCurrentLocalDayKey", () => ({
+  useCurrentLocalDayKey: () => ({ dayKey: "2026-07-20" }),
+}));
+
+jest.mock("@/lib/ui/calendar/dayKeyDisplayFormat", () => ({
+  formatDayKeyStackNavTitle: () => "Mon Jul 20, 2026",
+}));
+
+jest.mock("@/lib/hooks/useTodayHealthHero", () => ({
+  useTodayHealthHero: () => ({
+    energy: undefined,
+    energyLoading: false,
+    energyError: null,
+    sleepCardVm: { status: "missing", day: "2026-07-20", message: "No sleep" },
+    exactDayRestingHeartRateBpm: null,
+    refetch: jest.fn(),
+  }),
+}));
+
+jest.mock("@/lib/hooks/useDailyReadinessCard", () => ({
+  useDailyReadinessCard: () => ({
+    vm: { status: "missing", day: "2026-07-20", message: "Waiting" },
+    refetch: jest.fn(),
+  }),
+}));
+
+jest.mock("@/lib/data/dash/useBodyCompositionDashCard", () => ({
+  useBodyCompositionDashCard: () => ({
+    loading: false,
+    error: null,
+    hasUser: true,
+    goalsHref: "/(app)/body/settings",
+    overviewDay: null,
+    built: { tag: "empty" as const },
+  }),
+}));
+
+jest.mock("@/lib/data/dash/useDailyNutritionCard", () => ({
+  useDailyNutritionCard: () => ({
+    model: { calorieLabel: "—", hasAnyNutrition: false, rows: [] },
+    loading: false,
+    error: null,
+  }),
+}));
+
+jest.mock("@/lib/ui/navigation/useFloatingTabBarScrollPadding", () => ({
+  useFloatingTabBarScrollPadding: () => 120,
+}));
+
+jest.mock("@/components/navigation/ManageNavigationContext", () => ({
+  useManageNavigation: () => ({
+    manageVisible: false,
+    menuAnchor: null,
+    openManage: jest.fn(),
+    closeManage: jest.fn(),
+  }),
+}));
+
+jest.mock("@/lib/data/profile/useUserProfileMain", () => ({
+  useUserProfileMain: () => ({ state: { status: "missing" } }),
+}));
+
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+  useFocusEffect: (cb: () => void | (() => void)) => {
+    cb();
+  },
+}));
+
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { DailyMonitorHost } = require("../DailyMonitorHost");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { LegacyDashHost } = require("../LegacyDashHost");
+
+function collectText(root: renderer.ReactTestInstance): string {
+  return root
+    .findAllByType("Text")
+    .map((n) =>
+      (n.children as (string | number)[])
+        .filter((c) => typeof c === "string" || typeof c === "number")
+        .join(""),
+    )
+    .join(" | ");
+}
+
+describe("Daily Monitor header hierarchy", () => {
+  it("uses Oli in the fixed header and Daily Monitor + date in page content", async () => {
+    allowConsoleForThisTest({ error: [/not wrapped in act/] });
+    let tree!: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(React.createElement(DailyMonitorHost));
+      await Promise.resolve();
+    });
+
+    const header = tree.root.findByProps({ testID: "dash-screen-header" });
+    expect(header.props.accessibilityLabel).toBe(DAILY_MONITOR_APP_HEADER_TITLE);
+    expect(DAILY_MONITOR_APP_HEADER_TITLE).toBe("Oli");
+
+    const pageTitle = tree.root.findByProps({ testID: "daily-monitor-page-title" });
+    expect(pageTitle.props.children).toBe(DAILY_MONITOR_SCREEN_TITLE);
+    expect(pageTitle.props.accessibilityRole).toBe("header");
+    const pageDate = tree.root.findByProps({ testID: "daily-monitor-page-date" });
+    expect(pageDate.props.children).toBe("Mon Jul 20, 2026");
+    expect(pageDate.props.accessibilityRole).toBe("text");
+
+    const text = collectText(tree.root);
+    expect(text).toContain("Oli");
+    expect(text).toContain("Daily Monitor");
+    expect(text).toContain("Mon Jul 20, 2026");
+
+    const headerTitle = header.findAll(
+      (n) =>
+        n.type === "Text" &&
+        (n.props as { accessibilityRole?: string }).accessibilityRole === "header",
+    );
+    expect(headerTitle).toHaveLength(1);
+    expect(
+      (headerTitle[0]!.children as (string | number)[])
+        .filter((c) => typeof c === "string" || typeof c === "number")
+        .join(""),
+    ).toBe("Oli");
+    expect(header.findAllByProps({ testID: "daily-monitor-page-title" })).toHaveLength(0);
+    expect(header.findAllByProps({ testID: "daily-monitor-page-date" })).toHaveLength(0);
+    const headerJoined = header
+      .findAllByType("Text")
+      .map((n) =>
+        (n.children as (string | number)[])
+          .filter((c) => typeof c === "string" || typeof c === "number")
+          .join(""),
+      )
+      .join(" ");
+    expect(headerJoined).not.toContain("Daily Monitor");
+    expect(headerJoined).not.toContain("Mon Jul 20");
+    tree.unmount();
+  });
+
+  it("preserves legacy Oli Fitness header and does not show Monitor page intro", async () => {
+    allowConsoleForThisTest({ error: [/not wrapped in act/] });
+    let tree!: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(React.createElement(LegacyDashHost));
+      await Promise.resolve();
+    });
+
+    const header = tree.root.findByProps({ testID: "dash-screen-header" });
+    const headerTexts = header
+      .findAllByType("Text")
+      .map((n) =>
+        (n.children as (string | number)[])
+          .filter((c) => typeof c === "string" || typeof c === "number")
+          .join(""),
+      );
+    expect(headerTexts).toContain(LEGACY_DASH_SCREEN_TITLE);
+    expect(headerTexts.join(" ")).not.toContain("Daily Monitor");
+    expect(tree.root.findAllByProps({ testID: "daily-monitor-page-title" })).toHaveLength(0);
+    tree.unmount();
+  });
+});

--- a/lib/data/dash/__tests__/buildDailyMonitorActivityCardModel.test.ts
+++ b/lib/data/dash/__tests__/buildDailyMonitorActivityCardModel.test.ts
@@ -1,0 +1,96 @@
+import {
+  buildDailyMonitorActivityCardModel,
+  resolveActivityMonitorPresence,
+} from "../buildDailyMonitorActivityCardModel";
+import type { DailyFactsDto } from "@/lib/contracts/dailyFacts";
+
+function facts(partial: Partial<DailyFactsDto> & { date: string }): DailyFactsDto {
+  return {
+    userId: "u1",
+    ...partial,
+  } as DailyFactsDto;
+}
+
+describe("buildDailyMonitorActivityCardModel", () => {
+  it("presents current-day steps including valid zero", () => {
+    const model = buildDailyMonitorActivityCardModel({
+      requestedDay: "2026-07-20",
+      facts: facts({
+        date: "2026-07-20",
+        activity: { steps: 0, moveMinutes: 12, distanceKm: 0.1 },
+      }),
+    });
+    expect(model).not.toBeNull();
+    expect(model!.steps).toBe(0);
+    expect(model!.stepsLabel).toBe("0");
+    expect(model!.accessibilityLabel).toMatch(/0 steps/i);
+    expect(resolveActivityMonitorPresence({
+      loading: false,
+      error: null,
+      model,
+      factsDay: "2026-07-20",
+      requestedDay: "2026-07-20",
+    })).toBe("present_complete");
+  });
+
+  it("marks missing secondary metrics unavailable rather than inventing zero", () => {
+    const model = buildDailyMonitorActivityCardModel({
+      requestedDay: "2026-07-20",
+      facts: facts({
+        date: "2026-07-20",
+        activity: { steps: 1200 },
+      }),
+    });
+    expect(model).not.toBeNull();
+    expect(model!.rows.every((r) => !r.isAvailable)).toBe(true);
+    expect(model!.rows.every((r) => r.valueLabel === "Unavailable")).toBe(true);
+    expect(
+      resolveActivityMonitorPresence({
+        loading: false,
+        error: null,
+        model,
+        factsDay: "2026-07-20",
+        requestedDay: "2026-07-20",
+      }),
+    ).toBe("present_partial");
+  });
+
+  it("is absent when steps evidence is missing", () => {
+    expect(
+      buildDailyMonitorActivityCardModel({
+        requestedDay: "2026-07-20",
+        facts: facts({ date: "2026-07-20", activity: {} }),
+      }),
+    ).toBeNull();
+  });
+
+  it("is absent when DailyFacts belong to another day", () => {
+    expect(
+      buildDailyMonitorActivityCardModel({
+        requestedDay: "2026-07-20",
+        facts: facts({ date: "2026-07-19", activity: { steps: 5000 } }),
+      }),
+    ).toBeNull();
+  });
+
+  it("presents a positive step count", () => {
+    const model = buildDailyMonitorActivityCardModel({
+      requestedDay: "2026-07-20",
+      facts: facts({
+        date: "2026-07-20",
+        activity: { steps: 8432, moveMinutes: 40, distanceKm: 5.2 },
+      }),
+    });
+    expect(model?.steps).toBe(8432);
+    expect(model?.rows.every((r) => r.isAvailable)).toBe(true);
+    expect(
+      resolveActivityMonitorPresence({
+        loading: false,
+        error: null,
+        model,
+        factsDay: "2026-07-20",
+        requestedDay: "2026-07-20",
+      }),
+    ).toBe("present_complete");
+  });
+});

--- a/lib/data/dash/__tests__/buildDailyMonitorActivityCardModel.test.ts
+++ b/lib/data/dash/__tests__/buildDailyMonitorActivityCardModel.test.ts
@@ -3,6 +3,8 @@ import {
   resolveActivityMonitorPresence,
 } from "../buildDailyMonitorActivityCardModel";
 import type { DailyFactsDto } from "@/lib/contracts/dailyFacts";
+import { formatDistanceDualDisplay } from "@/lib/modules/commandCenterCardio";
+import { ACTIVITY_STEP_DESCRIPTOR_PILL_LABELS } from "@/lib/utils/activityStepRating";
 
 function facts(partial: Partial<DailyFactsDto> & { date: string }): DailyFactsDto {
   return {
@@ -12,7 +14,7 @@ function facts(partial: Partial<DailyFactsDto> & { date: string }): DailyFactsDt
 }
 
 describe("buildDailyMonitorActivityCardModel — compact contract", () => {
-  it("presents primary as formatted Steps with so-far rating and allocation rows", () => {
+  it("presents primary as formatted Steps with category rating and allocation rows", () => {
     const model = buildDailyMonitorActivityCardModel({
       requestedDay: "2026-07-20",
       facts: facts({
@@ -33,21 +35,67 @@ describe("buildDailyMonitorActivityCardModel — compact contract", () => {
     });
     expect(model).not.toBeNull();
     expect(model!.primaryLabel).toBe("2,883 Steps");
-    expect(model!.ratingLabel).toMatch(/so far$/);
+    expect(model!.ratingLabel).toBe("Sedentary");
+    expect(model!.ratingLabel).not.toMatch(/so far/i);
+    expect(model!.ratingTone).toBe("critical");
     expect(model!.rows.map((r) => r.label)).toEqual([
       "Distance",
       "NEAT Steps",
       "Workout Steps",
       "Cardio Steps",
     ]);
-    expect(model!.rows[0]?.valueLabel).toBe("2.1 km");
+    expect(model!.rows[0]?.valueLabel).toBe(
+      formatDistanceDualDisplay({ distanceKm: 2.1, locale: "en-US" }).primary,
+    );
     expect(model!.rows[1]?.valueLabel).toBe("2,000 steps");
     expect(model!.rows[2]?.valueLabel).toBe("500 steps");
     expect(model!.rows[3]?.valueLabel).toBe("383 steps");
     expect(model!.accessibilityLabel).toMatch(/Activity\. 2,883 Steps/);
-    expect(model!.accessibilityLabel).toMatch(/so far/);
+    expect(model!.accessibilityLabel).not.toMatch(/so far/i);
     expect(model!.accessibilityLabel).toMatch(/Opens Activity/);
-    expect(model!.ratingLabel).toBe("Sedentary so far");
+    expect(model!.accessibilityLabel).not.toMatch(/health grade|fitness capacity/i);
+  });
+
+  it("updates the written rating when steps cross existing category boundaries", () => {
+    const cases: { steps: number; label: (typeof ACTIVITY_STEP_DESCRIPTOR_PILL_LABELS)[number] }[] = [
+      { steps: 0, label: "Sedentary" },
+      { steps: 4999, label: "Sedentary" },
+      { steps: 5000, label: "Lightly Active" },
+      { steps: 7499, label: "Lightly Active" },
+      { steps: 7500, label: "Moderately Active" },
+      { steps: 9999, label: "Moderately Active" },
+      { steps: 10000, label: "Active" },
+      { steps: 12499, label: "Active" },
+      { steps: 12500, label: "Very Active" },
+      { steps: 14999, label: "Very Active" },
+      { steps: 15000, label: "Highly Active" },
+    ];
+    for (const c of cases) {
+      const model = buildDailyMonitorActivityCardModel({
+        requestedDay: "2026-07-20",
+        facts: facts({ date: "2026-07-20", activity: { steps: c.steps } }),
+      });
+      expect(model!.ratingLabel).toBe(c.label);
+      expect(model!.ratingTone).toBeTruthy();
+    }
+  });
+
+  it("keeps measured zero distance as zero and missing distance Unavailable", () => {
+    const zero = buildDailyMonitorActivityCardModel({
+      requestedDay: "2026-07-20",
+      facts: facts({ date: "2026-07-20", activity: { steps: 1000, distanceKm: 0 } }),
+    });
+    expect(zero!.rows[0]?.isAvailable).toBe(true);
+    expect(zero!.rows[0]?.valueLabel).toBe(
+      formatDistanceDualDisplay({ distanceKm: 0, locale: "en-US" }).primary,
+    );
+
+    const missing = buildDailyMonitorActivityCardModel({
+      requestedDay: "2026-07-20",
+      facts: facts({ date: "2026-07-20", activity: { steps: 1000 } }),
+    });
+    expect(missing!.rows[0]?.valueLabel).toBe("Unavailable");
+    expect(missing!.rows[0]?.isAvailable).toBe(false);
   });
 
   it("presents valid zero steps and keeps missing allocation Unavailable", () => {
@@ -59,10 +107,7 @@ describe("buildDailyMonitorActivityCardModel — compact contract", () => {
       }),
     });
     expect(model!.primaryLabel).toBe("0 Steps");
-    expect(model!.ratingLabel).toBe("Sedentary so far");
-    expect(model!.rows.every((r) => r.key === "distance" || !r.isAvailable || r.valueLabel.includes("0"))).toBe(
-      true,
-    );
+    expect(model!.ratingLabel).toBe("Sedentary");
     expect(model!.rows.filter((r) => r.key !== "distance").every((r) => r.valueLabel === "Unavailable")).toBe(
       true,
     );
@@ -87,7 +132,7 @@ describe("buildDailyMonitorActivityCardModel — compact contract", () => {
     expect(
       buildDailyMonitorActivityCardModel({
         requestedDay: "2026-07-20",
-        facts: facts({ date: "2026-07-19", activity: { steps: 5000 } }),
+        facts: facts({ date: "2026-07-19", activity: { steps: 5000, distanceKm: 3 } }),
       }),
     ).toBeNull();
   });

--- a/lib/data/dash/__tests__/buildDailyMonitorActivityCardModel.test.ts
+++ b/lib/data/dash/__tests__/buildDailyMonitorActivityCardModel.test.ts
@@ -11,39 +11,61 @@ function facts(partial: Partial<DailyFactsDto> & { date: string }): DailyFactsDt
   } as DailyFactsDto;
 }
 
-describe("buildDailyMonitorActivityCardModel", () => {
-  it("presents current-day steps including valid zero", () => {
+describe("buildDailyMonitorActivityCardModel — compact contract", () => {
+  it("presents primary as formatted Steps with so-far rating and allocation rows", () => {
     const model = buildDailyMonitorActivityCardModel({
       requestedDay: "2026-07-20",
       facts: facts({
         date: "2026-07-20",
-        activity: { steps: 0, moveMinutes: 12, distanceKm: 0.1 },
+        activity: {
+          steps: 2883,
+          distanceKm: 2.1,
+          stepsAllocation: {
+            modelVersion: "activity_steps_allocation_v1",
+            neatSteps: 2000,
+            strengthSteps: 500,
+            cardioSteps: 383,
+            inputsUsed: [],
+            inputsMissing: [],
+          },
+        },
       }),
     });
     expect(model).not.toBeNull();
-    expect(model!.steps).toBe(0);
-    expect(model!.stepsLabel).toBe("0");
-    expect(model!.accessibilityLabel).toMatch(/0 steps/i);
-    expect(resolveActivityMonitorPresence({
-      loading: false,
-      error: null,
-      model,
-      factsDay: "2026-07-20",
-      requestedDay: "2026-07-20",
-    })).toBe("present_complete");
+    expect(model!.primaryLabel).toBe("2,883 Steps");
+    expect(model!.ratingLabel).toMatch(/so far$/);
+    expect(model!.rows.map((r) => r.label)).toEqual([
+      "Distance",
+      "NEAT Steps",
+      "Workout Steps",
+      "Cardio Steps",
+    ]);
+    expect(model!.rows[0]?.valueLabel).toBe("2.1 km");
+    expect(model!.rows[1]?.valueLabel).toBe("2,000 steps");
+    expect(model!.rows[2]?.valueLabel).toBe("500 steps");
+    expect(model!.rows[3]?.valueLabel).toBe("383 steps");
+    expect(model!.accessibilityLabel).toMatch(/Activity\. 2,883 Steps/);
+    expect(model!.accessibilityLabel).toMatch(/so far/);
+    expect(model!.accessibilityLabel).toMatch(/Opens Activity/);
+    expect(model!.ratingLabel).toBe("Sedentary so far");
   });
 
-  it("marks missing secondary metrics unavailable rather than inventing zero", () => {
+  it("presents valid zero steps and keeps missing allocation Unavailable", () => {
     const model = buildDailyMonitorActivityCardModel({
       requestedDay: "2026-07-20",
       facts: facts({
         date: "2026-07-20",
-        activity: { steps: 1200 },
+        activity: { steps: 0 },
       }),
     });
-    expect(model).not.toBeNull();
-    expect(model!.rows.every((r) => !r.isAvailable)).toBe(true);
-    expect(model!.rows.every((r) => r.valueLabel === "Unavailable")).toBe(true);
+    expect(model!.primaryLabel).toBe("0 Steps");
+    expect(model!.ratingLabel).toBe("Sedentary so far");
+    expect(model!.rows.every((r) => r.key === "distance" || !r.isAvailable || r.valueLabel.includes("0"))).toBe(
+      true,
+    );
+    expect(model!.rows.filter((r) => r.key !== "distance").every((r) => r.valueLabel === "Unavailable")).toBe(
+      true,
+    );
     expect(
       resolveActivityMonitorPresence({
         loading: false,
@@ -55,42 +77,18 @@ describe("buildDailyMonitorActivityCardModel", () => {
     ).toBe("present_partial");
   });
 
-  it("is absent when steps evidence is missing", () => {
+  it("is absent when steps evidence is missing or wrong day", () => {
     expect(
       buildDailyMonitorActivityCardModel({
         requestedDay: "2026-07-20",
         facts: facts({ date: "2026-07-20", activity: {} }),
       }),
     ).toBeNull();
-  });
-
-  it("is absent when DailyFacts belong to another day", () => {
     expect(
       buildDailyMonitorActivityCardModel({
         requestedDay: "2026-07-20",
         facts: facts({ date: "2026-07-19", activity: { steps: 5000 } }),
       }),
     ).toBeNull();
-  });
-
-  it("presents a positive step count", () => {
-    const model = buildDailyMonitorActivityCardModel({
-      requestedDay: "2026-07-20",
-      facts: facts({
-        date: "2026-07-20",
-        activity: { steps: 8432, moveMinutes: 40, distanceKm: 5.2 },
-      }),
-    });
-    expect(model?.steps).toBe(8432);
-    expect(model?.rows.every((r) => r.isAvailable)).toBe(true);
-    expect(
-      resolveActivityMonitorPresence({
-        loading: false,
-        error: null,
-        model,
-        factsDay: "2026-07-20",
-        requestedDay: "2026-07-20",
-      }),
-    ).toBe("present_complete");
   });
 });

--- a/lib/data/dash/__tests__/buildDailyMonitorSessionCards.test.ts
+++ b/lib/data/dash/__tests__/buildDailyMonitorSessionCards.test.ts
@@ -1,0 +1,145 @@
+import {
+  buildDailyMonitorCardioCardModel,
+  buildDailyMonitorWorkoutCardModel,
+  resolveCardioMonitorPresence,
+  resolveWorkoutMonitorPresence,
+} from "../buildDailyMonitorSessionCards";
+import type { WorkoutHistoryItem } from "@/lib/data/workouts/parseWorkoutFromRawEvent";
+
+const day = "2026-07-20" as const;
+
+function strengthItem(id: string, title: string): WorkoutHistoryItem {
+  return {
+    id,
+    observedAt: `${day}T18:00:00.000Z`,
+    sourceId: "apple_health",
+    title,
+    workoutType: "strength",
+    start: `${day}T18:00:00.000Z`,
+    end: `${day}T19:00:00.000Z`,
+    durationMinutes: 60,
+    calories: null,
+  } as WorkoutHistoryItem;
+}
+
+function cardioItem(id: string, title: string): WorkoutHistoryItem {
+  return {
+    id,
+    observedAt: `${day}T07:00:00.000Z`,
+    sourceId: "apple_health",
+    title,
+    workoutType: "running",
+    start: `${day}T07:00:00.000Z`,
+    end: `${day}T07:40:00.000Z`,
+    durationMinutes: 40,
+    calories: null,
+    distanceMeters: 5000,
+  } as WorkoutHistoryItem;
+}
+
+describe("Daily Monitor session cards", () => {
+  it("creates Workout for a current-day strength session", () => {
+    const model = buildDailyMonitorWorkoutCardModel({
+      requestedDay: day,
+      calendarDays: [{ day, workouts: [strengthItem("s1", "Evening Lift")] }],
+    });
+    expect(model).not.toBeNull();
+    expect(model!.primaryTitle).toMatch(/Evening Lift|Strength/i);
+    expect(resolveWorkoutMonitorPresence({ loading: false, error: null, model })).toBe(
+      "present_complete",
+    );
+  });
+
+  it("summarizes multiple strength sessions without inventing volume", () => {
+    const morning: WorkoutHistoryItem = {
+      ...strengthItem("s1", "AM Lift"),
+      start: `${day}T08:00:00.000Z`,
+      end: `${day}T08:45:00.000Z`,
+      observedAt: `${day}T08:00:00.000Z`,
+      durationMinutes: 45,
+    };
+    const evening: WorkoutHistoryItem = {
+      ...strengthItem("s2", "PM Lift"),
+      start: `${day}T18:00:00.000Z`,
+      end: `${day}T19:10:00.000Z`,
+      observedAt: `${day}T18:00:00.000Z`,
+      durationMinutes: 70,
+    };
+    const model = buildDailyMonitorWorkoutCardModel({
+      requestedDay: day,
+      calendarDays: [{ day, workouts: [morning, evening] }],
+    });
+    expect(model).not.toBeNull();
+    // Prefer an honest multi-session summary when reconciliation keeps both;
+    // never invent capacity / 1RM / Health State copy.
+    expect(model!.sessionCount).toBeGreaterThanOrEqual(1);
+    if (model!.sessionCount > 1) {
+      expect(model!.primaryTitle).toMatch(/workouts/i);
+    } else {
+      expect(model!.primaryTitle.length).toBeGreaterThan(0);
+    }
+    expect(JSON.stringify(model)).not.toMatch(/1RM|Elite|Deficient|Health State/);
+  });
+
+  it("does not create Workout for rest / empty day", () => {
+    expect(
+      buildDailyMonitorWorkoutCardModel({
+        requestedDay: day,
+        calendarDays: [{ day, workouts: [] }],
+      }),
+    ).toBeNull();
+  });
+
+  it("does not create Workout from a prior-day session", () => {
+    expect(
+      buildDailyMonitorWorkoutCardModel({
+        requestedDay: day,
+        calendarDays: [
+          {
+            day: "2026-07-19",
+            workouts: [strengthItem("s1", "Yesterday")],
+          },
+        ],
+      }),
+    ).toBeNull();
+  });
+
+  it("creates Cardio for a current-day cardio session and not from strength alone", () => {
+    const cardio = buildDailyMonitorCardioCardModel({
+      requestedDay: day,
+      calendarDays: [{ day, workouts: [cardioItem("c1", "Morning Run")] }],
+    });
+    expect(cardio).not.toBeNull();
+    expect(resolveCardioMonitorPresence({ loading: false, error: null, model: cardio })).toBe(
+      "present_complete",
+    );
+
+    const strengthOnly = buildDailyMonitorCardioCardModel({
+      requestedDay: day,
+      calendarDays: [{ day, workouts: [strengthItem("s1", "Lift")] }],
+    });
+    expect(strengthOnly).toBeNull();
+  });
+
+  it("keeps strength and cardio as separate cards without duplicating the same modality", () => {
+    const days = [
+      {
+        day,
+        workouts: [strengthItem("s1", "Lift"), cardioItem("c1", "Run")],
+      },
+    ];
+    const workout = buildDailyMonitorWorkoutCardModel({ requestedDay: day, calendarDays: days });
+    const cardio = buildDailyMonitorCardioCardModel({ requestedDay: day, calendarDays: days });
+    expect(workout).not.toBeNull();
+    expect(cardio).not.toBeNull();
+  });
+
+  it("does not create Cardio from steps-only evidence (no sessions)", () => {
+    expect(
+      buildDailyMonitorCardioCardModel({
+        requestedDay: day,
+        calendarDays: [{ day, workouts: [] }],
+      }),
+    ).toBeNull();
+  });
+});

--- a/lib/data/dash/__tests__/buildDailyMonitorSessionCards.test.ts
+++ b/lib/data/dash/__tests__/buildDailyMonitorSessionCards.test.ts
@@ -152,13 +152,14 @@ describe("Daily Monitor session cards", () => {
     expect(model!.intensityLabel).toBeNull();
   });
 
-  it("summarizes multiple strength sessions without inventing capacity", () => {
+  it("summarizes multiple strength sessions with latest-session title and metrics", () => {
     const morning: WorkoutHistoryItem = {
       ...strengthItem("s1", "AM Lift"),
       start: `${day}T08:00:00.000Z`,
       end: `${day}T08:45:00.000Z`,
       observedAt: `${day}T08:00:00.000Z`,
       durationMinutes: 45,
+      strengthVolumeKg: 500,
     };
     const evening: WorkoutHistoryItem = {
       ...strengthItem("s2", "PM Lift"),
@@ -166,17 +167,52 @@ describe("Daily Monitor session cards", () => {
       end: `${day}T19:10:00.000Z`,
       observedAt: `${day}T18:00:00.000Z`,
       durationMinutes: 70,
+      strengthVolumeKg: 1600,
+      strengthIngestExercises: legDayExercises,
     };
     const model = buildDailyMonitorWorkoutCardModel({
       requestedDay: day,
       calendarDays: [{ day, workouts: [morning, evening] }],
     });
     expect(model).not.toBeNull();
-    expect(model!.sessionCount).toBeGreaterThanOrEqual(1);
-    if (model!.sessionCount > 1) {
-      expect(model!.primaryTitle).toMatch(/workouts/i);
-    }
+    expect(model!.sessionCount).toBeGreaterThanOrEqual(2);
+    expect(model!.primaryTitle).toMatch(/PM Lift/i);
+    expect(model!.primaryTitle).not.toMatch(/^\d+ workouts$/i);
+    expect(model!.rows.find((r) => r.key === "total_volume")?.isAvailable).toBe(true);
+    expect(model!.accessibilityLabel).toMatch(/Latest of \d+ workouts today/);
     expect(JSON.stringify(model)).not.toMatch(/1RM|Elite|Deficient|Health State/);
+  });
+
+  it("keeps Total Volume Unavailable when load data is absent (no missing-as-zero)", () => {
+    const model = buildDailyMonitorWorkoutCardModel({
+      requestedDay: day,
+      calendarDays: [{ day, workouts: [strengthItem("s1", "Push")] }],
+    });
+    expect(model!.rows.find((r) => r.key === "total_volume")?.valueLabel).toBe("Unavailable");
+    expect(model!.rows.find((r) => r.key === "total_volume")?.isAvailable).toBe(false);
+    expect(model!.intensityLabel).toBeNull();
+  });
+
+  it("does not invent an absolute-tonnage Low/Moderate/High volume badge", () => {
+    const model = buildDailyMonitorWorkoutCardModel({
+      requestedDay: day,
+      calendarDays: [
+        {
+          day,
+          workouts: [
+            {
+              ...strengthItem("s1", "Leg Day A"),
+              strengthVolumeKg: 1600,
+              strengthIngestExercises: legDayExercises,
+            },
+          ],
+        },
+      ],
+    });
+    expect(model!.intensityLabel).toBe("High");
+    expect(model!.accessibilityLabel).toMatch(/Workout intensity High/);
+    expect(model!.accessibilityLabel).not.toMatch(/volume (Low|Moderate|High)/i);
+    expect(JSON.stringify(model)).not.toMatch(/vs recent|On target for this workout|tonnage/i);
   });
 
   it("does not create Workout for rest / empty day", () => {

--- a/lib/data/dash/__tests__/buildDailyMonitorSessionCards.test.ts
+++ b/lib/data/dash/__tests__/buildDailyMonitorSessionCards.test.ts
@@ -5,6 +5,7 @@ import {
   resolveWorkoutMonitorPresence,
 } from "../buildDailyMonitorSessionCards";
 import type { WorkoutHistoryItem } from "@/lib/data/workouts/parseWorkoutFromRawEvent";
+import type { ManualWorkoutExerciseSummary } from "@/lib/workouts/journal/manualWorkoutSummary";
 
 const day = "2026-07-20" as const;
 
@@ -37,20 +38,121 @@ function cardioItem(id: string, title: string): WorkoutHistoryItem {
   } as WorkoutHistoryItem;
 }
 
+const legDayExercises: ManualWorkoutExerciseSummary[] = [
+  {
+    exerciseId: "squat",
+    name: "Squat",
+    sets: [
+      { setNumber: 1, reps: 8, weightKg: 100, intensity: 7 },
+      { setNumber: 2, reps: 8, weightKg: 100, intensity: 8 },
+    ],
+  },
+];
+
 describe("Daily Monitor session cards", () => {
-  it("creates Workout for a current-day strength session", () => {
+  it("creates compact Workout with ordered rows and intensity from RPE", () => {
     const model = buildDailyMonitorWorkoutCardModel({
       requestedDay: day,
-      calendarDays: [{ day, workouts: [strengthItem("s1", "Evening Lift")] }],
+      calendarDays: [
+        {
+          day,
+          workouts: [
+            {
+              ...strengthItem("s1", "Leg Day A"),
+              strengthVolumeKg: 1600,
+              strengthIngestExercises: legDayExercises,
+              averageHeartRateBpm: 128,
+            },
+          ],
+        },
+      ],
+      energy: {
+        day,
+        estimatedKcal: { low: 1800, high: 2200, midpoint: 2000 },
+        confidence: "high",
+        variancePct: 0.1,
+        factors: {
+          strength: { low: 120, high: 180, midpoint: 150 },
+        },
+      } as never,
     });
     expect(model).not.toBeNull();
-    expect(model!.primaryTitle).toMatch(/Evening Lift|Strength/i);
-    expect(resolveWorkoutMonitorPresence({ loading: false, error: null, model })).toBe(
-      "present_complete",
+    expect(model!.primaryTitle).toMatch(/Leg Day A/i);
+    expect(model!.intensityLabel).toBe("High");
+    expect(model!.rows.map((r) => r.label)).toEqual([
+      "Duration",
+      "Total Volume",
+      "Estimated Calorie Burn",
+      "Average Heart Rate",
+    ]);
+    expect(model!.rows[1]?.valueLabel).toMatch(/lb|kg/);
+    expect(model!.rows[1]?.isAvailable).toBe(true);
+    expect(model!.rows[3]?.valueLabel).toBe("128 bpm");
+    expect(model!.accessibilityLabel).toMatch(/Opens Workouts/);
+    expect(model!.accessibilityLabel).toMatch(/Workout intensity High/);
+    expect(JSON.stringify(model)).not.toMatch(/1RM|Health State|Quads focused|14 sets/);
+    expect(resolveWorkoutMonitorPresence({ loading: false, error: null, model })).toMatch(
+      /^present_/,
     );
   });
 
-  it("summarizes multiple strength sessions without inventing volume", () => {
+  it("formats Total Volume in the preferred mass unit", () => {
+    const base = {
+      requestedDay: day,
+      calendarDays: [
+        {
+          day,
+          workouts: [
+            {
+              ...strengthItem("s1", "Leg Day A"),
+              strengthVolumeKg: 100,
+              strengthIngestExercises: legDayExercises,
+            },
+          ],
+        },
+      ],
+    } as const;
+    const lb = buildDailyMonitorWorkoutCardModel({ ...base, massUnit: "lb" });
+    const kg = buildDailyMonitorWorkoutCardModel({ ...base, massUnit: "kg" });
+    expect(lb!.rows.find((r) => r.key === "total_volume")?.valueLabel).toMatch(/lb/);
+    expect(kg!.rows.find((r) => r.key === "total_volume")?.valueLabel).toBe("100 kg");
+  });
+
+  it("does not infer intensity from heart rate alone", () => {
+    const model = buildDailyMonitorWorkoutCardModel({
+      requestedDay: day,
+      calendarDays: [
+        {
+          day,
+          workouts: [
+            {
+              ...strengthItem("s1", "Push"),
+              averageHeartRateBpm: 155,
+              // no ingest intensity / RPE
+            },
+          ],
+        },
+      ],
+    });
+    expect(model!.intensityLabel).toBeNull();
+    expect(model!.rows.find((r) => r.key === "average_heart_rate")?.valueLabel).toBe("155 bpm");
+  });
+
+  it("keeps missing calorie and HR as Unavailable, not zero", () => {
+    const model = buildDailyMonitorWorkoutCardModel({
+      requestedDay: day,
+      calendarDays: [{ day, workouts: [strengthItem("s1", "Push")] }],
+    });
+    expect(model).not.toBeNull();
+    const cal = model!.rows.find((r) => r.key === "estimated_calorie_burn");
+    const hr = model!.rows.find((r) => r.key === "average_heart_rate");
+    expect(cal?.valueLabel).toBe("Unavailable");
+    expect(hr?.valueLabel).toBe("Unavailable");
+    expect(cal?.isAvailable).toBe(false);
+    expect(model!.intensityLabel).toBeNull();
+  });
+
+  it("summarizes multiple strength sessions without inventing capacity", () => {
     const morning: WorkoutHistoryItem = {
       ...strengthItem("s1", "AM Lift"),
       start: `${day}T08:00:00.000Z`,
@@ -70,13 +172,9 @@ describe("Daily Monitor session cards", () => {
       calendarDays: [{ day, workouts: [morning, evening] }],
     });
     expect(model).not.toBeNull();
-    // Prefer an honest multi-session summary when reconciliation keeps both;
-    // never invent capacity / 1RM / Health State copy.
     expect(model!.sessionCount).toBeGreaterThanOrEqual(1);
     if (model!.sessionCount > 1) {
       expect(model!.primaryTitle).toMatch(/workouts/i);
-    } else {
-      expect(model!.primaryTitle.length).toBeGreaterThan(0);
     }
     expect(JSON.stringify(model)).not.toMatch(/1RM|Elite|Deficient|Health State/);
   });

--- a/lib/data/dash/__tests__/buildDailyMonitorStressCardModel.test.ts
+++ b/lib/data/dash/__tests__/buildDailyMonitorStressCardModel.test.ts
@@ -1,0 +1,57 @@
+import {
+  buildDailyMonitorStressCardModel,
+  resolveStressMonitorPresence,
+} from "../buildDailyMonitorStressCardModel";
+import type { OuraDailyStressDayDto } from "@oli/contracts/ouraVendor";
+
+describe("buildDailyMonitorStressCardModel", () => {
+  it("presents current-day Oura stress summary without inventing a score", () => {
+    const day: OuraDailyStressDayDto = {
+      day: "2026-07-20",
+      daySummary: "normal",
+      stressHighSeconds: 3600,
+      recoveryHighSeconds: 1800,
+      source: "oura",
+    } as OuraDailyStressDayDto;
+    const model = buildDailyMonitorStressCardModel({
+      requestedDay: "2026-07-20",
+      day,
+    });
+    expect(model?.daySummaryLabel).toBe("Normal");
+    expect(model?.sourceLabel).toBe("Oura");
+    expect(model?.stressedMinutesLabel).toBe("60 min");
+    expect(JSON.stringify(model)).not.toMatch(/"score"|0–100|Deficient|Elite/);
+    expect(
+      resolveStressMonitorPresence({
+        loading: false,
+        error: null,
+        ouraDisconnected: false,
+        model,
+      }),
+    ).toBe("present_complete");
+  });
+
+  it("rejects prior-day stress", () => {
+    expect(
+      buildDailyMonitorStressCardModel({
+        requestedDay: "2026-07-20",
+        day: {
+          day: "2026-07-19",
+          daySummary: "stressful",
+          source: "oura",
+        } as OuraDailyStressDayDto,
+      }),
+    ).toBeNull();
+  });
+
+  it("marks disconnect without day evidence as unavailable_source", () => {
+    expect(
+      resolveStressMonitorPresence({
+        loading: false,
+        error: null,
+        ouraDisconnected: true,
+        model: null,
+      }),
+    ).toBe("unavailable_source");
+  });
+});

--- a/lib/data/dash/__tests__/buildDailyMonitorViewModel.test.ts
+++ b/lib/data/dash/__tests__/buildDailyMonitorViewModel.test.ts
@@ -1,0 +1,107 @@
+import { buildDailyMonitorViewModel } from "../buildDailyMonitorViewModel";
+import type { DailyMonitorPresenceStatus } from "../dailyMonitorPresence";
+
+function domain(
+  domainId:
+    | "sleep"
+    | "readiness"
+    | "energy"
+    | "nutrition"
+    | "body_composition",
+  presence: DailyMonitorPresenceStatus,
+) {
+  return { domainId, presence };
+}
+
+describe("buildDailyMonitorViewModel", () => {
+  it("shows loading when all domains are unresolved", () => {
+    const vm = buildDailyMonitorViewModel({
+      requestedDay: "2026-07-20",
+      dateLabel: "Mon Jul 20, 2026",
+      signedOut: false,
+      domains: [
+        domain("sleep", "loading_presence"),
+        domain("readiness", "loading_presence"),
+        domain("energy", "loading_presence"),
+        domain("nutrition", "loading_presence"),
+        domain("body_composition", "loading_presence"),
+      ],
+    });
+    expect(vm.screenStatus).toBe("loading");
+    expect(vm.visibleDomainIds).toEqual([]);
+    expect(vm.sections).toEqual([]);
+  });
+
+  it("omits empty sections and keeps stable domain order", () => {
+    const vm = buildDailyMonitorViewModel({
+      requestedDay: "2026-07-20",
+      dateLabel: "Mon Jul 20, 2026",
+      signedOut: false,
+      domains: [
+        domain("sleep", "present_complete"),
+        domain("readiness", "absent_no_day_evidence"),
+        domain("energy", "present_partial"),
+        domain("nutrition", "absent_no_day_evidence"),
+        domain("body_composition", "absent_no_day_evidence"),
+      ],
+    });
+    expect(vm.screenStatus).toBe("ready");
+    expect(vm.visibleDomainIds).toEqual(["sleep", "energy"]);
+    expect(vm.sections.map((s) => s.id)).toEqual(["recovery", "movement_output"]);
+    expect(vm.sections[0]?.domainIds).toEqual(["sleep"]);
+    expect(vm.sections[1]?.domainIds).toEqual(["energy"]);
+  });
+
+  it("shows empty Monitor when all domains lack current-day evidence", () => {
+    const vm = buildDailyMonitorViewModel({
+      requestedDay: "2026-07-20",
+      dateLabel: "Mon Jul 20, 2026",
+      signedOut: false,
+      domains: [
+        domain("sleep", "absent_no_day_evidence"),
+        domain("readiness", "unavailable_source"),
+        domain("energy", "absent_no_day_evidence"),
+        domain("nutrition", "absent_no_day_evidence"),
+        domain("body_composition", "absent_no_day_evidence"),
+      ],
+    });
+    expect(vm.screenStatus).toBe("empty");
+    expect(vm.emptyTitle).toMatch(/No health data is available for today/i);
+    expect(vm.visibleDomainIds).toEqual([]);
+  });
+
+  it("shows partial refresh banner when cards are present and some domains erred", () => {
+    const vm = buildDailyMonitorViewModel({
+      requestedDay: "2026-07-20",
+      dateLabel: "Mon Jul 20, 2026",
+      signedOut: false,
+      domains: [
+        domain("sleep", "present_complete"),
+        domain("readiness", "screen_level_error"),
+        domain("energy", "absent_no_day_evidence"),
+        domain("nutrition", "absent_no_day_evidence"),
+        domain("body_composition", "absent_no_day_evidence"),
+      ],
+    });
+    expect(vm.screenStatus).toBe("partial_refresh");
+    expect(vm.showPartialRefreshBanner).toBe(true);
+    expect(vm.visibleDomainIds).toEqual(["sleep"]);
+  });
+
+  it("shows full error when every domain failed", () => {
+    const vm = buildDailyMonitorViewModel({
+      requestedDay: "2026-07-20",
+      dateLabel: "Mon Jul 20, 2026",
+      signedOut: false,
+      domains: [
+        domain("sleep", "screen_level_error"),
+        domain("readiness", "screen_level_error"),
+        domain("energy", "screen_level_error"),
+        domain("nutrition", "screen_level_error"),
+        domain("body_composition", "screen_level_error"),
+      ],
+    });
+    expect(vm.screenStatus).toBe("error");
+    expect(vm.errorMessage).toBeTruthy();
+  });
+});

--- a/lib/data/dash/__tests__/buildDailyMonitorViewModel.test.ts
+++ b/lib/data/dash/__tests__/buildDailyMonitorViewModel.test.ts
@@ -1,16 +1,24 @@
+import type { DailyMonitorDomainId, DailyMonitorPresenceStatus } from "../dailyMonitorPresence";
 import { buildDailyMonitorViewModel } from "../buildDailyMonitorViewModel";
-import type { DailyMonitorPresenceStatus } from "../dailyMonitorPresence";
 
-function domain(
-  domainId:
-    | "sleep"
-    | "readiness"
-    | "energy"
-    | "nutrition"
-    | "body_composition",
-  presence: DailyMonitorPresenceStatus,
-) {
+function domain(domainId: DailyMonitorDomainId, presence: DailyMonitorPresenceStatus) {
   return { domainId, presence };
+}
+
+function allDomains(presence: DailyMonitorPresenceStatus) {
+  return (
+    [
+      "sleep",
+      "readiness",
+      "stress",
+      "activity",
+      "workout",
+      "cardio",
+      "energy",
+      "nutrition",
+      "body_composition",
+    ] as const
+  ).map((id) => domain(id, presence));
 }
 
 describe("buildDailyMonitorViewModel", () => {
@@ -19,20 +27,14 @@ describe("buildDailyMonitorViewModel", () => {
       requestedDay: "2026-07-20",
       dateLabel: "Mon Jul 20, 2026",
       signedOut: false,
-      domains: [
-        domain("sleep", "loading_presence"),
-        domain("readiness", "loading_presence"),
-        domain("energy", "loading_presence"),
-        domain("nutrition", "loading_presence"),
-        domain("body_composition", "loading_presence"),
-      ],
+      domains: allDomains("loading_presence"),
     });
     expect(vm.screenStatus).toBe("loading");
     expect(vm.visibleDomainIds).toEqual([]);
     expect(vm.sections).toEqual([]);
   });
 
-  it("omits empty sections and keeps stable domain order", () => {
+  it("omits empty sections and keeps stable domain order including new domains", () => {
     const vm = buildDailyMonitorViewModel({
       requestedDay: "2026-07-20",
       dateLabel: "Mon Jul 20, 2026",
@@ -40,16 +42,20 @@ describe("buildDailyMonitorViewModel", () => {
       domains: [
         domain("sleep", "present_complete"),
         domain("readiness", "absent_no_day_evidence"),
+        domain("stress", "present_complete"),
+        domain("activity", "present_complete"),
+        domain("workout", "present_complete"),
+        domain("cardio", "absent_no_day_evidence"),
         domain("energy", "present_partial"),
         domain("nutrition", "absent_no_day_evidence"),
         domain("body_composition", "absent_no_day_evidence"),
       ],
     });
     expect(vm.screenStatus).toBe("ready");
-    expect(vm.visibleDomainIds).toEqual(["sleep", "energy"]);
+    expect(vm.visibleDomainIds).toEqual(["sleep", "stress", "activity", "workout", "energy"]);
     expect(vm.sections.map((s) => s.id)).toEqual(["recovery", "movement_output"]);
-    expect(vm.sections[0]?.domainIds).toEqual(["sleep"]);
-    expect(vm.sections[1]?.domainIds).toEqual(["energy"]);
+    expect(vm.sections[0]?.domainIds).toEqual(["sleep", "stress"]);
+    expect(vm.sections[1]?.domainIds).toEqual(["activity", "workout", "energy"]);
   });
 
   it("shows empty Monitor when all domains lack current-day evidence", () => {
@@ -57,13 +63,7 @@ describe("buildDailyMonitorViewModel", () => {
       requestedDay: "2026-07-20",
       dateLabel: "Mon Jul 20, 2026",
       signedOut: false,
-      domains: [
-        domain("sleep", "absent_no_day_evidence"),
-        domain("readiness", "unavailable_source"),
-        domain("energy", "absent_no_day_evidence"),
-        domain("nutrition", "absent_no_day_evidence"),
-        domain("body_composition", "absent_no_day_evidence"),
-      ],
+      domains: allDomains("absent_no_day_evidence"),
     });
     expect(vm.screenStatus).toBe("empty");
     expect(vm.emptyTitle).toMatch(/No health data is available for today/i);
@@ -78,6 +78,10 @@ describe("buildDailyMonitorViewModel", () => {
       domains: [
         domain("sleep", "present_complete"),
         domain("readiness", "screen_level_error"),
+        domain("stress", "absent_no_day_evidence"),
+        domain("activity", "absent_no_day_evidence"),
+        domain("workout", "absent_no_day_evidence"),
+        domain("cardio", "absent_no_day_evidence"),
         domain("energy", "absent_no_day_evidence"),
         domain("nutrition", "absent_no_day_evidence"),
         domain("body_composition", "absent_no_day_evidence"),
@@ -93,13 +97,7 @@ describe("buildDailyMonitorViewModel", () => {
       requestedDay: "2026-07-20",
       dateLabel: "Mon Jul 20, 2026",
       signedOut: false,
-      domains: [
-        domain("sleep", "screen_level_error"),
-        domain("readiness", "screen_level_error"),
-        domain("energy", "screen_level_error"),
-        domain("nutrition", "screen_level_error"),
-        domain("body_composition", "screen_level_error"),
-      ],
+      domains: allDomains("screen_level_error"),
     });
     expect(vm.screenStatus).toBe("error");
     expect(vm.errorMessage).toBeTruthy();

--- a/lib/data/dash/__tests__/dailyMonitorPresentationRatings.test.ts
+++ b/lib/data/dash/__tests__/dailyMonitorPresentationRatings.test.ts
@@ -1,9 +1,13 @@
 import {
   buildDailyMonitorActivityRatingLabel,
   buildDailyMonitorEnergyEstimatedRating,
+  buildOuraProviderSourceAccessibility,
+  buildOuraRatingAccessibility,
   buildOuraScoreRatingAccessibility,
+  mapOuraProviderRatingToTone,
   mapWorkoutAverageIntensityToLabel,
 } from "../dailyMonitorPresentationRatings";
+import { DASH_MONITOR_RATING_TONE_CHROME_DARK } from "@/lib/ui/theme/dashMonitorRatingToneChrome";
 
 describe("dailyMonitorPresentationRatings", () => {
   it("appends so far to Activity Today descriptors", () => {
@@ -34,12 +38,36 @@ describe("dailyMonitorPresentationRatings", () => {
     );
   });
 
-  it("builds Oura rating accessibility without inventing scores", () => {
+  it("maps Oura provider labels to semantic tones without numeric thresholds", () => {
+    expect(mapOuraProviderRatingToTone("Pay attention")).toBe("critical");
+    expect(mapOuraProviderRatingToTone("Fair")).toBe("caution");
+    expect(mapOuraProviderRatingToTone("Good")).toBe("positive");
+    expect(mapOuraProviderRatingToTone("Optimal")).toBe("optimal");
+    expect(mapOuraProviderRatingToTone(null)).toBeNull();
+    expect(mapOuraProviderRatingToTone(undefined)).toBeNull();
+    expect(mapOuraProviderRatingToTone("Elite")).toBeNull();
+    expect(mapOuraProviderRatingToTone("Average")).toBeNull();
+    // Tone mapper source must not embed score bands (owned by ouraScore.ts).
+    const src = mapOuraProviderRatingToTone.toString();
+    expect(src).not.toMatch(/\b85\b/);
+    expect(src).not.toMatch(/\b70\b/);
+    expect(src).not.toMatch(/\b60\b/);
+  });
+
+  it("resolves distinct chrome for each Oura tone (optimal is blue-family)", () => {
+    expect(DASH_MONITOR_RATING_TONE_CHROME_DARK.critical.foreground).toMatch(/FFB3B8|#FF/i);
+    expect(DASH_MONITOR_RATING_TONE_CHROME_DARK.caution.foreground).toMatch(/FFE08A|#FF/i);
+    expect(DASH_MONITOR_RATING_TONE_CHROME_DARK.positive.foreground).toMatch(/B8F7CF|#B8/i);
+    expect(DASH_MONITOR_RATING_TONE_CHROME_DARK.optimal.foreground).toMatch(/C9D9FF|#C9/i);
+    expect(DASH_MONITOR_RATING_TONE_CHROME_DARK.optimal.background).toMatch(/58,\s*91,\s*219/);
+  });
+
+  it("builds distinct source and rating accessibility without color names", () => {
+    expect(buildOuraProviderSourceAccessibility()).toBe("Source: Oura");
+    expect(buildOuraRatingAccessibility("Optimal")).toBe("Rating Optimal.");
     expect(buildOuraScoreRatingAccessibility({ domain: "sleep", ratingLabel: "Optimal" })).toBe(
-      "Oura sleep rating: Optimal",
+      "Rating Optimal.",
     );
-    expect(
-      buildOuraScoreRatingAccessibility({ domain: "readiness", ratingLabel: "Good" }),
-    ).toBe("Oura readiness rating: Good");
+    expect(buildOuraRatingAccessibility("Good")).not.toMatch(/blue|green|red|amber|color/i);
   });
 });

--- a/lib/data/dash/__tests__/dailyMonitorPresentationRatings.test.ts
+++ b/lib/data/dash/__tests__/dailyMonitorPresentationRatings.test.ts
@@ -1,0 +1,45 @@
+import {
+  buildDailyMonitorActivityRatingLabel,
+  buildDailyMonitorEnergyEstimatedRating,
+  buildOuraScoreRatingAccessibility,
+  mapWorkoutAverageIntensityToLabel,
+} from "../dailyMonitorPresentationRatings";
+
+describe("dailyMonitorPresentationRatings", () => {
+  it("appends so far to Activity Today descriptors", () => {
+    expect(buildDailyMonitorActivityRatingLabel(0).label).toBe("Sedentary so far");
+    expect(buildDailyMonitorActivityRatingLabel(6000).label).toBe("Lightly Active so far");
+    expect(buildDailyMonitorActivityRatingLabel(11000).label).toBe("Active so far");
+    expect(buildDailyMonitorActivityRatingLabel(0).accessibilityLabel).toMatch(/Activity level/);
+  });
+
+  it("maps 0–10 average intensity to Low/Moderate/High/Very High", () => {
+    expect(mapWorkoutAverageIntensityToLabel(0)?.label).toBe("Low");
+    expect(mapWorkoutAverageIntensityToLabel(4)?.label).toBe("Low");
+    expect(mapWorkoutAverageIntensityToLabel(5)?.label).toBe("Moderate");
+    expect(mapWorkoutAverageIntensityToLabel(6)?.label).toBe("Moderate");
+    expect(mapWorkoutAverageIntensityToLabel(6.9)?.label).toBe("Moderate");
+    expect(mapWorkoutAverageIntensityToLabel(7)?.label).toBe("High");
+    expect(mapWorkoutAverageIntensityToLabel(9)?.label).toBe("Very High");
+    expect(mapWorkoutAverageIntensityToLabel(10)?.label).toBe("Very High");
+    expect(mapWorkoutAverageIntensityToLabel(null)).toBeNull();
+    expect(mapWorkoutAverageIntensityToLabel(11)).toBeNull();
+    expect(mapWorkoutAverageIntensityToLabel(-1)).toBeNull();
+  });
+
+  it("uses Estimated for Energy when no normalized PAL classifier exists", () => {
+    expect(buildDailyMonitorEnergyEstimatedRating().label).toBe("Estimated");
+    expect(buildDailyMonitorEnergyEstimatedRating().accessibilityLabel).toMatch(
+      /Estimated energy expenditure level/,
+    );
+  });
+
+  it("builds Oura rating accessibility without inventing scores", () => {
+    expect(buildOuraScoreRatingAccessibility({ domain: "sleep", ratingLabel: "Optimal" })).toBe(
+      "Oura sleep rating: Optimal",
+    );
+    expect(
+      buildOuraScoreRatingAccessibility({ domain: "readiness", ratingLabel: "Good" }),
+    ).toBe("Oura readiness rating: Good");
+  });
+});

--- a/lib/data/dash/__tests__/dailyMonitorPresentationRatings.test.ts
+++ b/lib/data/dash/__tests__/dailyMonitorPresentationRatings.test.ts
@@ -1,20 +1,51 @@
 import {
   buildDailyMonitorActivityRatingLabel,
-  buildDailyMonitorEnergyEstimatedRating,
   buildOuraProviderSourceAccessibility,
   buildOuraRatingAccessibility,
   buildOuraScoreRatingAccessibility,
+  mapActivityStepDescriptorToTone,
   mapOuraProviderRatingToTone,
   mapWorkoutAverageIntensityToLabel,
 } from "../dailyMonitorPresentationRatings";
+import { ACTIVITY_STEP_DESCRIPTOR_PILL_LABELS } from "@/lib/utils/activityStepRating";
 import { DASH_MONITOR_RATING_TONE_CHROME_DARK } from "@/lib/ui/theme/dashMonitorRatingToneChrome";
 
 describe("dailyMonitorPresentationRatings", () => {
-  it("appends so far to Activity Today descriptors", () => {
-    expect(buildDailyMonitorActivityRatingLabel(0).label).toBe("Sedentary so far");
-    expect(buildDailyMonitorActivityRatingLabel(6000).label).toBe("Lightly Active so far");
-    expect(buildDailyMonitorActivityRatingLabel(11000).label).toBe("Active so far");
-    expect(buildDailyMonitorActivityRatingLabel(0).accessibilityLabel).toMatch(/Activity level/);
+  it("uses Activity Today descriptors without so far and maps tones", () => {
+    expect(buildDailyMonitorActivityRatingLabel(0).label).toBe("Sedentary");
+    expect(buildDailyMonitorActivityRatingLabel(0).label).not.toMatch(/so far/i);
+    expect(buildDailyMonitorActivityRatingLabel(6000).label).toBe("Lightly Active");
+    expect(buildDailyMonitorActivityRatingLabel(8000).label).toBe("Moderately Active");
+    expect(buildDailyMonitorActivityRatingLabel(11000).label).toBe("Active");
+    expect(buildDailyMonitorActivityRatingLabel(13000).label).toBe("Very Active");
+    expect(buildDailyMonitorActivityRatingLabel(16000).label).toBe("Highly Active");
+    expect(buildDailyMonitorActivityRatingLabel(0).accessibilityLabel).toBe("Activity level Sedentary.");
+    expect(buildDailyMonitorActivityRatingLabel(0).accessibilityLabel).not.toMatch(/so far/i);
+    expect(buildDailyMonitorActivityRatingLabel(0).tone).toBe("critical");
+    expect(buildDailyMonitorActivityRatingLabel(6000).tone).toBe("caution");
+    expect(buildDailyMonitorActivityRatingLabel(11000).tone).toBe("positive");
+    expect(buildDailyMonitorActivityRatingLabel(16000).tone).toBe("optimal");
+    expect(ACTIVITY_STEP_DESCRIPTOR_PILL_LABELS).toEqual([
+      "Sedentary",
+      "Lightly Active",
+      "Moderately Active",
+      "Active",
+      "Very Active",
+      "Highly Active",
+    ]);
+  });
+
+  it("maps activity step descriptors to tones without embedding step thresholds", () => {
+    expect(mapActivityStepDescriptorToTone(0)).toBe("critical");
+    expect(mapActivityStepDescriptorToTone(4999)).toBe("critical");
+    expect(mapActivityStepDescriptorToTone(5000)).toBe("caution");
+    expect(mapActivityStepDescriptorToTone(9999)).toBe("caution");
+    expect(mapActivityStepDescriptorToTone(10000)).toBe("positive");
+    expect(mapActivityStepDescriptorToTone(14999)).toBe("positive");
+    expect(mapActivityStepDescriptorToTone(15000)).toBe("optimal");
+    const src = mapActivityStepDescriptorToTone.toString();
+    expect(src).not.toMatch(/\b5000\b/);
+    expect(src).not.toMatch(/\b7500\b/);
   });
 
   it("maps 0–10 average intensity to Low/Moderate/High/Very High", () => {
@@ -31,11 +62,9 @@ describe("dailyMonitorPresentationRatings", () => {
     expect(mapWorkoutAverageIntensityToLabel(-1)).toBeNull();
   });
 
-  it("uses Estimated for Energy when no normalized PAL classifier exists", () => {
-    expect(buildDailyMonitorEnergyEstimatedRating().label).toBe("Estimated");
-    expect(buildDailyMonitorEnergyEstimatedRating().accessibilityLabel).toMatch(
-      /Estimated energy expenditure level/,
-    );
+  it("does not classify Energy with Estimated or absolute-kcal bands", () => {
+    expect(buildDailyMonitorActivityRatingLabel.toString()).not.toMatch(/Estimated/);
+    expect(mapWorkoutAverageIntensityToLabel.toString()).not.toMatch(/PAL|kcal/i);
   });
 
   it("maps Oura provider labels to semantic tones without numeric thresholds", () => {
@@ -69,5 +98,8 @@ describe("dailyMonitorPresentationRatings", () => {
       "Rating Optimal.",
     );
     expect(buildOuraRatingAccessibility("Good")).not.toMatch(/blue|green|red|amber|color/i);
+    expect(buildDailyMonitorActivityRatingLabel(11000).accessibilityLabel).not.toMatch(
+      /blue|green|red|amber|color/i,
+    );
   });
 });

--- a/lib/data/dash/__tests__/dashDailyMonitorFoundation.test.ts
+++ b/lib/data/dash/__tests__/dashDailyMonitorFoundation.test.ts
@@ -1,0 +1,55 @@
+import {
+  DASH_DAILY_MONITOR_FOUNDATION_ENV_KEY,
+  DASH_DAILY_MONITOR_FOUNDATION_FLAG_ID,
+  DAILY_MONITOR_SCREEN_TITLE,
+  DAILY_MONITOR_TAB_A11Y_LABEL,
+  DAILY_MONITOR_TAB_TITLE,
+  isDashDailyMonitorFoundationEnabled,
+  setDashDailyMonitorFoundationEnabledForTests,
+} from "../dashDailyMonitorFoundation";
+
+describe("dashDailyMonitorFoundation flag", () => {
+  const prevEnv = process.env[DASH_DAILY_MONITOR_FOUNDATION_ENV_KEY];
+
+  afterEach(() => {
+    setDashDailyMonitorFoundationEnabledForTests(null);
+    if (prevEnv === undefined) {
+      delete process.env[DASH_DAILY_MONITOR_FOUNDATION_ENV_KEY];
+    } else {
+      process.env[DASH_DAILY_MONITOR_FOUNDATION_ENV_KEY] = prevEnv;
+    }
+  });
+
+  it("exposes the conceptual product flag id and consumer copy", () => {
+    expect(DASH_DAILY_MONITOR_FOUNDATION_FLAG_ID).toBe("dashDailyMonitorFoundation");
+    expect(DAILY_MONITOR_SCREEN_TITLE).toBe("Daily Monitor");
+    expect(DAILY_MONITOR_TAB_TITLE).toBe("Monitor");
+    expect(DAILY_MONITOR_TAB_A11Y_LABEL).toBe("Daily Monitor");
+  });
+
+  it("defaults to enabled", () => {
+    delete process.env[DASH_DAILY_MONITOR_FOUNDATION_ENV_KEY];
+    expect(isDashDailyMonitorFoundationEnabled()).toBe(true);
+  });
+
+  it("disables when env override is 0", () => {
+    process.env[DASH_DAILY_MONITOR_FOUNDATION_ENV_KEY] = "0";
+    expect(isDashDailyMonitorFoundationEnabled()).toBe(false);
+  });
+
+  it("enables when env override is 1", () => {
+    process.env[DASH_DAILY_MONITOR_FOUNDATION_ENV_KEY] = "1";
+    expect(isDashDailyMonitorFoundationEnabled()).toBe(true);
+  });
+
+  it("treats unexpected env values as enabled", () => {
+    process.env[DASH_DAILY_MONITOR_FOUNDATION_ENV_KEY] = "false";
+    expect(isDashDailyMonitorFoundationEnabled()).toBe(true);
+  });
+
+  it("test override wins over env", () => {
+    process.env[DASH_DAILY_MONITOR_FOUNDATION_ENV_KEY] = "0";
+    setDashDailyMonitorFoundationEnabledForTests(true);
+    expect(isDashDailyMonitorFoundationEnabled()).toBe(true);
+  });
+});

--- a/lib/data/dash/__tests__/dashDailyMonitorFoundation.test.ts
+++ b/lib/data/dash/__tests__/dashDailyMonitorFoundation.test.ts
@@ -1,6 +1,7 @@
 import {
   DASH_DAILY_MONITOR_FOUNDATION_ENV_KEY,
   DASH_DAILY_MONITOR_FOUNDATION_FLAG_ID,
+  DAILY_MONITOR_APP_HEADER_TITLE,
   DAILY_MONITOR_SCREEN_TITLE,
   DAILY_MONITOR_TAB_A11Y_LABEL,
   DAILY_MONITOR_TAB_TITLE,
@@ -22,6 +23,7 @@ describe("dashDailyMonitorFoundation flag", () => {
 
   it("exposes the conceptual product flag id and consumer copy", () => {
     expect(DASH_DAILY_MONITOR_FOUNDATION_FLAG_ID).toBe("dashDailyMonitorFoundation");
+    expect(DAILY_MONITOR_APP_HEADER_TITLE).toBe("Oli");
     expect(DAILY_MONITOR_SCREEN_TITLE).toBe("Daily Monitor");
     expect(DAILY_MONITOR_TAB_TITLE).toBe("Monitor");
     expect(DAILY_MONITOR_TAB_A11Y_LABEL).toBe("Daily Monitor");

--- a/lib/data/dash/__tests__/dashExperienceHostMounting.test.tsx
+++ b/lib/data/dash/__tests__/dashExperienceHostMounting.test.tsx
@@ -2,6 +2,9 @@
  * Proves only one Dash experience host mounts for each flag combination.
  */
 
+import fs from "node:fs";
+import path from "node:path";
+
 import React, { act } from "react";
 import renderer from "react-test-renderer";
 
@@ -85,5 +88,16 @@ describe("Dash experience host mounting", () => {
     expect(mockLegacyDashHost).toHaveBeenCalledTimes(1);
     expect(mockDailyMonitorHost).not.toHaveBeenCalled();
     tree.unmount();
+  });
+
+  it("keeps Monitor-only domain hooks out of LegacyDashHost source", () => {
+    const legacySrc = fs.readFileSync(
+      path.join(__dirname, "../../../../components/dashboard/LegacyDashHost.tsx"),
+      "utf8",
+    );
+    expect(legacySrc).not.toMatch(/useDailyMonitorActivityCard/);
+    expect(legacySrc).not.toMatch(/useDailyMonitorSessionCards/);
+    expect(legacySrc).not.toMatch(/useDailyMonitorStressCard/);
+    expect(legacySrc).not.toMatch(/DailyMonitorDomainCards/);
   });
 });

--- a/lib/data/dash/__tests__/dashExperienceHostMounting.test.tsx
+++ b/lib/data/dash/__tests__/dashExperienceHostMounting.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * Proves only one Dash experience host mounts for each flag combination.
+ */
+
+import React, { act } from "react";
+import renderer from "react-test-renderer";
+
+import { setDashDailyMonitorFoundationEnabledForTests } from "@/lib/data/dash/dashDailyMonitorFoundation";
+import { setDashWeeklyProgressRelocationEnabledForTests } from "@/lib/data/dash/dashWeeklyProgressRelocation";
+import { allowConsoleForThisTest } from "../../../../scripts/test/consoleGuard";
+
+const mockDailyMonitorHost = jest.fn(() => null);
+const mockLegacyDashHost = jest.fn(() => null);
+
+jest.mock("@/components/dashboard/DailyMonitorHost", () => ({
+  DailyMonitorHost: () => mockDailyMonitorHost(),
+}));
+
+jest.mock("@/components/dashboard/LegacyDashHost", () => ({
+  LegacyDashHost: () => mockLegacyDashHost(),
+}));
+
+jest.mock("@/lib/ui/ScreenStates", () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const R = require("react");
+  return {
+    ScreenContainer: ({ children }: { children: unknown }) =>
+      R.createElement(R.Fragment, null, children),
+  };
+});
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const DashScreen = require("../../../../app/(app)/(tabs)/dash").default;
+
+describe("Dash experience host mounting", () => {
+  afterEach(() => {
+    setDashDailyMonitorFoundationEnabledForTests(null);
+    setDashWeeklyProgressRelocationEnabledForTests(null);
+    mockDailyMonitorHost.mockClear();
+    mockLegacyDashHost.mockClear();
+  });
+
+  async function mountDash(): Promise<renderer.ReactTestRenderer> {
+    // React may emit act() warnings for synchronous host mount bookkeeping; allow and flush.
+    allowConsoleForThisTest({ error: [/not wrapped in act/] });
+    let tree!: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(React.createElement(DashScreen));
+      await Promise.resolve();
+    });
+    return tree;
+  }
+
+  it("mounts Daily Monitor when both flags are enabled", async () => {
+    setDashDailyMonitorFoundationEnabledForTests(true);
+    setDashWeeklyProgressRelocationEnabledForTests(true);
+    const tree = await mountDash();
+    expect(mockDailyMonitorHost).toHaveBeenCalledTimes(1);
+    expect(mockLegacyDashHost).not.toHaveBeenCalled();
+    tree.unmount();
+  });
+
+  it("mounts legacy Dash when Daily Monitor is disabled", async () => {
+    setDashDailyMonitorFoundationEnabledForTests(false);
+    setDashWeeklyProgressRelocationEnabledForTests(true);
+    const tree = await mountDash();
+    expect(mockLegacyDashHost).toHaveBeenCalledTimes(1);
+    expect(mockDailyMonitorHost).not.toHaveBeenCalled();
+    tree.unmount();
+  });
+
+  it("falls back to legacy when Daily Monitor is on but relocation is off", async () => {
+    setDashDailyMonitorFoundationEnabledForTests(true);
+    setDashWeeklyProgressRelocationEnabledForTests(false);
+    const tree = await mountDash();
+    expect(mockLegacyDashHost).toHaveBeenCalledTimes(1);
+    expect(mockDailyMonitorHost).not.toHaveBeenCalled();
+    tree.unmount();
+  });
+
+  it("mounts legacy Dash when both flags are disabled", async () => {
+    setDashDailyMonitorFoundationEnabledForTests(false);
+    setDashWeeklyProgressRelocationEnabledForTests(false);
+    const tree = await mountDash();
+    expect(mockLegacyDashHost).toHaveBeenCalledTimes(1);
+    expect(mockDailyMonitorHost).not.toHaveBeenCalled();
+    tree.unmount();
+  });
+});

--- a/lib/data/dash/__tests__/resolveDailyMonitorDomainPresence.test.ts
+++ b/lib/data/dash/__tests__/resolveDailyMonitorDomainPresence.test.ts
@@ -1,0 +1,335 @@
+import {
+  resolveBodyCompositionMonitorPresence,
+  resolveEnergyMonitorPresence,
+  resolveNutritionMonitorPresence,
+  resolveReadinessMonitorPresence,
+  resolveSleepMonitorPresence,
+} from "../resolveDailyMonitorDomainPresence";
+import type { DailySleepCardViewModel } from "../dailySleepCardViewModel";
+import type { DailyReadinessCardViewModel } from "@/lib/ui/dash/DailyReadinessCard";
+import type { BuiltBodyCompositionDashCard } from "../buildBodyCompositionDashCardModel";
+
+describe("resolveSleepMonitorPresence", () => {
+  it("marks exact ready signal as present", () => {
+    const vm = {
+      status: "ready",
+      day: "2026-07-20",
+      isRefreshing: false,
+      model: {
+        day: "2026-07-20",
+        headlineValueText: "90",
+        durationValueText: "7h",
+        scoreUnavailable: false,
+        scoreUnavailableLabel: null,
+        scoreValueText: "90",
+        ratingLabel: "Optimal",
+        ratingTone: "optimal",
+        summarySentence: "ok",
+        metricRows: [
+          {
+            id: "sleep_duration",
+            label: "Duration",
+            value: "7h",
+            accessibilityValue: "7h",
+            isAvailable: true,
+            detail: { title: "Duration", value: "7h", body: "" },
+          },
+        ],
+        hasAnySignal: true,
+        emptyStateTitle: null,
+        emptyStateSubtitle: null,
+        lastNightSubtitle: "Last night’s sleep",
+      },
+    } as DailySleepCardViewModel;
+    expect(resolveSleepMonitorPresence(vm)).toBe("present_complete");
+  });
+
+  it("marks missing / prior-night path as absent", () => {
+    const vm = {
+      status: "missing",
+      day: "2026-07-20",
+      message: "No sleep data logged for this day.",
+      reason: "no_data",
+    } as DailySleepCardViewModel;
+    expect(resolveSleepMonitorPresence(vm)).toBe("absent_no_day_evidence");
+  });
+
+  it("marks oura disconnect without day data as unavailable_source", () => {
+    const vm = {
+      status: "missing",
+      day: "2026-07-20",
+      message: "Reconnect Oura",
+      reason: "oura_disconnected",
+      cta: { label: "Reconnect", href: "/(app)/settings/devices/oura" },
+    } as DailySleepCardViewModel;
+    expect(resolveSleepMonitorPresence(vm)).toBe("unavailable_source");
+  });
+
+  it("marks partial secondary metrics without converting missing to zero", () => {
+    const vm = {
+      status: "ready",
+      day: "2026-07-20",
+      isRefreshing: false,
+      model: {
+        day: "2026-07-20",
+        headlineValueText: "88",
+        durationValueText: "7h",
+        scoreUnavailable: false,
+        scoreUnavailableLabel: null,
+        scoreValueText: "88",
+        ratingLabel: "Optimal",
+        ratingTone: "optimal",
+        summarySentence: "ok",
+        metricRows: [
+          {
+            id: "sleep_duration",
+            label: "Duration",
+            value: "7h",
+            accessibilityValue: "7h",
+            isAvailable: true,
+            detail: { title: "Duration", value: "7h", body: "" },
+          },
+          {
+            id: "efficiency",
+            label: "Efficiency",
+            value: "—",
+            accessibilityValue: "Unavailable",
+            isAvailable: false,
+            detail: { title: "Efficiency", value: "—", body: "" },
+          },
+        ],
+        hasAnySignal: true,
+        emptyStateTitle: null,
+        emptyStateSubtitle: null,
+        lastNightSubtitle: "Last night’s sleep",
+      },
+    } as DailySleepCardViewModel;
+    expect(resolveSleepMonitorPresence(vm)).toBe("present_partial");
+  });
+
+  it("marks unavailable score as present_partial without zeroing", () => {
+    const vm = {
+      status: "ready",
+      day: "2026-07-20",
+      isRefreshing: false,
+      model: {
+        day: "2026-07-20",
+        headlineValueText: null,
+        durationValueText: "7h",
+        scoreUnavailable: true,
+        scoreUnavailableLabel: "Sleep score unavailable",
+        scoreValueText: null,
+        ratingLabel: null,
+        ratingTone: null,
+        summarySentence: "ok",
+        metricRows: [
+          {
+            id: "sleep_duration",
+            label: "Duration",
+            value: "7h",
+            accessibilityValue: "7h",
+            isAvailable: true,
+            detail: { title: "Duration", value: "7h", body: "" },
+          },
+        ],
+        hasAnySignal: true,
+        emptyStateTitle: null,
+        emptyStateSubtitle: null,
+        lastNightSubtitle: "Last night’s sleep",
+      },
+    } as DailySleepCardViewModel;
+    expect(resolveSleepMonitorPresence(vm)).toBe("present_partial");
+  });
+});
+
+describe("resolveReadinessMonitorPresence", () => {
+  it("marks fallback/missing as absent", () => {
+    const vm = {
+      status: "missing",
+      day: "2026-07-20",
+      message: "No current-day readiness",
+    } as DailyReadinessCardViewModel;
+    expect(resolveReadinessMonitorPresence(vm)).toBe("absent_no_day_evidence");
+  });
+
+  it("marks disconnect CTA without day data as unavailable_source", () => {
+    const vm = {
+      status: "missing",
+      day: "2026-07-20",
+      message: "Connect Oura",
+      cta: { label: "Reconnect", href: "/(app)/settings/devices/oura" },
+    } as DailyReadinessCardViewModel;
+    expect(resolveReadinessMonitorPresence(vm)).toBe("unavailable_source");
+  });
+
+  it("marks exact current-day readiness as present", () => {
+    const vm = {
+      status: "ready",
+      day: "2026-07-20",
+      accessibilityLabel: "Readiness 82",
+      model: {
+        day: "2026-07-20",
+        headlineValueText: "82",
+        ratingLabel: "Good",
+        summarySentence: "ok",
+        sourceLabel: "Oura",
+        hasAnySignal: true,
+        emptyStateTitle: null,
+        emptyStateSubtitle: null,
+        metricRows: [
+          {
+            id: "hrv_balance",
+            label: "HRV balance",
+            value: "70",
+            accessibilityValue: "70",
+            isAvailable: true,
+          },
+        ],
+      },
+    } as DailyReadinessCardViewModel;
+    expect(resolveReadinessMonitorPresence(vm)).toBe("present_complete");
+  });
+});
+
+describe("resolveEnergyMonitorPresence", () => {
+  it("requires energy.day to match requested day", () => {
+    expect(
+      resolveEnergyMonitorPresence({
+        energy: {
+          modelVersion: "v1",
+          computedAt: "2026-07-19T12:00:00.000Z",
+          day: "2026-07-19",
+          estimatedKcal: { low: 1800, high: 2200, midpoint: 2000 },
+          variancePct: 0.1,
+          confidence: "moderate",
+          factors: {},
+          missingRequiredInputs: [],
+        },
+        loading: false,
+        error: null,
+        requestedDay: "2026-07-20",
+      }),
+    ).toBe("absent_no_day_evidence");
+  });
+
+  it("presents current-day energy", () => {
+    expect(
+      resolveEnergyMonitorPresence({
+        energy: {
+          modelVersion: "v1",
+          computedAt: "2026-07-20T12:00:00.000Z",
+          day: "2026-07-20",
+          estimatedKcal: { low: 1800, high: 2200, midpoint: 2000 },
+          variancePct: 0.1,
+          confidence: "moderate",
+          factors: {},
+          missingRequiredInputs: [],
+        },
+        loading: false,
+        error: null,
+        requestedDay: "2026-07-20",
+      }),
+    ).toBe("present_complete");
+  });
+
+  it("treats absent energy as absent", () => {
+    expect(
+      resolveEnergyMonitorPresence({
+        energy: undefined,
+        loading: false,
+        error: null,
+        requestedDay: "2026-07-20",
+      }),
+    ).toBe("absent_no_day_evidence");
+  });
+});
+
+describe("resolveNutritionMonitorPresence", () => {
+  it("requires meaningful nutrition evidence", () => {
+    expect(
+      resolveNutritionMonitorPresence({
+        model: {
+          calorieLabel: "—",
+          hasAnyNutrition: false,
+          rows: [
+            { key: "protein", label: "Protein", valueLabel: "—" },
+            { key: "carbs", label: "Carbs", valueLabel: "—" },
+            { key: "fat", label: "Fat", valueLabel: "—" },
+          ],
+        },
+        loading: false,
+        error: null,
+      }),
+    ).toBe("absent_no_day_evidence");
+  });
+
+  it("marks partial macros as present_partial", () => {
+    expect(
+      resolveNutritionMonitorPresence({
+        model: {
+          calorieLabel: "1,200 kcal",
+          hasAnyNutrition: true,
+          rows: [
+            { key: "protein", label: "Protein", valueLabel: "80 g" },
+            { key: "carbs", label: "Carbs", valueLabel: "—" },
+            { key: "fat", label: "Fat", valueLabel: "40 g" },
+          ],
+        },
+        loading: false,
+        error: null,
+      }),
+    ).toBe("present_partial");
+  });
+});
+
+describe("resolveBodyCompositionMonitorPresence — prior-day regression", () => {
+  const readyBuilt = {
+    tag: "ready",
+    weightPrimaryLabel: "160 lb",
+    readingAsOfLabel: "As of July 17th",
+    rows: [
+      {
+        key: "bmi",
+        label: "BMI",
+        valueLabel: "22.0",
+        bar: {
+          marker01: 0.5,
+          zone: "good",
+          displayLabel: "Healthy",
+          hasValue: true,
+        },
+        accessibilityLabel: "BMI",
+      },
+    ],
+    cardAccessibilityLabel: "Body composition card.",
+  } as BuiltBodyCompositionDashCard;
+
+  it("hides Body Composition when latest observation is a prior day", () => {
+    expect(
+      resolveBodyCompositionMonitorPresence({
+        requestedDay: "2026-07-20",
+        overviewDay: "2026-07-17",
+        seriesLoading: false,
+        seriesError: null,
+        hasUser: true,
+        built: readyBuilt,
+      }),
+    ).toBe("absent_no_day_evidence");
+  });
+
+  it("shows Body Composition when observation day matches requested day", () => {
+    expect(
+      resolveBodyCompositionMonitorPresence({
+        requestedDay: "2026-07-20",
+        overviewDay: "2026-07-20",
+        seriesLoading: false,
+        seriesError: null,
+        hasUser: true,
+        built: {
+          ...readyBuilt,
+          readingAsOfLabel: "As of today",
+        } as BuiltBodyCompositionDashCard,
+      }),
+    ).toBe("present_complete");
+  });
+});

--- a/lib/data/dash/__tests__/resolveDashExperienceMode.test.ts
+++ b/lib/data/dash/__tests__/resolveDashExperienceMode.test.ts
@@ -1,0 +1,39 @@
+import { resolveDashExperienceMode } from "../resolveDashExperienceMode";
+
+describe("resolveDashExperienceMode", () => {
+  it("enables Daily Monitor only when both flags are on", () => {
+    expect(
+      resolveDashExperienceMode({
+        dailyMonitorEnabled: true,
+        weeklyProgressRelocationEnabled: true,
+      }),
+    ).toBe("daily_monitor");
+  });
+
+  it("uses legacy Dash when Daily Monitor is off and relocation is on", () => {
+    expect(
+      resolveDashExperienceMode({
+        dailyMonitorEnabled: false,
+        weeklyProgressRelocationEnabled: true,
+      }),
+    ).toBe("legacy_dash");
+  });
+
+  it("uses legacy Dash when both flags are off", () => {
+    expect(
+      resolveDashExperienceMode({
+        dailyMonitorEnabled: false,
+        weeklyProgressRelocationEnabled: false,
+      }),
+    ).toBe("legacy_dash");
+  });
+
+  it("falls back to legacy Dash when Daily Monitor is on but relocation is off", () => {
+    expect(
+      resolveDashExperienceMode({
+        dailyMonitorEnabled: true,
+        weeklyProgressRelocationEnabled: false,
+      }),
+    ).toBe("legacy_dash");
+  });
+});

--- a/lib/data/dash/buildDailyMonitorActivityCardModel.ts
+++ b/lib/data/dash/buildDailyMonitorActivityCardModel.ts
@@ -5,7 +5,9 @@
 
 import type { DailyFactsDto } from "@/lib/contracts/dailyFacts";
 import type { DailyMonitorPresenceStatus } from "@/lib/data/dash/dailyMonitorPresence";
+import type { DailyMonitorRatingTone } from "@/lib/data/dash/dailyMonitorPresentationRatings";
 import { buildDailyMonitorActivityRatingLabel } from "@/lib/data/dash/dailyMonitorPresentationRatings";
+import { formatDistanceDualDisplay } from "@/lib/modules/commandCenterCardio";
 import type { DayKey } from "@/lib/ui/calendar/types";
 
 export type DailyMonitorActivityMetricRow = {
@@ -24,6 +26,8 @@ export type DailyMonitorActivityCardModel = {
   primaryLabel: string;
   ratingLabel: string;
   ratingAccessibilityLabel: string;
+  /** Supplemental semantic tone for the Activity category badge. */
+  ratingTone: DailyMonitorRatingTone;
   rows: readonly DailyMonitorActivityMetricRow[];
   accessibilityLabel: string;
 };
@@ -32,12 +36,20 @@ function formatStepsDigits(steps: number): string {
   return steps.toLocaleString("en-US");
 }
 
-function formatOptionalDistanceKm(value: number | undefined): DailyMonitorActivityMetricRow {
+/**
+ * Measured current-day `activity.distanceKm` only — never estimated from steps/stride.
+ * Formatting reuses {@link formatDistanceDualDisplay} (locale miles/km preference).
+ */
+function formatOptionalDistanceKm(
+  value: number | undefined,
+  locale: string,
+): DailyMonitorActivityMetricRow {
   if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
+    const { primary } = formatDistanceDualDisplay({ distanceKm: value, locale });
     return {
       key: "distance",
       label: "Distance",
-      valueLabel: `${value.toFixed(value >= 10 ? 0 : 1)} km`,
+      valueLabel: primary,
       isAvailable: true,
     };
   }
@@ -80,6 +92,8 @@ function formatOptionalStepBucket(
 export function buildDailyMonitorActivityCardModel(input: {
   requestedDay: DayKey;
   facts: DailyFactsDto | null | undefined;
+  /** Locale for distance primary unit (miles-first for en-US). Defaults to en-US. */
+  locale?: string;
 }): DailyMonitorActivityCardModel | null {
   if (input.facts == null) return null;
   if (input.facts.date !== input.requestedDay) return null;
@@ -91,8 +105,9 @@ export function buildDailyMonitorActivityCardModel(input: {
   const primaryLabel = `${stepsDigits} Steps`;
   const rating = buildDailyMonitorActivityRatingLabel(rounded);
   const allocation = input.facts.activity?.stepsAllocation;
+  const locale = input.locale ?? "en-US";
   const rows: DailyMonitorActivityMetricRow[] = [
-    formatOptionalDistanceKm(input.facts.activity?.distanceKm),
+    formatOptionalDistanceKm(input.facts.activity?.distanceKm, locale),
     formatOptionalStepBucket("neat_steps", "NEAT Steps", allocation?.neatSteps),
     formatOptionalStepBucket("workout_steps", "Workout Steps", allocation?.strengthSteps),
     formatOptionalStepBucket("cardio_steps", "Cardio Steps", allocation?.cardioSteps),
@@ -105,6 +120,7 @@ export function buildDailyMonitorActivityCardModel(input: {
     primaryLabel,
     ratingLabel: rating.label,
     ratingAccessibilityLabel: rating.accessibilityLabel,
+    ratingTone: rating.tone,
     rows,
     accessibilityLabel: `Activity. ${primaryLabel}. ${rating.accessibilityLabel} Opens Activity.`,
   };

--- a/lib/data/dash/buildDailyMonitorActivityCardModel.ts
+++ b/lib/data/dash/buildDailyMonitorActivityCardModel.ts
@@ -5,10 +5,11 @@
 
 import type { DailyFactsDto } from "@/lib/contracts/dailyFacts";
 import type { DailyMonitorPresenceStatus } from "@/lib/data/dash/dailyMonitorPresence";
+import { buildDailyMonitorActivityRatingLabel } from "@/lib/data/dash/dailyMonitorPresentationRatings";
 import type { DayKey } from "@/lib/ui/calendar/types";
 
 export type DailyMonitorActivityMetricRow = {
-  key: string;
+  key: "distance" | "neat_steps" | "workout_steps" | "cardio_steps";
   label: string;
   valueLabel: string;
   isAvailable: boolean;
@@ -17,31 +18,18 @@ export type DailyMonitorActivityMetricRow = {
 export type DailyMonitorActivityCardModel = {
   day: DayKey;
   steps: number;
-  stepsLabel: string;
+  /** Locale-aware digits only (e.g. `2,883`). */
+  stepsDigits: string;
+  /** Primary display: `{digits} Steps`. */
+  primaryLabel: string;
+  ratingLabel: string;
+  ratingAccessibilityLabel: string;
   rows: readonly DailyMonitorActivityMetricRow[];
-  sourceLabel: string | null;
   accessibilityLabel: string;
 };
 
-function formatSteps(steps: number): string {
+function formatStepsDigits(steps: number): string {
   return steps.toLocaleString("en-US");
-}
-
-function formatOptionalMinutes(value: number | undefined): DailyMonitorActivityMetricRow {
-  if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
-    return {
-      key: "move_minutes",
-      label: "Move minutes",
-      valueLabel: `${Math.round(value)} min`,
-      isAvailable: true,
-    };
-  }
-  return {
-    key: "move_minutes",
-    label: "Move minutes",
-    valueLabel: "Unavailable",
-    isAvailable: false,
-  };
 }
 
 function formatOptionalDistanceKm(value: number | undefined): DailyMonitorActivityMetricRow {
@@ -61,9 +49,33 @@ function formatOptionalDistanceKm(value: number | undefined): DailyMonitorActivi
   };
 }
 
+function formatOptionalStepBucket(
+  key: DailyMonitorActivityMetricRow["key"],
+  label: string,
+  value: number | undefined | null,
+): DailyMonitorActivityMetricRow {
+  if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
+    return {
+      key,
+      label,
+      valueLabel: `${Math.round(value).toLocaleString("en-US")} steps`,
+      isAvailable: true,
+    };
+  }
+  return {
+    key,
+    label,
+    valueLabel: "Unavailable",
+    isAvailable: false,
+  };
+}
+
 /**
  * Builds Activity Monitor card when DailyFacts for requestedDay includes a finite steps value
  * (including 0). Returns null when steps evidence is absent.
+ *
+ * Rows (exact order): Distance → NEAT steps → Workout steps → Cardio steps.
+ * Allocation uses DailyFacts `activity.stepsAllocation` (strength → Workout steps).
  */
 export function buildDailyMonitorActivityCardModel(input: {
   requestedDay: DayKey;
@@ -75,20 +87,26 @@ export function buildDailyMonitorActivityCardModel(input: {
   if (typeof steps !== "number" || !Number.isFinite(steps) || steps < 0) return null;
 
   const rounded = Math.round(steps);
-  const stepsLabel = formatSteps(rounded);
-  const rows = [
-    formatOptionalMinutes(input.facts.activity?.moveMinutes),
+  const stepsDigits = formatStepsDigits(rounded);
+  const primaryLabel = `${stepsDigits} Steps`;
+  const rating = buildDailyMonitorActivityRatingLabel(rounded);
+  const allocation = input.facts.activity?.stepsAllocation;
+  const rows: DailyMonitorActivityMetricRow[] = [
     formatOptionalDistanceKm(input.facts.activity?.distanceKm),
+    formatOptionalStepBucket("neat_steps", "NEAT Steps", allocation?.neatSteps),
+    formatOptionalStepBucket("workout_steps", "Workout Steps", allocation?.strengthSteps),
+    formatOptionalStepBucket("cardio_steps", "Cardio Steps", allocation?.cardioSteps),
   ];
-  const sourceLabel = null;
 
   return {
     day: input.requestedDay,
     steps: rounded,
-    stepsLabel,
+    stepsDigits,
+    primaryLabel,
+    ratingLabel: rating.label,
+    ratingAccessibilityLabel: rating.accessibilityLabel,
     rows,
-    sourceLabel,
-    accessibilityLabel: `Activity. ${stepsLabel} steps.`,
+    accessibilityLabel: `Activity. ${primaryLabel}. ${rating.accessibilityLabel} Opens Activity.`,
   };
 }
 

--- a/lib/data/dash/buildDailyMonitorActivityCardModel.ts
+++ b/lib/data/dash/buildDailyMonitorActivityCardModel.ts
@@ -1,0 +1,112 @@
+/**
+ * Pure Activity card model + presence for Daily Monitor (current-day Steps).
+ * Valid measured zero is present; missing activity.steps is absent.
+ */
+
+import type { DailyFactsDto } from "@/lib/contracts/dailyFacts";
+import type { DailyMonitorPresenceStatus } from "@/lib/data/dash/dailyMonitorPresence";
+import type { DayKey } from "@/lib/ui/calendar/types";
+
+export type DailyMonitorActivityMetricRow = {
+  key: string;
+  label: string;
+  valueLabel: string;
+  isAvailable: boolean;
+};
+
+export type DailyMonitorActivityCardModel = {
+  day: DayKey;
+  steps: number;
+  stepsLabel: string;
+  rows: readonly DailyMonitorActivityMetricRow[];
+  sourceLabel: string | null;
+  accessibilityLabel: string;
+};
+
+function formatSteps(steps: number): string {
+  return steps.toLocaleString("en-US");
+}
+
+function formatOptionalMinutes(value: number | undefined): DailyMonitorActivityMetricRow {
+  if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
+    return {
+      key: "move_minutes",
+      label: "Move minutes",
+      valueLabel: `${Math.round(value)} min`,
+      isAvailable: true,
+    };
+  }
+  return {
+    key: "move_minutes",
+    label: "Move minutes",
+    valueLabel: "Unavailable",
+    isAvailable: false,
+  };
+}
+
+function formatOptionalDistanceKm(value: number | undefined): DailyMonitorActivityMetricRow {
+  if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
+    return {
+      key: "distance",
+      label: "Distance",
+      valueLabel: `${value.toFixed(value >= 10 ? 0 : 1)} km`,
+      isAvailable: true,
+    };
+  }
+  return {
+    key: "distance",
+    label: "Distance",
+    valueLabel: "Unavailable",
+    isAvailable: false,
+  };
+}
+
+/**
+ * Builds Activity Monitor card when DailyFacts for requestedDay includes a finite steps value
+ * (including 0). Returns null when steps evidence is absent.
+ */
+export function buildDailyMonitorActivityCardModel(input: {
+  requestedDay: DayKey;
+  facts: DailyFactsDto | null | undefined;
+}): DailyMonitorActivityCardModel | null {
+  if (input.facts == null) return null;
+  if (input.facts.date !== input.requestedDay) return null;
+  const steps = input.facts.activity?.steps;
+  if (typeof steps !== "number" || !Number.isFinite(steps) || steps < 0) return null;
+
+  const rounded = Math.round(steps);
+  const stepsLabel = formatSteps(rounded);
+  const rows = [
+    formatOptionalMinutes(input.facts.activity?.moveMinutes),
+    formatOptionalDistanceKm(input.facts.activity?.distanceKm),
+  ];
+  const sourceLabel = null;
+
+  return {
+    day: input.requestedDay,
+    steps: rounded,
+    stepsLabel,
+    rows,
+    sourceLabel,
+    accessibilityLabel: `Activity. ${stepsLabel} steps.`,
+  };
+}
+
+export function resolveActivityMonitorPresence(input: {
+  loading: boolean;
+  error: string | null;
+  model: DailyMonitorActivityCardModel | null;
+  factsDay: string | null;
+  requestedDay: DayKey;
+}): DailyMonitorPresenceStatus {
+  if (input.loading && input.model == null) return "loading_presence";
+  if (input.error != null && input.model == null) return "screen_level_error";
+  if (input.error != null && input.model != null) {
+    if (input.factsDay !== input.requestedDay) return "absent_no_day_evidence";
+    return "refresh_error_with_cached_day_evidence";
+  }
+  if (input.model == null) return "absent_no_day_evidence";
+  if (input.model.day !== input.requestedDay) return "absent_no_day_evidence";
+  const anyUnavailable = input.model.rows.some((r) => !r.isAvailable);
+  return anyUnavailable ? "present_partial" : "present_complete";
+}

--- a/lib/data/dash/buildDailyMonitorSessionCards.ts
+++ b/lib/data/dash/buildDailyMonitorSessionCards.ts
@@ -23,9 +23,8 @@ import {
   STRENGTH_TODAY_DETAIL_MISSING_VALUE,
 } from "@/lib/data/workouts/strengthTodayDetailVm";
 import { resolveStrengthTodayAverageHeartRateBpm } from "@/lib/data/workouts/resolveStrengthTodayAverageHeartRateBpm";
-import { computeStrengthMetricsFromExercises } from "@/lib/workouts/journal/manualWorkoutSummary";
 import { kgToLbs } from "@/lib/metrics/metricUnits";
-import { trainingVolumeKgForManualExercises } from "@/lib/workouts/strength/strengthVolumeKg";
+import { resolveStrengthSessionExerciseDisplay } from "@/lib/data/workouts/workoutSessionSurface";
 
 const UNAVAILABLE = "Unavailable" as const;
 
@@ -95,27 +94,31 @@ export function buildDailyMonitorWorkoutCardModel(input: {
     ? collectStrengthOverviewTabSessions([{ day: input.requestedDay, workouts: dayRow.workouts }])
     : [];
   const sessionCount = Math.max(1, sessions.length);
+  /**
+   * Latest-session title + latest-session metrics (honest multi-session contract).
+   * Do not pair an aggregate “N workouts” title with unlabeled latest-session values.
+   */
   const primaryTitle =
-    sessionCount > 1
-      ? `${sessionCount} workouts`
-      : todayModel.primaryTitle.trim().length > 0
-        ? todayModel.primaryTitle
-        : "Strength";
+    todayModel.primaryTitle.trim().length > 0 ? todayModel.primaryTitle : "Strength";
 
   const latest = pickLatestStrengthSessionToday(sessions);
   const actionWorkout = latest?.workouts[0];
-  const ingestExercises = actionWorkout?.strengthIngestExercises ?? [];
-  const metricsFromIngest =
-    ingestExercises.length > 0 ? computeStrengthMetricsFromExercises(ingestExercises) : null;
-  const volumeKg =
-    (typeof actionWorkout?.strengthVolumeKg === "number" &&
+  const resolved = actionWorkout
+    ? resolveStrengthSessionExerciseDisplay(null, actionWorkout)
+    : { exercises: [], totalVolume: null, avgIntensity: null };
+  const volumeKgFromField =
+    typeof actionWorkout?.strengthVolumeKg === "number" &&
     Number.isFinite(actionWorkout.strengthVolumeKg) &&
     actionWorkout.strengthVolumeKg > 0
       ? actionWorkout.strengthVolumeKg
-      : null) ??
-    (ingestExercises.length > 0 ? trainingVolumeKgForManualExercises(ingestExercises) : null) ??
-    metricsFromIngest?.totalVolume ??
-    null;
+      : null;
+  const volumeKgFromSets =
+    typeof resolved.totalVolume === "number" &&
+    Number.isFinite(resolved.totalVolume) &&
+    resolved.totalVolume > 0
+      ? resolved.totalVolume
+      : null;
+  const volumeKg = volumeKgFromField ?? volumeKgFromSets;
   const volumeLabel = formatVolumeKg(volumeKg, input.massUnit ?? "lb");
 
   const calorieRaw = formatStrengthTodayCalorieBurnValue(input.energy?.factors.strength);
@@ -128,7 +131,7 @@ export function buildDailyMonitorWorkoutCardModel(input: {
   const hrRaw = formatStrengthTodayAvgHeartRateValue(avgHrBpm);
   const hr = missingDashToUnavailable(hrRaw);
 
-  const intensity = mapWorkoutAverageIntensityToLabel(metricsFromIngest?.avgIntensity ?? null);
+  const intensity = mapWorkoutAverageIntensityToLabel(resolved.avgIntensity ?? null);
 
   const durationAvailable =
     todayModel.durationLabel.trim().length > 0 && todayModel.durationLabel !== "—";
@@ -162,6 +165,8 @@ export function buildDailyMonitorWorkoutCardModel(input: {
 
   const intensityPart =
     intensity != null ? ` ${intensity.accessibilityLabel}` : "";
+  const multiSessionPart =
+    sessionCount > 1 ? ` Latest of ${sessionCount} workouts today.` : "";
   return {
     day: input.requestedDay,
     sessionCount,
@@ -169,7 +174,7 @@ export function buildDailyMonitorWorkoutCardModel(input: {
     intensityLabel: intensity?.label ?? null,
     intensityAccessibilityLabel: intensity?.accessibilityLabel ?? null,
     rows,
-    accessibilityLabel: `Workout. ${primaryTitle}.${intensityPart} Opens Workouts.`.trim(),
+    accessibilityLabel: `Workout. ${primaryTitle}.${multiSessionPart}${intensityPart} Opens Workouts.`.trim(),
   };
 }
 

--- a/lib/data/dash/buildDailyMonitorSessionCards.ts
+++ b/lib/data/dash/buildDailyMonitorSessionCards.ts
@@ -1,0 +1,133 @@
+/**
+ * Pure Workout + Cardio Monitor models from current-day calendar sessions.
+ * Strength sessions → Workout; cardio-classified sessions → Cardio.
+ * Rest days are absent (no empty rest cards on Daily Monitor).
+ */
+
+import { collectStrengthOverviewTabSessions } from "@/lib/data/workouts/strengthOverviewCardModel";
+import { mapWorkoutCalendarDaysForDomain } from "@/lib/data/workouts/workoutDomain";
+import type { WorkoutCalendarDayLike } from "@/lib/data/workouts/workoutsCalendarModel";
+import { buildStrengthTodayCardModel } from "@/lib/data/workouts/strengthTodayCardModel";
+import { buildCardioTodayCardModel } from "@/lib/data/workouts/cardioTodayCardModel";
+import type { WorkoutOverride } from "@/lib/data/workouts/workoutOverrides";
+import type { DayKey } from "@/lib/ui/calendar/types";
+import type { DailyMonitorPresenceStatus } from "@/lib/data/dash/dailyMonitorPresence";
+
+export type DailyMonitorWorkoutCardModel = {
+  day: DayKey;
+  sessionCount: number;
+  /** Strength or existing session title for a single session. */
+  primaryTitle: string;
+  durationLabel: string;
+  subtitle: string;
+  accessibilityLabel: string;
+};
+
+export type DailyMonitorCardioCardModel = {
+  day: DayKey;
+  sessionCount: number;
+  primaryTitle: string;
+  primaryLine: string;
+  metaLine: string;
+  accessibilityLabel: string;
+};
+
+export function buildDailyMonitorWorkoutCardModel(input: {
+  requestedDay: DayKey;
+  calendarDays: readonly WorkoutCalendarDayLike[];
+  overridesByWorkoutId?: Record<string, WorkoutOverride | undefined>;
+  durableTitlesByWorkoutId?: Record<string, string | undefined>;
+}): DailyMonitorWorkoutCardModel | null {
+  const strengthDays = mapWorkoutCalendarDaysForDomain(input.calendarDays, "strength");
+  const todayModel = buildStrengthTodayCardModel({
+    strengthCalendarDays: strengthDays,
+    todayDayKey: input.requestedDay,
+    overridesByWorkoutId: input.overridesByWorkoutId ?? {},
+    durableTitlesByWorkoutId: input.durableTitlesByWorkoutId ?? {},
+  });
+  if (todayModel.kind !== "completed") return null;
+
+  const dayRow = strengthDays.find((d) => d.day === input.requestedDay);
+  const sessions = dayRow
+    ? collectStrengthOverviewTabSessions([{ day: input.requestedDay, workouts: dayRow.workouts }])
+    : [];
+  const sessionCount = Math.max(1, sessions.length);
+  const primaryTitle =
+    sessionCount > 1
+      ? `${sessionCount} workouts`
+      : todayModel.primaryTitle.trim().length > 0
+        ? todayModel.primaryTitle
+        : "Strength";
+
+  return {
+    day: input.requestedDay,
+    sessionCount,
+    primaryTitle,
+    durationLabel: todayModel.durationLabel,
+    subtitle: todayModel.subtitle,
+    accessibilityLabel: `Workout. ${primaryTitle}. ${todayModel.durationLabel}. ${todayModel.subtitle}`.trim(),
+  };
+}
+
+export function buildDailyMonitorCardioCardModel(input: {
+  requestedDay: DayKey;
+  calendarDays: readonly WorkoutCalendarDayLike[];
+  overridesByWorkoutId?: Record<string, WorkoutOverride | undefined>;
+  durableTitlesByWorkoutId?: Record<string, string | undefined>;
+}): DailyMonitorCardioCardModel | null {
+  const cardioDays = mapWorkoutCalendarDaysForDomain(input.calendarDays, "cardio");
+  const todayModel = buildCardioTodayCardModel({
+    cardioCalendarDays: cardioDays,
+    todayDayKey: input.requestedDay,
+    overridesByWorkoutId: input.overridesByWorkoutId ?? {},
+    durableTitlesByWorkoutId: input.durableTitlesByWorkoutId ?? {},
+  });
+  if (todayModel.kind !== "completed" || todayModel.sessions.length === 0) return null;
+
+  const sessionCount = todayModel.sessions.length;
+  const first = todayModel.sessions[0]!;
+  const modalityFromMeta = first.metaLine.includes(" · ")
+    ? first.metaLine.split(" · ")[0]!.trim()
+    : first.metaLine.trim();
+  const primaryTitle =
+    sessionCount > 1
+      ? `${sessionCount} cardio sessions`
+      : modalityFromMeta.length > 0
+        ? modalityFromMeta
+        : "Cardio";
+  const primaryLine = first.primaryLine === "—" ? "Unavailable" : first.primaryLine;
+  const metaLine = first.metaLine === "—" ? "" : first.metaLine;
+
+  return {
+    day: input.requestedDay,
+    sessionCount,
+    primaryTitle,
+    primaryLine,
+    metaLine,
+    accessibilityLabel: `Cardio. ${primaryTitle}. ${primaryLine}. ${metaLine}`.trim(),
+  };
+}
+
+export function resolveWorkoutMonitorPresence(input: {
+  loading: boolean;
+  error: string | null;
+  model: DailyMonitorWorkoutCardModel | null;
+}): DailyMonitorPresenceStatus {
+  if (input.loading && input.model == null) return "loading_presence";
+  if (input.error != null && input.model == null) return "screen_level_error";
+  if (input.error != null && input.model != null) return "refresh_error_with_cached_day_evidence";
+  if (input.model == null) return "absent_no_day_evidence";
+  return "present_complete";
+}
+
+export function resolveCardioMonitorPresence(input: {
+  loading: boolean;
+  error: string | null;
+  model: DailyMonitorCardioCardModel | null;
+}): DailyMonitorPresenceStatus {
+  if (input.loading && input.model == null) return "loading_presence";
+  if (input.error != null && input.model == null) return "screen_level_error";
+  if (input.error != null && input.model != null) return "refresh_error_with_cached_day_evidence";
+  if (input.model == null) return "absent_no_day_evidence";
+  return "present_complete";
+}

--- a/lib/data/dash/buildDailyMonitorSessionCards.ts
+++ b/lib/data/dash/buildDailyMonitorSessionCards.ts
@@ -7,19 +7,43 @@
 import { collectStrengthOverviewTabSessions } from "@/lib/data/workouts/strengthOverviewCardModel";
 import { mapWorkoutCalendarDaysForDomain } from "@/lib/data/workouts/workoutDomain";
 import type { WorkoutCalendarDayLike } from "@/lib/data/workouts/workoutsCalendarModel";
-import { buildStrengthTodayCardModel } from "@/lib/data/workouts/strengthTodayCardModel";
+import {
+  buildStrengthTodayCardModel,
+  pickLatestStrengthSessionToday,
+} from "@/lib/data/workouts/strengthTodayCardModel";
 import { buildCardioTodayCardModel } from "@/lib/data/workouts/cardioTodayCardModel";
 import type { WorkoutOverride } from "@/lib/data/workouts/workoutOverrides";
 import type { DayKey } from "@/lib/ui/calendar/types";
 import type { DailyMonitorPresenceStatus } from "@/lib/data/dash/dailyMonitorPresence";
+import { mapWorkoutAverageIntensityToLabel } from "@/lib/data/dash/dailyMonitorPresentationRatings";
+import type { DailyEnergyCardDto } from "@/lib/data/dash/useDailyEnergyCard";
+import {
+  formatStrengthTodayAvgHeartRateValue,
+  formatStrengthTodayCalorieBurnValue,
+  STRENGTH_TODAY_DETAIL_MISSING_VALUE,
+} from "@/lib/data/workouts/strengthTodayDetailVm";
+import { resolveStrengthTodayAverageHeartRateBpm } from "@/lib/data/workouts/resolveStrengthTodayAverageHeartRateBpm";
+import { computeStrengthMetricsFromExercises } from "@/lib/workouts/journal/manualWorkoutSummary";
+import { kgToLbs } from "@/lib/metrics/metricUnits";
+import { trainingVolumeKgForManualExercises } from "@/lib/workouts/strength/strengthVolumeKg";
+
+const UNAVAILABLE = "Unavailable" as const;
+
+export type DailyMonitorWorkoutMetricRow = {
+  key: "duration" | "total_volume" | "estimated_calorie_burn" | "average_heart_rate";
+  label: string;
+  valueLabel: string;
+  isAvailable: boolean;
+};
 
 export type DailyMonitorWorkoutCardModel = {
   day: DayKey;
   sessionCount: number;
   /** Strength or existing session title for a single session. */
   primaryTitle: string;
-  durationLabel: string;
-  subtitle: string;
+  intensityLabel: string | null;
+  intensityAccessibilityLabel: string | null;
+  rows: readonly DailyMonitorWorkoutMetricRow[];
   accessibilityLabel: string;
 };
 
@@ -32,11 +56,30 @@ export type DailyMonitorCardioCardModel = {
   accessibilityLabel: string;
 };
 
+function missingDashToUnavailable(value: string): { valueLabel: string; isAvailable: boolean } {
+  if (value === STRENGTH_TODAY_DETAIL_MISSING_VALUE || value.trim().length === 0) {
+    return { valueLabel: UNAVAILABLE, isAvailable: false };
+  }
+  return { valueLabel: value, isAvailable: true };
+}
+
+function formatVolumeKg(volumeKg: number | null | undefined, massUnit: "lb" | "kg"): string | null {
+  if (typeof volumeKg !== "number" || !Number.isFinite(volumeKg) || volumeKg <= 0) return null;
+  if (massUnit === "kg") {
+    return `${Math.round(volumeKg).toLocaleString("en-US")} kg`;
+  }
+  return `${Math.round(kgToLbs(volumeKg)).toLocaleString("en-US")} lb`;
+}
+
 export function buildDailyMonitorWorkoutCardModel(input: {
   requestedDay: DayKey;
   calendarDays: readonly WorkoutCalendarDayLike[];
   overridesByWorkoutId?: Record<string, WorkoutOverride | undefined>;
   durableTitlesByWorkoutId?: Record<string, string | undefined>;
+  /** Shared Daily Energy DTO for the same day (calories / influencer HR). */
+  energy?: DailyEnergyCardDto | null;
+  /** Preferred mass unit for Total Volume. Defaults to lb (repo Strength UI default). */
+  massUnit?: "lb" | "kg";
 }): DailyMonitorWorkoutCardModel | null {
   const strengthDays = mapWorkoutCalendarDaysForDomain(input.calendarDays, "strength");
   const todayModel = buildStrengthTodayCardModel({
@@ -59,13 +102,74 @@ export function buildDailyMonitorWorkoutCardModel(input: {
         ? todayModel.primaryTitle
         : "Strength";
 
+  const latest = pickLatestStrengthSessionToday(sessions);
+  const actionWorkout = latest?.workouts[0];
+  const ingestExercises = actionWorkout?.strengthIngestExercises ?? [];
+  const metricsFromIngest =
+    ingestExercises.length > 0 ? computeStrengthMetricsFromExercises(ingestExercises) : null;
+  const volumeKg =
+    (typeof actionWorkout?.strengthVolumeKg === "number" &&
+    Number.isFinite(actionWorkout.strengthVolumeKg) &&
+    actionWorkout.strengthVolumeKg > 0
+      ? actionWorkout.strengthVolumeKg
+      : null) ??
+    (ingestExercises.length > 0 ? trainingVolumeKgForManualExercises(ingestExercises) : null) ??
+    metricsFromIngest?.totalVolume ??
+    null;
+  const volumeLabel = formatVolumeKg(volumeKg, input.massUnit ?? "lb");
+
+  const calorieRaw = formatStrengthTodayCalorieBurnValue(input.energy?.factors.strength);
+  const calorie = missingDashToUnavailable(calorieRaw);
+
+  const avgHrBpm = resolveStrengthTodayAverageHeartRateBpm({
+    todayStrengthSessions: sessions,
+    dailyFactsAverageHeartRateBpm: input.energy?.energyInfluencers?.strength?.averageHeartRateBpm,
+  });
+  const hrRaw = formatStrengthTodayAvgHeartRateValue(avgHrBpm);
+  const hr = missingDashToUnavailable(hrRaw);
+
+  const intensity = mapWorkoutAverageIntensityToLabel(metricsFromIngest?.avgIntensity ?? null);
+
+  const durationAvailable =
+    todayModel.durationLabel.trim().length > 0 && todayModel.durationLabel !== "—";
+
+  const rows: DailyMonitorWorkoutMetricRow[] = [
+    {
+      key: "duration",
+      label: "Duration",
+      valueLabel: durationAvailable ? todayModel.durationLabel : UNAVAILABLE,
+      isAvailable: durationAvailable,
+    },
+    {
+      key: "total_volume",
+      label: "Total Volume",
+      valueLabel: volumeLabel ?? UNAVAILABLE,
+      isAvailable: volumeLabel != null,
+    },
+    {
+      key: "estimated_calorie_burn",
+      label: "Estimated Calorie Burn",
+      valueLabel: calorie.valueLabel,
+      isAvailable: calorie.isAvailable,
+    },
+    {
+      key: "average_heart_rate",
+      label: "Average Heart Rate",
+      valueLabel: hr.valueLabel,
+      isAvailable: hr.isAvailable,
+    },
+  ];
+
+  const intensityPart =
+    intensity != null ? ` ${intensity.accessibilityLabel}` : "";
   return {
     day: input.requestedDay,
     sessionCount,
     primaryTitle,
-    durationLabel: todayModel.durationLabel,
-    subtitle: todayModel.subtitle,
-    accessibilityLabel: `Workout. ${primaryTitle}. ${todayModel.durationLabel}. ${todayModel.subtitle}`.trim(),
+    intensityLabel: intensity?.label ?? null,
+    intensityAccessibilityLabel: intensity?.accessibilityLabel ?? null,
+    rows,
+    accessibilityLabel: `Workout. ${primaryTitle}.${intensityPart} Opens Workouts.`.trim(),
   };
 }
 
@@ -95,7 +199,7 @@ export function buildDailyMonitorCardioCardModel(input: {
       : modalityFromMeta.length > 0
         ? modalityFromMeta
         : "Cardio";
-  const primaryLine = first.primaryLine === "—" ? "Unavailable" : first.primaryLine;
+  const primaryLine = first.primaryLine === "—" ? UNAVAILABLE : first.primaryLine;
   const metaLine = first.metaLine === "—" ? "" : first.metaLine;
 
   return {
@@ -117,7 +221,8 @@ export function resolveWorkoutMonitorPresence(input: {
   if (input.error != null && input.model == null) return "screen_level_error";
   if (input.error != null && input.model != null) return "refresh_error_with_cached_day_evidence";
   if (input.model == null) return "absent_no_day_evidence";
-  return "present_complete";
+  const anyUnavailable = input.model.rows.some((r) => !r.isAvailable);
+  return anyUnavailable ? "present_partial" : "present_complete";
 }
 
 export function resolveCardioMonitorPresence(input: {

--- a/lib/data/dash/buildDailyMonitorStressCardModel.ts
+++ b/lib/data/dash/buildDailyMonitorStressCardModel.ts
@@ -1,0 +1,73 @@
+/**
+ * Pure Stress Monitor card from current-day Oura stress day DTO.
+ * No Oli 0–100 score and no five-level Health State.
+ */
+
+import type { OuraDailyStressDayDto } from "@oli/contracts/ouraVendor";
+import type { DailyMonitorPresenceStatus } from "@/lib/data/dash/dailyMonitorPresence";
+import type { DayKey } from "@/lib/ui/calendar/types";
+
+export type DailyMonitorStressCardModel = {
+  day: DayKey;
+  daySummaryLabel: string;
+  stressedMinutesLabel: string | null;
+  restoredMinutesLabel: string | null;
+  sourceLabel: "Oura";
+  accessibilityLabel: string;
+};
+
+function formatMinutesFromSeconds(seconds: number | null | undefined): string | null {
+  if (typeof seconds !== "number" || !Number.isFinite(seconds) || seconds < 0) return null;
+  return `${Math.round(seconds / 60)} min`;
+}
+
+function daySummaryLabel(summary: OuraDailyStressDayDto["daySummary"]): string {
+  switch (summary) {
+    case "restored":
+      return "Restored";
+    case "normal":
+      return "Normal";
+    case "stressful":
+      return "Stressful";
+    default:
+      return "Unavailable";
+  }
+}
+
+export function buildDailyMonitorStressCardModel(input: {
+  requestedDay: DayKey;
+  day: OuraDailyStressDayDto | null | undefined;
+}): DailyMonitorStressCardModel | null {
+  if (input.day == null) return null;
+  if (input.day.day !== input.requestedDay) return null;
+  if (input.day.daySummary == null) return null;
+
+  const summary = daySummaryLabel(input.day.daySummary);
+  const stressedMinutesLabel = formatMinutesFromSeconds(input.day.stressHighSeconds);
+  const restoredMinutesLabel = formatMinutesFromSeconds(input.day.recoveryHighSeconds);
+
+  return {
+    day: input.requestedDay,
+    daySummaryLabel: summary,
+    stressedMinutesLabel,
+    restoredMinutesLabel,
+    sourceLabel: "Oura",
+    accessibilityLabel: `Stress. ${summary}. Source Oura.`,
+  };
+}
+
+export function resolveStressMonitorPresence(input: {
+  loading: boolean;
+  error: string | null;
+  ouraDisconnected: boolean;
+  model: DailyMonitorStressCardModel | null;
+}): DailyMonitorPresenceStatus {
+  if (input.loading && input.model == null) return "loading_presence";
+  if (input.ouraDisconnected && input.model == null) return "unavailable_source";
+  if (input.error != null && input.model == null) return "screen_level_error";
+  if (input.error != null && input.model != null) return "refresh_error_with_cached_day_evidence";
+  if (input.model == null) return "absent_no_day_evidence";
+  const partial =
+    input.model.stressedMinutesLabel == null || input.model.restoredMinutesLabel == null;
+  return partial ? "present_partial" : "present_complete";
+}

--- a/lib/data/dash/buildDailyMonitorViewModel.ts
+++ b/lib/data/dash/buildDailyMonitorViewModel.ts
@@ -1,0 +1,154 @@
+/**
+ * Pure Daily Monitor screen view-model builder (Phase 2C).
+ * No React Native / Firebase imports.
+ */
+
+import {
+  DAILY_MONITOR_DOMAIN_ORDER,
+  DAILY_MONITOR_DOMAIN_SECTION,
+  DAILY_MONITOR_SECTION_ORDER,
+  DAILY_MONITOR_SECTION_TITLES,
+  presenceCreatesMainStackCard,
+  type DailyMonitorDomainId,
+  type DailyMonitorPresenceStatus,
+  type DailyMonitorSectionId,
+} from "@/lib/data/dash/dailyMonitorPresence";
+import type { DayKey } from "@/lib/ui/calendar/types";
+
+export type DailyMonitorDomainPresenceInput = {
+  domainId: DailyMonitorDomainId;
+  presence: DailyMonitorPresenceStatus;
+};
+
+export type DailyMonitorScreenStatus =
+  | "loading"
+  | "ready"
+  | "empty"
+  | "partial_refresh"
+  | "error"
+  | "signed_out";
+
+export type DailyMonitorSectionModel = {
+  id: DailyMonitorSectionId;
+  title: string;
+  domainIds: DailyMonitorDomainId[];
+};
+
+export type DailyMonitorViewModel = {
+  requestedDay: DayKey;
+  /** Consumer date line for the header (preformatted). */
+  dateLabel: string;
+  screenStatus: DailyMonitorScreenStatus;
+  sections: DailyMonitorSectionModel[];
+  /** Domains that should mount cards, stable order. */
+  visibleDomainIds: DailyMonitorDomainId[];
+  showPartialRefreshBanner: boolean;
+  emptyTitle: string | null;
+  emptySubtitle: string | null;
+  errorMessage: string | null;
+};
+
+export type BuildDailyMonitorViewModelInput = {
+  requestedDay: DayKey;
+  dateLabel: string;
+  signedOut: boolean;
+  domains: readonly DailyMonitorDomainPresenceInput[];
+};
+
+function presenceByDomain(
+  domains: readonly DailyMonitorDomainPresenceInput[],
+): Map<DailyMonitorDomainId, DailyMonitorPresenceStatus> {
+  const map = new Map<DailyMonitorDomainId, DailyMonitorPresenceStatus>();
+  for (const d of domains) map.set(d.domainId, d.presence);
+  return map;
+}
+
+export function buildDailyMonitorViewModel(
+  input: BuildDailyMonitorViewModelInput,
+): DailyMonitorViewModel {
+  if (input.signedOut) {
+    return {
+      requestedDay: input.requestedDay,
+      dateLabel: input.dateLabel,
+      screenStatus: "signed_out",
+      sections: [],
+      visibleDomainIds: [],
+      showPartialRefreshBanner: false,
+      emptyTitle: null,
+      emptySubtitle: null,
+      errorMessage: null,
+    };
+  }
+
+  const byDomain = presenceByDomain(input.domains);
+  const statuses = DAILY_MONITOR_DOMAIN_ORDER.map(
+    (id) => byDomain.get(id) ?? "absent_no_day_evidence",
+  );
+
+  const allLoading = statuses.every((s) => s === "loading_presence");
+  const anyLoading = statuses.some((s) => s === "loading_presence");
+  const visibleDomainIds = DAILY_MONITOR_DOMAIN_ORDER.filter((id) => {
+    const p = byDomain.get(id);
+    return p != null && presenceCreatesMainStackCard(p);
+  });
+
+  const anyError = statuses.some(
+    (s) => s === "screen_level_error" || s === "refresh_error_with_cached_day_evidence",
+  );
+  const allTerminalAbsentOrUnavailable = statuses.every(
+    (s) =>
+      s === "absent_no_day_evidence" ||
+      s === "unavailable_source" ||
+      s === "screen_level_error",
+  );
+  const allFailed =
+    statuses.every((s) => s === "screen_level_error") && !anyLoading;
+
+  let screenStatus: DailyMonitorScreenStatus;
+  let emptyTitle: string | null = null;
+  let emptySubtitle: string | null = null;
+  let errorMessage: string | null = null;
+  let showPartialRefreshBanner = false;
+
+  if (allLoading || (anyLoading && visibleDomainIds.length === 0)) {
+    screenStatus = "loading";
+  } else if (allFailed) {
+    screenStatus = "error";
+    errorMessage = "Couldn't load today's health data. Please try again.";
+  } else if (visibleDomainIds.length === 0 && allTerminalAbsentOrUnavailable && !anyLoading) {
+    screenStatus = "empty";
+    emptyTitle = "No health data is available for today yet.";
+    emptySubtitle = "Data will appear as devices sync or you add entries.";
+  } else {
+    screenStatus = "ready";
+    if (anyError && visibleDomainIds.length > 0) {
+      showPartialRefreshBanner = true;
+      screenStatus = "partial_refresh";
+    }
+  }
+
+  const sections: DailyMonitorSectionModel[] = [];
+  for (const sectionId of DAILY_MONITOR_SECTION_ORDER) {
+    const domainIds = visibleDomainIds.filter(
+      (id) => DAILY_MONITOR_DOMAIN_SECTION[id] === sectionId,
+    );
+    if (domainIds.length === 0) continue;
+    sections.push({
+      id: sectionId,
+      title: DAILY_MONITOR_SECTION_TITLES[sectionId],
+      domainIds,
+    });
+  }
+
+  return {
+    requestedDay: input.requestedDay,
+    dateLabel: input.dateLabel,
+    screenStatus,
+    sections,
+    visibleDomainIds,
+    showPartialRefreshBanner,
+    emptyTitle,
+    emptySubtitle,
+    errorMessage,
+  };
+}

--- a/lib/data/dash/dailyMonitorPresence.ts
+++ b/lib/data/dash/dailyMonitorPresence.ts
@@ -19,6 +19,10 @@ export type DailyMonitorPresenceStatus = (typeof DAILY_MONITOR_PRESENCE_STATUSES
 export type DailyMonitorDomainId =
   | "sleep"
   | "readiness"
+  | "stress"
+  | "activity"
+  | "workout"
+  | "cardio"
   | "energy"
   | "nutrition"
   | "body_composition";
@@ -54,21 +58,30 @@ export const DAILY_MONITOR_SECTION_TITLES: Record<DailyMonitorSectionId, string>
   measurements: "Measurements",
 };
 
-/** Stable domain order within each section for Phase 2C. */
+/** Stable domain order within each section for Phase 2C completion. */
 export const DAILY_MONITOR_DOMAIN_SECTION: Record<
   DailyMonitorDomainId,
   DailyMonitorSectionId
 > = {
   sleep: "recovery",
   readiness: "recovery",
+  stress: "recovery",
+  activity: "movement_output",
+  workout: "movement_output",
+  cardio: "movement_output",
   energy: "movement_output",
   nutrition: "intake_exposures",
   body_composition: "measurements",
 };
 
+/** Stable card order across the full Monitor stack. */
 export const DAILY_MONITOR_DOMAIN_ORDER: readonly DailyMonitorDomainId[] = [
   "sleep",
   "readiness",
+  "stress",
+  "activity",
+  "workout",
+  "cardio",
   "energy",
   "nutrition",
   "body_composition",

--- a/lib/data/dash/dailyMonitorPresence.ts
+++ b/lib/data/dash/dailyMonitorPresence.ts
@@ -1,0 +1,75 @@
+/**
+ * Typed Daily Monitor presence contract (Phase 2C).
+ * UI/read-model only — not persisted to RawEvent, CanonicalEvent, DailyFacts, or Firestore.
+ */
+
+export const DAILY_MONITOR_PRESENCE_STATUSES = [
+  "loading_presence",
+  "present_complete",
+  "present_partial",
+  "absent_no_day_evidence",
+  "unavailable_source",
+  "refresh_error_with_cached_day_evidence",
+  "screen_level_error",
+  "signed_out",
+] as const;
+
+export type DailyMonitorPresenceStatus = (typeof DAILY_MONITOR_PRESENCE_STATUSES)[number];
+
+export type DailyMonitorDomainId =
+  | "sleep"
+  | "readiness"
+  | "energy"
+  | "nutrition"
+  | "body_composition";
+
+export type DailyMonitorSectionId =
+  | "recovery"
+  | "movement_output"
+  | "intake_exposures"
+  | "measurements";
+
+/** Domains that occupy the main card stack. */
+export function presenceCreatesMainStackCard(
+  status: DailyMonitorPresenceStatus,
+): boolean {
+  return (
+    status === "present_complete" ||
+    status === "present_partial" ||
+    status === "refresh_error_with_cached_day_evidence"
+  );
+}
+
+export const DAILY_MONITOR_SECTION_ORDER: readonly DailyMonitorSectionId[] = [
+  "recovery",
+  "movement_output",
+  "intake_exposures",
+  "measurements",
+] as const;
+
+export const DAILY_MONITOR_SECTION_TITLES: Record<DailyMonitorSectionId, string> = {
+  recovery: "Recovery",
+  movement_output: "Movement & Output",
+  intake_exposures: "Intake & Exposures",
+  measurements: "Measurements",
+};
+
+/** Stable domain order within each section for Phase 2C. */
+export const DAILY_MONITOR_DOMAIN_SECTION: Record<
+  DailyMonitorDomainId,
+  DailyMonitorSectionId
+> = {
+  sleep: "recovery",
+  readiness: "recovery",
+  energy: "movement_output",
+  nutrition: "intake_exposures",
+  body_composition: "measurements",
+};
+
+export const DAILY_MONITOR_DOMAIN_ORDER: readonly DailyMonitorDomainId[] = [
+  "sleep",
+  "readiness",
+  "energy",
+  "nutrition",
+  "body_composition",
+] as const;

--- a/lib/data/dash/dailyMonitorPresentationRatings.ts
+++ b/lib/data/dash/dailyMonitorPresentationRatings.ts
@@ -3,7 +3,37 @@
  * Not Health State, not medical grades, not absolute-kcal classifiers.
  */
 
+import type { OuraRatingLabel } from "@/lib/format/ouraScore";
 import { getStepRatingActivityDescriptorPill } from "@/lib/utils/activityStepRating";
+
+/** Semantic presentation tones for Oura provider rating badges (Sleep / Readiness only). */
+export type DailyMonitorRatingTone = "critical" | "caution" | "positive" | "optimal";
+
+/**
+ * Maps an existing Oura provider rating label to a presentation tone.
+ * Does not inspect numeric scores and does not duplicate provider thresholds.
+ * Unknown / absent labels fail closed (null) — never invent a positive tone.
+ */
+export function mapOuraProviderRatingToTone(
+  ratingLabel: OuraRatingLabel | string | null | undefined,
+): DailyMonitorRatingTone | null {
+  if (ratingLabel == null) return null;
+  switch (ratingLabel) {
+    case "Pay attention":
+      return "critical";
+    case "Fair":
+      return "caution";
+    case "Good":
+      return "positive";
+    case "Optimal":
+      return "optimal";
+    default: {
+      const _exhaustive: string = ratingLabel;
+      void _exhaustive;
+      return null;
+    }
+  }
+}
 
 /**
  * Current-day Activity descriptor with in-progress wording.
@@ -64,10 +94,24 @@ export function buildDailyMonitorEnergyEstimatedRating(): {
   };
 }
 
+/** Neutral provider source announcement (distinct from the rating label). */
+export function buildOuraProviderSourceAccessibility(): string {
+  return "Source: Oura";
+}
+
+/** Rating-only announcement — does not include provider source or color names. */
+export function buildOuraRatingAccessibility(ratingLabel: string): string {
+  return `Rating ${ratingLabel}.`;
+}
+
+/**
+ * @deprecated Prefer {@link buildOuraRatingAccessibility} + separate source announcement.
+ * Kept for call-site migration; does not include color names.
+ */
 export function buildOuraScoreRatingAccessibility(input: {
   domain: "sleep" | "readiness";
   ratingLabel: string;
 }): string {
-  const noun = input.domain === "sleep" ? "sleep" : "readiness";
-  return `Oura ${noun} rating: ${input.ratingLabel}`;
+  void input.domain;
+  return buildOuraRatingAccessibility(input.ratingLabel);
 }

--- a/lib/data/dash/dailyMonitorPresentationRatings.ts
+++ b/lib/data/dash/dailyMonitorPresentationRatings.ts
@@ -4,9 +4,12 @@
  */
 
 import type { OuraRatingLabel } from "@/lib/format/ouraScore";
-import { getStepRatingActivityDescriptorPill } from "@/lib/utils/activityStepRating";
+import {
+  getStepRatingActivityDescriptorPill,
+  getStepRatingTierIndex,
+} from "@/lib/utils/activityStepRating";
 
-/** Semantic presentation tones for Oura provider rating badges (Sleep / Readiness only). */
+/** Semantic presentation tones for Monitor rating badges (written label remains primary). */
 export type DailyMonitorRatingTone = "critical" | "caution" | "positive" | "optimal";
 
 /**
@@ -36,18 +39,32 @@ export function mapOuraProviderRatingToTone(
 }
 
 /**
- * Current-day Activity descriptor with in-progress wording.
- * Reuses Activity Today classifier labels; appends ` so far` for unfinished day semantics.
+ * Maps current-day Activity step descriptor tiers onto Monitor presentation tones.
+ * Thresholds remain owned by {@link getStepRatingTierIndex} — this only picks chrome.
+ * Color is supplemental; the written Activity descriptor remains the primary signal.
+ */
+export function mapActivityStepDescriptorToTone(steps: number): DailyMonitorRatingTone {
+  const i = getStepRatingTierIndex(steps);
+  if (i <= 0) return "critical";
+  if (i <= 2) return "caution";
+  if (i <= 4) return "positive";
+  return "optimal";
+}
+
+/**
+ * Current-day Activity step-category label (not a health or fitness-capacity grade).
+ * Reuses Activity Today classifier labels exactly — no `so far` suffix.
  */
 export function buildDailyMonitorActivityRatingLabel(steps: number): {
   label: string;
   accessibilityLabel: string;
+  tone: DailyMonitorRatingTone;
 } {
   const base = getStepRatingActivityDescriptorPill(steps).label;
-  const label = `${base} so far`;
   return {
-    label,
-    accessibilityLabel: `Activity level ${label}.`,
+    label: base,
+    accessibilityLabel: `Activity level ${base}.`,
+    tone: mapActivityStepDescriptorToTone(steps),
   };
 }
 
@@ -81,18 +98,10 @@ export function mapWorkoutAverageIntensityToLabel(
 }
 
 /**
- * Energy expenditure presentation badge when no normalized PAL/activity-level classifier exists.
- * Neutral presentation — not a health grade.
+ * Energy Monitor has no top-right badge until a projected 24-hour TEE / age-gated PAL
+ * contract exists. The current hybrid output mixes full-day baseline with activity so far
+ * and must not be labeled Estimated, Low/Moderate/High, or used to derive PAL.
  */
-export function buildDailyMonitorEnergyEstimatedRating(): {
-  label: "Estimated";
-  accessibilityLabel: string;
-} {
-  return {
-    label: "Estimated",
-    accessibilityLabel: "Estimated energy expenditure level: Estimated.",
-  };
-}
 
 /** Neutral provider source announcement (distinct from the rating label). */
 export function buildOuraProviderSourceAccessibility(): string {

--- a/lib/data/dash/dailyMonitorPresentationRatings.ts
+++ b/lib/data/dash/dailyMonitorPresentationRatings.ts
@@ -1,0 +1,73 @@
+/**
+ * Pure Daily Monitor presentation ratings (UI-only).
+ * Not Health State, not medical grades, not absolute-kcal classifiers.
+ */
+
+import { getStepRatingActivityDescriptorPill } from "@/lib/utils/activityStepRating";
+
+/**
+ * Current-day Activity descriptor with in-progress wording.
+ * Reuses Activity Today classifier labels; appends ` so far` for unfinished day semantics.
+ */
+export function buildDailyMonitorActivityRatingLabel(steps: number): {
+  label: string;
+  accessibilityLabel: string;
+} {
+  const base = getStepRatingActivityDescriptorPill(steps).label;
+  const label = `${base} so far`;
+  return {
+    label,
+    accessibilityLabel: `Activity level ${label}.`,
+  };
+}
+
+/**
+ * Maps mean set RPE / average intensity on the documented 0–10 relative-exertion scale
+ * (from journal/ingest set `intensity` / RPE fields) to a Monitor intensity label.
+ *
+ * Scale contract (product Phase 2C compact cards), half-open bands:
+ * - [0, 5) → Low
+ * - [5, 7) → Moderate
+ * - [7, 9) → High
+ * - [9, 10] → Very High
+ *
+ * Aligns with integer bands 0–4 / 5–6 / 7–8 / 9–10 for whole RPE values.
+ */
+export function mapWorkoutAverageIntensityToLabel(
+  averageIntensity: number | null | undefined,
+): { label: string; accessibilityLabel: string } | null {
+  if (typeof averageIntensity !== "number" || !Number.isFinite(averageIntensity)) return null;
+  if (averageIntensity < 0 || averageIntensity > 10) return null;
+  const n = averageIntensity;
+  let label: string;
+  if (n < 5) label = "Low";
+  else if (n < 7) label = "Moderate";
+  else if (n < 9) label = "High";
+  else label = "Very High";
+  return {
+    label,
+    accessibilityLabel: `Workout intensity ${label}.`,
+  };
+}
+
+/**
+ * Energy expenditure presentation badge when no normalized PAL/activity-level classifier exists.
+ * Neutral presentation — not a health grade.
+ */
+export function buildDailyMonitorEnergyEstimatedRating(): {
+  label: "Estimated";
+  accessibilityLabel: string;
+} {
+  return {
+    label: "Estimated",
+    accessibilityLabel: "Estimated energy expenditure level: Estimated.",
+  };
+}
+
+export function buildOuraScoreRatingAccessibility(input: {
+  domain: "sleep" | "readiness";
+  ratingLabel: string;
+}): string {
+  const noun = input.domain === "sleep" ? "sleep" : "readiness";
+  return `Oura ${noun} rating: ${input.ratingLabel}`;
+}

--- a/lib/data/dash/dashDailyMonitorFoundation.ts
+++ b/lib/data/dash/dashDailyMonitorFoundation.ts
@@ -1,0 +1,59 @@
+/**
+ * Dash Phase 2C — Daily Monitor foundation.
+ *
+ * When enabled (with Weekly Progress relocation also enabled), the Dash tab
+ * presents as the consumer Daily Monitor: current-day evidence only, hybrid
+ * sections, and presence-driven cards.
+ *
+ * Convention mirrors `isDashWeeklyProgressRelocationEnabled`: typed helper with
+ * an env kill-switch / force-enable override. Default is ENABLED.
+ *
+ * Overrides:
+ * - `process.env.EXPO_PUBLIC_DASH_DAILY_MONITOR_FOUNDATION === "0"` → disabled
+ * - `process.env.EXPO_PUBLIC_DASH_DAILY_MONITOR_FOUNDATION === "1"` → enabled
+ * - unset / any other string → enabled (same as default / `"1"`)
+ *
+ * Non-secret. Value is embedded when Metro/EAS builds the JS bundle; changing
+ * it requires a cleared Metro reload or a new EAS Update / binary — it is not a
+ * server-side remote kill switch by itself. Documented in `.env.example`.
+ *
+ * Tests may call {@link setDashDailyMonitorFoundationEnabledForTests}.
+ */
+
+export const DASH_DAILY_MONITOR_FOUNDATION_ENV_KEY =
+  "EXPO_PUBLIC_DASH_DAILY_MONITOR_FOUNDATION" as const;
+
+/** Conceptual product id; env key is the runtime control surface. */
+export const DASH_DAILY_MONITOR_FOUNDATION_FLAG_ID = "dashDailyMonitorFoundation" as const;
+
+/** Consumer-visible screen title when Daily Monitor is active. */
+export const DAILY_MONITOR_SCREEN_TITLE = "Daily Monitor" as const;
+
+/** Consumer-visible tab title (width-constrained). */
+export const DAILY_MONITOR_TAB_TITLE = "Monitor" as const;
+
+/** Tab accessibility label (full name). */
+export const DAILY_MONITOR_TAB_A11Y_LABEL = "Daily Monitor" as const;
+
+/** Legacy Dash screen title when Daily Monitor is inactive. */
+export const LEGACY_DASH_SCREEN_TITLE = "Oli Fitness" as const;
+
+let testOverride: boolean | null = null;
+
+/**
+ * Test-only override. Pass `null` to clear and fall back to env/default.
+ * Production code must not call this.
+ */
+export function setDashDailyMonitorFoundationEnabledForTests(
+  enabled: boolean | null,
+): void {
+  testOverride = enabled;
+}
+
+export function isDashDailyMonitorFoundationEnabled(): boolean {
+  if (testOverride != null) return testOverride;
+  const override = process.env[DASH_DAILY_MONITOR_FOUNDATION_ENV_KEY];
+  if (override === "0") return false;
+  if (override === "1") return true;
+  return true;
+}

--- a/lib/data/dash/dashDailyMonitorFoundation.ts
+++ b/lib/data/dash/dashDailyMonitorFoundation.ts
@@ -26,7 +26,13 @@ export const DASH_DAILY_MONITOR_FOUNDATION_ENV_KEY =
 /** Conceptual product id; env key is the runtime control surface. */
 export const DASH_DAILY_MONITOR_FOUNDATION_FLAG_ID = "dashDailyMonitorFoundation" as const;
 
-/** Consumer-visible screen title when Daily Monitor is active. */
+/**
+ * Fixed app-header wordmark in Daily Monitor mode.
+ * Must not include “Daily Monitor” or the current date (those live in page content).
+ */
+export const DAILY_MONITOR_APP_HEADER_TITLE = "Oli" as const;
+
+/** Consumer-visible page heading inside scroll content when Daily Monitor is active. */
 export const DAILY_MONITOR_SCREEN_TITLE = "Daily Monitor" as const;
 
 /** Consumer-visible tab title (width-constrained). */

--- a/lib/data/dash/resolveDailyMonitorDomainPresence.ts
+++ b/lib/data/dash/resolveDailyMonitorDomainPresence.ts
@@ -1,0 +1,108 @@
+/**
+ * Pure domain → Daily Monitor presence resolvers (Phase 2C).
+ * Reuses existing attribution / day-match decisions; does not invent scores.
+ */
+
+import type { DailyNutritionCardModel } from "@/lib/data/dash/buildDailyNutritionCardModel";
+import type { BuiltBodyCompositionDashCard } from "@/lib/data/dash/buildBodyCompositionDashCardModel";
+import type { DailyEnergyCardDto } from "@/lib/data/dash/useDailyEnergyCard";
+import type { DailySleepCardViewModel } from "@/lib/data/dash/dailySleepCardViewModel";
+import type { DailyMonitorPresenceStatus } from "@/lib/data/dash/dailyMonitorPresence";
+import type { DailyReadinessCardViewModel } from "@/lib/ui/dash/DailyReadinessCard";
+import type { DayKey } from "@/lib/ui/calendar/types";
+
+export function resolveSleepMonitorPresence(
+  vm: DailySleepCardViewModel,
+): DailyMonitorPresenceStatus {
+  if (vm.status === "partial") return "loading_presence";
+  if (vm.status === "error") return "screen_level_error";
+  if (vm.status === "missing") {
+    if (vm.reason === "oura_disconnected") return "unavailable_source";
+    return "absent_no_day_evidence";
+  }
+  // ready
+  if (!vm.model.hasAnySignal) return "absent_no_day_evidence";
+  const rows = vm.model.metricRows;
+  const anyUnavailable = rows.some((r) => !r.isAvailable);
+  if (anyUnavailable || vm.model.scoreUnavailable) return "present_partial";
+  return "present_complete";
+}
+
+export function resolveReadinessMonitorPresence(
+  vm: DailyReadinessCardViewModel,
+): DailyMonitorPresenceStatus {
+  if (vm.status === "partial") return "loading_presence";
+  if (vm.status === "error") return "screen_level_error";
+  if (vm.status === "missing") {
+    if (vm.cta != null) return "unavailable_source";
+    return "absent_no_day_evidence";
+  }
+  if (!vm.model.hasAnySignal) return "absent_no_day_evidence";
+  const anyUnavailable = vm.model.metricRows.some((r) => !r.isAvailable);
+  return anyUnavailable ? "present_partial" : "present_complete";
+}
+
+export function resolveEnergyMonitorPresence(input: {
+  energy: DailyEnergyCardDto | undefined;
+  loading: boolean;
+  error: string | null;
+  requestedDay: DayKey;
+}): DailyMonitorPresenceStatus {
+  if (input.loading && input.energy == null) return "loading_presence";
+  if (input.error != null && input.energy == null) return "screen_level_error";
+  if (input.error != null && input.energy != null) {
+    if (input.energy.day !== input.requestedDay) return "absent_no_day_evidence";
+    return "refresh_error_with_cached_day_evidence";
+  }
+  if (input.energy == null) return "absent_no_day_evidence";
+  if (input.energy.day !== input.requestedDay) return "absent_no_day_evidence";
+  const missing = input.energy.missingRequiredInputs?.length ?? 0;
+  if (missing > 0 || input.energy.confidence === "low") return "present_partial";
+  return "present_complete";
+}
+
+export function resolveNutritionMonitorPresence(input: {
+  model: DailyNutritionCardModel;
+  loading: boolean;
+  error: string | null;
+}): DailyMonitorPresenceStatus {
+  if (input.loading) return "loading_presence";
+  if (input.error != null) return "screen_level_error";
+  if (!input.model.hasAnyNutrition) return "absent_no_day_evidence";
+  const anyDash = input.model.rows.some((r) => r.valueLabel === "—");
+  if (anyDash || input.model.calorieLabel === "—") return "present_partial";
+  return "present_complete";
+}
+
+/**
+ * Body Composition for Daily Monitor: observation day must equal requested day.
+ * Prior-day latest-known values → absent_no_day_evidence.
+ */
+export function resolveBodyCompositionMonitorPresence(input: {
+  requestedDay: DayKey;
+  /** Calendar day of the overview snapshot (latest observation day). */
+  overviewDay: string | null;
+  seriesLoading: boolean;
+  seriesError: string | null;
+  hasUser: boolean;
+  built: BuiltBodyCompositionDashCard | null;
+}): DailyMonitorPresenceStatus {
+  if (!input.hasUser) return "signed_out";
+  if (input.seriesLoading || input.built == null || input.built.tag === "partial") {
+    return "loading_presence";
+  }
+  if (input.seriesError != null || input.built.tag === "error") {
+    return "screen_level_error";
+  }
+  if (input.built.tag === "missing") {
+    return "absent_no_day_evidence";
+  }
+  // ready
+  if (input.overviewDay == null || input.overviewDay !== input.requestedDay) {
+    return "absent_no_day_evidence";
+  }
+  const anyUnavailable = input.built.rows.some(
+    (r) => r.valueLabel === "—" || !r.bar.hasValue,
+  );
+  return anyUnavailable ? "present_partial" : "present_complete";
+}

--- a/lib/data/dash/resolveDashExperienceMode.ts
+++ b/lib/data/dash/resolveDashExperienceMode.ts
@@ -1,0 +1,41 @@
+/**
+ * Pure Dash experience-mode resolver (Phase 2C).
+ *
+ * Daily Monitor is valid only when Weekly Progress relocation is also enabled.
+ * When Daily Monitor is ON but relocation is OFF, fall back to legacy Dash so
+ * Weekly Fitness and Daily Monitor never hybridize.
+ */
+
+import { isDashDailyMonitorFoundationEnabled } from "@/lib/data/dash/dashDailyMonitorFoundation";
+import { isDashWeeklyProgressRelocationEnabled } from "@/lib/data/dash/dashWeeklyProgressRelocation";
+
+export type DashExperienceMode = "daily_monitor" | "legacy_dash";
+
+export type DashExperienceModeInput = {
+  dailyMonitorEnabled: boolean;
+  weeklyProgressRelocationEnabled: boolean;
+};
+
+/**
+ * Deterministic matrix:
+ * 1. Monitor ON + relocation ON → daily_monitor
+ * 2. Monitor OFF + relocation ON → legacy_dash (post–Phase 1)
+ * 3. Monitor OFF + relocation OFF → legacy_dash (Weekly Fitness on Dash)
+ * 4. Monitor ON + relocation OFF → legacy_dash (no hybrid)
+ */
+export function resolveDashExperienceMode(
+  input: DashExperienceModeInput,
+): DashExperienceMode {
+  if (input.dailyMonitorEnabled && input.weeklyProgressRelocationEnabled) {
+    return "daily_monitor";
+  }
+  return "legacy_dash";
+}
+
+/** Reads current env/test overrides and resolves the active experience. */
+export function resolveDashExperienceModeFromFlags(): DashExperienceMode {
+  return resolveDashExperienceMode({
+    dailyMonitorEnabled: isDashDailyMonitorFoundationEnabled(),
+    weeklyProgressRelocationEnabled: isDashWeeklyProgressRelocationEnabled(),
+  });
+}

--- a/lib/data/dash/useBodyCompositionDashCard.ts
+++ b/lib/data/dash/useBodyCompositionDashCard.ts
@@ -31,6 +31,11 @@ export type UseBodyCompositionDashCardResult = {
   error: string | null;
   hasUser: boolean;
   goalsHref: string;
+  /**
+   * Calendar day of the overview snapshot (latest observation day).
+   * Daily Monitor presence must require this to equal the requested Monitor day.
+   */
+  overviewDay: string | null;
   /** Present after auth settles; may be `partial` while upstream series hydrates (prefer `loading`). */
   built: BuiltBodyCompositionDashCard | null;
 };
@@ -132,6 +137,7 @@ export function useBodyCompositionDashCard(): UseBodyCompositionDashCardResult {
     error,
     hasUser: Boolean(user),
     goalsHref: BODY_COMPOSITION_DASH_ROUTES.goalsEditor,
+    overviewDay: overviewSlice.overviewDay,
     built,
   };
 }

--- a/lib/data/dash/useDailyMonitorActivityCard.ts
+++ b/lib/data/dash/useDailyMonitorActivityCard.ts
@@ -1,0 +1,41 @@
+/**
+ * Daily Monitor Activity — reuses DailyFacts session cache (same day as Energy).
+ */
+
+import { useMemo } from "react";
+
+import {
+  buildDailyMonitorActivityCardModel,
+  resolveActivityMonitorPresence,
+  type DailyMonitorActivityCardModel,
+} from "@/lib/data/dash/buildDailyMonitorActivityCardModel";
+import type { DailyMonitorPresenceStatus } from "@/lib/data/dash/dailyMonitorPresence";
+import { useDailyFacts } from "@/lib/data/useDailyFacts";
+import type { DayKey } from "@/lib/ui/calendar/types";
+
+export type UseDailyMonitorActivityCardResult = {
+  presence: DailyMonitorPresenceStatus;
+  model: DailyMonitorActivityCardModel | null;
+  href: "/(app)/activity";
+};
+
+export function useDailyMonitorActivityCard(requestedDay: DayKey): UseDailyMonitorActivityCardResult {
+  const facts = useDailyFacts(requestedDay);
+
+  return useMemo(() => {
+    const readyFacts =
+      facts.status === "ready" && facts.data.date === requestedDay ? facts.data : null;
+    const model = buildDailyMonitorActivityCardModel({
+      requestedDay,
+      facts: readyFacts,
+    });
+    const presence = resolveActivityMonitorPresence({
+      loading: facts.status === "partial",
+      error: facts.status === "error" ? facts.error : null,
+      model,
+      factsDay: facts.status === "ready" ? facts.data.date : null,
+      requestedDay,
+    });
+    return { presence, model, href: "/(app)/activity" as const };
+  }, [facts, requestedDay]);
+}

--- a/lib/data/dash/useDailyMonitorSessionCards.ts
+++ b/lib/data/dash/useDailyMonitorSessionCards.ts
@@ -1,0 +1,65 @@
+/**
+ * Daily Monitor Workout + Cardio from one bounded current-day calendar hydrate.
+ */
+
+import { useMemo } from "react";
+
+import {
+  buildDailyMonitorCardioCardModel,
+  buildDailyMonitorWorkoutCardModel,
+  resolveCardioMonitorPresence,
+  resolveWorkoutMonitorPresence,
+  type DailyMonitorCardioCardModel,
+  type DailyMonitorWorkoutCardModel,
+} from "@/lib/data/dash/buildDailyMonitorSessionCards";
+import type { DailyMonitorPresenceStatus } from "@/lib/data/dash/dailyMonitorPresence";
+import { useWorkoutsCalendarRange } from "@/lib/data/workouts/useWorkoutsCalendar";
+import type { DayKey } from "@/lib/ui/calendar/types";
+
+export type UseDailyMonitorSessionCardsResult = {
+  workoutPresence: DailyMonitorPresenceStatus;
+  workoutModel: DailyMonitorWorkoutCardModel | null;
+  workoutHref: "/(app)/workouts";
+  cardioPresence: DailyMonitorPresenceStatus;
+  cardioModel: DailyMonitorCardioCardModel | null;
+  cardioHref: "/(app)/cardio";
+};
+
+export function useDailyMonitorSessionCards(
+  requestedDay: DayKey,
+): UseDailyMonitorSessionCardsResult {
+  const range = useWorkoutsCalendarRange(requestedDay, requestedDay);
+
+  return useMemo(() => {
+    const loading = range.status === "partial";
+    const error = range.status === "error" ? range.error : null;
+    const days = range.status === "ready" ? range.days : [];
+    const durable = range.status === "ready" ? range.durableTitlesByWorkoutId : {};
+
+    const workoutModel =
+      !loading && error == null
+        ? buildDailyMonitorWorkoutCardModel({
+            requestedDay,
+            calendarDays: days,
+            durableTitlesByWorkoutId: durable,
+          })
+        : null;
+    const cardioModel =
+      !loading && error == null
+        ? buildDailyMonitorCardioCardModel({
+            requestedDay,
+            calendarDays: days,
+            durableTitlesByWorkoutId: durable,
+          })
+        : null;
+
+    return {
+      workoutPresence: resolveWorkoutMonitorPresence({ loading, error, model: workoutModel }),
+      workoutModel,
+      workoutHref: "/(app)/workouts" as const,
+      cardioPresence: resolveCardioMonitorPresence({ loading, error, model: cardioModel }),
+      cardioModel,
+      cardioHref: "/(app)/cardio" as const,
+    };
+  }, [range, requestedDay]);
+}

--- a/lib/data/dash/useDailyMonitorSessionCards.ts
+++ b/lib/data/dash/useDailyMonitorSessionCards.ts
@@ -13,7 +13,9 @@ import {
   type DailyMonitorWorkoutCardModel,
 } from "@/lib/data/dash/buildDailyMonitorSessionCards";
 import type { DailyMonitorPresenceStatus } from "@/lib/data/dash/dailyMonitorPresence";
+import type { DailyEnergyCardDto } from "@/lib/data/dash/useDailyEnergyCard";
 import { useWorkoutsCalendarRange } from "@/lib/data/workouts/useWorkoutsCalendar";
+import { usePreferences } from "@/lib/preferences/PreferencesProvider";
 import type { DayKey } from "@/lib/ui/calendar/types";
 
 export type UseDailyMonitorSessionCardsResult = {
@@ -27,8 +29,11 @@ export type UseDailyMonitorSessionCardsResult = {
 
 export function useDailyMonitorSessionCards(
   requestedDay: DayKey,
+  energy?: DailyEnergyCardDto | null,
 ): UseDailyMonitorSessionCardsResult {
   const range = useWorkoutsCalendarRange(requestedDay, requestedDay);
+  const { state: prefState } = usePreferences();
+  const massUnit = prefState.preferences?.units?.mass ?? "lb";
 
   return useMemo(() => {
     const loading = range.status === "partial";
@@ -42,6 +47,8 @@ export function useDailyMonitorSessionCards(
             requestedDay,
             calendarDays: days,
             durableTitlesByWorkoutId: durable,
+            energy: energy ?? null,
+            massUnit,
           })
         : null;
     const cardioModel =
@@ -61,5 +68,5 @@ export function useDailyMonitorSessionCards(
       cardioModel,
       cardioHref: "/(app)/cardio" as const,
     };
-  }, [range, requestedDay]);
+  }, [range, requestedDay, energy, massUnit]);
 }

--- a/lib/data/dash/useDailyMonitorStressCard.ts
+++ b/lib/data/dash/useDailyMonitorStressCard.ts
@@ -1,0 +1,61 @@
+/**
+ * Daily Monitor Stress — bounded single-day Oura stress range.
+ */
+
+import { useMemo } from "react";
+
+import {
+  buildDailyMonitorStressCardModel,
+  resolveStressMonitorPresence,
+  type DailyMonitorStressCardModel,
+} from "@/lib/data/dash/buildDailyMonitorStressCardModel";
+import type { DailyMonitorPresenceStatus } from "@/lib/data/dash/dailyMonitorPresence";
+import { useOuraStressRange } from "@/lib/data/dash/useOuraStressRange";
+import { useOuraPresence } from "@/lib/data/useOuraPresence";
+import { useAuth } from "@/lib/auth/AuthProvider";
+import type { DayKey } from "@/lib/ui/calendar/types";
+
+export type UseDailyMonitorStressCardResult = {
+  presence: DailyMonitorPresenceStatus;
+  model: DailyMonitorStressCardModel | null;
+  href: "/(app)/recovery/stress";
+};
+
+export function useDailyMonitorStressCard(requestedDay: DayKey): UseDailyMonitorStressCardResult {
+  const { user, initializing } = useAuth();
+  const enabled = Boolean(user) && !initializing;
+  const presenceState = useOuraPresence();
+  const stressRange = useOuraStressRange(requestedDay, requestedDay, { enabled });
+
+  return useMemo(() => {
+    const ouraDisconnected =
+      presenceState.status === "ready" && presenceState.data.connected === false;
+    const dayDto =
+      stressRange.status === "ready" || stressRange.status === "error"
+        ? stressRange.days.find((d) => d.day === requestedDay) ?? null
+        : null;
+    const model = buildDailyMonitorStressCardModel({
+      requestedDay,
+      day: dayDto,
+    });
+    const loading =
+      (enabled && presenceState.status === "partial") || stressRange.status === "partial";
+    const error =
+      stressRange.status === "error"
+        ? stressRange.error
+        : presenceState.status === "error"
+          ? presenceState.error
+          : null;
+
+    return {
+      presence: resolveStressMonitorPresence({
+        loading,
+        error,
+        ouraDisconnected,
+        model,
+      }),
+      model,
+      href: "/(app)/recovery/stress" as const,
+    };
+  }, [enabled, presenceState, stressRange, requestedDay]);
+}

--- a/lib/hooks/__tests__/useCurrentLocalDayKey.test.tsx
+++ b/lib/hooks/__tests__/useCurrentLocalDayKey.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * Day-key lifecycle for Daily Monitor: midnight rollover, foreground refresh, cleanup.
+ */
+
+import React from "react";
+import renderer, { act } from "react-test-renderer";
+import { AppState } from "react-native";
+
+import { useCurrentLocalDayKey } from "../useCurrentLocalDayKey";
+
+const mockGetTodayDayKeyLocal = jest.fn(() => "2026-07-20");
+
+jest.mock("@/lib/ui/calendar/dateUtils", () => ({
+  getTodayDayKeyLocal: () => mockGetTodayDayKeyLocal(),
+}));
+
+let appStateListener: ((state: "active" | "inactive" | "background") => void) | null = null;
+let removeSpy: jest.Mock;
+
+function Host({ onState }: { onState: (s: ReturnType<typeof useCurrentLocalDayKey>) => void }) {
+  const state = useCurrentLocalDayKey();
+  onState(state);
+  return null;
+}
+
+describe("useCurrentLocalDayKey", () => {
+  let appStateAddListenerSpy: jest.SpyInstance;
+  let latest: ReturnType<typeof useCurrentLocalDayKey> | null = null;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    mockGetTodayDayKeyLocal.mockReturnValue("2026-07-20");
+    appStateListener = null;
+    removeSpy = jest.fn();
+    appStateAddListenerSpy = jest
+      .spyOn(AppState, "addEventListener")
+      .mockImplementation((_event, cb: (s: "active" | "inactive" | "background") => void) => {
+        appStateListener = cb;
+        return { remove: removeSpy };
+      });
+    latest = null;
+  });
+
+  afterEach(() => {
+    appStateAddListenerSpy.mockRestore();
+    jest.useRealTimers();
+  });
+
+  it("initializes from the canonical local-day helper", () => {
+    act(() => {
+      renderer.create(
+        React.createElement(Host, {
+          onState: (s) => {
+            latest = s;
+          },
+        }),
+      );
+    });
+    expect(latest?.dayKey).toBe("2026-07-20");
+    expect(appStateAddListenerSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("updates the day key after local midnight without duplicate storm", () => {
+    act(() => {
+      renderer.create(
+        React.createElement(Host, {
+          onState: (s) => {
+            latest = s;
+          },
+        }),
+      );
+    });
+    expect(latest?.dayKey).toBe("2026-07-20");
+
+    mockGetTodayDayKeyLocal.mockReturnValue("2026-07-21");
+    act(() => {
+      // Advance past the scheduled midnight timeout (capped by msUntilNextLocalMidnight).
+      jest.advanceTimersByTime(24 * 60 * 60 * 1000 + 1000);
+    });
+    expect(latest?.dayKey).toBe("2026-07-21");
+
+    const callsBefore = mockGetTodayDayKeyLocal.mock.calls.length;
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+    // Unchanged key must not thrash setState / extra unnecessary churn beyond the timer tick.
+    expect(mockGetTodayDayKeyLocal.mock.calls.length).toBeLessThanOrEqual(callsBefore + 1);
+    expect(latest?.dayKey).toBe("2026-07-21");
+  });
+
+  it("refreshes when the app returns to the foreground", () => {
+    act(() => {
+      renderer.create(
+        React.createElement(Host, {
+          onState: (s) => {
+            latest = s;
+          },
+        }),
+      );
+    });
+    mockGetTodayDayKeyLocal.mockReturnValue("2026-07-21");
+    act(() => {
+      appStateListener?.("active");
+    });
+    expect(latest?.dayKey).toBe("2026-07-21");
+  });
+
+  it("does not update state when the day key is unchanged on foreground", () => {
+    act(() => {
+      renderer.create(
+        React.createElement(Host, {
+          onState: (s) => {
+            latest = s;
+          },
+        }),
+      );
+    });
+    const before = latest;
+    act(() => {
+      appStateListener?.("active");
+    });
+    expect(latest?.dayKey).toBe("2026-07-20");
+    expect(latest).toBe(before);
+  });
+
+  it("cleans up AppState listener and timers on unmount", () => {
+    let tree: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(
+        React.createElement(Host, {
+          onState: (s) => {
+            latest = s;
+          },
+        }),
+      );
+    });
+    act(() => {
+      tree!.unmount();
+    });
+    expect(removeSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/lib/hooks/useCurrentLocalDayKey.ts
+++ b/lib/hooks/useCurrentLocalDayKey.ts
@@ -1,0 +1,67 @@
+/**
+ * Owns the active local calendar day key for Daily Monitor.
+ * No network I/O. Updates after local midnight and when the app returns to foreground.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { AppState, type AppStateStatus } from "react-native";
+
+import { getTodayDayKeyLocal } from "@/lib/ui/calendar/dateUtils";
+import type { DayKey } from "@/lib/ui/calendar/types";
+
+function msUntilNextLocalMidnight(now: Date = new Date()): number {
+  const next = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1, 0, 0, 0, 0);
+  return Math.max(250, next.getTime() - now.getTime() + 50);
+}
+
+export type UseCurrentLocalDayKeyResult = {
+  dayKey: DayKey;
+  /** Force re-read from the canonical local-day helper (e.g. tests). */
+  refreshDayKey: () => void;
+};
+
+export function useCurrentLocalDayKey(): UseCurrentLocalDayKeyResult {
+  const [dayKey, setDayKey] = useState<DayKey>(() => getTodayDayKeyLocal());
+  const dayKeyRef = useRef(dayKey);
+  dayKeyRef.current = dayKey;
+
+  const refreshDayKey = useCallback(() => {
+    const next = getTodayDayKeyLocal();
+    if (next !== dayKeyRef.current) {
+      setDayKey(next);
+    }
+  }, []);
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const scheduleMidnight = () => {
+      if (timer != null) clearTimeout(timer);
+      timer = setTimeout(() => {
+        refreshDayKey();
+        scheduleMidnight();
+      }, msUntilNextLocalMidnight());
+      // Allow Jest / process exit while a long midnight timer is pending.
+      if (typeof (timer as { unref?: () => void }).unref === "function") {
+        (timer as { unref: () => void }).unref();
+      }
+    };
+
+    scheduleMidnight();
+
+    const onAppState = (next: AppStateStatus) => {
+      if (next === "active") {
+        refreshDayKey();
+        scheduleMidnight();
+      }
+    };
+    const sub = AppState.addEventListener("change", onAppState);
+
+    return () => {
+      if (timer != null) clearTimeout(timer);
+      sub.remove();
+    };
+  }, [refreshDayKey]);
+
+  return { dayKey, refreshDayKey };
+}

--- a/lib/ui/dash/BodyCompositionCard.tsx
+++ b/lib/ui/dash/BodyCompositionCard.tsx
@@ -29,6 +29,8 @@ export type BodyCompositionCardProps = {
   hasUser: boolean;
   goalsHref: string;
   built: BuiltBodyCompositionDashCard | null;
+  /** When true, hide prior-day “As of …” subtitle (Daily Monitor same-day only). */
+  suppressAsOfLabel?: boolean;
 };
 
 export function BodyCompositionCard({
@@ -37,6 +39,7 @@ export function BodyCompositionCard({
   hasUser,
   goalsHref,
   built,
+  suppressAsOfLabel = false,
 }: BodyCompositionCardProps): React.ReactElement {
   const router = useRouter();
 
@@ -115,7 +118,7 @@ export function BodyCompositionCard({
               {built.weightPrimaryLabel}
             </Text>
           </Pressable>
-          {built.readingAsOfLabel ? (
+          {built.readingAsOfLabel && !suppressAsOfLabel ? (
             <Text style={styles.subtitle} testID="body-composition-reading-as-of">
               {built.readingAsOfLabel}
             </Text>

--- a/lib/ui/dash/BodyCompositionCard.tsx
+++ b/lib/ui/dash/BodyCompositionCard.tsx
@@ -12,7 +12,6 @@ import { ErrorState } from "@/lib/ui/ScreenStates";
 import { elevatedCardSurfaceStyle } from "@/lib/ui/theme/elevatedCardSurface";
 import {
   UI_CARD_SURFACE,
-  UI_GOAL_PILL_SURFACE,
   UI_TEXT_MUTED,
   UI_TEXT_PRIMARY,
   UI_TEXT_SECONDARY,
@@ -27,25 +26,25 @@ export type BodyCompositionCardProps = {
   loading: boolean;
   error: string | null;
   hasUser: boolean;
-  goalsHref: string;
   built: BuiltBodyCompositionDashCard | null;
   /** When true, hide prior-day “As of …” subtitle (Daily Monitor same-day only). */
   suppressAsOfLabel?: boolean;
 };
 
+/**
+ * Daily Monitor Body Composition summary.
+ * No goal chip / My Goal navigation — goals remain under Body / Program settings.
+ * No card-level composition badge: existing interpretation bars are per-metric and BMI-inclusive;
+ * a safe single Monitor badge requires a sex-aware, non-BMI-alone model with method limitations.
+ */
 export function BodyCompositionCard({
   loading,
   error,
   hasUser,
-  goalsHref,
   built,
   suppressAsOfLabel = false,
 }: BodyCompositionCardProps): React.ReactElement {
   const router = useRouter();
-
-  const onPressGoals = useCallback(() => {
-    router.push(goalsHref as Href);
-  }, [goalsHref, router]);
 
   const onPressWeight = useCallback(() => {
     router.push("/(app)/body" as Href);
@@ -72,21 +71,9 @@ export function BodyCompositionCard({
 
   return (
     <View style={styles.card} accessibilityLabel={cardAccessibilityLabel}>
-      <View style={styles.headerRow}>
-        <Text style={styles.title} accessibilityRole="header">
-          Body Composition
-        </Text>
-        <Pressable
-          accessibilityRole="button"
-          accessibilityLabel="My goal, open body composition settings"
-          onPress={onPressGoals}
-          style={({ pressed }) => [styles.goalsButton, pressed && styles.goalsButtonPressed]}
-          testID="body-composition-my-goal"
-          hitSlop={8}
-        >
-          <Text style={styles.goalsButtonText}>My goal</Text>
-        </Pressable>
-      </View>
+      <Text style={styles.title} accessibilityRole="header">
+        Body Composition
+      </Text>
 
       {loading ? <Text style={styles.status}>Loading body composition…</Text> : null}
 
@@ -173,31 +160,7 @@ const styles = StyleSheet.create({
     marginTop: 12,
     backgroundColor: UI_CARD_SURFACE,
   },
-  headerRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-    gap: 12,
-  },
   title: strengthMetricCardTitleTextStyle,
-  goalsButton: {
-    paddingVertical: 6,
-    paddingHorizontal: 10,
-    borderRadius: 8,
-    backgroundColor: UI_GOAL_PILL_SURFACE,
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  goalsButtonPressed: {
-    opacity: 0.85,
-  },
-  goalsButtonText: {
-    fontSize: 13,
-    lineHeight: 18,
-    fontWeight: "600",
-    color: UI_TEXT_PRIMARY,
-    letterSpacing: -0.08,
-  },
   status: {
     fontSize: 14,
     lineHeight: 20,

--- a/lib/ui/dash/DailyEnergyCard.tsx
+++ b/lib/ui/dash/DailyEnergyCard.tsx
@@ -27,6 +27,8 @@ type Props = {
   energy: DailyEnergyCardDto | undefined;
   loading: boolean;
   error: string | null;
+  /** Consumer card title. Defaults to “Daily Energy”. */
+  title?: string;
 };
 
 function formatRange(energy: DailyEnergyCardDto): string {
@@ -43,7 +45,12 @@ function formatVariancePct(variancePct: number): string {
   return `${(variancePct * 100).toFixed(1)}%`;
 }
 
-export function DailyEnergyCard({ energy, loading, error }: Props): React.ReactElement {
+export function DailyEnergyCard({
+  energy,
+  loading,
+  error,
+  title = "Daily Energy",
+}: Props): React.ReactElement {
   const router = useRouter();
   const rows = energy ? getEnergyFactorRows(energy) : [];
 
@@ -55,11 +62,11 @@ export function DailyEnergyCard({ energy, loading, error }: Props): React.ReactE
   }, [canOpenEnergy, router]);
 
   const headerA11y = useMemo(() => {
-    if (loading) return "Daily Energy header. Loading daily energy.";
-    if (error) return "Daily Energy header. Could not load data.";
-    if (!energy) return "Daily Energy header. Not enough data yet to estimate energy.";
-    return `Daily Energy header. ${formatRange(energy)}. Estimated burn today. Opens Daily Energy details.`;
-  }, [loading, error, energy]);
+    if (loading) return `${title} header. Loading daily energy.`;
+    if (error) return `${title} header. Could not load data.`;
+    if (!energy) return `${title} header. Not enough data yet to estimate energy.`;
+    return `${title} header. ${formatRange(energy)}. Estimated burn today. Opens Daily Energy details.`;
+  }, [loading, error, energy, title]);
 
   const onPressMetricRow = useCallback(
     (metricKey: (typeof rows)[number]["key"]) => {
@@ -82,7 +89,7 @@ export function DailyEnergyCard({ energy, loading, error }: Props): React.ReactE
         onPress={onOpenEnergy}
         style={({ pressed }) => [styles.headerPressable, pressed && canOpenEnergy && styles.headerPressed]}
       >
-        <Text style={styles.title}>Daily Energy</Text>
+        <Text style={styles.title}>{title}</Text>
         {loading ? <Text style={styles.status}>Loading daily energy\u2026</Text> : null}
         {!loading && error ? <Text style={styles.status}>Could not load daily energy</Text> : null}
         {!loading && !error && !energy ? (

--- a/lib/ui/dash/DailyEnergyCard.tsx
+++ b/lib/ui/dash/DailyEnergyCard.tsx
@@ -11,7 +11,6 @@ import { buildDailyMonitorEnergyEstimatedRating } from "@/lib/data/dash/dailyMon
 import { getEnergyFactorRows } from "@/lib/ui/energy/energyPresentation";
 import {
   DashCompactCardHeader,
-  dashCompactDescriptorTextStyle,
   dashCompactPrimaryValueTextStyle,
 } from "@/lib/ui/dash/DashCompactCardHeader";
 import { elevatedCardSurfaceStyle } from "@/lib/ui/theme/elevatedCardSurface";
@@ -101,10 +100,7 @@ export function DailyEnergyCard({
           <Text style={styles.status}>Not enough data yet to estimate energy.</Text>
         ) : null}
         {!loading && !error && energy ? (
-          <>
-            <Text style={styles.rangeValue}>{formatRange(energy)}</Text>
-            <Text style={styles.subtitle}>Estimated burn today</Text>
-          </>
+          <Text style={styles.rangeValue}>{formatRange(energy)}</Text>
         ) : null}
       </Pressable>
       {!loading && !error && energy ? (
@@ -155,7 +151,6 @@ const styles = StyleSheet.create({
   headerPressed: {
     opacity: 0.92,
   },
-  subtitle: dashCompactDescriptorTextStyle,
   status: {
     fontSize: 14,
     lineHeight: 20,

--- a/lib/ui/dash/DailyEnergyCard.tsx
+++ b/lib/ui/dash/DailyEnergyCard.tsx
@@ -7,21 +7,23 @@ import {
   ENERGY_METRIC_EXPLAINER_PATHNAME,
 } from "@/lib/data/energy/energyMetricExplainerRoutes";
 import type { DailyEnergyCardDto } from "@/lib/data/dash/useDailyEnergyCard";
+import { buildDailyMonitorEnergyEstimatedRating } from "@/lib/data/dash/dailyMonitorPresentationRatings";
 import { getEnergyFactorRows } from "@/lib/ui/energy/energyPresentation";
+import {
+  DashCompactCardHeader,
+  dashCompactDescriptorTextStyle,
+  dashCompactPrimaryValueTextStyle,
+} from "@/lib/ui/dash/DashCompactCardHeader";
 import { elevatedCardSurfaceStyle } from "@/lib/ui/theme/elevatedCardSurface";
 import {
   UI_BORDER_HAIRLINE,
   UI_CARD_SURFACE,
   UI_TEXT_MUTED,
-  UI_TEXT_PRIMARY,
-  UI_TEXT_SECONDARY,
-  UI_TEXT_TERTIARY_LABEL,
 } from "@/lib/ui/theme/uiTokens";
 import {
   dashMetricRowLabelTextStyle,
   dashMetricRowValueTextStyle,
 } from "@/lib/ui/dash/dashMetricRowTextStyle";
-import { strengthMetricCardTitleTextStyle } from "@/lib/ui/workouts/strengthMetricCardTitleStyle";
 
 type Props = {
   energy: DailyEnergyCardDto | undefined;
@@ -37,14 +39,6 @@ function formatRange(energy: DailyEnergyCardDto): string {
   return `${low}\u2013${high} kcal`;
 }
 
-function capitalizeConfidence(confidence: DailyEnergyCardDto["confidence"]): string {
-  return confidence.charAt(0).toUpperCase() + confidence.slice(1);
-}
-
-function formatVariancePct(variancePct: number): string {
-  return `${(variancePct * 100).toFixed(1)}%`;
-}
-
 export function DailyEnergyCard({
   energy,
   loading,
@@ -53,6 +47,7 @@ export function DailyEnergyCard({
 }: Props): React.ReactElement {
   const router = useRouter();
   const rows = energy ? getEnergyFactorRows(energy) : [];
+  const estimatedRating = buildDailyMonitorEnergyEstimatedRating();
 
   const canOpenEnergy = !loading && !error && energy != null;
 
@@ -65,8 +60,8 @@ export function DailyEnergyCard({
     if (loading) return `${title} header. Loading daily energy.`;
     if (error) return `${title} header. Could not load data.`;
     if (!energy) return `${title} header. Not enough data yet to estimate energy.`;
-    return `${title} header. ${formatRange(energy)}. Estimated burn today. Opens Daily Energy details.`;
-  }, [loading, error, energy, title]);
+    return `${title}. Estimated ${Math.round(energy.estimatedKcal.low).toLocaleString()} to ${Math.round(energy.estimatedKcal.high).toLocaleString()} kilocalories. ${estimatedRating.accessibilityLabel} Opens Daily Energy details.`;
+  }, [loading, error, energy, title, estimatedRating.accessibilityLabel]);
 
   const onPressMetricRow = useCallback(
     (metricKey: (typeof rows)[number]["key"]) => {
@@ -89,7 +84,17 @@ export function DailyEnergyCard({
         onPress={onOpenEnergy}
         style={({ pressed }) => [styles.headerPressable, pressed && canOpenEnergy && styles.headerPressed]}
       >
-        <Text style={styles.title}>{title}</Text>
+        <DashCompactCardHeader
+          title={title}
+          rating={
+            !loading && !error && energy != null
+              ? {
+                  label: estimatedRating.label,
+                  accessibilityLabel: estimatedRating.accessibilityLabel,
+                }
+              : null
+          }
+        />
         {loading ? <Text style={styles.status}>Loading daily energy\u2026</Text> : null}
         {!loading && error ? <Text style={styles.status}>Could not load daily energy</Text> : null}
         {!loading && !error && !energy ? (
@@ -99,10 +104,6 @@ export function DailyEnergyCard({
           <>
             <Text style={styles.rangeValue}>{formatRange(energy)}</Text>
             <Text style={styles.subtitle}>Estimated burn today</Text>
-            <Text style={styles.meta}>
-              {`Confidence ${capitalizeConfidence(energy.confidence)} · ±`}
-              {formatVariancePct(energy.variancePct)}
-            </Text>
           </>
         ) : null}
       </Pressable>
@@ -154,29 +155,13 @@ const styles = StyleSheet.create({
   headerPressed: {
     opacity: 0.92,
   },
-  title: strengthMetricCardTitleTextStyle,
-  subtitle: {
-    fontSize: 14,
-    lineHeight: 20,
-    color: UI_TEXT_SECONDARY,
-  },
+  subtitle: dashCompactDescriptorTextStyle,
   status: {
     fontSize: 14,
     lineHeight: 20,
     color: UI_TEXT_MUTED,
   },
-  rangeValue: {
-    fontSize: 34,
-    lineHeight: 40,
-    color: UI_TEXT_PRIMARY,
-    fontWeight: "700",
-    letterSpacing: -0.2,
-  },
-  meta: {
-    fontSize: 14,
-    lineHeight: 20,
-    color: UI_TEXT_TERTIARY_LABEL,
-  },
+  rangeValue: dashCompactPrimaryValueTextStyle,
   factors: {
     borderTopWidth: StyleSheet.hairlineWidth,
     borderTopColor: UI_BORDER_HAIRLINE,

--- a/lib/ui/dash/DailyEnergyCard.tsx
+++ b/lib/ui/dash/DailyEnergyCard.tsx
@@ -7,7 +7,6 @@ import {
   ENERGY_METRIC_EXPLAINER_PATHNAME,
 } from "@/lib/data/energy/energyMetricExplainerRoutes";
 import type { DailyEnergyCardDto } from "@/lib/data/dash/useDailyEnergyCard";
-import { buildDailyMonitorEnergyEstimatedRating } from "@/lib/data/dash/dailyMonitorPresentationRatings";
 import { getEnergyFactorRows } from "@/lib/ui/energy/energyPresentation";
 import {
   DashCompactCardHeader,
@@ -46,7 +45,6 @@ export function DailyEnergyCard({
 }: Props): React.ReactElement {
   const router = useRouter();
   const rows = energy ? getEnergyFactorRows(energy) : [];
-  const estimatedRating = buildDailyMonitorEnergyEstimatedRating();
 
   const canOpenEnergy = !loading && !error && energy != null;
 
@@ -59,8 +57,8 @@ export function DailyEnergyCard({
     if (loading) return `${title} header. Loading daily energy.`;
     if (error) return `${title} header. Could not load data.`;
     if (!energy) return `${title} header. Not enough data yet to estimate energy.`;
-    return `${title}. Estimated ${Math.round(energy.estimatedKcal.low).toLocaleString()} to ${Math.round(energy.estimatedKcal.high).toLocaleString()} kilocalories. ${estimatedRating.accessibilityLabel} Opens Daily Energy details.`;
-  }, [loading, error, energy, title, estimatedRating.accessibilityLabel]);
+    return `${title}. ${Math.round(energy.estimatedKcal.low).toLocaleString()} to ${Math.round(energy.estimatedKcal.high).toLocaleString()} kilocalories. Opens Daily Energy details.`;
+  }, [loading, error, energy, title]);
 
   const onPressMetricRow = useCallback(
     (metricKey: (typeof rows)[number]["key"]) => {
@@ -83,17 +81,7 @@ export function DailyEnergyCard({
         onPress={onOpenEnergy}
         style={({ pressed }) => [styles.headerPressable, pressed && canOpenEnergy && styles.headerPressed]}
       >
-        <DashCompactCardHeader
-          title={title}
-          rating={
-            !loading && !error && energy != null
-              ? {
-                  label: estimatedRating.label,
-                  accessibilityLabel: estimatedRating.accessibilityLabel,
-                }
-              : null
-          }
-        />
+        <DashCompactCardHeader title={title} rating={null} />
         {loading ? <Text style={styles.status}>Loading daily energy\u2026</Text> : null}
         {!loading && error ? <Text style={styles.status}>Could not load daily energy</Text> : null}
         {!loading && !error && !energy ? (

--- a/lib/ui/dash/DailyMonitorDomainCards.tsx
+++ b/lib/ui/dash/DailyMonitorDomainCards.tsx
@@ -11,6 +11,7 @@ import type {
   DailyMonitorCardioCardModel,
   DailyMonitorWorkoutCardModel,
 } from "@/lib/data/dash/buildDailyMonitorSessionCards";
+import type { DailyMonitorStressCardModel } from "@/lib/data/dash/buildDailyMonitorStressCardModel";
 import { elevatedCardSurfaceStyle } from "@/lib/ui/theme/elevatedCardSurface";
 import {
   UI_BORDER_HAIRLINE,
@@ -117,6 +118,50 @@ export function DailyMonitorCardioCard({
   );
 }
 
+export function DailyMonitorStressCard({
+  model,
+  href,
+}: {
+  model: DailyMonitorStressCardModel;
+  href: "/(app)/recovery/stress";
+}): React.ReactElement {
+  const router = useRouter();
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={model.accessibilityLabel}
+      accessibilityHint="Opens Stress"
+      onPress={() => router.push(href)}
+      style={({ pressed }) => [styles.card, pressed && styles.pressed]}
+    >
+      <Text style={styles.title}>Stress</Text>
+      <Text style={styles.primaryValue}>{model.daySummaryLabel}</Text>
+      <Text style={styles.subtitle}>Source: {model.sourceLabel}</Text>
+      {model.stressedMinutesLabel != null ? (
+        <View style={styles.row}>
+          <Text style={dashMetricRowLabelTextStyle}>Stressed time</Text>
+          <Text style={dashMetricRowValueTextStyle}>{model.stressedMinutesLabel}</Text>
+        </View>
+      ) : (
+        <View style={styles.row}>
+          <Text style={dashMetricRowLabelTextStyle}>Stressed time</Text>
+          <Text style={dashMetricRowValueTextStyle}>Unavailable</Text>
+        </View>
+      )}
+      {model.restoredMinutesLabel != null ? (
+        <View style={styles.row}>
+          <Text style={dashMetricRowLabelTextStyle}>Restored time</Text>
+          <Text style={dashMetricRowValueTextStyle}>{model.restoredMinutesLabel}</Text>
+        </View>
+      ) : (
+        <View style={styles.row}>
+          <Text style={dashMetricRowLabelTextStyle}>Restored time</Text>
+          <Text style={dashMetricRowValueTextStyle}>Unavailable</Text>
+        </View>
+      )}
+    </Pressable>
+  );
+}
 
 const styles = StyleSheet.create({
   card: cardChrome,

--- a/lib/ui/dash/DailyMonitorDomainCards.tsx
+++ b/lib/ui/dash/DailyMonitorDomainCards.tsx
@@ -12,6 +12,11 @@ import type {
   DailyMonitorWorkoutCardModel,
 } from "@/lib/data/dash/buildDailyMonitorSessionCards";
 import type { DailyMonitorStressCardModel } from "@/lib/data/dash/buildDailyMonitorStressCardModel";
+import {
+  DashCompactCardHeader,
+  dashCompactCardDividerStyle,
+  dashCompactPrimaryValueTextStyle,
+} from "@/lib/ui/dash/DashCompactCardHeader";
 import { elevatedCardSurfaceStyle } from "@/lib/ui/theme/elevatedCardSurface";
 import {
   UI_BORDER_HAIRLINE,
@@ -53,19 +58,26 @@ export function DailyMonitorActivityCard({
       onPress={() => router.push(href)}
       style={({ pressed }) => [styles.card, pressed && styles.pressed]}
     >
-      <Text style={styles.title}>Activity</Text>
+      <DashCompactCardHeader
+        title="Activity"
+        rating={{
+          label: model.ratingLabel,
+          accessibilityLabel: model.ratingAccessibilityLabel,
+        }}
+      />
       <Text style={styles.primaryValue} accessibilityRole="text">
-        {model.stepsLabel}
+        {model.primaryLabel}
       </Text>
-      <Text style={styles.subtitle}>Steps</Text>
-      {model.rows.map((row) => (
-        <View key={row.key} style={styles.row}>
-          <Text style={dashMetricRowLabelTextStyle}>{row.label}</Text>
-          <Text style={dashMetricRowValueTextStyle}>
-            {row.isAvailable ? row.valueLabel : "Unavailable"}
-          </Text>
-        </View>
-      ))}
+      <View style={styles.divider}>
+        {model.rows.map((row) => (
+          <View key={row.key} style={styles.row}>
+            <Text style={dashMetricRowLabelTextStyle}>{row.label}</Text>
+            <Text style={dashMetricRowValueTextStyle}>
+              {row.isAvailable ? row.valueLabel : "Unavailable"}
+            </Text>
+          </View>
+        ))}
+      </View>
     </Pressable>
   );
 }
@@ -86,10 +98,29 @@ export function DailyMonitorWorkoutCard({
       onPress={() => router.push(href)}
       style={({ pressed }) => [styles.card, pressed && styles.pressed]}
     >
-      <Text style={styles.title}>Workout</Text>
+      <DashCompactCardHeader
+        title="Workout"
+        rating={
+          model.intensityLabel != null
+            ? {
+                label: model.intensityLabel,
+                accessibilityLabel:
+                  model.intensityAccessibilityLabel ?? `Workout intensity ${model.intensityLabel}.`,
+              }
+            : null
+        }
+      />
       <Text style={styles.primaryValue}>{model.primaryTitle}</Text>
-      {model.durationLabel ? <Text style={styles.subtitle}>{model.durationLabel}</Text> : null}
-      {model.subtitle ? <Text style={styles.muted}>{model.subtitle}</Text> : null}
+      <View style={styles.divider}>
+        {model.rows.map((row) => (
+          <View key={row.key} style={styles.row}>
+            <Text style={dashMetricRowLabelTextStyle}>{row.label}</Text>
+            <Text style={dashMetricRowValueTextStyle}>
+              {row.isAvailable ? row.valueLabel : "Unavailable"}
+            </Text>
+          </View>
+        ))}
+      </View>
     </Pressable>
   );
 }
@@ -170,12 +201,7 @@ const styles = StyleSheet.create({
     ...strengthMetricCardTitleTextStyle,
     color: UI_TEXT_PRIMARY,
   },
-  primaryValue: {
-    marginTop: 8,
-    fontSize: 28,
-    fontWeight: "600",
-    color: UI_TEXT_PRIMARY,
-  },
+  primaryValue: dashCompactPrimaryValueTextStyle,
   subtitle: {
     marginTop: 4,
     fontSize: 14,
@@ -186,6 +212,9 @@ const styles = StyleSheet.create({
     marginTop: 4,
     fontSize: 13,
     color: UI_TEXT_MUTED,
+  },
+  divider: {
+    ...dashCompactCardDividerStyle,
   },
   row: {
     marginTop: 8,

--- a/lib/ui/dash/DailyMonitorDomainCards.tsx
+++ b/lib/ui/dash/DailyMonitorDomainCards.tsx
@@ -62,6 +62,7 @@ export function DailyMonitorActivityCard({
         title="Activity"
         rating={{
           label: model.ratingLabel,
+          tone: model.ratingTone,
           accessibilityLabel: model.ratingAccessibilityLabel,
         }}
       />

--- a/lib/ui/dash/DailyMonitorDomainCards.tsx
+++ b/lib/ui/dash/DailyMonitorDomainCards.tsx
@@ -1,0 +1,152 @@
+/**
+ * Presentation-only Daily Monitor domain summary cards.
+ */
+
+import React from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import { useRouter } from "expo-router";
+
+import type { DailyMonitorActivityCardModel } from "@/lib/data/dash/buildDailyMonitorActivityCardModel";
+import type {
+  DailyMonitorCardioCardModel,
+  DailyMonitorWorkoutCardModel,
+} from "@/lib/data/dash/buildDailyMonitorSessionCards";
+import { elevatedCardSurfaceStyle } from "@/lib/ui/theme/elevatedCardSurface";
+import {
+  UI_BORDER_HAIRLINE,
+  UI_CARD_SURFACE,
+  UI_TEXT_MUTED,
+  UI_TEXT_PRIMARY,
+  UI_TEXT_SECONDARY,
+} from "@/lib/ui/theme/uiTokens";
+import {
+  dashMetricRowLabelTextStyle,
+  dashMetricRowValueTextStyle,
+} from "@/lib/ui/dash/dashMetricRowTextStyle";
+import { strengthMetricCardTitleTextStyle } from "@/lib/ui/workouts/strengthMetricCardTitleStyle";
+
+const cardChrome = {
+  ...elevatedCardSurfaceStyle,
+  backgroundColor: UI_CARD_SURFACE,
+  borderWidth: StyleSheet.hairlineWidth,
+  borderColor: UI_BORDER_HAIRLINE,
+  borderRadius: 14,
+  padding: 16,
+  marginTop: 10,
+  minHeight: 44,
+} as const;
+
+export function DailyMonitorActivityCard({
+  model,
+  href,
+}: {
+  model: DailyMonitorActivityCardModel;
+  href: "/(app)/activity";
+}): React.ReactElement {
+  const router = useRouter();
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={model.accessibilityLabel}
+      accessibilityHint="Opens Activity"
+      onPress={() => router.push(href)}
+      style={({ pressed }) => [styles.card, pressed && styles.pressed]}
+    >
+      <Text style={styles.title}>Activity</Text>
+      <Text style={styles.primaryValue} accessibilityRole="text">
+        {model.stepsLabel}
+      </Text>
+      <Text style={styles.subtitle}>Steps</Text>
+      {model.rows.map((row) => (
+        <View key={row.key} style={styles.row}>
+          <Text style={dashMetricRowLabelTextStyle}>{row.label}</Text>
+          <Text style={dashMetricRowValueTextStyle}>
+            {row.isAvailable ? row.valueLabel : "Unavailable"}
+          </Text>
+        </View>
+      ))}
+    </Pressable>
+  );
+}
+
+export function DailyMonitorWorkoutCard({
+  model,
+  href,
+}: {
+  model: DailyMonitorWorkoutCardModel;
+  href: "/(app)/workouts";
+}): React.ReactElement {
+  const router = useRouter();
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={model.accessibilityLabel}
+      accessibilityHint="Opens Workouts"
+      onPress={() => router.push(href)}
+      style={({ pressed }) => [styles.card, pressed && styles.pressed]}
+    >
+      <Text style={styles.title}>Workout</Text>
+      <Text style={styles.primaryValue}>{model.primaryTitle}</Text>
+      {model.durationLabel ? <Text style={styles.subtitle}>{model.durationLabel}</Text> : null}
+      {model.subtitle ? <Text style={styles.muted}>{model.subtitle}</Text> : null}
+    </Pressable>
+  );
+}
+
+export function DailyMonitorCardioCard({
+  model,
+  href,
+}: {
+  model: DailyMonitorCardioCardModel;
+  href: "/(app)/cardio";
+}): React.ReactElement {
+  const router = useRouter();
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={model.accessibilityLabel}
+      accessibilityHint="Opens Cardio"
+      onPress={() => router.push(href)}
+      style={({ pressed }) => [styles.card, pressed && styles.pressed]}
+    >
+      <Text style={styles.title}>Cardio</Text>
+      <Text style={styles.primaryValue}>{model.primaryTitle}</Text>
+      <Text style={styles.subtitle}>{model.primaryLine}</Text>
+      {model.metaLine ? <Text style={styles.muted}>{model.metaLine}</Text> : null}
+    </Pressable>
+  );
+}
+
+
+const styles = StyleSheet.create({
+  card: cardChrome,
+  pressed: { opacity: 0.92 },
+  title: {
+    ...strengthMetricCardTitleTextStyle,
+    color: UI_TEXT_PRIMARY,
+  },
+  primaryValue: {
+    marginTop: 8,
+    fontSize: 28,
+    fontWeight: "600",
+    color: UI_TEXT_PRIMARY,
+  },
+  subtitle: {
+    marginTop: 4,
+    fontSize: 14,
+    fontWeight: "500",
+    color: UI_TEXT_SECONDARY,
+  },
+  muted: {
+    marginTop: 4,
+    fontSize: 13,
+    color: UI_TEXT_MUTED,
+  },
+  row: {
+    marginTop: 8,
+    minHeight: 44,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+});

--- a/lib/ui/dash/DailyNutritionCard.tsx
+++ b/lib/ui/dash/DailyNutritionCard.tsx
@@ -21,14 +21,22 @@ type Props = {
   loading: boolean;
   error: string | null;
   onPress?: () => void;
+  /** Consumer card title. Defaults to “Daily Nutrition”. */
+  title?: string;
 };
 
-export function DailyNutritionCard({ model, loading, error, onPress }: Props): React.ReactElement {
+export function DailyNutritionCard({
+  model,
+  loading,
+  error,
+  onPress,
+  title = "Daily Nutrition",
+}: Props): React.ReactElement {
   const content = (
     <>
-      <Text style={styles.title}>Daily Nutrition</Text>
+      <Text style={styles.title}>{title}</Text>
 
-      {loading ? <Text style={styles.status}>Loading daily nutrition…</Text> : null}
+      {loading ? <Text style={styles.status}>Loading daily nutrition{"\u2026"}</Text> : null}
       {!loading && error ? <Text style={styles.status}>Could not load daily nutrition</Text> : null}
 
       {!loading && !error ? (
@@ -39,7 +47,7 @@ export function DailyNutritionCard({ model, loading, error, onPress }: Props): R
               <Text style={styles.subtitle}>Logged today</Text>
             </>
           ) : (
-            <Text style={styles.status}>No nutrition logged today</Text>
+            <Text style={styles.status}>No nutrition record is available for today.</Text>
           )}
 
           <View style={styles.factors} accessibilityRole="list">

--- a/lib/ui/dash/DailyReadinessCard.tsx
+++ b/lib/ui/dash/DailyReadinessCard.tsx
@@ -12,9 +12,7 @@ import {
 import { DashMetricRow } from "@/lib/ui/dash/DashMetricRow";
 import {
   DashCompactCardHeader,
-  DashCompactProviderSourceChip,
-  dashCompactPrimaryRowStyle,
-  dashCompactPrimaryValueInRowTextStyle,
+  dashCompactPrimaryValueTextStyle,
 } from "@/lib/ui/dash/DashCompactCardHeader";
 import { elevatedCardSurfaceStyle } from "@/lib/ui/theme/elevatedCardSurface";
 import {
@@ -96,8 +94,6 @@ export function DailyReadinessCard({
     return `Readiness Score ${model.headlineValueText}`;
   }, [model]);
 
-  const showOuraSource = vm.status === "ready" && model?.hasAnySignal === true;
-
   const rating = useMemo(() => {
     if (model?.ratingLabel == null) return null;
     return {
@@ -112,7 +108,7 @@ export function DailyReadinessCard({
       ? [
           title,
           primaryScoreLabel != null ? `${primaryScoreLabel}.` : null,
-          showOuraSource ? "Oura." : null,
+          // Provider provenance remains in typed/detail data; Monitor summary omits Oura.
           rating != null ? `Rating ${rating.label}.` : null,
           "Opens Readiness details.",
         ]
@@ -140,13 +136,8 @@ export function DailyReadinessCard({
           style={({ pressed }) => [styles.headerPressable, pressed && canOpen && styles.headerPressed]}
         >
           <DashCompactCardHeader title={title} rating={rating} />
-          {vm.status === "ready" && model?.hasAnySignal ? (
-            <View style={styles.primaryRow}>
-              {primaryScoreLabel != null ? (
-                <Text style={styles.headlineValue}>{primaryScoreLabel}</Text>
-              ) : null}
-              {showOuraSource ? <DashCompactProviderSourceChip label="Oura" /> : null}
-            </View>
+          {primaryScoreLabel != null ? (
+            <Text style={styles.headlineValue}>{primaryScoreLabel}</Text>
           ) : null}
           {loading ? <Text style={styles.mutedLine}>Loading daily readiness…</Text> : null}
           {error ? <Text style={styles.mutedLine}>Could not load daily readiness</Text> : null}
@@ -206,8 +197,7 @@ const styles = StyleSheet.create({
   headerPressed: {
     opacity: 0.9,
   },
-  primaryRow: dashCompactPrimaryRowStyle,
-  headlineValue: dashCompactPrimaryValueInRowTextStyle,
+  headlineValue: dashCompactPrimaryValueTextStyle,
   mutedLine: {
     fontSize: 14,
     lineHeight: 20,

--- a/lib/ui/dash/DailyReadinessCard.tsx
+++ b/lib/ui/dash/DailyReadinessCard.tsx
@@ -45,18 +45,14 @@ export type DailyReadinessCardViewModel =
 
 type Props = {
   vm: DailyReadinessCardViewModel;
+  /** Consumer card title. Defaults to “Oura Readiness”. */
+  title?: string;
 };
 
-const HEADLINE_VALUE_TEXT: React.ComponentProps<typeof Text>["style"] = {
-  fontSize: 34,
-  lineHeight: 40,
-  color: UI_TEXT_PRIMARY,
-  fontWeight: "700",
-  letterSpacing: -0.2,
-  fontVariant: ["tabular-nums"],
-};
-
-export function DailyReadinessCard({ vm }: Props): React.ReactElement {
+export function DailyReadinessCard({
+  vm,
+  title = "Oura Readiness",
+}: Props): React.ReactElement {
   const router = useRouter();
 
   const loading = vm.status === "partial";
@@ -91,17 +87,17 @@ export function DailyReadinessCard({ vm }: Props): React.ReactElement {
     vm.status === "ready"
       ? vm.accessibilityLabel
       : loading
-        ? "Oura Readiness header. Loading."
+        ? `${title} header. Loading.`
         : error
-          ? "Oura Readiness header. Could not load data."
-          : `Oura Readiness header. ${missingMessage ?? "No readiness data."}`;
+          ? `${title} header. Could not load data.`
+          : `${title} header. ${missingMessage ?? "No readiness data."}`;
 
   const canOpen = vm.status === "ready" && model?.hasAnySignal;
   const showMetricSection =
     vm.status === "ready" && model?.hasAnySignal === true && (model.metricRows?.length ?? 0) > 0;
 
   return (
-    <View style={styles.outer} accessibilityLabel="Oura Readiness card">
+    <View style={styles.outer} accessibilityLabel={`${title} card`}>
       <View style={styles.card}>
         <Pressable
           accessibilityRole="button"
@@ -111,7 +107,7 @@ export function DailyReadinessCard({ vm }: Props): React.ReactElement {
           onPress={onOpenReadiness}
           style={({ pressed }) => [styles.headerPressable, pressed && canOpen && styles.headerPressed]}
         >
-          <Text style={styles.title}>Oura Readiness</Text>
+          <Text style={styles.title}>{title}</Text>
           {model?.sourceLabel ? (
             <Text style={styles.subtitle}>Source: {model.sourceLabel}</Text>
           ) : null}
@@ -162,6 +158,15 @@ export function DailyReadinessCard({ vm }: Props): React.ReactElement {
     </View>
   );
 }
+
+const HEADLINE_VALUE_TEXT: React.ComponentProps<typeof Text>["style"] = {
+  fontSize: 34,
+  lineHeight: 40,
+  color: UI_TEXT_PRIMARY,
+  fontWeight: "700",
+  letterSpacing: -0.2,
+  fontVariant: ["tabular-nums"],
+};
 
 const styles = StyleSheet.create({
   outer: {

--- a/lib/ui/dash/DailyReadinessCard.tsx
+++ b/lib/ui/dash/DailyReadinessCard.tsx
@@ -1,20 +1,23 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo } from "react";
 import { Pressable, StyleSheet, Text, View } from "react-native";
 import { useRouter } from "expo-router";
 
 import type { DailyReadinessCardModel } from "@/lib/data/dash/buildDailyReadinessCardModel";
 import type { DashReadinessMetricRowId } from "@/lib/data/dash/buildDashReadinessMetricRows";
 import type { Readiness } from "@/lib/contracts/readiness";
+import { buildOuraScoreRatingAccessibility } from "@/lib/data/dash/dailyMonitorPresentationRatings";
 import { DashMetricRow } from "@/lib/ui/dash/DashMetricRow";
+import {
+  DashCompactCardHeader,
+  dashCompactPrimaryValueTextStyle,
+} from "@/lib/ui/dash/DashCompactCardHeader";
 import { elevatedCardSurfaceStyle } from "@/lib/ui/theme/elevatedCardSurface";
 import {
   UI_BORDER_HAIRLINE,
   UI_CARD_SURFACE,
   UI_TEXT_MUTED,
   UI_TEXT_PRIMARY,
-  UI_TEXT_SECONDARY,
 } from "@/lib/ui/theme/uiTokens";
-import { strengthMetricCardTitleTextStyle } from "@/lib/ui/workouts/strengthMetricCardTitleStyle";
 
 const READINESS_DETAIL_HREF = "/(app)/recovery/readiness" as const;
 
@@ -83,9 +86,36 @@ export function DailyReadinessCard({
     router.push(missingCta.href as Parameters<typeof router.push>[0]);
   }, [missingCta, router]);
 
+  const primaryScoreLabel = useMemo(() => {
+    if (model?.headlineValueText == null || model.headlineValueText.length === 0) return null;
+    return `Readiness Score ${model.headlineValueText}`;
+  }, [model]);
+
+  const rating = useMemo(() => {
+    if (model?.ratingLabel == null) return null;
+    const source =
+      model.sourceLabel != null && model.sourceLabel.trim().length > 0 ? model.sourceLabel : "Oura";
+    return {
+      label: model.ratingLabel,
+      sourceLabel: source,
+      accessibilityLabel: buildOuraScoreRatingAccessibility({
+        domain: "readiness",
+        ratingLabel: model.ratingLabel,
+      }),
+    };
+  }, [model]);
+
   const headerA11y =
     vm.status === "ready"
-      ? vm.accessibilityLabel
+      ? [
+          title,
+          primaryScoreLabel != null ? `${primaryScoreLabel}.` : null,
+          // Single Oura+rating announcement (badge is accessibility-hidden under the Pressable).
+          rating != null ? `${rating.accessibilityLabel}.` : "Source Oura.",
+          "Opens Readiness details.",
+        ]
+          .filter(Boolean)
+          .join(" ")
       : loading
         ? `${title} header. Loading.`
         : error
@@ -107,14 +137,10 @@ export function DailyReadinessCard({
           onPress={onOpenReadiness}
           style={({ pressed }) => [styles.headerPressable, pressed && canOpen && styles.headerPressed]}
         >
-          <Text style={styles.title}>{title}</Text>
-          {model?.sourceLabel ? (
-            <Text style={styles.subtitle}>Source: {model.sourceLabel}</Text>
+          <DashCompactCardHeader title={title} rating={rating} />
+          {primaryScoreLabel != null ? (
+            <Text style={styles.headlineValue}>{primaryScoreLabel}</Text>
           ) : null}
-          {model?.headlineValueText ? (
-            <Text style={styles.headlineValue}>{model.headlineValueText}</Text>
-          ) : null}
-          {model?.ratingLabel ? <Text style={styles.rating}>{model.ratingLabel}</Text> : null}
           {loading ? <Text style={styles.mutedLine}>Loading daily readiness…</Text> : null}
           {error ? <Text style={styles.mutedLine}>Could not load daily readiness</Text> : null}
           {vm.status === "missing" ? (
@@ -131,9 +157,6 @@ export function DailyReadinessCard({
                 </Pressable>
               ) : null}
             </>
-          ) : null}
-          {model?.summarySentence && model.hasAnySignal ? (
-            <Text style={styles.summary}>{model.summarySentence}</Text>
           ) : null}
         </Pressable>
 
@@ -159,15 +182,6 @@ export function DailyReadinessCard({
   );
 }
 
-const HEADLINE_VALUE_TEXT: React.ComponentProps<typeof Text>["style"] = {
-  fontSize: 34,
-  lineHeight: 40,
-  color: UI_TEXT_PRIMARY,
-  fontWeight: "700",
-  letterSpacing: -0.2,
-  fontVariant: ["tabular-nums"],
-};
-
 const styles = StyleSheet.create({
   outer: {
     marginTop: 12,
@@ -185,26 +199,7 @@ const styles = StyleSheet.create({
   headerPressed: {
     opacity: 0.9,
   },
-  title: strengthMetricCardTitleTextStyle,
-  subtitle: {
-    fontSize: 13,
-    lineHeight: 18,
-    color: UI_TEXT_MUTED,
-    fontWeight: "500",
-  },
-  headlineValue: HEADLINE_VALUE_TEXT,
-  rating: {
-    fontSize: 15,
-    lineHeight: 20,
-    fontWeight: "600",
-    color: UI_TEXT_SECONDARY,
-  },
-  summary: {
-    fontSize: 14,
-    lineHeight: 20,
-    color: UI_TEXT_SECONDARY,
-    marginTop: 4,
-  },
+  headlineValue: dashCompactPrimaryValueTextStyle,
   mutedLine: {
     fontSize: 14,
     lineHeight: 20,

--- a/lib/ui/dash/DailyReadinessCard.tsx
+++ b/lib/ui/dash/DailyReadinessCard.tsx
@@ -5,11 +5,16 @@ import { useRouter } from "expo-router";
 import type { DailyReadinessCardModel } from "@/lib/data/dash/buildDailyReadinessCardModel";
 import type { DashReadinessMetricRowId } from "@/lib/data/dash/buildDashReadinessMetricRows";
 import type { Readiness } from "@/lib/contracts/readiness";
-import { buildOuraScoreRatingAccessibility } from "@/lib/data/dash/dailyMonitorPresentationRatings";
+import {
+  buildOuraRatingAccessibility,
+  mapOuraProviderRatingToTone,
+} from "@/lib/data/dash/dailyMonitorPresentationRatings";
 import { DashMetricRow } from "@/lib/ui/dash/DashMetricRow";
 import {
   DashCompactCardHeader,
-  dashCompactPrimaryValueTextStyle,
+  DashCompactProviderSourceChip,
+  dashCompactPrimaryRowStyle,
+  dashCompactPrimaryValueInRowTextStyle,
 } from "@/lib/ui/dash/DashCompactCardHeader";
 import { elevatedCardSurfaceStyle } from "@/lib/ui/theme/elevatedCardSurface";
 import {
@@ -91,17 +96,14 @@ export function DailyReadinessCard({
     return `Readiness Score ${model.headlineValueText}`;
   }, [model]);
 
+  const showOuraSource = vm.status === "ready" && model?.hasAnySignal === true;
+
   const rating = useMemo(() => {
     if (model?.ratingLabel == null) return null;
-    const source =
-      model.sourceLabel != null && model.sourceLabel.trim().length > 0 ? model.sourceLabel : "Oura";
     return {
       label: model.ratingLabel,
-      sourceLabel: source,
-      accessibilityLabel: buildOuraScoreRatingAccessibility({
-        domain: "readiness",
-        ratingLabel: model.ratingLabel,
-      }),
+      tone: mapOuraProviderRatingToTone(model.ratingLabel),
+      accessibilityLabel: buildOuraRatingAccessibility(model.ratingLabel),
     };
   }, [model]);
 
@@ -110,8 +112,8 @@ export function DailyReadinessCard({
       ? [
           title,
           primaryScoreLabel != null ? `${primaryScoreLabel}.` : null,
-          // Single Oura+rating announcement (badge is accessibility-hidden under the Pressable).
-          rating != null ? `${rating.accessibilityLabel}.` : "Source Oura.",
+          showOuraSource ? "Oura." : null,
+          rating != null ? `Rating ${rating.label}.` : null,
           "Opens Readiness details.",
         ]
           .filter(Boolean)
@@ -138,8 +140,13 @@ export function DailyReadinessCard({
           style={({ pressed }) => [styles.headerPressable, pressed && canOpen && styles.headerPressed]}
         >
           <DashCompactCardHeader title={title} rating={rating} />
-          {primaryScoreLabel != null ? (
-            <Text style={styles.headlineValue}>{primaryScoreLabel}</Text>
+          {vm.status === "ready" && model?.hasAnySignal ? (
+            <View style={styles.primaryRow}>
+              {primaryScoreLabel != null ? (
+                <Text style={styles.headlineValue}>{primaryScoreLabel}</Text>
+              ) : null}
+              {showOuraSource ? <DashCompactProviderSourceChip label="Oura" /> : null}
+            </View>
           ) : null}
           {loading ? <Text style={styles.mutedLine}>Loading daily readiness…</Text> : null}
           {error ? <Text style={styles.mutedLine}>Could not load daily readiness</Text> : null}
@@ -199,7 +206,8 @@ const styles = StyleSheet.create({
   headerPressed: {
     opacity: 0.9,
   },
-  headlineValue: dashCompactPrimaryValueTextStyle,
+  primaryRow: dashCompactPrimaryRowStyle,
+  headlineValue: dashCompactPrimaryValueInRowTextStyle,
   mutedLine: {
     fontSize: 14,
     lineHeight: 20,

--- a/lib/ui/dash/DailySleepCard.tsx
+++ b/lib/ui/dash/DailySleepCard.tsx
@@ -7,33 +7,26 @@ import { SCORE_UNAVAILABLE_A11Y } from "@/lib/data/dash/buildDailySleepCardModel
 import type { DailySleepCardViewModel } from "@/lib/data/dash/dailySleepCardViewModel";
 import { MetricDetailsSheet } from "@/lib/ui/common/MetricDetailsSheet";
 import { DashMetricRow } from "@/lib/ui/dash/DashMetricRow";
+import {
+  DashCompactCardHeader,
+  dashCompactPrimaryValueTextStyle,
+} from "@/lib/ui/dash/DashCompactCardHeader";
+import { buildOuraScoreRatingAccessibility } from "@/lib/data/dash/dailyMonitorPresentationRatings";
 import { elevatedCardSurfaceStyle } from "@/lib/ui/theme/elevatedCardSurface";
 import {
   UI_BORDER_HAIRLINE,
   UI_CARD_SURFACE,
   UI_TEXT_MUTED,
   UI_TEXT_PRIMARY,
-  UI_TEXT_SECONDARY,
 } from "@/lib/ui/theme/uiTokens";
-import { strengthMetricCardTitleTextStyle } from "@/lib/ui/workouts/strengthMetricCardTitleStyle";
 
 const SLEEP_DETAIL_HREF = "/(app)/recovery/sleep" as const;
-
-/** Match Oura Readiness / Daily Energy hero score treatment. */
-const HEADLINE_VALUE_TEXT: React.ComponentProps<typeof Text>["style"] = {
-  fontSize: 34,
-  lineHeight: 40,
-  color: UI_TEXT_PRIMARY,
-  fontWeight: "700",
-  letterSpacing: -0.2,
-  fontVariant: ["tabular-nums"],
-};
 
 type Props = {
   vm: DailySleepCardViewModel;
   /** Consumer card title. Defaults to “Daily Sleep”. */
   title?: string;
-  /** Caption under the score (e.g. “Oura Sleep Score”). */
+  /** @deprecated Kept for call-site compatibility; Oura provenance now lives on the rating badge. */
   scoreCaption?: string | null;
   cardAccessibilityLabel?: string;
 };
@@ -41,9 +34,10 @@ type Props = {
 export function DailySleepCard({
   vm,
   title = "Daily Sleep",
-  scoreCaption = null,
+  scoreCaption: _scoreCaption = null,
   cardAccessibilityLabel = "Daily Sleep card",
 }: Props): React.ReactElement {
+  void _scoreCaption;
   const router = useRouter();
   const [metricSheet, setMetricSheet] = useState<DailySleepMetricDetail | null>(null);
 
@@ -65,27 +59,52 @@ export function DailySleepCard({
     router.push(SLEEP_DETAIL_HREF);
   }, [error, loading, router, vm.status]);
 
+  const primaryScoreLabel = useMemo(() => {
+    if (!model?.hasAnySignal) return null;
+    if (model.scoreUnavailable) return null;
+    if (model.headlineValueText == null || model.headlineValueText.length === 0) return null;
+    return `Sleep Score ${model.headlineValueText}`;
+  }, [model]);
+
+  const rating = useMemo(() => {
+    if (!model?.ratingLabel || model.scoreUnavailable) return null;
+    return {
+      label: model.ratingLabel,
+      sourceLabel: "Oura" as const,
+      accessibilityLabel: buildOuraScoreRatingAccessibility({
+        domain: "sleep",
+        ratingLabel: model.ratingLabel,
+      }),
+    };
+  }, [model]);
+
   const headerA11y = useMemo(() => {
     if (loading) return `${title} header. Loading sleep summary.`;
     if (isRefreshing) return `${title} header. Refreshing.`;
     if (error) return `${title} header. Could not load data.`;
     if (vm.status === "missing") return `${title} header. ${missingMessage ?? "No sleep data."}`;
     if (!model) return `${title} header. Not enough data.`;
-    const parts: string[] = [];
-    if (model.lastNightSubtitle) parts.push(model.lastNightSubtitle);
-    if (model.scoreUnavailable) {
+    const parts: string[] = [title];
+    if (primaryScoreLabel) {
+      parts.push(`${primaryScoreLabel}.`);
+    } else if (model.scoreUnavailable) {
       parts.push(SCORE_UNAVAILABLE_A11Y);
-    } else if (model.headlineValueText) {
-      parts.push(
-        scoreCaption
-          ? `${scoreCaption} ${model.headlineValueText}.`
-          : `Sleep score ${model.headlineValueText}.`,
-      );
-      if (model.ratingLabel) parts.push(model.ratingLabel);
     }
-    if (model.summarySentence) parts.push(model.summarySentence);
-    return `${title} header. ${parts.join(" ")} Opens Sleep details.`;
-  }, [loading, isRefreshing, error, vm.status, missingMessage, model, title, scoreCaption]);
+    // Single Oura+rating announcement (badge is accessibility-hidden under the Pressable).
+    if (rating != null) parts.push(`${rating.accessibilityLabel}.`);
+    else parts.push("Source Oura.");
+    return `${parts.join(" ")} Opens Sleep details.`;
+  }, [
+    loading,
+    isRefreshing,
+    error,
+    vm.status,
+    missingMessage,
+    model,
+    title,
+    primaryScoreLabel,
+    rating,
+  ]);
 
   const showEmptyBody = vm.status === "missing" || (vm.status === "ready" && model != null && !model.hasAnySignal);
   const canOpenSleep = vm.status === "ready" && model != null && model.hasAnySignal;
@@ -103,34 +122,20 @@ export function DailySleepCard({
           onPress={onOpenSleep}
           style={({ pressed }) => [styles.headerPressable, pressed && canOpenSleep && styles.headerPressed]}
         >
-          <Text style={styles.title}>{title}</Text>
-          {vm.status === "ready" && model?.lastNightSubtitle ? (
-            <Text style={styles.subtitle}>{model.lastNightSubtitle}</Text>
-          ) : null}
+          <DashCompactCardHeader title={title} rating={rating} />
           {vm.status === "ready" && model?.hasAnySignal ? (
-            model.scoreUnavailable ? (
-              <>
-                <Text
-                  style={styles.headlineValue}
-                  accessibilityLabel={SCORE_UNAVAILABLE_A11Y}
-                  accessibilityRole="text"
-                >
-                  {"\u2014"}
-                </Text>
-                <Text style={styles.rating}>{model.scoreUnavailableLabel}</Text>
-              </>
-            ) : model.headlineValueText ? (
-              <>
-                <Text style={styles.headlineValue} accessibilityRole="text">
-                  {model.headlineValueText}
-                </Text>
-                {scoreCaption ? (
-                  <Text style={styles.rating} accessibilityRole="text">
-                    {scoreCaption}
-                  </Text>
-                ) : null}
-                {model.ratingLabel ? <Text style={styles.rating}>{model.ratingLabel}</Text> : null}
-              </>
+            primaryScoreLabel != null ? (
+              <Text style={styles.headlineValue} accessibilityRole="text">
+                {primaryScoreLabel}
+              </Text>
+            ) : model.scoreUnavailable ? (
+              <Text
+                style={styles.mutedLine}
+                accessibilityLabel={SCORE_UNAVAILABLE_A11Y}
+                accessibilityRole="text"
+              >
+                Unavailable
+              </Text>
             ) : null
           ) : null}
           {loading ? <Text style={styles.mutedLine}>Loading daily sleep\u2026</Text> : null}
@@ -154,16 +159,11 @@ export function DailySleepCard({
               ) : null}
             </>
           ) : null}
-          {vm.status === "ready" && model ? (
+          {vm.status === "ready" && model && showEmptyBody && model.emptyStateTitle ? (
             <>
-              {model.summarySentence ? <Text style={styles.summary}>{model.summarySentence}</Text> : null}
-              {showEmptyBody && model.emptyStateTitle ? (
-                <>
-                  <Text style={styles.emptyTitle}>{model.emptyStateTitle}</Text>
-                  {model.emptyStateSubtitle ? (
-                    <Text style={styles.emptySubtitle}>{model.emptyStateSubtitle}</Text>
-                  ) : null}
-                </>
+              <Text style={styles.emptyTitle}>{model.emptyStateTitle}</Text>
+              {model.emptyStateSubtitle ? (
+                <Text style={styles.emptySubtitle}>{model.emptyStateSubtitle}</Text>
               ) : null}
             </>
           ) : null}
@@ -236,25 +236,7 @@ const styles = StyleSheet.create({
   headerPressed: {
     opacity: 0.92,
   },
-  title: strengthMetricCardTitleTextStyle,
-  subtitle: {
-    fontSize: 14,
-    lineHeight: 20,
-    color: UI_TEXT_SECONDARY,
-  },
-  headlineValue: HEADLINE_VALUE_TEXT,
-  rating: {
-    fontSize: 15,
-    lineHeight: 20,
-    fontWeight: "600",
-    color: UI_TEXT_SECONDARY,
-  },
-  summary: {
-    fontSize: 14,
-    lineHeight: 20,
-    color: UI_TEXT_SECONDARY,
-    marginTop: 2,
-  },
+  headlineValue: dashCompactPrimaryValueTextStyle,
   mutedLine: {
     fontSize: 14,
     lineHeight: 20,

--- a/lib/ui/dash/DailySleepCard.tsx
+++ b/lib/ui/dash/DailySleepCard.tsx
@@ -9,9 +9,7 @@ import { MetricDetailsSheet } from "@/lib/ui/common/MetricDetailsSheet";
 import { DashMetricRow } from "@/lib/ui/dash/DashMetricRow";
 import {
   DashCompactCardHeader,
-  DashCompactProviderSourceChip,
-  dashCompactPrimaryRowStyle,
-  dashCompactPrimaryValueInRowTextStyle,
+  dashCompactPrimaryValueTextStyle,
 } from "@/lib/ui/dash/DashCompactCardHeader";
 import {
   buildOuraRatingAccessibility,
@@ -31,7 +29,7 @@ type Props = {
   vm: DailySleepCardViewModel;
   /** Consumer card title. Defaults to “Daily Sleep”. */
   title?: string;
-  /** @deprecated Kept for call-site compatibility; Oura provenance is a separate neutral chip. */
+  /** @deprecated Kept for call-site compatibility; Monitor summary no longer shows provider copy. */
   scoreCaption?: string | null;
   cardAccessibilityLabel?: string;
 };
@@ -71,8 +69,6 @@ export function DailySleepCard({
     return `Sleep Score ${model.headlineValueText}`;
   }, [model]);
 
-  const showOuraSource = vm.status === "ready" && model != null && model.hasAnySignal;
-
   const rating = useMemo(() => {
     if (!model?.ratingLabel || model.scoreUnavailable) return null;
     return {
@@ -94,8 +90,7 @@ export function DailySleepCard({
     } else if (model.scoreUnavailable) {
       parts.push(SCORE_UNAVAILABLE_A11Y);
     }
-    // Distinct source + rating; badge/source chip are a11y-hidden under the Pressable.
-    if (showOuraSource) parts.push("Oura.");
+    // Provider provenance is retained in typed/detail data; Monitor summary omits Oura.
     if (rating != null) parts.push(`Rating ${rating.label}.`);
     return `${parts.join(" ")} Opens Sleep details.`;
   }, [
@@ -108,7 +103,6 @@ export function DailySleepCard({
     title,
     primaryScoreLabel,
     rating,
-    showOuraSource,
   ]);
 
   const showEmptyBody = vm.status === "missing" || (vm.status === "ready" && model != null && !model.hasAnySignal);
@@ -129,22 +123,19 @@ export function DailySleepCard({
         >
           <DashCompactCardHeader title={title} rating={rating} />
           {vm.status === "ready" && model?.hasAnySignal ? (
-            <View style={styles.primaryRow}>
-              {primaryScoreLabel != null ? (
-                <Text style={styles.headlineValue} accessibilityRole="text">
-                  {primaryScoreLabel}
-                </Text>
-              ) : model.scoreUnavailable ? (
-                <Text
-                  style={styles.mutedLine}
-                  accessibilityLabel={SCORE_UNAVAILABLE_A11Y}
-                  accessibilityRole="text"
-                >
-                  Unavailable
-                </Text>
-              ) : null}
-              {showOuraSource ? <DashCompactProviderSourceChip label="Oura" /> : null}
-            </View>
+            primaryScoreLabel != null ? (
+              <Text style={styles.headlineValue} accessibilityRole="text">
+                {primaryScoreLabel}
+              </Text>
+            ) : model.scoreUnavailable ? (
+              <Text
+                style={styles.mutedLine}
+                accessibilityLabel={SCORE_UNAVAILABLE_A11Y}
+                accessibilityRole="text"
+              >
+                Unavailable
+              </Text>
+            ) : null
           ) : null}
           {loading ? <Text style={styles.mutedLine}>Loading daily sleep\u2026</Text> : null}
           {isRefreshing ? <Text style={styles.mutedLine}>Refreshing daily sleep\u2026</Text> : null}
@@ -244,8 +235,7 @@ const styles = StyleSheet.create({
   headerPressed: {
     opacity: 0.92,
   },
-  primaryRow: dashCompactPrimaryRowStyle,
-  headlineValue: dashCompactPrimaryValueInRowTextStyle,
+  headlineValue: dashCompactPrimaryValueTextStyle,
   mutedLine: {
     fontSize: 14,
     lineHeight: 20,

--- a/lib/ui/dash/DailySleepCard.tsx
+++ b/lib/ui/dash/DailySleepCard.tsx
@@ -31,9 +31,19 @@ const HEADLINE_VALUE_TEXT: React.ComponentProps<typeof Text>["style"] = {
 
 type Props = {
   vm: DailySleepCardViewModel;
+  /** Consumer card title. Defaults to “Daily Sleep”. */
+  title?: string;
+  /** Caption under the score (e.g. “Oura Sleep Score”). */
+  scoreCaption?: string | null;
+  cardAccessibilityLabel?: string;
 };
 
-export function DailySleepCard({ vm }: Props): React.ReactElement {
+export function DailySleepCard({
+  vm,
+  title = "Daily Sleep",
+  scoreCaption = null,
+  cardAccessibilityLabel = "Daily Sleep card",
+}: Props): React.ReactElement {
   const router = useRouter();
   const [metricSheet, setMetricSheet] = useState<DailySleepMetricDetail | null>(null);
 
@@ -56,22 +66,26 @@ export function DailySleepCard({ vm }: Props): React.ReactElement {
   }, [error, loading, router, vm.status]);
 
   const headerA11y = useMemo(() => {
-    if (loading) return "Daily Sleep header. Loading sleep summary.";
-    if (isRefreshing) return "Daily Sleep header. Refreshing.";
-    if (error) return "Daily Sleep header. Could not load data.";
-    if (vm.status === "missing") return `Daily Sleep header. ${missingMessage ?? "No sleep data."}`;
-    if (!model) return "Daily Sleep header. Not enough data.";
+    if (loading) return `${title} header. Loading sleep summary.`;
+    if (isRefreshing) return `${title} header. Refreshing.`;
+    if (error) return `${title} header. Could not load data.`;
+    if (vm.status === "missing") return `${title} header. ${missingMessage ?? "No sleep data."}`;
+    if (!model) return `${title} header. Not enough data.`;
     const parts: string[] = [];
     if (model.lastNightSubtitle) parts.push(model.lastNightSubtitle);
     if (model.scoreUnavailable) {
       parts.push(SCORE_UNAVAILABLE_A11Y);
     } else if (model.headlineValueText) {
-      parts.push(`Sleep score ${model.headlineValueText}.`);
+      parts.push(
+        scoreCaption
+          ? `${scoreCaption} ${model.headlineValueText}.`
+          : `Sleep score ${model.headlineValueText}.`,
+      );
       if (model.ratingLabel) parts.push(model.ratingLabel);
     }
     if (model.summarySentence) parts.push(model.summarySentence);
-    return `Daily Sleep header. ${parts.join(" ")} Opens Sleep details.`;
-  }, [loading, isRefreshing, error, vm.status, missingMessage, model]);
+    return `${title} header. ${parts.join(" ")} Opens Sleep details.`;
+  }, [loading, isRefreshing, error, vm.status, missingMessage, model, title, scoreCaption]);
 
   const showEmptyBody = vm.status === "missing" || (vm.status === "ready" && model != null && !model.hasAnySignal);
   const canOpenSleep = vm.status === "ready" && model != null && model.hasAnySignal;
@@ -79,7 +93,7 @@ export function DailySleepCard({ vm }: Props): React.ReactElement {
   const showMetricSection = vm.status === "ready" && Boolean(model?.metricRows.length) && model?.hasAnySignal;
 
   return (
-    <View style={styles.outer} accessibilityLabel="Daily Sleep card">
+    <View style={styles.outer} accessibilityLabel={cardAccessibilityLabel}>
       <View style={styles.card}>
         <Pressable
           accessibilityRole="button"
@@ -89,7 +103,7 @@ export function DailySleepCard({ vm }: Props): React.ReactElement {
           onPress={onOpenSleep}
           style={({ pressed }) => [styles.headerPressable, pressed && canOpenSleep && styles.headerPressed]}
         >
-          <Text style={styles.title}>Daily Sleep</Text>
+          <Text style={styles.title}>{title}</Text>
           {vm.status === "ready" && model?.lastNightSubtitle ? (
             <Text style={styles.subtitle}>{model.lastNightSubtitle}</Text>
           ) : null}
@@ -110,6 +124,11 @@ export function DailySleepCard({ vm }: Props): React.ReactElement {
                 <Text style={styles.headlineValue} accessibilityRole="text">
                   {model.headlineValueText}
                 </Text>
+                {scoreCaption ? (
+                  <Text style={styles.rating} accessibilityRole="text">
+                    {scoreCaption}
+                  </Text>
+                ) : null}
                 {model.ratingLabel ? <Text style={styles.rating}>{model.ratingLabel}</Text> : null}
               </>
             ) : null

--- a/lib/ui/dash/DailySleepCard.tsx
+++ b/lib/ui/dash/DailySleepCard.tsx
@@ -9,9 +9,14 @@ import { MetricDetailsSheet } from "@/lib/ui/common/MetricDetailsSheet";
 import { DashMetricRow } from "@/lib/ui/dash/DashMetricRow";
 import {
   DashCompactCardHeader,
-  dashCompactPrimaryValueTextStyle,
+  DashCompactProviderSourceChip,
+  dashCompactPrimaryRowStyle,
+  dashCompactPrimaryValueInRowTextStyle,
 } from "@/lib/ui/dash/DashCompactCardHeader";
-import { buildOuraScoreRatingAccessibility } from "@/lib/data/dash/dailyMonitorPresentationRatings";
+import {
+  buildOuraRatingAccessibility,
+  mapOuraProviderRatingToTone,
+} from "@/lib/data/dash/dailyMonitorPresentationRatings";
 import { elevatedCardSurfaceStyle } from "@/lib/ui/theme/elevatedCardSurface";
 import {
   UI_BORDER_HAIRLINE,
@@ -26,7 +31,7 @@ type Props = {
   vm: DailySleepCardViewModel;
   /** Consumer card title. Defaults to “Daily Sleep”. */
   title?: string;
-  /** @deprecated Kept for call-site compatibility; Oura provenance now lives on the rating badge. */
+  /** @deprecated Kept for call-site compatibility; Oura provenance is a separate neutral chip. */
   scoreCaption?: string | null;
   cardAccessibilityLabel?: string;
 };
@@ -66,15 +71,14 @@ export function DailySleepCard({
     return `Sleep Score ${model.headlineValueText}`;
   }, [model]);
 
+  const showOuraSource = vm.status === "ready" && model != null && model.hasAnySignal;
+
   const rating = useMemo(() => {
     if (!model?.ratingLabel || model.scoreUnavailable) return null;
     return {
       label: model.ratingLabel,
-      sourceLabel: "Oura" as const,
-      accessibilityLabel: buildOuraScoreRatingAccessibility({
-        domain: "sleep",
-        ratingLabel: model.ratingLabel,
-      }),
+      tone: mapOuraProviderRatingToTone(model.ratingLabel),
+      accessibilityLabel: buildOuraRatingAccessibility(model.ratingLabel),
     };
   }, [model]);
 
@@ -90,9 +94,9 @@ export function DailySleepCard({
     } else if (model.scoreUnavailable) {
       parts.push(SCORE_UNAVAILABLE_A11Y);
     }
-    // Single Oura+rating announcement (badge is accessibility-hidden under the Pressable).
-    if (rating != null) parts.push(`${rating.accessibilityLabel}.`);
-    else parts.push("Source Oura.");
+    // Distinct source + rating; badge/source chip are a11y-hidden under the Pressable.
+    if (showOuraSource) parts.push("Oura.");
+    if (rating != null) parts.push(`Rating ${rating.label}.`);
     return `${parts.join(" ")} Opens Sleep details.`;
   }, [
     loading,
@@ -104,6 +108,7 @@ export function DailySleepCard({
     title,
     primaryScoreLabel,
     rating,
+    showOuraSource,
   ]);
 
   const showEmptyBody = vm.status === "missing" || (vm.status === "ready" && model != null && !model.hasAnySignal);
@@ -124,19 +129,22 @@ export function DailySleepCard({
         >
           <DashCompactCardHeader title={title} rating={rating} />
           {vm.status === "ready" && model?.hasAnySignal ? (
-            primaryScoreLabel != null ? (
-              <Text style={styles.headlineValue} accessibilityRole="text">
-                {primaryScoreLabel}
-              </Text>
-            ) : model.scoreUnavailable ? (
-              <Text
-                style={styles.mutedLine}
-                accessibilityLabel={SCORE_UNAVAILABLE_A11Y}
-                accessibilityRole="text"
-              >
-                Unavailable
-              </Text>
-            ) : null
+            <View style={styles.primaryRow}>
+              {primaryScoreLabel != null ? (
+                <Text style={styles.headlineValue} accessibilityRole="text">
+                  {primaryScoreLabel}
+                </Text>
+              ) : model.scoreUnavailable ? (
+                <Text
+                  style={styles.mutedLine}
+                  accessibilityLabel={SCORE_UNAVAILABLE_A11Y}
+                  accessibilityRole="text"
+                >
+                  Unavailable
+                </Text>
+              ) : null}
+              {showOuraSource ? <DashCompactProviderSourceChip label="Oura" /> : null}
+            </View>
           ) : null}
           {loading ? <Text style={styles.mutedLine}>Loading daily sleep\u2026</Text> : null}
           {isRefreshing ? <Text style={styles.mutedLine}>Refreshing daily sleep\u2026</Text> : null}
@@ -236,7 +244,8 @@ const styles = StyleSheet.create({
   headerPressed: {
     opacity: 0.92,
   },
-  headlineValue: dashCompactPrimaryValueTextStyle,
+  primaryRow: dashCompactPrimaryRowStyle,
+  headlineValue: dashCompactPrimaryValueInRowTextStyle,
   mutedLine: {
     fontSize: 14,
     lineHeight: 20,

--- a/lib/ui/dash/DashCompactCardHeader.tsx
+++ b/lib/ui/dash/DashCompactCardHeader.tsx
@@ -1,14 +1,18 @@
 /**
  * Presentation-only compact Daily Monitor / Dash card header.
- * Title left; optional rating (+ source) right. No classification logic.
+ * Title left; optional rating badge right. Provider source is a separate chip.
+ * No classification / threshold logic.
  */
 
-import React from "react";
-import { StyleSheet, Text, View } from "react-native";
+import React, { useMemo } from "react";
+import { StyleSheet, Text, View, type StyleProp, type ViewStyle } from "react-native";
 
+import type { DailyMonitorRatingTone } from "@/lib/data/dash/dailyMonitorPresentationRatings";
+import { resolveDashMonitorRatingToneChrome } from "@/lib/ui/theme/dashMonitorRatingToneChrome";
 import {
   UI_BORDER_HAIRLINE,
   UI_CARD_SURFACE,
+  UI_PROVIDER_SOURCE_CHIP_BG,
   UI_TEXT_MUTED,
   UI_TEXT_PRIMARY,
   UI_TEXT_SECONDARY,
@@ -16,11 +20,11 @@ import {
 import { strengthMetricCardTitleTextStyle } from "@/lib/ui/workouts/strengthMetricCardTitleStyle";
 
 export type DashCompactCardRating = {
-  /** Visible primary rating label (e.g. Optimal, Moderate). */
+  /** Visible primary rating label (e.g. Optimal). Source must not be nested here. */
   label: string;
-  /** Optional small source under the rating (e.g. Oura). */
-  sourceLabel?: string | null;
-  /** Combined announcement for the rating cluster (includes purpose + source). */
+  /** Optional semantic tone for Sleep/Readiness Oura badges. Omit for neutral badges. */
+  tone?: DailyMonitorRatingTone | null;
+  /** Combined announcement for the rating (rating only — no color names). */
   accessibilityLabel: string;
 };
 
@@ -38,32 +42,75 @@ export function DashCompactCardHeader({
   rating = null,
 }: DashCompactCardHeaderProps): React.ReactElement {
   const showRating = rating != null && rating.label.trim().length > 0;
+  const toneChrome = useMemo(() => {
+    if (!showRating || rating?.tone == null) return null;
+    return resolveDashMonitorRatingToneChrome(rating.tone);
+  }, [showRating, rating?.tone]);
+
+  const badgeStyle: StyleProp<ViewStyle> = toneChrome
+    ? [
+        styles.badge,
+        {
+          backgroundColor: toneChrome.background,
+          borderColor: toneChrome.border,
+        },
+      ]
+    : styles.badge;
 
   return (
     <View style={styles.row} accessibilityRole="header">
       <Text style={styles.title} numberOfLines={2}>
         {title}
       </Text>
-      {showRating ? (
+      {showRating && rating != null ? (
         <View
-          style={styles.badge}
+          style={badgeStyle}
           // Parent card Pressable owns spoken order; keep label for tests / tooling.
           accessible={false}
           accessibilityElementsHidden
           importantForAccessibility="no-hide-descendants"
           accessibilityLabel={rating.accessibilityLabel}
           accessibilityRole="text"
+          testID="dash-compact-rating-badge"
         >
-          <Text style={styles.ratingLabel} numberOfLines={2}>
+          <Text
+            style={[styles.ratingLabel, toneChrome != null ? { color: toneChrome.foreground } : null]}
+            numberOfLines={2}
+          >
             {rating.label}
           </Text>
-          {rating.sourceLabel != null && rating.sourceLabel.trim().length > 0 ? (
-            <Text style={styles.sourceLabel} numberOfLines={1}>
-              {rating.sourceLabel}
-            </Text>
-          ) : null}
         </View>
       ) : null}
+    </View>
+  );
+}
+
+export type DashCompactProviderSourceChipProps = {
+  /** Visible provider name (e.g. Oura). */
+  label?: string;
+};
+
+/**
+ * Neutral provider provenance chip — visually separate from the semantic rating badge.
+ * Non-interactive; parent card Pressable owns the spoken summary.
+ */
+export function DashCompactProviderSourceChip({
+  label = "Oura",
+}: DashCompactProviderSourceChipProps): React.ReactElement {
+  const trimmed = label.trim().length > 0 ? label.trim() : "Oura";
+  return (
+    <View
+      style={styles.sourceChip}
+      accessible={false}
+      accessibilityElementsHidden
+      importantForAccessibility="no-hide-descendants"
+      accessibilityLabel={`Source: ${trimmed}`}
+      accessibilityRole="text"
+      testID="dash-compact-provider-source"
+    >
+      <Text style={styles.sourceChipText} numberOfLines={1}>
+        {trimmed}
+      </Text>
     </View>
   );
 }
@@ -101,13 +148,23 @@ const styles = StyleSheet.create({
     color: UI_TEXT_PRIMARY,
     textAlign: "right",
   },
-  sourceLabel: {
-    marginTop: 2,
-    fontSize: 11,
-    lineHeight: 14,
-    fontWeight: "500",
+  sourceChip: {
+    flexShrink: 0,
+    alignSelf: "center",
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 8,
+    backgroundColor: UI_PROVIDER_SOURCE_CHIP_BG,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: UI_BORDER_HAIRLINE,
+    minHeight: 28,
+    justifyContent: "center",
+  },
+  sourceChipText: {
+    fontSize: 12,
+    lineHeight: 16,
+    fontWeight: "600",
     color: UI_TEXT_SECONDARY,
-    textAlign: "right",
   },
 });
 
@@ -143,4 +200,23 @@ export const dashCompactMutedTextStyle = {
   fontSize: 13,
   lineHeight: 18,
   color: UI_TEXT_MUTED,
+};
+
+/** Primary metric row: large value + optional neutral provider chip. */
+export const dashCompactPrimaryRowStyle = {
+  marginTop: 8,
+  flexDirection: "row" as const,
+  flexWrap: "wrap" as const,
+  alignItems: "center" as const,
+  gap: 8,
+};
+
+export const dashCompactPrimaryValueInRowTextStyle = {
+  fontSize: 28,
+  lineHeight: 34,
+  fontWeight: "700" as const,
+  letterSpacing: -0.2,
+  color: UI_TEXT_PRIMARY,
+  fontVariant: ["tabular-nums" as const],
+  flexShrink: 1,
 };

--- a/lib/ui/dash/DashCompactCardHeader.tsx
+++ b/lib/ui/dash/DashCompactCardHeader.tsx
@@ -1,0 +1,146 @@
+/**
+ * Presentation-only compact Daily Monitor / Dash card header.
+ * Title left; optional rating (+ source) right. No classification logic.
+ */
+
+import React from "react";
+import { StyleSheet, Text, View } from "react-native";
+
+import {
+  UI_BORDER_HAIRLINE,
+  UI_CARD_SURFACE,
+  UI_TEXT_MUTED,
+  UI_TEXT_PRIMARY,
+  UI_TEXT_SECONDARY,
+} from "@/lib/ui/theme/uiTokens";
+import { strengthMetricCardTitleTextStyle } from "@/lib/ui/workouts/strengthMetricCardTitleStyle";
+
+export type DashCompactCardRating = {
+  /** Visible primary rating label (e.g. Optimal, Moderate). */
+  label: string;
+  /** Optional small source under the rating (e.g. Oura). */
+  sourceLabel?: string | null;
+  /** Combined announcement for the rating cluster (includes purpose + source). */
+  accessibilityLabel: string;
+};
+
+export type DashCompactCardHeaderProps = {
+  title: string;
+  rating?: DashCompactCardRating | null;
+};
+
+/**
+ * Compact card header: title on the left, optional rating badge on the right.
+ * Rating is omitted when null/undefined. Not a button by itself.
+ */
+export function DashCompactCardHeader({
+  title,
+  rating = null,
+}: DashCompactCardHeaderProps): React.ReactElement {
+  const showRating = rating != null && rating.label.trim().length > 0;
+
+  return (
+    <View style={styles.row} accessibilityRole="header">
+      <Text style={styles.title} numberOfLines={2}>
+        {title}
+      </Text>
+      {showRating ? (
+        <View
+          style={styles.badge}
+          // Parent card Pressable owns spoken order; keep label for tests / tooling.
+          accessible={false}
+          accessibilityElementsHidden
+          importantForAccessibility="no-hide-descendants"
+          accessibilityLabel={rating.accessibilityLabel}
+          accessibilityRole="text"
+        >
+          <Text style={styles.ratingLabel} numberOfLines={2}>
+            {rating.label}
+          </Text>
+          {rating.sourceLabel != null && rating.sourceLabel.trim().length > 0 ? (
+            <Text style={styles.sourceLabel} numberOfLines={1}>
+              {rating.sourceLabel}
+            </Text>
+          ) : null}
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    justifyContent: "space-between",
+    gap: 12,
+    minHeight: 28,
+  },
+  title: {
+    ...strengthMetricCardTitleTextStyle,
+    flexShrink: 1,
+    flexGrow: 1,
+    color: UI_TEXT_PRIMARY,
+  },
+  badge: {
+    flexShrink: 0,
+    maxWidth: "46%",
+    alignItems: "flex-end",
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 10,
+    backgroundColor: UI_CARD_SURFACE,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: UI_BORDER_HAIRLINE,
+    minHeight: 28,
+  },
+  ratingLabel: {
+    fontSize: 13,
+    lineHeight: 16,
+    fontWeight: "600",
+    color: UI_TEXT_PRIMARY,
+    textAlign: "right",
+  },
+  sourceLabel: {
+    marginTop: 2,
+    fontSize: 11,
+    lineHeight: 14,
+    fontWeight: "500",
+    color: UI_TEXT_SECONDARY,
+    textAlign: "right",
+  },
+});
+
+/** Shared subtle metric divider used under the primary area. */
+export const dashCompactCardDividerStyle = {
+  borderTopWidth: StyleSheet.hairlineWidth,
+  borderTopColor: UI_BORDER_HAIRLINE,
+  paddingTop: 6,
+  gap: 2,
+  marginTop: 4,
+} as const;
+
+export const dashCompactPrimaryValueTextStyle = {
+  marginTop: 8,
+  fontSize: 28,
+  lineHeight: 34,
+  fontWeight: "700" as const,
+  letterSpacing: -0.2,
+  color: UI_TEXT_PRIMARY,
+  fontVariant: ["tabular-nums" as const],
+};
+
+export const dashCompactDescriptorTextStyle = {
+  marginTop: 4,
+  fontSize: 14,
+  lineHeight: 20,
+  fontWeight: "500" as const,
+  color: UI_TEXT_SECONDARY,
+};
+
+export const dashCompactMutedTextStyle = {
+  marginTop: 4,
+  fontSize: 13,
+  lineHeight: 18,
+  color: UI_TEXT_MUTED,
+};

--- a/lib/ui/dash/__tests__/BodyCompositionCard.test.tsx
+++ b/lib/ui/dash/__tests__/BodyCompositionCard.test.tsx
@@ -19,8 +19,6 @@ jest.mock("react-native", () => ({
   StyleSheet: { create: (s: unknown) => s, hairlineWidth: 1 },
 }));
 
-const goalsHref = "/(app)/body/settings";
-
 const sampleReadyBuilt: BuiltBodyCompositionDashCard = {
   tag: "ready",
   weightPrimaryLabel: "159.3 lb",
@@ -90,14 +88,14 @@ describe("BodyCompositionCard", () => {
           loading={false}
           error={null}
           hasUser
-          goalsHref={goalsHref}
           built={sampleReadyBuilt}
         />,
       );
     });
     const text = collectAllText(test);
     expect(text).toContain("Body Composition");
-    expect(text).toContain("My goal");
+    expect(text).not.toContain("My goal");
+    expect(text).not.toContain("My Goal");
     expect(text).toContain("159.3 lb");
     expect(text).toContain("As of today");
     expect(text).toContain("BMI");
@@ -108,7 +106,7 @@ describe("BodyCompositionCard", () => {
     expect(text).toContain("130.4 lb");
   });
 
-  it("does not render Optimal range/status pills", () => {
+  it("does not render Optimal range/status pills or a card-level composition badge", () => {
     let test!: renderer.ReactTestRenderer;
     act(() => {
       test = renderer.create(
@@ -116,7 +114,6 @@ describe("BodyCompositionCard", () => {
           loading={false}
           error={null}
           hasUser
-          goalsHref={goalsHref}
           built={sampleReadyBuilt}
         />,
       );
@@ -125,6 +122,8 @@ describe("BodyCompositionCard", () => {
     expect(text).not.toContain("Optimal");
     expect(text).not.toContain("Good");
     expect(text).not.toContain("Fair");
+    expect(() => test.root.findByProps({ testID: "dash-compact-rating-badge" })).toThrow();
+    expect(() => test.root.findByProps({ testID: "body-composition-my-goal" })).toThrow();
   });
 
   it("renders the weight value", () => {
@@ -135,7 +134,6 @@ describe("BodyCompositionCard", () => {
           loading={false}
           error={null}
           hasUser
-          goalsHref={goalsHref}
           built={sampleReadyBuilt}
         />,
       );
@@ -152,7 +150,6 @@ describe("BodyCompositionCard", () => {
           loading={false}
           error={null}
           hasUser
-          goalsHref={goalsHref}
           built={sampleReadyBuilt}
         />,
       );
@@ -172,7 +169,6 @@ describe("BodyCompositionCard", () => {
           loading
           error={null}
           hasUser
-          goalsHref={goalsHref}
           built={null}
         />,
       );
@@ -188,7 +184,6 @@ describe("BodyCompositionCard", () => {
           loading={false}
           error="Offline"
           hasUser
-          goalsHref={goalsHref}
           built={null}
         />,
       );
@@ -204,7 +199,6 @@ describe("BodyCompositionCard", () => {
           loading={false}
           error={null}
           hasUser
-          goalsHref={goalsHref}
           built={{
             tag: "missing",
             cardAccessibilityLabel: "Body composition. Add body data to see your composition.",
@@ -223,7 +217,6 @@ describe("BodyCompositionCard", () => {
           loading={false}
           error={null}
           hasUser
-          goalsHref={goalsHref}
           built={sampleReadyBuilt}
         />,
       );
@@ -236,7 +229,7 @@ describe("BodyCompositionCard", () => {
     });
   });
 
-  it("My goal navigates to goalsHref", () => {
+  it("does not retain My Goal navigation from the summary card", () => {
     let test!: renderer.ReactTestRenderer;
     act(() => {
       test = renderer.create(
@@ -244,13 +237,11 @@ describe("BodyCompositionCard", () => {
           loading={false}
           error={null}
           hasUser
-          goalsHref={goalsHref}
           built={sampleReadyBuilt}
         />,
       );
     });
-    const btn = test.root.findByProps({ testID: "body-composition-my-goal" });
-    btn.props.onPress();
-    expect(mockPush).toHaveBeenCalledWith(goalsHref);
+    expect(() => test.root.findByProps({ testID: "body-composition-my-goal" })).toThrow();
+    expect(mockPush).not.toHaveBeenCalled();
   });
 });

--- a/lib/ui/dash/__tests__/DailyEnergyCard.test.tsx
+++ b/lib/ui/dash/__tests__/DailyEnergyCard.test.tsx
@@ -69,17 +69,31 @@ describe("DailyEnergyCard", () => {
       .filter((c) => typeof c === "string")
       .join(" ");
     expect(text).toContain("2,120–2,480 kcal");
+    expect(text).toContain("Estimated burn today");
+    expect(text).toContain("Estimated");
     expect(text).toContain("+1,520–1,710 kcal");
     expect(text).toContain("BMR");
     expect(text).toContain("NEAT");
     expect(text).toContain("Cardio");
     expect(text).toContain("Strength");
     expect(text).toContain("+90–180 kcal");
-    expect(text).toMatch(/Confidence \w+ · ±/);
+    expect(text).not.toMatch(/Confidence \w+ · ±/);
+    expect(text).not.toContain("Confidence High");
+    expect(text).not.toContain("8.1%");
+    expect(text).not.toContain("±");
     const factorPressables = tree.root
       .findAllByType("Pressable")
       .filter((p) => typeof p.props.testID === "string" && p.props.testID.startsWith("energy-row-"));
     expect(factorPressables).toHaveLength(4);
+    const header = tree.root
+      .findAllByType("Pressable")
+      .find(
+        (p) =>
+          typeof p.props.accessibilityLabel === "string" &&
+          p.props.accessibilityLabel.startsWith("Daily Energy"),
+      );
+    expect(header?.props.accessibilityLabel).toMatch(/Estimated energy expenditure level/);
+    expect(header?.props.accessibilityLabel).toMatch(/Opens Daily Energy details/);
   });
 
   it("hides Strength row when strength factor is absent", () => {
@@ -145,7 +159,7 @@ describe("DailyEnergyCard", () => {
       .find(
         (p) =>
           typeof p.props.accessibilityLabel === "string" &&
-          p.props.accessibilityLabel.startsWith("Daily Energy header"),
+          p.props.accessibilityLabel.startsWith("Daily Energy"),
       );
     expect(header).toBeDefined();
     act(() => {
@@ -164,7 +178,7 @@ describe("DailyEnergyCard", () => {
       .find(
         (p) =>
           typeof p.props.accessibilityLabel === "string" &&
-          p.props.accessibilityLabel.startsWith("Daily Energy header"),
+          p.props.accessibilityLabel.startsWith("Daily Energy"),
       );
     expect(header?.props.disabled).toBe(true);
   });

--- a/lib/ui/dash/__tests__/DailyEnergyCard.test.tsx
+++ b/lib/ui/dash/__tests__/DailyEnergyCard.test.tsx
@@ -70,7 +70,7 @@ describe("DailyEnergyCard", () => {
       .join(" ");
     expect(text).toContain("2,120–2,480 kcal");
     expect(text).not.toContain("Estimated burn today");
-    expect(text).toContain("Estimated");
+    expect(text).not.toMatch(/(^|\s)Estimated(\s|$)/);
     expect(text).toContain("+1,520–1,710 kcal");
     expect(text).toContain("BMR");
     expect(text).toContain("NEAT");
@@ -81,6 +81,8 @@ describe("DailyEnergyCard", () => {
     expect(text).not.toContain("Confidence High");
     expect(text).not.toContain("8.1%");
     expect(text).not.toContain("±");
+    expect(text).not.toMatch(/\b(Low|Moderate|High|Very High)\b/);
+    expect(text).not.toMatch(/\bPAL\b/);
     const factorPressables = tree.root
       .findAllByType("Pressable")
       .filter((p) => typeof p.props.testID === "string" && p.props.testID.startsWith("energy-row-"));
@@ -92,9 +94,10 @@ describe("DailyEnergyCard", () => {
           typeof p.props.accessibilityLabel === "string" &&
           p.props.accessibilityLabel.startsWith("Daily Energy"),
       );
-    expect(header?.props.accessibilityLabel).toMatch(/Estimated energy expenditure level/);
+    expect(header?.props.accessibilityLabel).not.toMatch(/Estimated energy expenditure level/);
+    expect(header?.props.accessibilityLabel).not.toMatch(/Estimated/);
     expect(header?.props.accessibilityLabel).toMatch(/Opens Daily Energy details/);
-    expect(header?.props.accessibilityLabel).not.toMatch(/Estimated burn today/);
+    expect(() => tree.root.findByProps({ testID: "dash-compact-rating-badge" })).toThrow();
   });
 
   it("hides Strength row when strength factor is absent", () => {

--- a/lib/ui/dash/__tests__/DailyEnergyCard.test.tsx
+++ b/lib/ui/dash/__tests__/DailyEnergyCard.test.tsx
@@ -69,7 +69,7 @@ describe("DailyEnergyCard", () => {
       .filter((c) => typeof c === "string")
       .join(" ");
     expect(text).toContain("2,120–2,480 kcal");
-    expect(text).toContain("Estimated burn today");
+    expect(text).not.toContain("Estimated burn today");
     expect(text).toContain("Estimated");
     expect(text).toContain("+1,520–1,710 kcal");
     expect(text).toContain("BMR");
@@ -94,6 +94,7 @@ describe("DailyEnergyCard", () => {
       );
     expect(header?.props.accessibilityLabel).toMatch(/Estimated energy expenditure level/);
     expect(header?.props.accessibilityLabel).toMatch(/Opens Daily Energy details/);
+    expect(header?.props.accessibilityLabel).not.toMatch(/Estimated burn today/);
   });
 
   it("hides Strength row when strength factor is absent", () => {

--- a/lib/ui/dash/__tests__/DailyNutritionCard.test.tsx
+++ b/lib/ui/dash/__tests__/DailyNutritionCard.test.tsx
@@ -65,7 +65,8 @@ describe("DailyNutritionCard", () => {
       );
     });
     const text = renderText(tree);
-    expect(text).toContain("No nutrition logged today");
+    expect(text).toContain("No nutrition record is available for today.");
+    expect(text).not.toMatch(/ate nothing|failed|nutritionally poor/i);
     expect(text).not.toContain("Logged today");
     expect(text).toContain("Protein");
     expect(text).toContain("Carbs");

--- a/lib/ui/dash/__tests__/DailyReadinessCard.test.tsx
+++ b/lib/ui/dash/__tests__/DailyReadinessCard.test.tsx
@@ -75,11 +75,21 @@ describe("DailyReadinessCard", () => {
     expect(root.root.findByProps({ testID: "readiness-metric-row-resting_heart_rate" })).toBeDefined();
     expect(root.root.findByProps({ testID: "readiness-metric-row-sleep_balance" })).toBeDefined();
 
+    const badge = root.root.findByProps({ testID: "dash-compact-rating-badge" });
+    expect(allVisibleText(badge)).toBe("Optimal");
+    expect(allVisibleText(badge)).not.toContain("Oura");
+    expect(allVisibleText(root.root.findByProps({ testID: "dash-compact-provider-source" }))).toBe(
+      "Oura",
+    );
+
     const header = root.root.findAllByType(Pressable)[0];
     expect(header.props.accessibilityLabel).toMatch(/Readiness Score 87/);
-    expect(header.props.accessibilityLabel).toMatch(/Oura readiness rating: Optimal/);
+    expect(header.props.accessibilityLabel).toMatch(/Oura\./);
+    expect(header.props.accessibilityLabel).toMatch(/Rating Optimal/);
     expect(header.props.accessibilityLabel).toMatch(/Opens Readiness details/);
     expect(header.props.accessibilityLabel.match(/Oura/g)?.length).toBe(1);
+    expect(header.props.accessibilityLabel.match(/Optimal/g)?.length).toBe(1);
+    expect(header.props.accessibilityLabel).not.toMatch(/blue|green|red|amber/i);
   });
 
   it("does not render contributor rows for fallback readiness", () => {

--- a/lib/ui/dash/__tests__/DailyReadinessCard.test.tsx
+++ b/lib/ui/dash/__tests__/DailyReadinessCard.test.tsx
@@ -40,7 +40,7 @@ describe("DailyReadinessCard", () => {
         isFallback: false,
         day: "2026-07-10",
         sourceId: "oura",
-        score: 86,
+        score: 87,
         contributors: {
           resting_heart_rate: 80,
           hrv_balance: 90,
@@ -60,17 +60,26 @@ describe("DailyReadinessCard", () => {
 
     let root!: renderer.ReactTestRenderer;
     act(() => {
-      root = renderer.create(<DailyReadinessCard vm={vm} />);
+      root = renderer.create(<DailyReadinessCard vm={vm} title="Readiness" />);
     });
 
     const flat = allVisibleText(root.root);
-    expect(flat).toContain("86");
+    expect(flat).toContain("Readiness Score 87");
     expect(flat).toContain("Optimal");
+    expect(flat).toContain("Oura");
     expect(flat).toContain("49 bpm");
     expect(flat).toContain("HRV balance");
+    expect(flat).not.toContain("Source: Oura");
+    expect(flat).not.toContain("Ready. Recovery signals are strong today.");
     expect(flat).not.toContain("Sleep regularity");
     expect(root.root.findByProps({ testID: "readiness-metric-row-resting_heart_rate" })).toBeDefined();
     expect(root.root.findByProps({ testID: "readiness-metric-row-sleep_balance" })).toBeDefined();
+
+    const header = root.root.findAllByType(Pressable)[0];
+    expect(header.props.accessibilityLabel).toMatch(/Readiness Score 87/);
+    expect(header.props.accessibilityLabel).toMatch(/Oura readiness rating: Optimal/);
+    expect(header.props.accessibilityLabel).toMatch(/Opens Readiness details/);
+    expect(header.props.accessibilityLabel.match(/Oura/g)?.length).toBe(1);
   });
 
   it("does not render contributor rows for fallback readiness", () => {

--- a/lib/ui/dash/__tests__/DailyReadinessCard.test.tsx
+++ b/lib/ui/dash/__tests__/DailyReadinessCard.test.tsx
@@ -66,7 +66,7 @@ describe("DailyReadinessCard", () => {
     const flat = allVisibleText(root.root);
     expect(flat).toContain("Readiness Score 87");
     expect(flat).toContain("Optimal");
-    expect(flat).toContain("Oura");
+    expect(flat).not.toContain("Oura");
     expect(flat).toContain("49 bpm");
     expect(flat).toContain("HRV balance");
     expect(flat).not.toContain("Source: Oura");
@@ -74,20 +74,17 @@ describe("DailyReadinessCard", () => {
     expect(flat).not.toContain("Sleep regularity");
     expect(root.root.findByProps({ testID: "readiness-metric-row-resting_heart_rate" })).toBeDefined();
     expect(root.root.findByProps({ testID: "readiness-metric-row-sleep_balance" })).toBeDefined();
+    expect(() => root.root.findByProps({ testID: "dash-compact-provider-source" })).toThrow();
 
     const badge = root.root.findByProps({ testID: "dash-compact-rating-badge" });
     expect(allVisibleText(badge)).toBe("Optimal");
     expect(allVisibleText(badge)).not.toContain("Oura");
-    expect(allVisibleText(root.root.findByProps({ testID: "dash-compact-provider-source" }))).toBe(
-      "Oura",
-    );
 
     const header = root.root.findAllByType(Pressable)[0];
     expect(header.props.accessibilityLabel).toMatch(/Readiness Score 87/);
-    expect(header.props.accessibilityLabel).toMatch(/Oura\./);
     expect(header.props.accessibilityLabel).toMatch(/Rating Optimal/);
     expect(header.props.accessibilityLabel).toMatch(/Opens Readiness details/);
-    expect(header.props.accessibilityLabel.match(/Oura/g)?.length).toBe(1);
+    expect(header.props.accessibilityLabel).not.toMatch(/Oura/i);
     expect(header.props.accessibilityLabel.match(/Optimal/g)?.length).toBe(1);
     expect(header.props.accessibilityLabel).not.toMatch(/blue|green|red|amber/i);
   });

--- a/lib/ui/dash/__tests__/DailySleepCard.test.tsx
+++ b/lib/ui/dash/__tests__/DailySleepCard.test.tsx
@@ -69,16 +69,31 @@ describe("DailySleepCard", () => {
 
     let root!: renderer.ReactTestRenderer;
     act(() => {
-      root = renderer.create(<DailySleepCard vm={readyVm(model)} />);
+      root = renderer.create(<DailySleepCard vm={readyVm(model)} title="Sleep" />);
     });
 
     const flat = allVisibleText(root.root);
-    expect(flat).toContain("Last night\u2019s sleep");
-    expect(flat).toContain("88");
+    expect(flat).toContain("Sleep Score 88");
     expect(flat).toContain("Optimal");
+    expect(flat).toContain("Oura");
     expect(flat).toContain("9h 11m");
+    expect(flat).not.toContain("Last night\u2019s sleep");
+    expect(flat).not.toContain("Oura Sleep Score");
+    expect(flat).not.toContain("Strong overall sleep quality for this day.");
     expect(root.root.findByProps({ testID: "sleep-metric-row-sleep_duration" })).toBeDefined();
     expect(root.root.findAllByType(Image)).toHaveLength(0);
+
+    const header = root.root
+      .findAllByType(Pressable)
+      .find(
+        (p) =>
+          typeof p.props.accessibilityLabel === "string" &&
+          p.props.accessibilityLabel.includes("Sleep Score 88"),
+      );
+    expect(header?.props.accessibilityLabel).toMatch(/Oura sleep rating: Optimal/);
+    expect(header?.props.accessibilityLabel).toMatch(/Opens Sleep details/);
+    // Spoken summary mentions Oura once via the rating cluster (not duplicated before the score).
+    expect(header?.props.accessibilityLabel.match(/Oura/g)?.length).toBe(1);
   });
 
   it("lists Duration → Deep → REM → Efficiency without LHR/HRV", () => {
@@ -130,7 +145,7 @@ describe("DailySleepCard", () => {
     });
 
     const flat = allVisibleText(root.root);
-    expect(flat).toContain("Sleep score unavailable");
+    expect(flat).toContain("Unavailable");
     expect(flat).toContain("8h");
     expect(flat).not.toMatch(/\|0\|/);
     const header = root.root
@@ -138,9 +153,9 @@ describe("DailySleepCard", () => {
       .find(
         (p) =>
           typeof p.props.accessibilityLabel === "string" &&
-          p.props.accessibilityLabel.startsWith("Daily Sleep header"),
+          p.props.accessibilityLabel.includes("Daily Sleep"),
       );
-    expect(header?.props.accessibilityLabel).toContain("Sleep score unavailable");
+    expect(header?.props.accessibilityLabel).toMatch(/unavailable|Unavailable/i);
   });
 
   it("renders score 0 as a real score with Pay attention", () => {
@@ -154,7 +169,7 @@ describe("DailySleepCard", () => {
       root = renderer.create(<DailySleepCard vm={readyVm(model)} />);
     });
     const flat = allVisibleText(root.root);
-    expect(flat).toContain("0");
+    expect(flat).toContain("Sleep Score 0");
     expect(flat).toContain("Pay attention");
     expect(flat).not.toContain("Sleep score unavailable");
   });
@@ -215,7 +230,7 @@ describe("DailySleepCard", () => {
       .find(
         (p) =>
           typeof p.props.accessibilityLabel === "string" &&
-          p.props.accessibilityLabel.startsWith("Daily Sleep header"),
+          p.props.accessibilityLabel.includes("Daily Sleep"),
       );
     expect(header).toBeDefined();
     act(() => {

--- a/lib/ui/dash/__tests__/DailySleepCard.test.tsx
+++ b/lib/ui/dash/__tests__/DailySleepCard.test.tsx
@@ -6,6 +6,7 @@ import type { SleepNightDocumentDto } from "@oli/contracts";
 import { buildDailySleepCardModel, type DailySleepCardModel } from "@/lib/data/dash/buildDailySleepCardModel";
 import type { DailySleepCardViewModel } from "@/lib/data/dash/dailySleepCardViewModel";
 import { DailySleepCard } from "@/lib/ui/dash/DailySleepCard";
+import { allowConsoleForThisTest } from "../../../../scripts/test/consoleGuard";
 
 const mockPush = jest.fn();
 
@@ -83,6 +84,12 @@ describe("DailySleepCard", () => {
     expect(root.root.findByProps({ testID: "sleep-metric-row-sleep_duration" })).toBeDefined();
     expect(root.root.findAllByType(Image)).toHaveLength(0);
 
+    const badge = root.root.findByProps({ testID: "dash-compact-rating-badge" });
+    expect(allVisibleText(badge)).toBe("Optimal");
+    expect(allVisibleText(badge)).not.toContain("Oura");
+    const chip = root.root.findByProps({ testID: "dash-compact-provider-source" });
+    expect(allVisibleText(chip)).toBe("Oura");
+
     const header = root.root
       .findAllByType(Pressable)
       .find(
@@ -90,10 +97,43 @@ describe("DailySleepCard", () => {
           typeof p.props.accessibilityLabel === "string" &&
           p.props.accessibilityLabel.includes("Sleep Score 88"),
       );
-    expect(header?.props.accessibilityLabel).toMatch(/Oura sleep rating: Optimal/);
+    expect(header?.props.accessibilityLabel).toMatch(/Sleep Score 88/);
+    expect(header?.props.accessibilityLabel).toMatch(/Oura\./);
+    expect(header?.props.accessibilityLabel).toMatch(/Rating Optimal/);
     expect(header?.props.accessibilityLabel).toMatch(/Opens Sleep details/);
-    // Spoken summary mentions Oura once via the rating cluster (not duplicated before the score).
     expect(header?.props.accessibilityLabel.match(/Oura/g)?.length).toBe(1);
+    expect(header?.props.accessibilityLabel.match(/Optimal/g)?.length).toBe(1);
+    expect(header?.props.accessibilityLabel).not.toMatch(/blue|green|red|amber/i);
+  });
+
+  it("applies semantic tones for representative Oura sleep ratings", () => {
+    allowConsoleForThisTest({ error: [/not wrapped in act/] });
+    const cases: { score: number; label: string }[] = [
+      { score: 88, label: "Optimal" },
+      { score: 75, label: "Good" },
+      { score: 65, label: "Fair" },
+      { score: 40, label: "Pay attention" },
+    ];
+    for (const c of cases) {
+      const model = buildDailySleepCardModel({
+        day,
+        sleepNightSettled: true,
+        sleepNight: minimalNight({ score: c.score, totalSleepMinutes: 480 }),
+      });
+      let root!: renderer.ReactTestRenderer;
+      act(() => {
+        root = renderer.create(<DailySleepCard vm={readyVm(model)} title="Sleep" />);
+      });
+      const badge = root.root.findByProps({ testID: "dash-compact-rating-badge" });
+      expect(allVisibleText(badge)).toBe(c.label);
+      expect(allVisibleText(badge)).not.toContain("Oura");
+      expect(allVisibleText(root.root.findByProps({ testID: "dash-compact-provider-source" }))).toBe(
+        "Oura",
+      );
+      act(() => {
+        root.unmount();
+      });
+    }
   });
 
   it("lists Duration → Deep → REM → Efficiency without LHR/HRV", () => {

--- a/lib/ui/dash/__tests__/DailySleepCard.test.tsx
+++ b/lib/ui/dash/__tests__/DailySleepCard.test.tsx
@@ -76,19 +76,18 @@ describe("DailySleepCard", () => {
     const flat = allVisibleText(root.root);
     expect(flat).toContain("Sleep Score 88");
     expect(flat).toContain("Optimal");
-    expect(flat).toContain("Oura");
+    expect(flat).not.toContain("Oura");
     expect(flat).toContain("9h 11m");
     expect(flat).not.toContain("Last night\u2019s sleep");
     expect(flat).not.toContain("Oura Sleep Score");
     expect(flat).not.toContain("Strong overall sleep quality for this day.");
     expect(root.root.findByProps({ testID: "sleep-metric-row-sleep_duration" })).toBeDefined();
     expect(root.root.findAllByType(Image)).toHaveLength(0);
+    expect(() => root.root.findByProps({ testID: "dash-compact-provider-source" })).toThrow();
 
     const badge = root.root.findByProps({ testID: "dash-compact-rating-badge" });
     expect(allVisibleText(badge)).toBe("Optimal");
     expect(allVisibleText(badge)).not.toContain("Oura");
-    const chip = root.root.findByProps({ testID: "dash-compact-provider-source" });
-    expect(allVisibleText(chip)).toBe("Oura");
 
     const header = root.root
       .findAllByType(Pressable)
@@ -98,10 +97,9 @@ describe("DailySleepCard", () => {
           p.props.accessibilityLabel.includes("Sleep Score 88"),
       );
     expect(header?.props.accessibilityLabel).toMatch(/Sleep Score 88/);
-    expect(header?.props.accessibilityLabel).toMatch(/Oura\./);
     expect(header?.props.accessibilityLabel).toMatch(/Rating Optimal/);
     expect(header?.props.accessibilityLabel).toMatch(/Opens Sleep details/);
-    expect(header?.props.accessibilityLabel.match(/Oura/g)?.length).toBe(1);
+    expect(header?.props.accessibilityLabel).not.toMatch(/Oura/i);
     expect(header?.props.accessibilityLabel.match(/Optimal/g)?.length).toBe(1);
     expect(header?.props.accessibilityLabel).not.toMatch(/blue|green|red|amber/i);
   });
@@ -127,9 +125,8 @@ describe("DailySleepCard", () => {
       const badge = root.root.findByProps({ testID: "dash-compact-rating-badge" });
       expect(allVisibleText(badge)).toBe(c.label);
       expect(allVisibleText(badge)).not.toContain("Oura");
-      expect(allVisibleText(root.root.findByProps({ testID: "dash-compact-provider-source" }))).toBe(
-        "Oura",
-      );
+      expect(() => root.root.findByProps({ testID: "dash-compact-provider-source" })).toThrow();
+      expect(allVisibleText(root.root)).not.toContain("Oura");
       act(() => {
         root.unmount();
       });

--- a/lib/ui/dash/__tests__/DashCompactCardHeader.test.tsx
+++ b/lib/ui/dash/__tests__/DashCompactCardHeader.test.tsx
@@ -1,0 +1,87 @@
+import React, { act } from "react";
+import { Text } from "react-native";
+import renderer from "react-test-renderer";
+
+import { DashCompactCardHeader } from "../DashCompactCardHeader";
+import { allowConsoleForThisTest } from "../../../../scripts/test/consoleGuard";
+
+function allText(root: renderer.ReactTestInstance): string {
+  return root
+    .findAllByType(Text)
+    .map((t) => {
+      const ch = t.props.children;
+      if (typeof ch === "string") return ch;
+      if (Array.isArray(ch)) return ch.filter((x): x is string => typeof x === "string").join("");
+      return "";
+    })
+    .join("|");
+}
+
+describe("DashCompactCardHeader", () => {
+  it("renders title left and rating/source right with a combined rating a11y label", async () => {
+    allowConsoleForThisTest({ error: [/not wrapped in act/] });
+    let tree!: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(
+        <DashCompactCardHeader
+          title="Sleep"
+          rating={{
+            label: "Optimal",
+            sourceLabel: "Oura",
+            accessibilityLabel: "Oura sleep rating: Optimal",
+          }}
+        />,
+      );
+      await Promise.resolve();
+    });
+    const flat = allText(tree.root);
+    expect(flat).toContain("Sleep");
+    expect(flat).toContain("Optimal");
+    expect(flat).toContain("Oura");
+    const badge = tree.root.find(
+      (n) =>
+        (n.props as { accessibilityLabel?: string }).accessibilityLabel ===
+        "Oura sleep rating: Optimal",
+    );
+    expect(badge).toBeTruthy();
+    tree.unmount();
+  });
+
+  it("omits the badge when rating is null", async () => {
+    allowConsoleForThisTest({ error: [/not wrapped in act/] });
+    let tree!: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<DashCompactCardHeader title="Activity" rating={null} />);
+      await Promise.resolve();
+    });
+    const flat = allText(tree.root);
+    expect(flat).toBe("Activity");
+    expect(flat).not.toContain("Optimal");
+    tree.unmount();
+  });
+
+  it("does not treat the rating cluster as an interactive control", async () => {
+    allowConsoleForThisTest({ error: [/not wrapped in act/] });
+    let tree!: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(
+        <DashCompactCardHeader
+          title="Workout"
+          rating={{
+            label: "High",
+            accessibilityLabel: "Workout intensity High.",
+          }}
+        />,
+      );
+      await Promise.resolve();
+    });
+    const badge = tree.root.find(
+      (n) =>
+        (n.props as { accessibilityLabel?: string }).accessibilityLabel ===
+        "Workout intensity High.",
+    );
+    expect(badge.props.accessibilityRole).toBe("text");
+    expect(badge.props.accessible).toBe(false);
+    tree.unmount();
+  });
+});

--- a/lib/ui/dash/__tests__/DashCompactCardHeader.test.tsx
+++ b/lib/ui/dash/__tests__/DashCompactCardHeader.test.tsx
@@ -2,7 +2,11 @@ import React, { act } from "react";
 import { Text } from "react-native";
 import renderer from "react-test-renderer";
 
-import { DashCompactCardHeader } from "../DashCompactCardHeader";
+import {
+  DashCompactCardHeader,
+  DashCompactProviderSourceChip,
+} from "../DashCompactCardHeader";
+import { resolveDashMonitorRatingToneChrome } from "@/lib/ui/theme/dashMonitorRatingToneChrome";
 import { allowConsoleForThisTest } from "../../../../scripts/test/consoleGuard";
 
 function allText(root: renderer.ReactTestInstance): string {
@@ -18,7 +22,7 @@ function allText(root: renderer.ReactTestInstance): string {
 }
 
 describe("DashCompactCardHeader", () => {
-  it("renders title left and rating/source right with a combined rating a11y label", async () => {
+  it("renders title and rating-only badge without nesting Oura in the badge", async () => {
     allowConsoleForThisTest({ error: [/not wrapped in act/] });
     let tree!: renderer.ReactTestRenderer;
     await act(async () => {
@@ -27,8 +31,8 @@ describe("DashCompactCardHeader", () => {
           title="Sleep"
           rating={{
             label: "Optimal",
-            sourceLabel: "Oura",
-            accessibilityLabel: "Oura sleep rating: Optimal",
+            tone: "optimal",
+            accessibilityLabel: "Rating Optimal.",
           }}
         />,
       );
@@ -37,13 +41,20 @@ describe("DashCompactCardHeader", () => {
     const flat = allText(tree.root);
     expect(flat).toContain("Sleep");
     expect(flat).toContain("Optimal");
-    expect(flat).toContain("Oura");
-    const badge = tree.root.find(
-      (n) =>
-        (n.props as { accessibilityLabel?: string }).accessibilityLabel ===
-        "Oura sleep rating: Optimal",
+    expect(flat).not.toContain("Oura");
+    const badge = tree.root.findByProps({ testID: "dash-compact-rating-badge" });
+    const badgeText = allText(badge);
+    expect(badgeText).toBe("Optimal");
+    expect(badgeText).not.toContain("Oura");
+    const chrome = resolveDashMonitorRatingToneChrome("optimal");
+    expect(badge.props.style).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          backgroundColor: chrome.background,
+          borderColor: chrome.border,
+        }),
+      ]),
     );
-    expect(badge).toBeTruthy();
     tree.unmount();
   });
 
@@ -57,10 +68,11 @@ describe("DashCompactCardHeader", () => {
     const flat = allText(tree.root);
     expect(flat).toBe("Activity");
     expect(flat).not.toContain("Optimal");
+    expect(() => tree.root.findByProps({ testID: "dash-compact-rating-badge" })).toThrow();
     tree.unmount();
   });
 
-  it("does not treat the rating cluster as an interactive control", async () => {
+  it("does not treat the rating badge as an interactive control", async () => {
     allowConsoleForThisTest({ error: [/not wrapped in act/] });
     let tree!: renderer.ReactTestRenderer;
     await act(async () => {
@@ -75,13 +87,47 @@ describe("DashCompactCardHeader", () => {
       );
       await Promise.resolve();
     });
-    const badge = tree.root.find(
-      (n) =>
-        (n.props as { accessibilityLabel?: string }).accessibilityLabel ===
-        "Workout intensity High.",
-    );
+    const badge = tree.root.findByProps({ testID: "dash-compact-rating-badge" });
     expect(badge.props.accessibilityRole).toBe("text");
     expect(badge.props.accessible).toBe(false);
+    tree.unmount();
+  });
+
+  it("renders a neutral provider source chip separate from the rating badge", async () => {
+    allowConsoleForThisTest({ error: [/not wrapped in act/] });
+    let tree!: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(
+        <>
+          <DashCompactCardHeader
+            title="Sleep"
+            rating={{
+              label: "Fair",
+              tone: "caution",
+              accessibilityLabel: "Rating Fair.",
+            }}
+          />
+          <DashCompactProviderSourceChip label="Oura" />
+        </>,
+      );
+      await Promise.resolve();
+    });
+    const badge = tree.root.findByProps({ testID: "dash-compact-rating-badge" });
+    const chip = tree.root.findByProps({ testID: "dash-compact-provider-source" });
+    expect(allText(badge)).toBe("Fair");
+    expect(allText(badge)).not.toContain("Oura");
+    expect(allText(chip)).toBe("Oura");
+    expect(chip.props.accessibilityLabel).toBe("Source: Oura");
+    expect(chip.props.accessible).toBe(false);
+    expect(chip.props.accessibilityRole).toBe("text");
+    const caution = resolveDashMonitorRatingToneChrome("caution");
+    expect(badge.props.style).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ backgroundColor: caution.background }),
+      ]),
+    );
+    // Source chip must not inherit caution chrome.
+    expect(JSON.stringify(chip.props.style)).not.toContain(caution.background);
     tree.unmount();
   });
 });

--- a/lib/ui/theme/dashMonitorRatingToneChrome.ts
+++ b/lib/ui/theme/dashMonitorRatingToneChrome.ts
@@ -1,0 +1,86 @@
+/**
+ * Semantic chrome for Daily Monitor Oura provider-rating badges.
+ * Color is supplementary — the written rating label remains the primary signal.
+ *
+ * Tones: critical (red), caution (amber), positive (green), optimal (blue).
+ * Optimal uses the product accent blue family — not a vendor-owned token name.
+ */
+
+import type { OliThemeMode } from "@/lib/ui/theme/oliTheme";
+import { SYSTEM_ACCENT } from "@/lib/ui/theme/systemAccent";
+
+export type DashMonitorRatingToneChromeKey =
+  | "critical"
+  | "caution"
+  | "positive"
+  | "optimal";
+
+export type DashMonitorRatingToneChrome = {
+  foreground: string;
+  background: string;
+  border: string;
+};
+
+/** Dark-elevated card appearance (primary reviewed Daily Monitor surface). */
+export const DASH_MONITOR_RATING_TONE_CHROME_DARK: Record<
+  DashMonitorRatingToneChromeKey,
+  DashMonitorRatingToneChrome
+> = {
+  critical: {
+    foreground: "#FFB3B8",
+    background: "rgba(255, 110, 118, 0.22)",
+    border: "rgba(255, 110, 118, 0.48)",
+  },
+  caution: {
+    foreground: "#FFE08A",
+    background: "rgba(255, 210, 115, 0.22)",
+    border: "rgba(255, 210, 115, 0.48)",
+  },
+  positive: {
+    foreground: "#B8F7CF",
+    background: "rgba(82, 235, 145, 0.22)",
+    border: "rgba(82, 235, 145, 0.48)",
+  },
+  optimal: {
+    foreground: "#C9D9FF",
+    background: "rgba(58, 91, 219, 0.28)",
+    border: "rgba(115, 165, 255, 0.52)",
+  },
+};
+
+/** Light appearance — darker foregrounds for contrast on pale badge fills. */
+export const DASH_MONITOR_RATING_TONE_CHROME_LIGHT: Record<
+  DashMonitorRatingToneChromeKey,
+  DashMonitorRatingToneChrome
+> = {
+  critical: {
+    foreground: "#B71C1C",
+    background: "rgba(198, 40, 40, 0.12)",
+    border: "rgba(198, 40, 40, 0.36)",
+  },
+  caution: {
+    foreground: "#9A6B00",
+    background: "rgba(255, 179, 0, 0.16)",
+    border: "rgba(201, 148, 0, 0.4)",
+  },
+  positive: {
+    foreground: "#1B7A45",
+    background: "rgba(46, 160, 90, 0.14)",
+    border: "rgba(46, 160, 90, 0.36)",
+  },
+  optimal: {
+    foreground: SYSTEM_ACCENT,
+    background: "rgba(58, 91, 219, 0.12)",
+    border: "rgba(58, 91, 219, 0.36)",
+  },
+};
+
+/** Resolve badge chrome for a tone. Defaults to dark (Dash cards use dark tokens today). */
+export function resolveDashMonitorRatingToneChrome(
+  tone: DashMonitorRatingToneChromeKey,
+  mode: OliThemeMode = "dark",
+): DashMonitorRatingToneChrome {
+  return mode === "light"
+    ? DASH_MONITOR_RATING_TONE_CHROME_LIGHT[tone]
+    : DASH_MONITOR_RATING_TONE_CHROME_DARK[tone];
+}

--- a/lib/ui/theme/uiTokens.ts
+++ b/lib/ui/theme/uiTokens.ts
@@ -111,3 +111,6 @@ export const UI_PROGRESS_TRACK_EMPTY = T.progressTrackEmpty;
 
 export const UI_BORDER_SUBTLE = T.borderSubtle;
 export const UI_BORDER_STRONG = T.borderStrong;
+
+/** Neutral provider-source chip fill on dark elevated Monitor cards (not rating-semantic). */
+export const UI_PROVIDER_SOURCE_CHIP_BG = "rgba(255, 255, 255, 0.06)";


### PR DESCRIPTION
## Summary

Daily Monitor Phase 2C foundation, continued with Activity / Workout / Energy / Body presentation corrections from physical-device review.

### This closeout (Activity, Workout, Energy, Body)
- **Activity:** Removed `so far` from the visible current-day step category; retained exact Activity Today descriptors (`Sedentary` … `Highly Active`) from `getStepRatingActivityDescriptorPill` / `activityStepRating.ts`; supplemental semantic tone via `mapActivityStepDescriptorToTone`.
- **Activity Distance:** Wired from DailyFacts `activity.distanceKm` only (no stride invent). Formatting reuses `formatDistanceDualDisplay`. When the source/DailyFacts omit `distanceKm`, row stays **Unavailable** (common for step sources without measured distance; server also omits zero).
- **Workout Total Volume:** Reuses `resolveStrengthSessionExerciseDisplay` + `strengthVolumeKg` / ingest set mass×reps (warmup excluded; missing load ≠ 0). Preferred mass unit honored. Multi-session contract: **latest-session title + latest-session metrics** (not “N workouts” with unlabeled latest values).
- **Workout rating:** Existing RPE/average-intensity badge retained when valid. **No** absolute-tonnage Low/Moderate/High. Volume rating blocked: `Workout volume rating blocked pending a personal/comparable-session volume contract.`
- **Energy:** Removed temporary **Estimated** top-right badge; no PAL / Low–Very High from hybrid output. Kcal range + BMR/NEAT/Strength/Cardio rows preserved. Blocker: baseline is full-day while activity factors are so-far — no projected 24h TEE.
- **Body:** Removed **My Goal** from Daily Monitor card (goals remain under Body / Program settings). **No** card-level Body badge — existing interpretation bars are per-metric and BMI-inclusive; no single tested Monitor-safe, non-BMI-alone, method-limited summary badge.

### Architecture
- Presentation-only cards; typed view models; no Firebase/API in screens.
- No backend / Firestore / RawEvent / CanonicalEvent / DailyFacts schema changes.
- No Energy compute, BMR, Oura/Readiness math, workout reconciliation, Timeline, or Program changes.
- No new routes or dependencies.

### Test / gate
- Focused suites + full `npm test -- --ci` (5261 tests).
- typecheck, lint, invariants, trust boundary, API/UI route asserts, Phase 1/2 proof gates, Expo public config, guardrails.

## Test plan
- [ ] Device: Activity — no `so far`; category label + color; Distance matches when DailyFacts has `distanceKm`, else Unavailable
- [ ] Device: Workout — Total Volume when ingest/set load exists; RPE intensity only; no volume Low/Moderate/High
- [ ] Device: Energy — no Estimated badge / gap; kcal range + factor rows
- [ ] Device: Body — no My Goal; Weight/BMI/Body Fat/Lean Mass; full-card Body nav
- [ ] VoiceOver / Dynamic Type / 44pt targets / floating-tab clearance
- [ ] Program + Timeline unchanged